### PR TITLE
Add OSX build job to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
 - "1.10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ os:
   - linux
   - osx
 
+matrix:
+  # allow failures until OSX tests have been tested for a while
+  allow_failures:
+    - os: osx
+
 go:
 - "1.10"
 


### PR DESCRIPTION
This currently allows OSX builds to fail, a follow-up PR can enable it as voting once it's proved itself for a while.

Fixes #185.