### PR TITLE
Set ENTRYPOINT and CMD for Dockerfile.controller

### DIFF
--- a/cmd/kubebuilder/initproject/dockerfile.go
+++ b/cmd/kubebuilder/initproject/dockerfile.go
@@ -85,15 +85,16 @@ COPY cmd/    cmd/
 COPY vendor/ vendor/
 
 # Build and test the API code
-RUN go build -a -o controller-manager ./cmd/controller-manager/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o controller-manager ./cmd/controller-manager/main.go
 RUN go test ./pkg/... ./cmd/...
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest  
+FROM scratch
 # RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/{{ .Repo }}/controller-manager .
-CMD ["./controller-manager", "--install-crds=false"]  
+ENTRYPOINT ["./controller-manager"]
+CMD ["--install-crds=false"]
 `
 
 //var apiserverDockerfileTemplate = `# Instructions to install API using the installer


### PR DESCRIPTION
Fixes #55 
- Set executable binary for ENTRYPOINT
- Set default value of --install-crds=false as CMD, which can be override.