### PR TITLE
Rollback base image to ubuntu

### DIFF
--- a/cmd/kubebuilder/initproject/dockerfile.go
+++ b/cmd/kubebuilder/initproject/dockerfile.go
@@ -89,7 +89,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o controller-manager ./cm
 RUN go test ./pkg/... ./cmd/...
 
 # Copy the controller-manager into a thin image
-FROM scratch
+FROM ubuntu:latest
 # RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/{{ .Repo }}/controller-manager .

--- a/samples/memcached-api-server/Dockerfile.controller
+++ b/samples/memcached-api-server/Dockerfile.controller
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o controller-manager ./cm
 RUN go test ./pkg/... ./cmd/...
 
 # Copy the controller-manager into a thin image
-FROM scratch
+FROM ubuntu:latest
 # RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kubernetes-sigs/kubebuilder/samples/memcached-api-server/controller-manager .


### PR DESCRIPTION
To ensure the controller works well, rollback base image to ubuntu for now.
Consider to revisit the part when we have sufficient e2e tests

Fix: https://github.com/kubernetes-sigs/kubebuilder/issues/191

/assign @pwittrock @droot 