### PR TITLE
certprovider interface

### DIFF
--- a/pkg/webhook/doc.go
+++ b/pkg/webhook/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Code under the internal directory is unstable and under development.
+package webhook

--- a/pkg/webhook/internal/certprovider/certprovider.go
+++ b/pkg/webhook/internal/certprovider/certprovider.go
@@ -16,29 +16,8 @@ limitations under the License.
 
 package certprovider
 
-import (
-	"crypto/tls"
-)
-
 // CertProvider is an interface to provide CA and server certificate.
 type CertProvider interface {
-	// GenerateCA generates a pair of CA key and certificate for signing the server certificate.
-	GenerateCA() error
-	// PersistCA persists the CA into a k8s secret named with name in namespace ns.
-	// The keyName and certName are the keys in the k8s secret.
-	PersistCA(ns, name, keyName, certName string) error
-	// GetCACert returns the CA certificate.
-	GetCACert() (cert []byte, err error)
-
-	// GenerateServerCert generates a pair of server key and certificate.
-	GenerateServerCert(org string, dnsNames []string, days int) error
-	// PersistServerCert persists the server key and certificate into a k8s
-	// secret named with name in namespace ns. The keyName and certName are the
-	// keys in the k8s secret.
-	PersistServerCert(ns, name, keyName, certName string) error
 	// GetServerCert returns the server key and certificate.
-	GetServerCert() (key []byte, cert []byte, err error)
-
-	// GetTLSConfig returns a tls config that can be used to config the http.Server.
-	GetTLSConfig() (*tls.Config, error)
+	GetServerCert() (key []byte, cert []byte, caCert []byte, err error)
 }

--- a/pkg/webhook/internal/certprovider/certprovider.go
+++ b/pkg/webhook/internal/certprovider/certprovider.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovider
+
+import (
+	"crypto/tls"
+)
+
+// CertProvider is an interface to provide CA and server certificate.
+type CertProvider interface {
+	// GenerateCA generates a pair of CA key and certificate for signing the server certificate.
+	GenerateCA() error
+	// PersistCA persists the CA into a k8s secret named with name in namespace ns.
+	// The keyName and certName are the keys in the k8s secret.
+	PersistCA(ns, name, keyName, certName string) error
+	// GetCACert returns the CA certificate.
+	GetCACert() (cert []byte, err error)
+
+	// GenerateServerCert generates a pair of server key and certificate.
+	GenerateServerCert(org string, dnsNames []string, days int) error
+	// PersistServerCert persists the server key and certificate into a k8s
+	// secret named with name in namespace ns. The keyName and certName are the
+	// keys in the k8s secret.
+	PersistServerCert(ns, name, keyName, certName string) error
+	// GetServerCert returns the server key and certificate.
+	GetServerCert() (key []byte, cert []byte, err error)
+
+	// GetTLSConfig returns a tls config that can be used to config the http.Server.
+	GetTLSConfig() (*tls.Config, error)
+}

--- a/pkg/webhook/internal/certprovider/doc.go
+++ b/pkg/webhook/internal/certprovider/doc.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package certprovider provides interface and implementation to provision
+certificates.
+
+Create a certprovider instance. For example:
+
+	cp := NewSelfSignedCertProvider()
+
+Generate and persist the CA if you want.
+
+	err := cp.GenerateCA()
+	if err != nil {
+		// handle error
+	}
+	err = cp.PersistCA(namespace, name, keyName, certName)
+	if err != nil {
+		// handle error
+	}
+
+Get the CA certificate.
+
+	caCert, err := cp.GetCACert()
+	if err != nil {
+		// handle error
+	}
+
+Generate and persist the server certificate.
+
+	err := cp.GenerateServerCert(org, dnsNames, days)
+	if err != nil {
+		// handle error
+	}
+	err = cp.PersistServerCert(namespace, name, keyName, certName)
+	if err != nil {
+		// handle error
+	}
+
+Consume the generated cert.
+You can consume the certificate in raw byte slice format. This approach is
+useful if you want to consume the certificate by mounting the secret as a volume
+in a pod.
+
+	key, cert, err := cp.GetServerCert()
+	if err != nil {
+		// handle error
+	}
+	// Store key and cert in keyFile and certFile respectively.
+	svr := &http.Server{
+		// configure your server
+	}
+	svr.ListenAndServeTLS(certFile, keyFile)
+
+You can also consume the certificate in the tls.Config format.
+
+	tls, err := cp.GetTLSConfig()
+	if err != nil {
+		// handle error
+	}
+
+	svr := &http.Server{
+		TLSConfig: tls,
+		// other server configuration
+	}
+	svr.ListenAndServeTLS("", "")
+
+*/
+package certprovider

--- a/pkg/webhook/internal/certprovider/doc.go
+++ b/pkg/webhook/internal/certprovider/doc.go
@@ -20,64 +20,24 @@ certificates.
 
 Create a certprovider instance. For example:
 
-	cp := NewSelfSignedCertProvider()
+	cp := SelfSignedCertProvider{
+		// your configuration
+	}
 
-Generate and persist the CA if you want.
+Generate and consume the certificates.
 
-	err := cp.GenerateCA()
+The certificates are stored in a secret, you can consume it by mounting the secret in a pod:
+https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod
+You then can pass the file names to method ListenAndServeTLS.
+
+	_, _, err := cp.GetServerCert()
 	if err != nil {
 		// handle error
 	}
-	err = cp.PersistCA(namespace, name, keyName, certName)
-	if err != nil {
-		// handle error
-	}
-
-Get the CA certificate.
-
-	caCert, err := cp.GetCACert()
-	if err != nil {
-		// handle error
-	}
-
-Generate and persist the server certificate.
-
-	err := cp.GenerateServerCert(org, dnsNames, days)
-	if err != nil {
-		// handle error
-	}
-	err = cp.PersistServerCert(namespace, name, keyName, certName)
-	if err != nil {
-		// handle error
-	}
-
-Consume the generated cert.
-You can consume the certificate in raw byte slice format. This approach is
-useful if you want to consume the certificate by mounting the secret as a volume
-in a pod.
-
-	key, cert, err := cp.GetServerCert()
-	if err != nil {
-		// handle error
-	}
-	// Store key and cert in keyFile and certFile respectively.
+	// key and cert are mounted as keyFile and certFile respectively.
 	svr := &http.Server{
 		// configure your server
 	}
 	svr.ListenAndServeTLS(certFile, keyFile)
-
-You can also consume the certificate in the tls.Config format.
-
-	tls, err := cp.GetTLSConfig()
-	if err != nil {
-		// handle error
-	}
-
-	svr := &http.Server{
-		TLSConfig: tls,
-		// other server configuration
-	}
-	svr.ListenAndServeTLS("", "")
-
 */
 package certprovider

--- a/pkg/webhook/internal/certprovider/example_test.go
+++ b/pkg/webhook/internal/certprovider/example_test.go
@@ -16,33 +16,24 @@ limitations under the License.
 
 package certprovider
 
-import (
-	"net/http"
-)
+func ExampleSelfSignedCertProvider() {
+	cp := SelfSignedCertProvider{
+		Organization: "k8s.io",
+		DNSNames:     []string{"myDNSName"},
+		ValidDays:    365,
 
-func ExampleNewSelfSignedCertProvider() {
-	cp := NewSelfSignedCertProvider()
+		SecretConfig: &SecretConfig{
+			Name:           "mySecret",
+			Namespace:      "myNamespace",
+			ServerCertName: "server-cert.pem",
+			ServerKeyName:  "server-key.pem",
+			CACertName:     "ca-cert.pem",
+			CAKeyName:      "ca-key.pem",
+		},
+	}
 
-	err := cp.GenerateCA()
+	key, cert, caCert, err := cp.GetServerCert()
 	if err != nil {
 		// handle error
 	}
-	err = cp.PersistCA("myNamespace", "mySecret", "ca-key.pem", "ca-cert.pem")
-	if err != nil {
-		// handle error
-	}
-
-	err = cp.GenerateServerCert("k8s.io", []string{"myDNSName"}, 365)
-	if err != nil {
-		// handle error
-	}
-	err = cp.PersistServerCert("myNamespace", "mySecret", "server-key.pem", "server-cert.pem")
-	if err != nil {
-		// handle error
-	}
-
-	svr := &http.Server{
-		// server configuration
-	}
-	svr.ListenAndServeTLS("path/to/server-cert.pem", "path/to/server-key.pem")
 }

--- a/pkg/webhook/internal/certprovider/example_test.go
+++ b/pkg/webhook/internal/certprovider/example_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovider
+
+import (
+	"net/http"
+)
+
+func ExampleNewSelfSignedCertProvider() {
+	cp := NewSelfSignedCertProvider()
+
+	err := cp.GenerateCA()
+	if err != nil {
+		// handle error
+	}
+	err = cp.PersistCA("myNamespace", "mySecret", "ca-key.pem", "ca-cert.pem")
+	if err != nil {
+		// handle error
+	}
+
+	err = cp.GenerateServerCert("k8s.io", []string{"myDNSName"}, 365)
+	if err != nil {
+		// handle error
+	}
+	err = cp.PersistServerCert("myNamespace", "mySecret", "server-key.pem", "server-cert.pem")
+	if err != nil {
+		// handle error
+	}
+
+	svr := &http.Server{
+		// server configuration
+	}
+	svr.ListenAndServeTLS("path/to/server-cert.pem", "path/to/server-key.pem")
+}

--- a/pkg/webhook/internal/certprovider/selfsignedcertprovider.go
+++ b/pkg/webhook/internal/certprovider/selfsignedcertprovider.go
@@ -16,55 +16,31 @@ limitations under the License.
 
 package certprovider
 
-import (
-	"crypto/tls"
-)
+// SelfSignedCertProvider implements the CertProvider interface.
+// It generates self-signed certificates.
+type SelfSignedCertProvider struct {
+	// Configuration for certificate generat
+	DNSNames     []string
+	Organization string
+	ValidDays    int // Number of days the certificate will be valid for.
 
-type selfSignedCertProvider struct {
-	cAKey      []byte
-	cACert     []byte
-	serverKey  []byte
-	serverCert []byte
-
-	genConfig *genCertConfig
-
-	secretConfig *secretConfig
+	// Configuration of how to persist the certificates in a k8s secret.
+	SecretConfig *SecretConfig
 }
 
-var _ CertProvider = &selfSignedCertProvider{}
+var _ CertProvider = &SelfSignedCertProvider{}
 
-type genCertConfig struct {
-	dnsNames     []string
-	organization string
+type SecretConfig struct {
+	Name           string
+	Namespace      string
+	CAKeyName      string
+	CACertName     string
+	ServerKeyName  string
+	ServerCertName string
 }
 
-type secretConfig struct {
-	name           string
-	namespace      string
-	caKeyName      string
-	caCertName     string
-	serverKeyName  string
-	serverCertName string
+// GetServerCert generates and persists the CA and server cert if it doesn't exist in the secret.
+// If they exist in the secret, GetServerCert gets the secret and returns the server key, server cert and CA cert.
+func (cp *SelfSignedCertProvider) GetServerCert() (key []byte, cert []byte, caCert []byte, err error) {
+	return nil, nil, nil, nil
 }
-
-func NewSelfSignedCertProvider() CertProvider { return nil }
-
-func (cp *selfSignedCertProvider) GenerateCA() error { return nil }
-
-func (cp *selfSignedCertProvider) GetCACert() ([]byte, error) { return nil, nil }
-
-func (cp *selfSignedCertProvider) GenerateServerCert(org string, dnsNames []string, days int) error {
-	return nil
-}
-
-func (cp *selfSignedCertProvider) GetServerCert() ([]byte, []byte, error) { return nil, nil, nil }
-
-func (cp *selfSignedCertProvider) PersistCA(namespace, name, keyName, certName string) error {
-	return nil
-}
-
-func (cp *selfSignedCertProvider) PersistServerCert(namespace, name, keyName, certName string) error {
-	return nil
-}
-
-func (cp *selfSignedCertProvider) GetTLSConfig() (*tls.Config, error) { return nil, nil }

--- a/pkg/webhook/internal/certprovider/selfsignedcertprovider.go
+++ b/pkg/webhook/internal/certprovider/selfsignedcertprovider.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovider
+
+import (
+	"crypto/tls"
+)
+
+type selfSignedCertProvider struct {
+	cAKey      []byte
+	cACert     []byte
+	serverKey  []byte
+	serverCert []byte
+
+	genConfig *genCertConfig
+
+	secretConfig *secretConfig
+}
+
+var _ CertProvider = &selfSignedCertProvider{}
+
+type genCertConfig struct {
+	dnsNames     []string
+	organization string
+}
+
+type secretConfig struct {
+	name           string
+	namespace      string
+	caKeyName      string
+	caCertName     string
+	serverKeyName  string
+	serverCertName string
+}
+
+func NewSelfSignedCertProvider() CertProvider { return nil }
+
+func (cp *selfSignedCertProvider) GenerateCA() error { return nil }
+
+func (cp *selfSignedCertProvider) GetCACert() ([]byte, error) { return nil, nil }
+
+func (cp *selfSignedCertProvider) GenerateServerCert(org string, dnsNames []string, days int) error {
+	return nil
+}
+
+func (cp *selfSignedCertProvider) GetServerCert() ([]byte, []byte, error) { return nil, nil, nil }
+
+func (cp *selfSignedCertProvider) PersistCA(namespace, name, keyName, certName string) error {
+	return nil
+}
+
+func (cp *selfSignedCertProvider) PersistServerCert(namespace, name, keyName, certName string) error {
+	return nil
+}
+
+func (cp *selfSignedCertProvider) GetTLSConfig() (*tls.Config, error) { return nil, nil }


### PR DESCRIPTION
Initial interface design for the `certprovider` interface.
This PR is split out from https://github.com/kubernetes-sigs/kubebuilder/pull/205.

The webhook interface will compose the `certprovider` interface and other webhook config options.

/cc @pwittrock @droot @Liujingfang1 @pmorie 