### PR TITLE
fixed gopkg.toml for Kubebuilder and generated project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ go:
 git:
   depth: 3
 
-
 go_import_path: github.com/kubernetes-sigs/kubebuilder
+
+before_install:
+- go get -u github.com/golang/dep/cmd/dep
 
 # Install must be set to prevent default `go get` to run.
 # The dependencies have already been vendored by `dep` so

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -582,7 +582,6 @@
   revision = "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 
 [[projects]]
-  branch = "master"
   name = "sigs.k8s.io/testing_frameworks"
   packages = [
     "integration",
@@ -593,6 +592,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "bdd3cd6805a7da6f0c03dfdc7b6daa9a96c0d563ee7c6fb36a5d7bb26481c6fc"
+  inputs-digest = "23dd99960429731773b751527608685fdd29b212b9ed7cedcd502b0f27d43c6c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,10 +18,6 @@ required = ["sigs.k8s.io/testing_frameworks/integration",
             "github.com/spf13/pflag"]
 
 [[constraint]]
-  version = "KUBEBUILDER_VERSION"
-  name = "github.com/kubernetes-sigs/kubebuilder"
-
-[[constraint]]
   name = "sigs.k8s.io/testing_frameworks"
   revision = "f53464b8b84b4507805a0b033a8377b225163fea"
 

--- a/build/build_vendor.sh
+++ b/build/build_vendor.sh
@@ -23,5 +23,4 @@ cp /workspace/LICENSE /workspace/vendor/github.com/kubernetes-sigs/kubebuilder/L
 
 export DEST=/workspace/_output/kubebuilder/bin/
 mkdir -p $DEST || echo ""
-sed -i "s/KUBEBUILDER_VERSION/"${VERSION-master}"/" Gopkg.toml
 tar -czvf $DEST/vendor.tar.gz vendor/ Gopkg.lock  Gopkg.toml


### PR DESCRIPTION
Highlights:
 - Removed self dependency in Gopkg.toml for Kubebuilder project
 - Update the Gopkg.toml file correctly for generated project
 - Added `dep ensure` test in test.sh
 - Update Travis config to add 'dep install'

Note: This also brings us one step closer to the goal of "not shipping vendors dir" in KB build. I will make a separate PR for that.