### PR TITLE
Add support for creating core type controllers

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -33,6 +33,7 @@ export TEST_ASSET_ETCD=/tmp/kubebuilder/bin/etcd
 kubebuilder init repo --domain sample.kubernetes.io
 kubebuilder create resource --group insect --version v1beta1 --kind Bee
 kubebuilder create resource --group insect --version v1beta1 --kind Wasp
+kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type
 
 # Verify the controller-manager builds and the tests pass
 go build ./cmd/...

--- a/cmd/kubebuilder/create/controller/controller.go
+++ b/cmd/kubebuilder/create/controller/controller.go
@@ -35,7 +35,7 @@ type controllerTemplateArgs struct {
 	Repo              string
 	PluralizedKind    string
 	NonNamespacedKind bool
-	CoreType bool
+	CoreType          bool
 }
 
 func doController(dir string, args controllerTemplateArgs) bool {

--- a/cmd/kubebuilder/create/controller/controller.go
+++ b/cmd/kubebuilder/create/controller/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resource
+package controller
 
 import (
 	"fmt"
@@ -25,7 +25,20 @@ import (
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/util"
 )
 
-func doController(dir string, args resourceTemplateArgs) bool {
+type controllerTemplateArgs struct {
+	BoilerPlate       string
+	Domain            string
+	Group             string
+	Version           string
+	Kind              string
+	Resource          string
+	Repo              string
+	PluralizedKind    string
+	NonNamespacedKind bool
+	CoreType bool
+}
+
+func doController(dir string, args controllerTemplateArgs) bool {
 	path := filepath.Join(dir, "pkg", "controller", strings.ToLower(createutil.KindName), "controller.go")
 	fmt.Printf("\t%s\n", filepath.Join(
 		"pkg", "controller", strings.ToLower(createutil.KindName), "controller.go"))
@@ -42,11 +55,17 @@ import (
     "github.com/kubernetes-sigs/kubebuilder/pkg/controller"
     "github.com/kubernetes-sigs/kubebuilder/pkg/controller/types"
     "k8s.io/client-go/tools/record"
-
+    {{if .CoreType}}
+    {{.Group}}{{.Version}}client "k8s.io/client-go/kubernetes/typed/{{.Group}}/{{.Version}}"
+    {{.Group}}{{.Version}}lister "k8s.io/client-go/listers/{{.Group}}/{{.Version}}"
+    {{.Group}}{{.Version}} "k8s.io/api/{{.Group}}/{{.Version}}"
+    {{.Group}}{{.Version}}informer "k8s.io/client-go/informers/{{.Group}}/{{.Version}}"
+    {{else}}
     {{.Group}}{{.Version}}client "{{.Repo}}/pkg/client/clientset/versioned/typed/{{.Group}}/{{.Version}}"
     {{.Group}}{{.Version}}lister "{{.Repo}}/pkg/client/listers/{{.Group}}/{{.Version}}"
     {{.Group}}{{.Version}} "{{.Repo}}/pkg/apis/{{.Group}}/{{.Version}}"
     {{.Group}}{{.Version}}informer "{{.Repo}}/pkg/client/informers/externalversions/{{.Group}}/{{.Version}}"
+    {{end}}
     "{{.Repo}}/pkg/inject/args"
 )
 
@@ -59,7 +78,7 @@ func (bc *{{.Kind}}Controller) Reconcile(k types.ReconcileKey) error {
     log.Printf("Implement the Reconcile function on {{lower .Kind}}.{{.Kind}}Controller to reconcile %s\n", k.Name)
     return nil
 }
-
+{{if .CoreType}}// +kubebuilder:informers:group={{ .Group }},version={{ .Version }},kind={{ .Kind }}{{end}}
 // +kubebuilder:controller:group={{ .Group }},version={{ .Version }},kind={{ .Kind}},resource={{ .Resource }}
 type {{.Kind}}Controller struct {
     // INSERT ADDITIONAL FIELDS HERE
@@ -76,7 +95,8 @@ func ProvideController(arguments args.InjectArgs) (*controller.GenericController
     // INSERT INITIALIZATIONS FOR ADDITIONAL FIELDS HERE
     bc := &{{.Kind}}Controller{
         {{lower .Kind}}Lister: arguments.ControllerManager.GetInformerProvider(&{{.Group}}{{.Version}}.{{.Kind}}{}).({{.Group}}{{.Version}}informer.{{.Kind}}Informer).Lister(),
-        {{lower .Kind}}client: arguments.Clientset.{{title .Group}}{{title .Version}}(),
+        {{if .CoreType}}{{lower .Kind}}client: arguments.KubernetesClientSet.{{title .Group}}{{title .Version}}(),{{else}}
+        {{lower .Kind}}client: arguments.Clientset.{{title .Group}}{{title .Version}}(),{{end}}
         {{lower .Kind}}recorder: arguments.CreateRecorder("{{.Kind}}Controller"),
     }
 

--- a/cmd/kubebuilder/create/controller/controllertest.go
+++ b/cmd/kubebuilder/create/controller/controllertest.go
@@ -52,14 +52,9 @@ import (
     "github.com/kubernetes-sigs/kubebuilder/pkg/test"
     "k8s.io/client-go/kubernetes"
     "k8s.io/client-go/rest"
-    {{if .CoreType}}
+    {{if not .CoreType}}"{{ .Repo }}/pkg/client/clientset/versioned"{{end}}
     "{{ .Repo }}/pkg/inject"
     "{{ .Repo }}/pkg/inject/args"
-    {{else}}
-    "{{ .Repo }}/pkg/client/clientset/versioned"
-    "{{ .Repo }}/pkg/inject"
-    "{{ .Repo }}/pkg/inject/args"
-    {{end}}
 )
 
 var (

--- a/cmd/kubebuilder/create/controller/run.go
+++ b/cmd/kubebuilder/create/controller/run.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	createutil "github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/util"
+	generatecmd "github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/generate"
+	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/util"
+	"github.com/markbates/inflect"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var nonNamespacedKind bool
+var generate bool
+var CoreType bool
+
+var createControllerCmd = &cobra.Command{
+	Use:   "controller",
+	Short: "Creates a controller for an API group, version and resource",
+	Long: `Creates a controller for an API group, version and resource.
+
+Also creates:
+- controller reconcile function
+- tests for the controller
+`,
+	Example: `# Create a controller for resource "Bee" in the "insect" group with version "v1beta"
+kubebuilder create controller --group insect --version v1beta1 --kind Bee
+
+# Create a controller for k8s core type "Deployment" in the "apps" group with version "v1beta2"
+kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type
+`,
+	Run: RunCreateController,
+}
+
+func AddCreateController(cmd *cobra.Command) {
+	createutil.RegisterResourceFlags(createControllerCmd)
+	createControllerCmd.Flags().BoolVar(&nonNamespacedKind, "non-namespaced", false, "if set, the API kind will be non namespaced")
+	createControllerCmd.Flags().BoolVar(&generate, "generate", true, "generate controller code")
+	createControllerCmd.Flags().BoolVar(&CoreType, "core-type", false, "generate controller for core type")
+	cmd.AddCommand(createControllerCmd)
+}
+
+func RunCreateController(cmd *cobra.Command, args []string) {
+	if _, err := os.Stat("pkg"); err != nil {
+		log.Fatalf("could not find 'pkg' directory.  must run kubebuilder init before creating controller")
+	}
+
+	util.GetDomain()
+	createutil.ValidateResourceFlags()
+
+	cr := util.GetCopyright(createutil.Copyright)
+
+	fmt.Printf("Creating controller ...\n")
+	CreateController(cr)
+	if generate {
+		fmt.Printf("Generating code for new controller... " +
+				"Regenerate after editing controller files by running `kubebuilder generate clean; kubebuilder generate`.\n")
+		generatecmd.RunGenerate(cmd, args)
+	}
+	fmt.Printf("Next: Run the controller and create an instance with:\n" +
+		"$ GOBIN=${PWD}/bin go install ${PWD#$GOPATH/src/}/cmd/controller-manager\n" +
+		"$ bin/controller-manager --kubeconfig ~/.kube/config\n" +
+		"$ kubectl apply -f hack/sample/" + strings.ToLower(createutil.KindName) + ".yaml\n")
+}
+
+func CreateController(boilerplate string) {
+	args := controllerTemplateArgs{
+		boilerplate,
+		util.Domain,
+		createutil.GroupName,
+		createutil.VersionName,
+		createutil.KindName,
+		createutil.ResourceName,
+		util.Repo,
+		inflect.NewDefaultRuleset().Pluralize(createutil.KindName),
+		nonNamespacedKind,
+		CoreType,
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Edit your controller function...\n")
+	doController(dir, args)
+	doControllerTest(dir, args)
+}

--- a/cmd/kubebuilder/create/create.go
+++ b/cmd/kubebuilder/create/create.go
@@ -18,6 +18,7 @@ package create
 
 import (
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/config"
+	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/controller"
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/example"
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/resource"
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/util"
@@ -41,6 +42,7 @@ func AddCreate(cmd *cobra.Command) {
 	resource.AddCreateResource(createCmd)
 	config.AddCreateConfig(createCmd)
 	example.AddCreateExample(createCmd)
+	controller.AddCreateController(createCmd)
 }
 
 func RunCreate(cmd *cobra.Command, args []string) {

--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-
 	"strings"
 
+	controllerct "github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/controller"
 	createutil "github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/create/util"
 	generatecmd "github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/generate"
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder/util"
@@ -75,6 +75,7 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 
 	cr := util.GetCopyright(createutil.Copyright)
 
+
 	fmt.Printf("Creating API files for you to edit...\n")
 	createGroup(cr)
 	createVersion(cr)
@@ -113,13 +114,11 @@ func createResource(boilerplate string) {
 	doResourceTest(dir, args)
 
 	if controller {
-		fmt.Printf("Edit your controller function...\n")
-		doController(dir, args)
-		doControllerTest(dir, args)
+		fmt.Printf("Creating controller ...\n")
+		controllerct.CoreType = false
+		controllerct.CreateController(boilerplate)
 	}
 
-	//doDockerfile(filepath.Join(dir, "build"), args)
-	//doExample(dir, args)
 	fmt.Printf("Edit your sample resource instance...\n")
 	doSample(dir, args)
 }

--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -75,7 +75,6 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 
 	cr := util.GetCopyright(createutil.Copyright)
 
-
 	fmt.Printf("Creating API files for you to edit...\n")
 	createGroup(cr)
 	createVersion(cr)
@@ -115,8 +114,8 @@ func createResource(boilerplate string) {
 
 	if controller {
 		fmt.Printf("Creating controller ...\n")
-		controllerct.CoreType = false
-		controllerct.CreateController(boilerplate)
+		c := controllerct.ControllerArguments{CoreType: false}
+		c.CreateController(boilerplate)
 	}
 
 	fmt.Printf("Edit your sample resource instance...\n")

--- a/cmd/kubebuilder/initproject/init.go
+++ b/cmd/kubebuilder/initproject/init.go
@@ -42,12 +42,14 @@ kubebuilder init repo --domain mydomain
 var domain string
 var copyright string
 var bazel bool
+var controllerOnly bool
 
 func AddInit(cmd *cobra.Command) {
 	cmd.AddCommand(repoCmd)
 	repoCmd.Flags().StringVar(&domain, "domain", "", "domain for the API groups")
 	repoCmd.Flags().StringVar(&copyright, "copyright", filepath.Join("hack", "boilerplate.go.txt"), "Location of copyright boilerplate file.")
 	repoCmd.Flags().BoolVar(&bazel, "bazel", false, "if true, setup Bazel workspace artifacts")
+	repoCmd.Flags().BoolVar(&controllerOnly, "controller-only", false, "if true, setup controller only")
 }
 
 func runInitRepo(cmd *cobra.Command, args []string) {
@@ -87,7 +89,7 @@ func runInitRepo(cmd *cobra.Command, args []string) {
 	}
 	doDockerfile()
 	doInject(cr)
-	doArgs(cr)
+	doArgs(cr, controllerOnly)
 	//os.MkdirAll("bin", 0700)
 	RunVendorInstall(nil, nil)
 
@@ -107,6 +109,7 @@ func execute(path, templateName, templateValue string, data interface{}) {
 type templateArgs struct {
 	BoilerPlate string
 	Repo        string
+	ControllerOnly bool
 }
 
 func versionCmp(v1 string, v2 string) int {

--- a/test.sh
+++ b/test.sh
@@ -361,7 +361,7 @@ EOF
 
 
   kubebuilder create resource --group insect --version v1beta1 --kind Wasp
-  kubebuilder create resource --group ant --version v1beta1 --kind Ant
+  kubebuilder create resource --group ant --version v1beta1 --kind Ant --controller=false
   kubebuilder create config --crds --output crd.yaml
 
   # Check for ordering of generated YAML
@@ -502,15 +502,61 @@ function test_docs {
   diff docs/reference/config.yaml $kb_orig/test/docs/expected/config.yaml
 }
 
+function generate_controller {
+  header_text "creating controller"
+    kubebuilder create controller --group ant --version v1beta1 --kind Ant
+}
+
+function update_controller_test {
+  # Update import
+  sed -i 's!"k8s.io/client-go/kubernetes/typed/apps/v1beta2"!&\n    "k8s.io/api/core/v1"!' ./pkg/controller/deployment/controller_test.go
+
+  # Fill deployment instance
+  sed -i 's!instance.Name = "instance-1"!&\n    instance.Spec.Template.Spec.Containers = []v1.Container{{Name: "name", Image: "someimage"}}\n    labels := map[string]string{"foo": "bar"}\n    instance.Spec.Template.ObjectMeta.Labels = labels\n    instance.Spec.Selector = \&metav1.LabelSelector{MatchLabels: labels}!' ./pkg/controller/deployment/controller_test.go
+}
+
+function generate_coretype_controller {
+    header_text "generating controller for coretype Deployment"
+
+    # Run the commands
+    kubebuilder init repo --domain sample.kubernetes.io --controller-only
+    kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type
+
+    # Update the controller test
+    update_controller_test
+}
+
+function generate_resource_with_coretype_controller {
+  header_text "generating CRD resource as well as controller for coretype Deployment"
+
+  # Run the commands
+  kubebuilder init repo --domain sample.kubernetes.io
+  kubebuilder create resource --group ant --version v1beta1 --kind Ant
+  kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type
+
+  # Update the controller test
+  update_controller_test
+}
+
 prepare_staging_dir
 fetch_tools
 build_kb
-prepare_testdir_under_gopath
 
+prepare_testdir_under_gopath
 generate_crd_resources
+generate_controller
 test_docs
 test_generated_controller
 test_vendor_update
 # re-running controller tests post vendor update
 test_generated_controller
+
+prepare_testdir_under_gopath
+generate_resource_with_coretype_controller
+test_generated_controller
+
+prepare_testdir_under_gopath
+generate_coretype_controller
+test_generated_controller
+
 exit $rc

--- a/test.sh
+++ b/test.sh
@@ -522,7 +522,7 @@ function generate_coretype_controller {
     kubebuilder init repo --domain sample.kubernetes.io --controller-only
     kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type
 
-    # Update the controller test
+  # Fill the required fileds of Deployment object so that the Deployment instance can be successfully created
     update_controller_test
 }
 
@@ -534,7 +534,7 @@ function generate_resource_with_coretype_controller {
   kubebuilder create resource --group ant --version v1beta1 --kind Ant
   kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type
 
-  # Update the controller test
+  # Fill the required fileds of Deployment object so that the Deployment instance can be successfully created
   update_controller_test
 }
 


### PR DESCRIPTION
- Add flag `controller-only` to init
- Add command `create controller` with flag `--core-type`
- Update controller template and inject template
- Add test with `create controller --core-type` in test.sh
This is to fix #41