### PR TITLE
Generate correct CRD primitive types

### DIFF
--- a/cmd/internal/codegen/parse/crd.go
+++ b/cmd/internal/codegen/parse/crd.go
@@ -224,6 +224,8 @@ func (b *APIs) parsePrimitiveValidation(t *types.Type, found sets.String, commen
 	if err := primitiveTemplate.Execute(buff, primitiveTemplateArgs{props, n, f, s}); err != nil {
 		log.Fatalf("%v", err)
 	}
+	props.Type = n
+	props.Format = f
 	return props, buff.String()
 }
 

--- a/test.sh
+++ b/test.sh
@@ -518,6 +518,7 @@ function test_crd_validation {
     // +kubebuilder:validation:Maximum=100\
     // +kubebuilder:validation:ExclusiveMinimum=true\
     Power float32 \`json:"power"\`\
+    Bricks int32 \`json:"bricks"\`\
     // +kubebuilder:validation:MaxLength=15\
     // +kubebuilder:validation:MinLength=1\
     Name string \`json:"name"\`\

--- a/test/data/resource/expected/crd-expected.yaml
+++ b/test/data/resource/expected/crd-expected.yaml
@@ -29,6 +29,9 @@ spec:
               - Wolf
               - Dragon
               type: string
+            bricks:
+              format: int32
+              type: integer
             knights:
               items:
                 type: string

--- a/test/data/resource/expected/crd-expected.yaml
+++ b/test/data/resource/expected/crd-expected.yaml
@@ -44,16 +44,18 @@ spec:
               type: string
             power:
               exclusiveMinimum: true
+              format: float
               maximum: 100
-              type: float32
+              type: number
             rank:
               enum:
               - 1
               - 2
               - 3
-              type: int
+              format: int64
+              type: integer
             winner:
-              type: bool
+              type: boolean
           type: object
         status:
           type: object


### PR DESCRIPTION
This is bit of a hack to make sure the crd schema uses JSON schema types. There's probably a better way to do this.

Fixes #200.