### PR TITLE
[WIP] admission webhook interface

### DIFF
--- a/pkg/webhook/doc.go
+++ b/pkg/webhook/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Code under the internal directory is unstable and under development.
+package webhook

--- a/pkg/webhook/internal/certprovider/certprovider.go
+++ b/pkg/webhook/internal/certprovider/certprovider.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovider
+
+// CertProvider is an interface to provide CA and server certificate.
+type CertProvider interface {
+	// GetServerCert returns the server key and certificate.
+	GetServerCert() (key []byte, cert []byte, caCert []byte, err error)
+}

--- a/pkg/webhook/internal/certprovider/doc.go
+++ b/pkg/webhook/internal/certprovider/doc.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package certprovider provides interface and implementation to provision
+certificates.
+
+Create a certprovider instance. For example:
+
+	cp := SelfSignedCertProvider{
+		// your configuration
+	}
+
+Generate and consume the certificates.
+
+The certificates are stored in a secret, you can consume it by mounting the secret in a pod:
+https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
+You then can pass the file names to method ListenAndServeTLS.
+
+	_, _, err := cp.GetServerCert()
+	if err != nil {
+		// handle error
+	}
+	// key and cert are mounted as keyFile and certFile respectively.
+	svr := &http.Server{
+		// configure your server
+	}
+	svr.ListenAndServeTLS(certFile, keyFile)
+*/
+package certprovider

--- a/pkg/webhook/internal/certprovider/example_test.go
+++ b/pkg/webhook/internal/certprovider/example_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovider
+
+func ExampleSelfSignedCertProvider() {
+	cp := SelfSignedCertProvider{
+		Organization: "k8s.io",
+		DNSNames:     []string{"myDNSName"},
+		ValidDays:    365,
+
+		SecretConfig: &SecretConfig{
+			Name:           "mySecret",
+			Namespace:      "myNamespace",
+			ServerCertName: "server-cert.pem",
+			ServerKeyName:  "server-key.pem",
+			CACertName:     "ca-cert.pem",
+			CAKeyName:      "ca-key.pem",
+		},
+	}
+
+	key, cert, caCert, err := cp.GetServerCert()
+	if err != nil {
+		// handle error
+	}
+}

--- a/pkg/webhook/internal/certprovider/selfsignedcertprovider.go
+++ b/pkg/webhook/internal/certprovider/selfsignedcertprovider.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovider
+
+// SelfSignedCertProvider implements the CertProvider interface.
+// It generates self-signed certificates.
+type SelfSignedCertProvider struct {
+	// Configuration for certificate generat
+	DNSNames     []string
+	Organization string
+	ValidDays    int // Number of days the certificate will be valid for.
+
+	// Configuration of how to persist the certificates in a k8s secret.
+	SecretConfig *SecretConfig
+}
+
+var _ CertProvider = &SelfSignedCertProvider{}
+
+// SecretConfig is the configuration of how to host the CA cert and server cert in a k8s secret.
+// An example SecretConfig is
+// SecretConfig {
+// 	Name:           "foo",
+// 	Namespace:      "bar",
+// 	CAKeyName:      "ca-key.pem",
+//	CACertName:     "ca-cert.pem",
+//	ServerKeyName:  "server-key.pem",
+//	ServerCertName: "server-cert.pem",
+// }
+type SecretConfig struct {
+	Name      string // Name of the secret
+	Namespace string // Namespace of the secret
+
+	CAKeyName      string // The key name of the CA key in the secret.Data field.
+	CACertName     string // The key name of the CA certificate in the secret.Data field.
+	ServerKeyName  string // The key name of the server key in the secret.Data field.
+	ServerCertName string // The key name of the server certificate in the secret.Data field.
+}
+
+// GetServerCert generates and persists the CA and server cert if it doesn't exist in the secret.
+// If they exist in the secret, GetServerCert gets the secret and returns the server key, server cert and CA cert.
+func (cp *SelfSignedCertProvider) GetServerCert() (key []byte, cert []byte, caCert []byte, err error) {
+	return nil, nil, nil, nil
+}

--- a/pkg/webhook/internal/deployer.go
+++ b/pkg/webhook/internal/deployer.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+// Deployer generates is an interface that generates the k8s API resources configuration.
+type Deployer interface {
+	// Generate generates k8s resources configuration.
+	Generate() (string, error)
+}
+
+var _ Deployer = &AdmissionServer{}

--- a/pkg/webhook/internal/doc.go
+++ b/pkg/webhook/internal/doc.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+The webhook package provides utilities to build 1) a admission webhook server
+2) an admission webhook installer to manage the certificate and the k8s admission webhook resources
+
+An example of how to build the admission webhook server
+
+	as := DefaultAdmissionServer(ValidatingType, []metav1.GroupVersionResource{{Version: "v1", Resource: "pods"}})
+	err := as.GetDefault()
+	if err != nil {
+		// handle error
+	}
+	for _, hc := range as.Config.ServerConfig {
+		as.HandleFunc(hc, someHandlerFn) // someHandlerFn is a handler function defined by the user.
+	}
+	err = as.ListenAndServeTLS()
+	if err != nil {
+		// handle error
+	}
+
+Use the admission webhook server to generate the k8s resources for deploying
+
+	resources, err := as.Generate()
+	if err != nil {
+		// handle error
+	}
+	// write resources to stdout or a file.
+
+*/
+package internal

--- a/pkg/webhook/internal/handler.go
+++ b/pkg/webhook/internal/handler.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AdmissionFunc func(review *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse
+
+// HandleEntry
+type admissionHandler struct {
+	Config *HandlerConfig
+	Fn     AdmissionFunc
+}
+
+// handle handles an admission request and returns a result
+func (ah admissionHandler) handle(request *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
+	//
+	foundMatchingOperation := false
+	for _, op := range ah.Config.Operations {
+		if string(request.Operation) == string(op) {
+			foundMatchingOperation = true
+			break
+		}
+	}
+	if !foundMatchingOperation {
+		// If getting an unexpected operation, admit it.
+		// This should not happen if the webhook configuration is registered properly.
+		glog.Infof("expected operation set: %v but got: %v", ah.Config.Operations, request.Operation)
+		return allowResponse()
+	}
+
+	foundMatchingGVR := false
+	for _, gvr := range ah.Config.GroupVersionResources {
+		if request.Resource == gvr {
+			foundMatchingGVR = true
+			break
+		}
+	}
+	if !foundMatchingGVR {
+		// If getting an unexpected GVR, admit it.
+		// This should not happen if the webhook configuration is registered properly.
+		glog.Infof("expected GroupVersionResource set: %v but got: %v", ah.Config.GroupVersionResources, request.Resource)
+		return allowResponse()
+	}
+
+	return ah.Fn(request)
+}
+
+// AdmissionServer is an admission webhook server that can serve traffic and
+// generates related k8s reources for deploying.
+type AdmissionServer struct {
+	SMux *http.ServeMux
+
+	// A map that maps a path to an admissionHandler.
+	Entries map[string]*admissionHandler
+
+	// Umbrella configuration of the admission webhook
+	Config *AdmissionWebhookInstallConfig
+
+	KeyPath  string // Path of the server key
+	CertPath string // Path of the server certificate
+
+	ConfigMapPath string // Path to mount the configMap
+}
+
+// DefaultAdmissionServer returns an AdmissionServer and defaults all possible fields.
+func DefaultAdmissionServer(t AdmissionWebhookConfigType, gvrs []metav1.GroupVersionResource) *AdmissionServer {
+	return &AdmissionServer{
+		Entries: map[string]*admissionHandler{},
+		SMux:    http.DefaultServeMux,
+		Config: &AdmissionWebhookInstallConfig{
+			ServerConfig: []*HandlerConfig{
+				{
+					WebhookType:           t,
+					GroupVersionResources: gvrs,
+				},
+			},
+			Port: 443,
+		},
+	}
+}
+
+// GetDefault does defaulting to the AdmissionServer.
+func (s *AdmissionServer) GetDefault() error {
+	return nil
+}
+
+// HandleFunc registers fn as an admission control webhook callback given the HandlerConfig
+func (s *AdmissionServer) HandleFunc(hc *HandlerConfig, fn AdmissionFunc) {
+	ah := &admissionHandler{Config: hc, Fn: fn}
+	// Register the entry so a Webhook config is created
+	s.Entries[hc.Path] = ah
+	// Register the handler path
+	s.SMux.Handle(hc.Path, httpHandler{ah})
+}
+
+// ListenAndServeTLS listens on the TCP network address and starts to serve.
+func (s *AdmissionServer) ListenAndServeTLS() error {
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%v", s.Config.Port),
+		Handler: s.SMux,
+	}
+	return srv.ListenAndServeTLS(s.CertPath, s.KeyPath)
+}
+
+// WriteConfig writes the configuration of the admission webhook server to the ConfigMapPath.
+// So the webhook installer can use the configuration to manage the webhook server.
+func (s *AdmissionServer) WriteConfig() error {
+	marshaledConfig, err := json.Marshal(s.Config)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(s.ConfigMapPath, marshaledConfig, 0644)
+}
+
+// Generate generates k8s resources configuration in yaml format.
+// It generates
+// - a deployment for the admission webhook server
+// - RBAC and serviceAccount for the deployment above
+// - a statefulSet for the admission webhook installer
+// - RBAC and serviceAccount for the statefulSet above
+func (s *AdmissionServer) Generate() (string, error) {
+	return "", nil
+}

--- a/pkg/webhook/internal/http.go
+++ b/pkg/webhook/internal/http.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/golang/glog"
+
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+)
+
+type httpHandler struct {
+	admit *admissionHandler
+}
+
+func (h httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		glog.Errorf("contentType=%s, expect application/json", contentType)
+		return
+	}
+
+	var reviewResponse *v1beta1.AdmissionResponse
+	ar := v1beta1.AdmissionReview{}
+	deserializer := codecs.UniversalDeserializer()
+	if _, _, err := deserializer.Decode(body, nil, &ar); err != nil {
+		glog.Error(err)
+		reviewResponse = errorResponse(err)
+	} else {
+		reviewResponse = h.admit.handle(ar.Request)
+	}
+
+	response := v1beta1.AdmissionReview{}
+	if reviewResponse != nil {
+		response.Response = reviewResponse
+		response.Response.UID = ar.Request.UID
+	}
+
+	resp, err := json.Marshal(response)
+	if err != nil {
+		glog.Error(err)
+	}
+	if _, err := w.Write(resp); err != nil {
+		glog.Error(err)
+	}
+}

--- a/pkg/webhook/internal/installer/doc.go
+++ b/pkg/webhook/internal/installer/doc.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+installer package provides an admission webhook manager to manage the lifecycle of
+the cert and webhook configuration for multiple admission webhook servers.
+
+	awm := AdmissionWebhookManager{}
+	err := awm.LoadConfig()
+	if err != nil {
+		// handle error
+	}
+	err = awm.Run()
+	if err != nil {
+		// handle error
+	}
+*/
+package installer

--- a/pkg/webhook/internal/installer/installer.go
+++ b/pkg/webhook/internal/installer/installer.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"github.com/kubernetes-sigs/kubebuilder/pkg/webhook/internal"
+)
+
+type AdmissionWebhookManager struct {
+	// Each installer manages an webhook.AdmissionServer
+	Installers []*AdmissionWebhookInstaller
+}
+
+// LoadConfig loads the configuration from configMaps for all of the admission webhook servers.
+func (awi *AdmissionWebhookManager) LoadConfig() error {
+	// Load configmaps that have a certain label, e.g. admissionWebhookManager:true
+	// Use the configmaps to initiate the admissionWebhookInstallers
+	return nil
+}
+
+// Run manages the lifecycle of the secret and webhook configuration for admission webhook servers.
+// It ensures the resources exist in case a user deletes them.
+// It watches the configMaps with a certain label, e.g. admissionWebhookManager:true and
+// responds when there is a change.
+func (awm *AdmissionWebhookManager) Run() error {
+	return nil
+}
+
+// AdmissionWebhookInstaller maps to an admission webhook server.
+type AdmissionWebhookInstaller struct {
+	Config *internal.AdmissionWebhookInstallConfig
+}
+
+// InstallCert creates a secret with the certificate.
+func (awi *AdmissionWebhookInstaller) InstallCert() error {
+	//_, _, _, err := awi.Config.CertProvider.GetServerCert()
+	// Set ownerRef for the secret.
+	return nil
+}
+
+// UninstallCert uninstalls the secret containing the certificate.
+func (awi *AdmissionWebhookInstaller) UninstallCert() error {
+	return nil
+}
+
+// InstallWebhooks installs or upgrades the k8s webhook configuration.
+// It respects the awi.Config.RegistrationDelay by waiting for a period of time
+// before creating or upgrading the k8s webhook configuration objects.
+func (awi *AdmissionWebhookInstaller) InstallWebhooks() error {
+	return nil
+}
+
+// UninstallWebhooks uninstalls the webhooks managed by this installer.
+func (awi *AdmissionWebhookInstaller) UninstallWebhooks() error {
+	return nil
+}

--- a/pkg/webhook/internal/response.go
+++ b/pkg/webhook/internal/response.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// errorResponse creates a new AdmissionResponse for an error handling the request
+func errorResponse(err error) *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		Result: &metav1.Status{
+			Message: err.Error(),
+		},
+	}
+}
+
+// denyResponse returns a new response for denying a request
+func denyResponse(msg string) *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		Allowed: false,
+		Result: &metav1.Status{
+			Reason: metav1.StatusReason(msg),
+		},
+	}
+}
+
+// allowResponse returns a new response for admitting a request
+func allowResponse() *v1beta1.AdmissionResponse {
+	return &v1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}

--- a/pkg/webhook/internal/webhook.go
+++ b/pkg/webhook/internal/webhook.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"time"
+
+	"github.com/kubernetes-sigs/kubebuilder/pkg/webhook/internal/certprovider"
+
+	admission "k8s.io/api/admission/v1beta1"
+	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AdmissionWebhookOptions covers all of the possible setting of the admission webhook
+type AdmissionWebhookInstallConfig struct {
+	CertProvider certprovider.CertProvider
+
+	// List of configuration for each webhook in the webhook server.
+	ServerConfig []*HandlerConfig
+
+	// Configuration of how the webhook can be accessed by the client
+	ClientConfig *AdmissionWebhookClientConfig
+
+	// Port where the webhook is served. Per k8s admission
+	// registration requirements this should be 443 unless there is
+	// only a single port for the service.
+	Port int
+
+	// RegistrationDelay controls how long admission registration
+	// occurs after the webhook is started. This is used to avoid
+	// potential races where registration completes and k8s apiserver
+	// invokes the webhook before the HTTP server is started.
+	RegistrationDelay time.Duration
+}
+
+type HandlerConfig struct {
+	// Mutating or validating webhook
+	WebhookType AdmissionWebhookConfigType
+
+	// Name of the webhook
+	Name string
+
+	// The GroupVersionResources that the admission webhook will manage.
+	// Required
+	GroupVersionResources []metav1.GroupVersionResource
+
+	// Operations is the operations the admission webhook cares about.
+	// Default to CREATE and UPDATE
+	Operations []admission.Operation
+
+	// Default to all namespace except kube-system.
+	// This will apply to all webhooks.
+	NamespaceSelector *metav1.LabelSelector
+
+	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
+	// allowed values are Ignore or Fail. Defaults to Ignore by the API server.
+	FailurePolicy *admissionregistration.FailurePolicyType
+
+	// An path that will be used for both server handler registration and
+	// webhook configuration registration.
+	Path string
+}
+
+type AdmissionWebhookConfigType string
+
+const (
+	MutatingType   AdmissionWebhookConfigType = "Mutating"
+	ValidatingType AdmissionWebhookConfigType = "Validating"
+)
+
+type AdmissionWebhookClientConfig struct {
+	// clientConfigType is the discriminator of AdmissionWebhookClientConfig which is an union.
+	ClientConfigType WebhookClientConfigType
+
+	// the URL of the webhook server
+	URL string
+
+	// the name of the k8s service that fronts the webhook server
+	ServiceName string
+	// the namespace of the k8s service that fronts the webhook server
+	ServiceNamespace string
+}
+
+type WebhookClientConfigType string
+
+const (
+	URLType     WebhookClientConfigType = "URL"
+	ServiceType WebhookClientConfigType = "Service"
+)


### PR DESCRIPTION
The `certprovider` interface is in https://github.com/kubernetes-sigs/kubebuilder/pull/217.

The webhook interface will compose the `certprovider` interface and other webhook config options.