### PR TITLE
Fix an issue in types.ReconcileKey.String()

### DIFF
--- a/pkg/controller/types/types.go
+++ b/pkg/controller/types/types.go
@@ -37,5 +37,17 @@ type ReconcileKey struct {
 }
 
 func (r ReconcileKey) String() string {
+	if r.Namespace == "" {
+		return r.Name
+	}
 	return r.Namespace + "/" + r.Name
+}
+
+// ParseReconcileKey returns the ReconcileKey that has been encoded into a string.
+func ParseReconcileKey(key string) (ReconcileKey, error) {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return ReconcileKey{}, err
+	}
+	return ReconcileKey{Name: name, Namespace: namespace}, nil
 }


### PR DESCRIPTION
While trying to determine what key to emit for an element without a
namespace, I looked at types.ReconcileKey which would emit "/name" which
doesn't appear to agree with the rest of the logic in kubebuilder. This
fixes types.ReconcileKey to emit the correct string value if namespace
is empty as well as adds a method to construct the object from a string.