### PR TITLE
standardize kubebuilder codegeneration labels to have +kubebuilder: prefix

### DIFF
--- a/cmd/internal/codegen/parse/apis.go
+++ b/cmd/internal/codegen/parse/apis.go
@@ -267,7 +267,7 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 
 func (b *APIs) genClient(c *types.Type) bool {
 	comments := Comments(c.CommentLines)
-	resource := comments.getTag("resource", ":")
+	resource := comments.getTag("resource", ":") + comments.getTag("kubebuilder:resource", ":")
 	return len(resource) > 0
 }
 

--- a/cmd/internal/codegen/parse/controllers.go
+++ b/cmd/internal/codegen/parse/controllers.go
@@ -46,9 +46,9 @@ func (b *APIs) parseControllers() {
 
 func (b *APIs) getControllerTag(c *types.Type) string {
 	comments := Comments(c.CommentLines)
-	resource := comments.getTag("controller", ":")
+	resource := comments.getTag("controller", ":") + comments.getTag("kubebuilder:controller", ":")
 	if len(resource) == 0 {
-		panic(errors.Errorf("Must specify +controller comment for type %v", c.Name))
+		panic(errors.Errorf("Must specify +kubebuilder:controller comment for type %v", c.Name))
 	}
 	return resource
 }
@@ -59,7 +59,7 @@ func parseControllerTag(tag string) controllerTags {
 	for _, elem := range strings.Split(tag, ",") {
 		kv := strings.Split(elem, "=")
 		if len(kv) != 2 {
-			log.Fatalf("// +controller: tags must be key value pairs.  Expected "+
+			log.Fatalf("// +kubebuilder:controller: tags must be key value pairs.  Expected "+
 				"keys [group=<group>,version=<version>,kind=<kind>,resource=<resource>] "+
 				"Got string: [%s]", tag)
 		}

--- a/cmd/internal/codegen/parse/index.go
+++ b/cmd/internal/codegen/parse/index.go
@@ -184,7 +184,7 @@ func parseResourceTag(tag string) resourceTags {
 	for _, elem := range strings.Split(tag, ",") {
 		kv := strings.Split(elem, "=")
 		if len(kv) != 2 {
-			log.Fatalf("// +resource: tags must be key value pairs.  Expected "+
+			log.Fatalf("// +kubebuilder:resource: tags must be key value pairs.  Expected "+
 				"keys [path=<subresourcepath>] "+
 				"Got string: [%s]", tag)
 		}
@@ -230,9 +230,9 @@ func parseResourceTag(tag string) resourceTags {
 // getResourceTag returns the value of the "+resource=" comment tag
 func (b *APIs) getResourceTag(c *types.Type) string {
 	comments := Comments(c.CommentLines)
-	resource := comments.getTag("resource", ":")
+	resource := comments.getTag("resource", ":") + comments.getTag("kubebuilder:resource", ":")
 	if len(resource) == 0 {
-		panic(errors.Errorf("Must specify +resource comment for type %v", c.Name))
+		panic(errors.Errorf("Must specify +kubebuilder:resource comment for type %v", c.Name))
 	}
 	return resource
 }

--- a/cmd/internal/codegen/parse/rbac.go
+++ b/cmd/internal/codegen/parse/rbac.go
@@ -39,8 +39,9 @@ func (b *APIs) parseRBAC() {
 func (b *APIs) getRBACTag(c *types.Type) []string {
     comments := Comments(c.CommentLines)
     resource := comments.getTags("rbac", ":")
+    resource = append(resource, comments.getTags("kubebuilder:rbac", ":")...)
     if len(resource) == 0 {
-        panic(fmt.Errorf("Must specify +rbac comment for type %v", c.Name))
+        panic(fmt.Errorf("Must specify +kubebuilder:rbac comment for type %v", c.Name))
     }
     return resource
 }
@@ -50,7 +51,7 @@ func parseRBACTag(tag string) rbacv1.PolicyRule {
     for _, elem := range strings.Split(tag, ",") {
         kv := strings.Split(elem, "=")
         if len(kv) != 2 {
-            log.Fatalf("// +rbac: tags must be key value pairs.  Expected "+
+            log.Fatalf("// +kubebuilder:rbac: tags must be key value pairs.  Expected "+
                 "keys [groups=<group1;group2>,resources=<resource1;resource2>,verbs=<verb1;verb2>] "+
                 "Got string: [%s]", tag)
         }
@@ -90,8 +91,9 @@ func (b *APIs) parseInformers() {
 func (b *APIs) getInformerTag(c *types.Type) []string {
     comments := Comments(c.CommentLines)
     resource := comments.getTags("informers", ":")
+    resource = append(resource, comments.getTags("kubebuilder:informers", ":")...)
     if len(resource) == 0 {
-        panic(fmt.Errorf("Must specify +informers comment for type %v", c.Name))
+        panic(fmt.Errorf("Must specify +kubebuilder:informers comment for type %v", c.Name))
     }
     return resource
 }
@@ -101,7 +103,7 @@ func parseInformerTag(tag string) v1.GroupVersionKind {
     for _, elem := range strings.Split(tag, ",") {
         kv := strings.Split(elem, "=")
         if len(kv) != 2 {
-            log.Fatalf("// +informers: tags must be key value pairs.  Expected "+
+            log.Fatalf("// +kubebuilder:informers: tags must be key value pairs.  Expected "+
                 "keys [group=core,version=v1,kind=Pod] "+
                 "Got string: [%s]", tag)
         }

--- a/cmd/internal/codegen/parse/util.go
+++ b/cmd/internal/codegen/parse/util.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/gengo/types"
 )
 
-// IsAPIResource returns true if t has a +resource comment tag
+// IsAPIResource returns true if t has a +resource/+kubebuilder:resource comment tag
 func IsAPIResource(t *types.Type) bool {
 	for _, c := range t.CommentLines {
-		if strings.Contains(c, "+resource") {
+		if strings.Contains(c, "+resource") || strings.Contains(c, "+kubebuilder:resource"){
 			return true
 		}
 	}
@@ -59,7 +59,7 @@ func IsNonNamespaced(t *types.Type) bool {
 
 func IsController(t *types.Type) bool {
 	for _, c := range t.CommentLines {
-		if strings.Contains(c, "+controller") {
+		if strings.Contains(c, "+controller") || strings.Contains(c, "+kubebuilder:controller") {
 			return true
 		}
 	}
@@ -68,7 +68,7 @@ func IsController(t *types.Type) bool {
 
 func IsRBAC(t *types.Type) bool {
 	for _, c := range t.CommentLines {
-		if strings.Contains(c, "+rbac") {
+		if strings.Contains(c, "+rbac") || strings.Contains(c, "+kubebuilder:rbac") {
 			return true
 		}
 	}
@@ -77,7 +77,7 @@ func IsRBAC(t *types.Type) bool {
 
 func IsInformer(t *types.Type) bool {
     for _, c := range t.CommentLines {
-        if strings.Contains(c, "+informers") {
+        if strings.Contains(c, "+informers") || strings.Contains(c, "+kubebuilder:informers") {
             return true
         }
     }

--- a/cmd/kubebuilder/create/resource/controller.go
+++ b/cmd/kubebuilder/create/resource/controller.go
@@ -59,7 +59,7 @@ func (bc *{{.Kind}}Controller) Reconcile(k types.ReconcileKey) error {
     return nil
 }
 
-// +controller:group={{ .Group }},version={{ .Version }},kind={{ .Kind}},resource={{ .Resource }}
+// +kubebuilder:controller:group={{ .Group }},version={{ .Version }},kind={{ .Kind}},resource={{ .Resource }}
 type {{.Kind}}Controller struct {
     // INSERT ADDITIONAL FIELDS HERE
     {{lower .Kind}}Lister {{.Group}}{{.Version}}lister.{{.Kind}}Lister

--- a/cmd/kubebuilder/create/resource/resource.go
+++ b/cmd/kubebuilder/create/resource/resource.go
@@ -77,7 +77,7 @@ type {{.Kind}}Status struct {
 
 // {{.Kind}}
 // +k8s:openapi-gen=true
-// +resource:path={{.Resource}}
+// +kubebuilder:resource:path={{.Resource}}
 type {{.Kind}} struct {
     metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
     metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `

--- a/docs/adding_non_namespaced_resources.md
+++ b/docs/adding_non_namespaced_resources.md
@@ -30,7 +30,7 @@ Example:
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +nonNamespaced=true
 
-// +resource:path=foos
+// +kubebuilder:resource:path=foos
 // +k8s:openapi-gen=true
 // Foo defines some thing
 type Foo struct {

--- a/docs/declaring_rbac_rules_for_controllers.md
+++ b/docs/declaring_rbac_rules_for_controllers.md
@@ -14,13 +14,13 @@ Since your controller will likely be interacting with additional resources
 (e.g. core resources), it is possible to declare additional RBAC rules
 for the controller ServiceAccount to be installed.
 
-To define additional rbac rules, add a `//+rbac` comment to the controller struct
+To define additional rbac rules, add a `//kubebuilder:+rbac` comment to the controller struct
 under `pkg/controller/<name>/controller.go`
 
 ```go
-// +rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch;create;update;delete
-// +rbac:groups=,resources=pods,verbs=get;list;watch;create;update;delete
-// +controller:group=foo,version=v1alpha1,kind=Bar,resource=bars
+// +kubebuilder:rbac:groups=apps;extensions,resources=deployments,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;create;update;delete
+// +kubebuilder:controller:group=foo,version=v1alpha1,kind=Bar,resource=bars
 type BarControllerImpl struct {
     builders.DefaultControllerFns
 

--- a/pkg/gen/apis/doc.go
+++ b/pkg/gen/apis/doc.go
@@ -20,7 +20,7 @@ The apis package describes the comment directives that may be applied to apis / 
 package apis
 
 // Resource annotates a type as a resource
-const Resource = "// +resource:path="
+const Resource = "// +kubebuilder:resource:path="
 
 // Maximum annotates a go struct field for CRD validation
 const Maximum = "// +kubebuilder:validation:Maximum="

--- a/pkg/gen/apis/example_test.go
+++ b/pkg/gen/apis/example_test.go
@@ -37,7 +37,7 @@ type FooStatus struct{}
 
 // Foo
 // +k8s:openapi-gen=true
-// +resource:path=foos
+// +kubebuilder:resource:path=foos
 type Foo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/gen/controller/doc.go
+++ b/pkg/gen/controller/doc.go
@@ -20,10 +20,10 @@ The controller package describes comment directives that may be applied to contr
 package controller
 
 // Controller annotates a type as being a controller for a specific resource
-const Controller = "// +controller:group=,version=,kind=,resource="
+const Controller = "// +kubebuilder:controller:group=,version=,kind=,resource="
 
 // RBAC annotates a controller struct as needing an RBAC rule to run
-const RBAC = "// +rbac:groups=<group1;group2>,resources=<resource1;resource2>,verbs=<verb1;verb2>"
+const RBAC = "// +kubebuilder:rbac:groups=<group1;group2>,resources=<resource1;resource2>,verbs=<verb1;verb2>"
 
 // Informers indicates that an informer must be started for this controller
-const Informers = "// +informers:group=core,version=v1,kind=Pod"
+const Informers = "// +kubebuilder:informers:group=core,version=v1,kind=Pod"

--- a/pkg/gen/controller/example_test.go
+++ b/pkg/gen/controller/example_test.go
@@ -18,9 +18,9 @@ package controller_test
 
 func Example() {}
 
-// +controller:group=foo,version=v1beta1,kind=Bar,resource=bars
-// +rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +informers:group=apps,version=v1,kind=Deployment
-// +rbac:groups="",resources=pods,verbs=get;watch;list
-// +informers:group=core,version=v1,kind=Pod
+// +kubebuilder:controller:group=foo,version=v1beta1,kind=Bar,resource=bars
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:informers:group=apps,version=v1,kind=Deployment
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;watch;list
+// +kubebuilder:informers:group=core,version=v1,kind=Pod
 type FooController struct{}


### PR DESCRIPTION
This is to fix #22 