### PR TITLE
disable debugging in GoReleaser command

### DIFF
--- a/build/build_kubebuilder.sh
+++ b/build/build_kubebuilder.sh
@@ -56,4 +56,4 @@ case $key in
 esac
 done
 
-/goreleaser release --config=build/.goreleaser.yml --debug --rm-dist ${SNAPSHOT}
+/goreleaser release --config=build/.goreleaser.yml --rm-dist ${SNAPSHOT}


### PR DESCRIPTION
GoReleaser debug output is flooding GCB console.