### PR TITLE
add support for creating coretype controller

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -20,6 +20,15 @@ builds:
    - amd64
   env:
    - CGO_ENABLED=0
+- main: ./cmd/controller-gen
+  binary: controller-gen
+  goos:
+   - darwin
+   - linux
+  goarch:
+   - amd64
+  env:
+   - CGO_ENABLED=0
 archive:
   files:
     - "/workspace/_output/kubebuilder/bin/vendor.tar.gz"

--- a/cmd/controller-gen/codegen/generators.go
+++ b/cmd/controller-gen/codegen/generators.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codegen
+
+import (
+	"github.com/kubernetes-sigs/kubebuilder/cmd/internal/codegen"
+	"k8s.io/gengo/generator"
+)
+
+// ControllerGenerator provides a code generator that takes a package of a controller
+// and generates a file
+type ControllerGenerator interface {
+	// GenerateInject returns a Generator for the controller package e.g. pkg/controller
+	GenerateInject(controllers []codegen.Controller, filename string) generator.Generator
+}

--- a/cmd/controller-gen/codegen/run/generator.go
+++ b/cmd/controller-gen/codegen/run/generator.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package run
+
+import (
+	"github.com/golang/glog"
+	"github.com/kubernetes-sigs/kubebuilder/cmd/internal/codegen/parse"
+	"github.com/kubernetes-sigs/kubebuilder/cmd/controller-gen/codegen"
+	"k8s.io/gengo/args"
+	"k8s.io/gengo/generator"
+)
+
+// CodeGenerator generates code for Kubernetes resources and controllers
+type CodeGenerator struct {
+	controllerGenerators []codegen.ControllerGenerator
+
+	// OutputFileBaseName is the base name used for output files
+	OutputFileBaseName string
+}
+
+// AddControllerGenerator adds a controller generator that will be called with parsed controllers
+func (g *CodeGenerator) AddControllerGenerator(generator codegen.ControllerGenerator) *CodeGenerator {
+	g.controllerGenerators = append(g.controllerGenerators, generator)
+	return g
+}
+
+type customArgs struct{}
+
+// Execute parses packages and executes the code generators against the resource and controller packages
+func (g *CodeGenerator) Execute() error {
+	arguments := args.Default()
+	arguments.CustomArgs = &customArgs{}
+	arguments.OutputFileBaseName = g.OutputFileBaseName
+
+	err := arguments.Execute(parse.NameSystems(), parse.DefaultNameSystem(), g.packages)
+	if err != nil {
+		glog.Fatalf("Error: %v", err)
+	}
+	return nil
+}
+
+// packages parses the observed packages and creates code generators
+func (g *CodeGenerator) packages(context *generator.Context, arguments *args.GeneratorArgs) generator.Packages {
+	p := packages{}
+
+	b := parse.NewControllers(context, arguments)
+
+	repo := ""
+	for _, c := range b.Controllers {
+		repo = c.Repo
+	}
+
+	// Do inject package
+	if len(b.Controllers) > 0 {
+		for _, cg := range g.controllerGenerators {
+			g := cg.GenerateInject(b.Controllers, arguments.OutputFileBaseName)
+			if g != nil {
+				p.add(context.Universe[repo+"/pkg/inject"].Path, g)
+			}
+		}
+	}
+
+	return p.value
+}

--- a/cmd/controller-gen/codegen/run/util.go
+++ b/cmd/controller-gen/codegen/run/util.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package run
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/gengo/generator"
+	"k8s.io/gengo/types"
+)
+
+// generatorToPackage creates a new package from a generator and package name
+func generatorToPackage(pkg string, gen generator.Generator) generator.Package {
+	name := strings.Split(filepath.Base(pkg), ".")[0]
+	return &generator.DefaultPackage{
+		PackageName: name,
+		PackagePath: pkg,
+		HeaderText:  generatedGoHeader(),
+		GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
+			return []generator.Generator{gen}
+		},
+		FilterFunc: func(c *generator.Context, t *types.Type) bool {
+			// Generators only see Types in the same package as the generator
+			return t.Name.Package == pkg
+		},
+	}
+}
+
+// generatedGoHeader returns the header to preprend to generated go files
+func generatedGoHeader() []byte {
+	cr, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt"))
+	if err != nil {
+		return []byte{}
+	}
+	return cr
+}
+
+// packages wraps a collection of generator.Packages
+type packages struct {
+	value generator.Packages
+}
+
+// add creates a new generator.Package from gen and adds it to the collection
+func (g *packages) add(pkg string, gen generator.Generator) {
+	g.value = append(g.value, generatorToPackage(pkg, gen))
+}

--- a/cmd/controller-gen/internal/controllergen/generator.go
+++ b/cmd/controller-gen/internal/controllergen/generator.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllergen
+
+import (
+	"github.com/kubernetes-sigs/kubebuilder/cmd/internal/codegen"
+	"k8s.io/gengo/generator"
+)
+
+type Generator struct{}
+
+// GenerateInject returns a Generator for the controller package e.g. pkg/controller
+func (g *Generator) GenerateInject(controllers []codegen.Controller, filename string) generator.Generator {
+	return &injectGenerator{
+		generator.DefaultGen{OptionalName: filename},
+		controllers,
+	}
+}

--- a/cmd/controller-gen/internal/controllergen/inject.go
+++ b/cmd/controller-gen/internal/controllergen/inject.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllergen
+
+import (
+	"io"
+	"strings"
+	"text/template"
+
+	"github.com/kubernetes-sigs/kubebuilder/cmd/internal/codegen"
+	"github.com/markbates/inflect"
+	"k8s.io/gengo/generator"
+)
+
+type injectGenerator struct {
+	generator.DefaultGen
+	Controllers []codegen.Controller
+}
+
+var _ generator.Generator = &injectGenerator{}
+
+func (d *injectGenerator) Imports(c *generator.Context) []string {
+	if len(d.Controllers) == 0 {
+		return []string{}
+	}
+
+	repo := d.Controllers[0].Repo
+	im := []string{
+		"time",
+		"github.com/kubernetes-sigs/kubebuilder/pkg/controller",
+		"k8s.io/client-go/rest",
+		repo + "/pkg/controller/sharedinformers",
+		repo + "/pkg/client/informers/externalversions",
+		repo + "/pkg/inject/args",
+		"rbacv1 \"k8s.io/api/rbac/v1\"",
+	}
+
+	// Import package for each controller
+	repos := map[string]string{}
+	for _, c := range d.Controllers {
+		repos[c.Pkg.Path] = ""
+	}
+	for k, _ := range repos {
+		im = append(im, k)
+	}
+
+	return im
+}
+
+func (d *injectGenerator) Finalize(context *generator.Context, w io.Writer) error {
+	temp := template.Must(template.New("all-controller-template").Funcs(
+		template.FuncMap{
+			"title":  strings.Title,
+			"plural": inflect.NewDefaultRuleset().Pluralize,
+		},
+	).Parse(injectAPITemplate))
+	return temp.Execute(w, d)
+}
+
+var injectAPITemplate = `
+func init() {
+
+    Inject = append(Inject, func(arguments args.InjectArgs) error {
+	    Injector.ControllerManager = arguments.ControllerManager
+
+        {{ range $c := .Controllers -}}
+        if c, err := {{ $c.Pkg.Name }}.ProvideController(arguments); err != nil {
+            return err
+        } else {
+            arguments.ControllerManager.AddController(c)
+        }
+        {{ end -}}
+        return nil
+    })
+
+	Injector.RunFns = append(Injector.RunFns, func(arguments run.RunArguments) error {
+	    Injector.ControllerManager.RunInformersAndControllers(arguments)
+	    return nil
+    })
+}
+`

--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/golang/glog"
+	"github.com/kubernetes-sigs/kubebuilder/cmd/controller-gen/codegen/run"
+	"github.com/kubernetes-sigs/kubebuilder/cmd/controller-gen/internal/controllergen"
+	"k8s.io/apiserver/pkg/util/logs"
+)
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	(&run.CodeGenerator{OutputFileBaseName: "zz_generated.kubebuilder"}).
+		AddControllerGenerator(&controllergen.Generator{}).
+		Execute()
+
+	glog.V(2).Info("Completed successfully.")
+}

--- a/cmd/internal/codegen/parse/parser.go
+++ b/cmd/internal/codegen/parse/parser.go
@@ -67,6 +67,16 @@ func NewAPIs(context *generator.Context, arguments *args.GeneratorArgs) *APIs {
 	return b
 }
 
+func NewControllers(context *generator.Context, arguments *args.GeneratorArgs) *APIs {
+	b := &APIs{
+		context: context,
+		arguments: arguments,
+	}
+	b.parseControllers()
+	b.parseRBAC()
+	return b
+}
+
 // parseGroupNames initializes b.GroupNames with the set of all groups
 func (b *APIs) parseGroupNames() {
 	b.GroupNames = sets.String{}

--- a/cmd/kubebuilder/create/resource/controller.go
+++ b/cmd/kubebuilder/create/resource/controller.go
@@ -42,11 +42,17 @@ import (
     "github.com/kubernetes-sigs/kubebuilder/pkg/controller"
     "github.com/kubernetes-sigs/kubebuilder/pkg/controller/types"
     "k8s.io/client-go/tools/record"
-
+    {{if .CoreType}}
+    {{.Group}}{{.Version}}client "k8s.io/client-go/kubernetes/typed/{{.Group}}/{{.Version}}"
+    {{.Group}}{{.Version}}lister "k8s.io/client-go/listers/{{.Group}}/{{.Version}}"
+    {{.Group}}{{.Version}} "k8s.io/api/{{.Group}}/{{.Version}}"
+    {{.Group}}{{.Version}}informer "k8s.io/client-go/informers/{{.Group}}/{{.Version}}"    
+    {{else}}
     {{.Group}}{{.Version}}client "{{.Repo}}/pkg/client/clientset/versioned/typed/{{.Group}}/{{.Version}}"
     {{.Group}}{{.Version}}lister "{{.Repo}}/pkg/client/listers/{{.Group}}/{{.Version}}"
     {{.Group}}{{.Version}} "{{.Repo}}/pkg/apis/{{.Group}}/{{.Version}}"
     {{.Group}}{{.Version}}informer "{{.Repo}}/pkg/client/informers/externalversions/{{.Group}}/{{.Version}}"
+    {{end}}
     "{{.Repo}}/pkg/inject/args"
 )
 

--- a/cmd/kubebuilder/create/resource/controllertest.go
+++ b/cmd/kubebuilder/create/resource/controllertest.go
@@ -52,16 +52,22 @@ import (
     "github.com/kubernetes-sigs/kubebuilder/pkg/test"
     "k8s.io/client-go/kubernetes"
     "k8s.io/client-go/rest"
-
+    {{if .CoreType}}
+    "{{ .Repo }}/pkg/inject"
+    "{{ .Repo }}/pkg/inject/args"
+    {{else}}
     "{{ .Repo }}/pkg/client/clientset/versioned"
     "{{ .Repo }}/pkg/inject"
     "{{ .Repo }}/pkg/inject/args"
+    {{end}}
 )
 
 var (
     testenv *test.TestEnvironment
     config *rest.Config
+    {{if not .CoreType}}
     cs *versioned.Clientset
+    {{end}}
     ks *kubernetes.Clientset
     shutdown chan struct{}
     ctrl *controller.GenericController
@@ -77,7 +83,9 @@ var _ = BeforeSuite(func() {
     var err error
     config, err = testenv.Start()
     Expect(err).NotTo(HaveOccurred())
+    {{if not .CoreType}}
     cs = versioned.NewForConfigOrDie(config)
+    {{end}}
     ks = kubernetes.NewForConfigOrDie(config)
 
     shutdown = make(chan struct{})
@@ -112,9 +120,13 @@ import (
 
 	"github.com/kubernetes-sigs/kubebuilder/pkg/controller/types"
     metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+    {{if .CoreType}}
+    . "k8s.io/api/{{.Group}}/{{.Version}}"
+    . "k8s.io/client-go/kubernetes/typed/{{.Group}}/{{.Version}}"
+    {{else}}
     . "{{ .Repo }}/pkg/apis/{{ .Group }}/{{ .Version }}"
     . "{{ .Repo }}/pkg/client/clientset/versioned/typed/{{ .Group }}/{{ .Version }}"
+    {{end}}
 )
 
 // EDIT THIS FILE!
@@ -153,7 +165,11 @@ var _ = Describe("{{ .Kind }} controller", func() {
             }
 
             // Create the instance
+            {{if .CoreType}}
+            client = ks.{{title .Group}}{{title .Version}}().{{ plural .Kind }}({{ if not .NonNamespacedKind }}"default"{{ end }})
+            {{else}}
             client = cs.{{title .Group}}{{title .Version}}().{{ plural .Kind }}({{ if not .NonNamespacedKind }}"default"{{ end }})
+            {{end}}
             _, err := client.Create(&instance)
             Expect(err).ShouldNot(HaveOccurred())
 

--- a/cmd/kubebuilder/create/resource/resource.go
+++ b/cmd/kubebuilder/create/resource/resource.go
@@ -35,6 +35,7 @@ type resourceTemplateArgs struct {
 	Repo              string
 	PluralizedKind    string
 	NonNamespacedKind bool
+	CoreType bool
 }
 
 func doResource(dir string, args resourceTemplateArgs) bool {

--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -79,6 +79,10 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 	if coreControllerOnly {
 		fmt.Printf("Creating controller for kubernetes core types ...\n")
 		createCoreController(cr)
+		if generate {
+			args = append(args, "core-controller-only")
+			generatecmd.RunGenerate(cmd, args)
+		}
 	} else {
 		fmt.Printf("Creating API files for you to edit...\n")
 		createGroup(cr)

--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -32,6 +32,7 @@ import (
 var nonNamespacedKind bool
 var controller bool
 var generate bool
+var coreControllerOnly bool
 
 var createResourceCmd = &cobra.Command{
 	Use:   "resource",
@@ -61,6 +62,7 @@ func AddCreateResource(cmd *cobra.Command) {
 	createResourceCmd.Flags().BoolVar(&nonNamespacedKind, "non-namespaced", false, "if set, the API kind will be non namespaced")
 	createResourceCmd.Flags().BoolVar(&controller, "controller", true, "if true, generate the controller code for the resource")
 	createResourceCmd.Flags().BoolVar(&generate, "generate", true, "generate source code")
+	createResourceCmd.Flags().BoolVar(&coreControllerOnly, "core-controller-only", false, "skip resources, generate controller only")
 	cmd.AddCommand(createResourceCmd)
 }
 
@@ -74,14 +76,19 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 
 	cr := util.GetCopyright(createutil.Copyright)
 
-	fmt.Printf("Creating API files for you to edit...\n")
-	createGroup(cr)
-	createVersion(cr)
-	createResource(cr)
-	if generate {
-		fmt.Printf("Generating code for new resource...  " +
-			"Regenerate after editing resources files by running `kubebuilder build generated`.\n")
-		generatecmd.RunGenerate(cmd, args)
+	if coreControllerOnly {
+		fmt.Printf("Creating controller for kubernetes core types ...\n")
+		createCoreController(cr)
+	} else {
+		fmt.Printf("Creating API files for you to edit...\n")
+		createGroup(cr)
+		createVersion(cr)
+		createResource(cr)
+		if generate {
+			fmt.Printf("Generating code for new resource...  " +
+				"Regenerate after editing resources files by running `kubebuilder build generated`.\n")
+			generatecmd.RunGenerate(cmd, args)
+		}
 	}
 	fmt.Printf("Next: Install the API, run the controller and create an instance with:\n" +
 		"$ GOBIN=${PWD}/bin go install ${PWD#$GOPATH/src/}/cmd/controller-manager\n" +
@@ -100,6 +107,7 @@ func createResource(boilerplate string) {
 		util.Repo,
 		inflect.NewDefaultRuleset().Pluralize(createutil.KindName),
 		nonNamespacedKind,
+		false,
 	}
 
 	dir, err := os.Getwd()
@@ -119,6 +127,32 @@ func createResource(boilerplate string) {
 
 	//doDockerfile(filepath.Join(dir, "build"), args)
 	//doExample(dir, args)
+	fmt.Printf("Edit your sample resource instance...\n")
+	doSample(dir, args)
+}
+
+func createCoreController(boilerplate string) {
+	args := resourceTemplateArgs{
+		boilerplate,
+		util.Domain,
+		createutil.GroupName,
+		createutil.VersionName,
+		createutil.KindName,
+		createutil.ResourceName,
+		util.Repo,
+		inflect.NewDefaultRuleset().Pluralize(createutil.KindName),
+		nonNamespacedKind,
+		true,
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Edit your controller function...\n")
+	doController(dir, args)
+	doControllerTest(dir, args)
+
 	fmt.Printf("Edit your sample resource instance...\n")
 	doSample(dir, args)
 }

--- a/cmd/kubebuilder/initproject/init.go
+++ b/cmd/kubebuilder/initproject/init.go
@@ -42,17 +42,19 @@ kubebuilder init repo --domain mydomain
 var domain string
 var copyright string
 var bazel bool
+var coreControllerOnly bool
 
 func AddInit(cmd *cobra.Command) {
 	cmd.AddCommand(repoCmd)
 	repoCmd.Flags().StringVar(&domain, "domain", "", "domain for the API groups")
 	repoCmd.Flags().StringVar(&copyright, "copyright", filepath.Join("hack", "boilerplate.go.txt"), "Location of copyright boilerplate file.")
 	repoCmd.Flags().BoolVar(&bazel, "bazel", false, "if true, setup Bazel workspace artifacts")
+	repoCmd.Flags().BoolVar(&coreControllerOnly, "core-controller-only", false, "if true, setup controller only")
 }
 
 func runInitRepo(cmd *cobra.Command, args []string) {
 	version := runtime.Version()
-	if versionCmp(version, "go1.10") < 0 {
+	if versionCmp(version, "go1.9") < 0 {
 		log.Fatalf("The go version is %v, must be 1.10+", version)
 	}
 
@@ -66,7 +68,7 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 	if bazel {
 		createBazelWorkspace()
 	}
-	createControllerManager(cr)
+	createControllerManager(cr, coreControllerOnly)
 	//createInstaller(cr)
 	createAPIs(cr)
 	//runCreateApiserver(cr)
@@ -85,7 +87,7 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 	}
 	doDockerfile()
 	doInject(cr)
-	doArgs(cr)
+	doArgs(cr, coreControllerOnly)
 	//os.MkdirAll("bin", 0700)
 
 	createBoilerplate()
@@ -104,6 +106,7 @@ func execute(path, templateName, templateValue string, data interface{}) {
 type templateArgs struct {
 	BoilerPlate string
 	Repo        string
+	CoreControllerOnly bool
 }
 
 func versionCmp(v1 string, v2 string) int {


### PR DESCRIPTION
Add a flag `core-controller-only` in kubebuilder init
Change inject and controller-manager template

Add a flag `core-controller-only` in kubebuilder create
Change controller template

Add a binary `controller-gen` to skip parsing resources
Pass `core-controller-only` to kubebuilder generate and call `controller-gen`