### PR TITLE
REL changelog should include changes since last release

### DIFF
--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -22,7 +22,7 @@
 
 steps:
 - name: "gcr.io/cloud-builders/git"
-  args: [fetch, --depth=100]
+  args: [fetch, --tags, --depth=100]
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/linux_amd64"]
 - name: "gcr.io/kubebuilder/thirdparty-linux:1.10.1"


### PR DESCRIPTION
fixed #127

Google cloud builder wasn't fetching all the tags which
was causing GoReleaser to include changes since the first commit