### PR TITLE
Don't terminate if GOPATH env var is unset

### DIFF
--- a/cmd/kubebuilder/main.go
+++ b/cmd/kubebuilder/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	gobuild "go/build"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ func main() {
 	util.CheckInstall()
 	gopath := os.Getenv("GOPATH")
 	if len(gopath) == 0 {
-		log.Fatal("GOPATH not defined")
+		gopath = gobuild.Default.GOPATH
 	}
 	util.GoSrc = filepath.Join(gopath, "src")
 


### PR DESCRIPTION
From version 1.8 onwards a default GOPATH is assumed, so use that if one
isn't explicitly set.