### PR TITLE
Control -x in test.sh with TRACE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   -
 
 script:
-  ./test.sh
+  TRACE=1 ./test.sh
 
 # TBD. Suppressing for now.
 notifications:

--- a/test.sh
+++ b/test.sh
@@ -15,7 +15,15 @@
 #  limitations under the License.
 
 set -e
-set -x
+
+# Enable tracing in this script off by setting the TRACE variable in your
+# environment to any value:
+#
+# $ TRACE=1 test.sh
+TRACE=${TRACE:""}
+if [ -n "$TRACE" ]; then
+  set -x
+fi
 
 # Make sure, we run in the root of the repo and
 # therefore run the tests on all packages


### PR DESCRIPTION
Makes the `set -x` behavior of test.sh dependent on `TRACE` environment variable; keeps current behavior in CI.