### PR TITLE
set version field correctly during KB compilation

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -3,7 +3,7 @@
 builds:
 - main: ./cmd/kubebuilder
   binary: kubebuilder
-  ldflags: -s -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.kubebuilderVersion={{.Version}} -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.gitCommit={{.Commit}} -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.buildDate={{.Date}} -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.kubernetesVendorVersion={{.Env.KUBERNETES_VERSION}}
+  ldflags: -s -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.kubeBuilderVersion={{.Version}} -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.gitCommit={{.Commit}} -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.buildDate={{.Date}} -X github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/version.kubernetesVendorVersion={{.Env.KUBERNETES_VERSION}}
   goos:
    - darwin
    - linux


### PR DESCRIPTION
kubebuilder version command was not returning correct version because
release process wasn't setting the version field correctly during
compilation of kubebuilder binary.