### PR TITLE
Add string method for ReconcileKey

### DIFF
--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -35,3 +35,7 @@ type ReconcileKey struct {
 	// Name is the name of the object.
 	Name string
 }
+
+func (r ReconcileKey) String() string {
+	return r.Namespace + "/" + r.Name
+}


### PR DESCRIPTION
For better display in log statements e.g.
```
glog.Infof("Implement reconcile for '%s'.\n", k)
-> Implement reconcile for namespace/object
``` 