### PR TITLE
Add truncate options when opening files to overwrite contents in existing files

### DIFF
--- a/cmd/kubebuilder/util/util.go
+++ b/cmd/kubebuilder/util/util.go
@@ -84,7 +84,7 @@ func WriteString(path, value string) {
 		create(path)
 	}
 
-	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
 	if err != nil {
 		log.Fatalf("Failed to create %s: %v", path, err)
 	}


### PR DESCRIPTION
Currently option `os.O_TRUNC` is only specified in func `create(path string)`, i.e for newly created files, but not for existing files.
Add the option in `OpenFile` func, to ensure old content in existing files get overwritten

Fix: https://github.com/kubernetes-sigs/kubebuilder/issues/190