### PR TITLE
Dockerfile.controller from scratch

### DIFF
--- a/cmd/kubebuilder/initproject/dockerfile.go
+++ b/cmd/kubebuilder/initproject/dockerfile.go
@@ -85,15 +85,15 @@ COPY cmd/    cmd/
 COPY vendor/ vendor/
 
 # Build and test the API code
-RUN go build -a -o controller-manager ./cmd/controller-manager/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o controller-manager ./cmd/controller-manager/main.go
 RUN go test ./pkg/... ./cmd/...
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest  
+FROM scratch
 # RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/{{ .Repo }}/controller-manager .
-CMD ["./controller-manager", "--install-crds=false"]  
+CMD ["./controller-manager", "--install-crds=false"]
 `
 
 //var apiserverDockerfileTemplate = `# Instructions to install API using the installer


### PR DESCRIPTION
Make image from scratch instead of ubuntu in Dockerfile.controller
Add build env for building go binary before copying to scratch.

Issue#56
https://github.com/kubernetes-sigs/kubebuilder/issues/56