### PR TITLE
Add skipmap flag to skip validation for AdditionlPropperties

### DIFF
--- a/cmd/internal/codegen/parse/crd.go
+++ b/cmd/internal/codegen/parse/crd.go
@@ -215,28 +215,36 @@ func (b *APIs) parsePrimitiveValidation(t *types.Type, found sets.String, commen
 	return props, buff.String()
 }
 
+type mapTempateArgs struct {
+	Result string
+	SkipMap bool
+}
+
 var mapTemplate = template.Must(template.New("map-template").Parse(
 	`v1beta1.JSONSchemaProps{
     Type:                 "object",
-    AdditionalProperties: &v1beta1.JSONSchemaPropsOrBool{
+    {{if not .SkipMap}}AdditionalProperties: &v1beta1.JSONSchemaPropsOrBool{
         Allows: true,
-        //Schema: &{{.}},
-    },
+        Schema: &{{.Result}},
+    },{{end}}
 }`))
 
 // parseMapValidation returns a JSONSchemaProps object and its serialization in
 // Go that describe the validations for the given map type.
 func (b *APIs) parseMapValidation(t *types.Type, found sets.String, comments []string) (v1beta1.JSONSchemaProps, string) {
-	additionalProps, _ := b.typeToJSONSchemaProps(t.Elem, found, comments)
+	additionalProps, result := b.typeToJSONSchemaProps(t.Elem, found, comments)
 	props := v1beta1.JSONSchemaProps{
 		Type: "object",
-		AdditionalProperties: &v1beta1.JSONSchemaPropsOrBool{
+	}
+    parseOption := b.arguments.CustomArgs.(*ParseOptions)
+	if !parseOption.SkipMap {
+		props.AdditionalProperties = &v1beta1.JSONSchemaPropsOrBool{
 			Allows: true,
-			Schema: &additionalProps},
+			Schema: &additionalProps}
 	}
 
 	buff := &bytes.Buffer{}
-	if err := mapTemplate.Execute(buff, ""); err != nil {
+	if err := mapTemplate.Execute(buff, mapTempateArgs{result, parseOption.SkipMap}); err != nil {
 		log.Fatalf("%v", err)
 	}
 	return props, buff.String()

--- a/cmd/internal/codegen/parse/crd.go
+++ b/cmd/internal/codegen/parse/crd.go
@@ -217,13 +217,13 @@ func (b *APIs) parsePrimitiveValidation(t *types.Type, found sets.String, commen
 
 type mapTempateArgs struct {
 	Result string
-	SkipMap bool
+	SkipMapValidation bool
 }
 
 var mapTemplate = template.Must(template.New("map-template").Parse(
 	`v1beta1.JSONSchemaProps{
     Type:                 "object",
-    {{if not .SkipMap}}AdditionalProperties: &v1beta1.JSONSchemaPropsOrBool{
+    {{if not .SkipMapValidation}}AdditionalProperties: &v1beta1.JSONSchemaPropsOrBool{
         Allows: true,
         Schema: &{{.Result}},
     },{{end}}
@@ -237,14 +237,14 @@ func (b *APIs) parseMapValidation(t *types.Type, found sets.String, comments []s
 		Type: "object",
 	}
     parseOption := b.arguments.CustomArgs.(*ParseOptions)
-	if !parseOption.SkipMap {
+	if !parseOption.SkipMapValidation {
 		props.AdditionalProperties = &v1beta1.JSONSchemaPropsOrBool{
 			Allows: true,
 			Schema: &additionalProps}
 	}
 
 	buff := &bytes.Buffer{}
-	if err := mapTemplate.Execute(buff, mapTempateArgs{result, parseOption.SkipMap}); err != nil {
+	if err := mapTemplate.Execute(buff, mapTempateArgs{Result: result, SkipMapValidation: parseOption.SkipMapValidation}); err != nil {
 		log.Fatalf("%v", err)
 	}
 	return props, buff.String()

--- a/cmd/internal/codegen/parse/util.go
+++ b/cmd/internal/codegen/parse/util.go
@@ -27,7 +27,7 @@ import (
 )
 
 type ParseOptions struct {
-    SkipMap bool
+    SkipMapValidation bool
 }
 
 // IsAPIResource returns true if t has a +resource/+kubebuilder:resource comment tag

--- a/cmd/internal/codegen/parse/util.go
+++ b/cmd/internal/codegen/parse/util.go
@@ -26,6 +26,10 @@ import (
 	"k8s.io/gengo/types"
 )
 
+type ParseOptions struct {
+    SkipMap bool
+}
+
 // IsAPIResource returns true if t has a +resource/+kubebuilder:resource comment tag
 func IsAPIResource(t *types.Type) bool {
 	for _, c := range t.CommentLines {

--- a/cmd/kubebuilder-gen/codegen/run/generator.go
+++ b/cmd/kubebuilder-gen/codegen/run/generator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubernetes-sigs/kubebuilder/cmd/kubebuilder-gen/codegen"
 	"k8s.io/gengo/args"
 	"k8s.io/gengo/generator"
+	"github.com/spf13/pflag"
 )
 
 // CodeGenerator generates code for Kubernetes resources and controllers
@@ -45,12 +46,16 @@ func (g *CodeGenerator) AddResourceGenerator(generator codegen.ResourceGenerator
 	return g
 }
 
-type customArgs struct{}
-
 // Execute parses packages and executes the code generators against the resource and controller packages
 func (g *CodeGenerator) Execute() error {
 	arguments := args.Default()
-	arguments.CustomArgs = &customArgs{}
+
+	// Custom args.
+	customArgs := &parse.ParseOptions{}
+	pflag.CommandLine.BoolVar(&customArgs.SkipMap, "skip-map", true,
+		"If set true, skip map types.")
+	arguments.CustomArgs = customArgs
+
 	arguments.OutputFileBaseName = g.OutputFileBaseName
 
 	err := arguments.Execute(parse.NameSystems(), parse.DefaultNameSystem(), g.packages)

--- a/cmd/kubebuilder-gen/codegen/run/generator.go
+++ b/cmd/kubebuilder-gen/codegen/run/generator.go
@@ -52,8 +52,8 @@ func (g *CodeGenerator) Execute() error {
 
 	// Custom args.
 	customArgs := &parse.ParseOptions{}
-	pflag.CommandLine.BoolVar(&customArgs.SkipMap, "skip-map", true,
-		"If set true, skip map types.")
+	pflag.CommandLine.BoolVar(&customArgs.SkipMapValidation, "skip-map-validation", true,
+		"if set to true, skip generating validation schema for map type in CRD.")
 	arguments.CustomArgs = customArgs
 
 	arguments.OutputFileBaseName = g.OutputFileBaseName

--- a/cmd/kubebuilder/create/config/config.go
+++ b/cmd/kubebuilder/create/config/config.go
@@ -57,14 +57,14 @@ kubebuilder create config --crds --output myextensionname.yaml
 			fmt.Printf("Must either specify the name of the extension with --name or set --crds.\n")
 			return
 		}
-		CodeGenerator{SkipMap: skipmap}.Execute()
+		CodeGenerator{SkipMapValidation: skipMapValidation}.Execute()
 		log.Printf("Config written to %s", output)
 	},
 }
 
 var (
 	controllerType, controllerImage, name, output, crdNamespace string
-	crds, skipmap                                               bool
+	crds, skipMapValidation                                     bool
 )
 
 func AddCreateConfig(cmd *cobra.Command) {
@@ -75,5 +75,5 @@ func AddCreateConfig(cmd *cobra.Command) {
 	configCmd.Flags().StringVar(&controllerImage, "controller-image", "", "name of the controller container to run.")
 	configCmd.Flags().StringVar(&name, "name", "", "name of the installation.  used to generate the namespace and resource names.")
 	configCmd.Flags().StringVar(&output, "output", filepath.Join("hack", "install.yaml"), "location to write yaml to")
-	configCmd.Flags().BoolVar(&skipmap, "skip-map", true, "if set to true, skip validation of map in CRD")
+	configCmd.Flags().BoolVar(&skipMapValidation, "skip-map-validation", true, "if set to true, skip generating validation schema for map type in CRD.")
 }

--- a/cmd/kubebuilder/create/config/config.go
+++ b/cmd/kubebuilder/create/config/config.go
@@ -57,14 +57,14 @@ kubebuilder create config --crds --output myextensionname.yaml
 			fmt.Printf("Must either specify the name of the extension with --name or set --crds.\n")
 			return
 		}
-		CodeGenerator{}.Execute()
+		CodeGenerator{SkipMap: skipmap}.Execute()
 		log.Printf("Config written to %s", output)
 	},
 }
 
 var (
 	controllerType, controllerImage, name, output, crdNamespace string
-	crds                                                        bool
+	crds, skipmap                                               bool
 )
 
 func AddCreateConfig(cmd *cobra.Command) {
@@ -75,4 +75,5 @@ func AddCreateConfig(cmd *cobra.Command) {
 	configCmd.Flags().StringVar(&controllerImage, "controller-image", "", "name of the controller container to run.")
 	configCmd.Flags().StringVar(&name, "name", "", "name of the installation.  used to generate the namespace and resource names.")
 	configCmd.Flags().StringVar(&output, "output", filepath.Join("hack", "install.yaml"), "location to write yaml to")
+	configCmd.Flags().BoolVar(&skipmap, "skip-map", true, "if set to true, skip validation of map in CRD")
 }

--- a/cmd/kubebuilder/create/config/gen.go
+++ b/cmd/kubebuilder/create/config/gen.go
@@ -37,7 +37,7 @@ import (
 
 // CodeGenerator generates code for Kubernetes resources and controllers
 type CodeGenerator struct{
-	SkipMap bool
+	SkipMapValidation bool
 }
 
 var kblabels = map[string]string{
@@ -69,7 +69,7 @@ func (g CodeGenerator) Execute() error {
 		return fmt.Errorf("Failed making a context: %v", err)
 	}
 
-	arguments.CustomArgs = &parse.ParseOptions{SkipMap: g.SkipMap}
+	arguments.CustomArgs = &parse.ParseOptions{SkipMapValidation: g.SkipMapValidation}
 
 	p := parse.NewAPIs(c, arguments)
 	if crds {

--- a/cmd/kubebuilder/create/config/gen.go
+++ b/cmd/kubebuilder/create/config/gen.go
@@ -36,7 +36,9 @@ import (
 )
 
 // CodeGenerator generates code for Kubernetes resources and controllers
-type CodeGenerator struct{}
+type CodeGenerator struct{
+	SkipMap bool
+}
 
 var kblabels = map[string]string{
 	"kubebuilder.k8s.io": version.GetVersion().KubeBuilderVersion,
@@ -67,7 +69,7 @@ func (g CodeGenerator) Execute() error {
 		return fmt.Errorf("Failed making a context: %v", err)
 	}
 
-	arguments.CustomArgs = &parse.ParseOptions{SkipMap: true}
+	arguments.CustomArgs = &parse.ParseOptions{SkipMap: g.SkipMap}
 
 	p := parse.NewAPIs(c, arguments)
 	if crds {

--- a/cmd/kubebuilder/create/config/gen.go
+++ b/cmd/kubebuilder/create/config/gen.go
@@ -67,6 +67,8 @@ func (g CodeGenerator) Execute() error {
 		return fmt.Errorf("Failed making a context: %v", err)
 	}
 
+	arguments.CustomArgs = &parse.ParseOptions{SkipMap: true}
+
 	p := parse.NewAPIs(c, arguments)
 	if crds {
 		util.WriteString(output, strings.Join(getCrds(p), "---\n"))

--- a/cmd/kubebuilder/docs/gen.go
+++ b/cmd/kubebuilder/docs/gen.go
@@ -32,6 +32,8 @@ func (g CodeGenerator) Execute(dir string) error {
 		return fmt.Errorf("Failed making a context: %v", err)
 	}
 
+	arguments.CustomArgs = &parse.ParseOptions{SkipMap: true}
+
 	p := parse.NewAPIs(c, arguments)
 	path := filepath.Join(dir, outputDir, "config.yaml")
 

--- a/cmd/kubebuilder/docs/gen.go
+++ b/cmd/kubebuilder/docs/gen.go
@@ -32,7 +32,7 @@ func (g CodeGenerator) Execute(dir string) error {
 		return fmt.Errorf("Failed making a context: %v", err)
 	}
 
-	arguments.CustomArgs = &parse.ParseOptions{SkipMap: true}
+	arguments.CustomArgs = &parse.ParseOptions{SkipMapValidation: true}
 
 	p := parse.NewAPIs(c, arguments)
 	path := filepath.Join(dir, outputDir, "config.yaml")

--- a/test.sh
+++ b/test.sh
@@ -150,6 +150,9 @@ function generate_crd_resources {
   sed -i -e "s|type Bee struct|// +kubebuilder:categories=foo,bar\ntype Bee struct|" pkg/apis/insect/v1beta1/bee_types.go
   sed -i -e "s|type BeeController struct {|// +kubebuilder:rbac:groups="",resources=pods,verbs=get;watch;list\ntype BeeController struct {|" pkg/controller/bee/controller.go
 
+  header_text "adding a map type to resource"
+  sed -i -e "s|type BeeSpec struct {|type BeeSpec struct {\n	Request map[string]string \`json:\"request,omitempty\"\`|" pkg/apis/insect/v1beta1/bee_types.go
+
   header_text "generating and testing CRD definition"
   kubebuilder create config --crds --output crd.yaml
   kubebuilder create config --controller-image myimage:v1 --name myextensionname --output install.yaml
@@ -187,6 +190,9 @@ spec:
         metadata:
           type: object
         spec:
+          properties:
+            request:
+              type: object
           type: object
         status:
           type: object
@@ -281,6 +287,9 @@ spec:
         metadata:
           type: object
         spec:
+          properties:
+            request:
+              type: object
           type: object
         status:
           type: object
@@ -429,6 +438,9 @@ spec:
         metadata:
           type: object
         spec:
+          properties:
+            request:
+              type: object
           type: object
         status:
           type: object

--- a/test/docs/expected/includes/_generated_bee_v1beta1_insect_concept.md
+++ b/test/docs/expected/includes/_generated_bee_v1beta1_insect_concept.md
@@ -39,6 +39,7 @@ Appears In:
 
 Field        | Description
 ------------ | -----------
+`request`<br /> *object*    | 
 
 ### BeeStatus v1beta1
 


### PR DESCRIPTION
#137 

For `types.go` with content
```
package v1beta1

import (
    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
)

type MyKindSpec struct {
    Replica int `json:"replica,omitempty"`
    Request map[string]string `json:"request,omitempty"`
}

type MyKindStatus struct {
    value int `json:"value,omitempty"`
}

// +genclient
// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

// MyKind
// +k8s:openapi-gen=true
// +resource:path=mykinds
type MyKind struct {
    metav1.TypeMeta   `json:",inline"`
    metav1.ObjectMeta `json:"metadata,omitempty"`

    Spec   MyKindSpec   `json:"spec,omitempty"`
    Status MyKindStatus `json:"status,omitempty"`
}
```
The `install.yaml` file is
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  creationTimestamp: null
  labels:
    api: ""
    kubebuilder.k8s.io: master
  name: mykinds.jingfang.example.com
spec:
  group: jingfang.example.com
  names:
    kind: MyKind
    plural: mykinds
  scope: Namespaced
  validation:
    openAPIV3Schema:
      properties:
        apiVersion:
          type: string
        kind:
          type: string
        metadata:
          type: object
        spec:
          properties:
            replica:
              type: int
            request:
              type: object
          type: object
        status:
          properties:
            value:
              type: int
          type: object
      type: object
  version: v1beta1
status:
  acceptedNames:
    kind: ""
    plural: ""
  conditions: null
```
`kubectl apply -f install.yaml` successfully creates the CRD