### PR TITLE
certprovider interface

### DIFF
--- a/pkg/webhook/doc.go
+++ b/pkg/webhook/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook

--- a/pkg/webhook/internal/certprovisioner/certprovisioner.go
+++ b/pkg/webhook/internal/certprovisioner/certprovisioner.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovisioner
+
+// CertProvisioner is an interface to provision the serving certificate.
+type CertProvisioner interface {
+	// ProvisionServingCert returns the key, serving certificate and the CA certificate.
+	ProvisionServingCert() (key []byte, cert []byte, caCert []byte, err error)
+}

--- a/pkg/webhook/internal/certprovisioner/doc.go
+++ b/pkg/webhook/internal/certprovisioner/doc.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package certprovisioner provides an interface and implementation to provision certificates.
+
+Create a implementation instance of certprovisioner.
+
+	cp := SelfSignedCertProvisioner{
+		// your configuration
+	}
+
+Provision the certificates.
+	key, cert, caCert, err := cp.ProvisionServingCert()
+	if err != nil {
+		// handle error
+	}
+*/
+package certprovisioner

--- a/pkg/webhook/internal/certprovisioner/example_test.go
+++ b/pkg/webhook/internal/certprovisioner/example_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovisioner
+
+func ExampleSelfSignedCertProvisioner() {
+	cp := SelfSignedCertProvisioner{
+		Organization: "k8s.io",
+		DNSNames:     []string{"myDNSName"},
+		ValidDays:    365,
+	}
+
+	key, cert, caCert, err := cp.ProvisionServingCert()
+	if err != nil {
+		// handle error
+	}
+}

--- a/pkg/webhook/internal/certprovisioner/selfsignedcertprovisioner.go
+++ b/pkg/webhook/internal/certprovisioner/selfsignedcertprovisioner.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certprovisioner
+
+// SelfSignedCertProvisioner implements the CertProvisioner interface.
+// It provisions self-signed certificates.
+type SelfSignedCertProvisioner struct {
+	// Required DNS names for your certificate
+	DNSNames []string
+	// Organization name
+	Organization string
+	// Number of days the certificate will be valid for.
+	ValidDays int
+}
+
+var _ CertProvisioner = &SelfSignedCertProvisioner{}
+
+// ProvisionServingCert generates a CA and a serving cert. It returns the key, serving cert, CA cert and a potential error.
+func (cp *SelfSignedCertProvisioner) ProvisionServingCert() (key []byte, cert []byte, caCert []byte, err error) {
+	// TODO: implement this
+	return nil, nil, nil, nil
+}


### PR DESCRIPTION
The certprovider interface.
This PR supersedes https://github.com/kubernetes-sigs/kubebuilder/pull/217. 
This PR is split out from #205 w/ minor change.
