### PR TITLE
fixed client-go dependencies for cmds

### DIFF
--- a/cmd/Gopkg.lock
+++ b/cmd/Gopkg.lock
@@ -181,10 +181,10 @@
   version = "kubernetes-1.10.1"
 
 [[projects]]
+  branch = "release-7.0"
   name = "k8s.io/client-go"
   packages = ["util/homedir"]
-  revision = "989be4278f353e42f26c416c53757d16fcff77db"
-  version = "kubernetes-1.10.1"
+  revision = "33f2870a2b83179c823ddc90e5513f9e5fe43b38"
 
 [[projects]]
   branch = "master"
@@ -201,6 +201,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "53c0546d5938231df9b5bf3a3e878723d37026c0048dd7238a5e57dcc5e47992"
+  inputs-digest = "c8f4482837cf8edad943fea608dc2729d91a36f9050758952f31bbdea7dfc4f7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/Gopkg.toml
+++ b/cmd/Gopkg.toml
@@ -41,5 +41,5 @@
   name = "k8s.io/apiserver"
 
 [[constraint]]
-  version = "kubernetes-1.10.1"
+  branch = "release-7.0"
   name = "k8s.io/client-go"

--- a/cmd/vendor/k8s.io/client-go/transport/cache.go
+++ b/cmd/vendor/k8s.io/client-go/transport/cache.go
@@ -44,6 +44,7 @@ type tlsCacheKey struct {
 	certData   string
 	keyData    string
 	serverName string
+	dial       string
 }
 
 func (t tlsCacheKey) String() string {
@@ -51,7 +52,7 @@ func (t tlsCacheKey) String() string {
 	if len(t.keyData) > 0 {
 		keyText = "<redacted>"
 	}
-	return fmt.Sprintf("insecure:%v, caData:%#v, certData:%#v, keyData:%s, serverName:%s", t.insecure, t.caData, t.certData, keyText, t.serverName)
+	return fmt.Sprintf("insecure:%v, caData:%#v, certData:%#v, keyData:%s, serverName:%s, dial:%s", t.insecure, t.caData, t.certData, keyText, t.serverName, t.dial)
 }
 
 func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
@@ -75,7 +76,7 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 		return nil, err
 	}
 	// The options didn't require a custom TLS config
-	if tlsConfig == nil {
+	if tlsConfig == nil && config.Dial == nil {
 		return http.DefaultTransport, nil
 	}
 
@@ -109,5 +110,6 @@ func tlsConfigKey(c *Config) (tlsCacheKey, error) {
 		certData:   string(c.TLS.CertData),
 		keyData:    string(c.TLS.KeyData),
 		serverName: c.TLS.ServerName,
+		dial:       fmt.Sprintf("%p", c.Dial),
 	}, nil
 }

--- a/cmd/vendor/k8s.io/client-go/transport/transport.go
+++ b/cmd/vendor/k8s.io/client-go/transport/transport.go
@@ -52,7 +52,7 @@ func New(config *Config) (http.RoundTripper, error) {
 // TLSConfigFor returns a tls.Config that will provide the transport level security defined
 // by the provided Config. Will return nil if no transport level security is requested.
 func TLSConfigFor(c *Config) (*tls.Config, error) {
-	if !(c.HasCA() || c.HasCertAuth() || c.TLS.Insecure) {
+	if !(c.HasCA() || c.HasCertAuth() || c.TLS.Insecure || len(c.TLS.ServerName) > 0) {
 		return nil, nil
 	}
 	if c.HasCA() && c.TLS.Insecure {


### PR DESCRIPTION
Realized client-go has different versioning scheme than K8s. version `kubernetes-1.10.1` doesn't exist on client-go.

Also note that we are specifying branch `release-7.0` instead of `7.0.0` version so that its easier to update deps for fixes for 7.0.0 version. Revision in Gopkg.lock will be used for reproducibility.