### PR TITLE
Category support

### DIFF
--- a/cmd/internal/codegen/parse/util.go
+++ b/cmd/internal/codegen/parse/util.go
@@ -110,6 +110,21 @@ func HasSubresource(t *types.Type) bool {
 	return false
 }
 
+// HasCategories returns true if t is an APIResource annotated with
+// +kubebuilder:categories.
+func HasCategories(t *types.Type) bool {
+	if !IsAPIResource(t) {
+		return false
+	}
+
+	for _, c := range t.CommentLines {
+		if strings.Contains(c, "+kubebuilder:categories") {
+			return true
+		}
+	}
+	return false
+}
+
 func IsUnversioned(t *types.Type, group string) bool {
 	return IsApisDir(filepath.Base(filepath.Dir(t.Name.Package))) && GetGroup(t) == group
 }

--- a/pkg/gen/apis/doc.go
+++ b/pkg/gen/apis/doc.go
@@ -22,6 +22,10 @@ package apis
 // Resource annotates a type as a resource
 const Resource = "// +kubebuilder:resource:path="
 
+// Categories annotates a type as belonging to a comma-delimited list of
+// categories
+const Categories = "// +kubebuilder:categories="
+
 // Maximum annotates a go struct field for CRD validation
 const Maximum = "// +kubebuilder:validation:Maximum="
 

--- a/pkg/gen/apis/example_test.go
+++ b/pkg/gen/apis/example_test.go
@@ -37,6 +37,7 @@ func Example() {
 	// Foo
 	// +k8s:openapi-gen=true
 	// +kubebuilder:resource:path=foos
+	// +kubebuilder:categories=foo,bar,baz
 	type Foo struct {
 		metav1.TypeMeta   `json:",inline"`
 		metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/test.sh
+++ b/test.sh
@@ -119,7 +119,10 @@ function generate_crd_resources {
   kubebuilder init repo --domain sample.kubernetes.io
   kubebuilder create resource --group insect --version v1beta1 --kind Bee
 
-  header_text "generating CRD definition"
+  header_text "editing generated files to simulate a user"
+  sed -i pkg/apis/insect/v1beta1/bee_types.go -e "s|type Bee struct|// +kubebuilder:categories=foo,bar\ntype Bee struct|"
+
+  header_text "generating and testing CRD definition"
   kubebuilder create config --crds --output crd.yaml
 
   # Test for the expected generated CRD definition
@@ -139,6 +142,9 @@ metadata:
 spec:
   group: insect.sample.kubernetes.io
   names:
+    categories:
+    - foo
+    - bar
     kind: Bee
     plural: bees
   scope: Namespaced


### PR DESCRIPTION
Support for kubectl categories using `+kubebuilder:categories=foo,bar,zab` tag

Closes #102 

Depends on #103