### PR TITLE
Add annotation tests into test projects

### DIFF
--- a/test/projects/validations/pkg/apis/apps/v1/testkind_types.go
+++ b/test/projects/validations/pkg/apis/apps/v1/testkind_types.go
@@ -14,6 +14,25 @@ type TestKindSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "kubebuilder generate" to regenerate code after modifying this file
 	Count int `json:"count"`
+
+	// +kubebuilder:validation:Maximum=100
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:ExclusiveMinimum=true
+	Power  float32 `json:"power,omitempty"`
+	Bricks int32   `json:"bricks,omitempty"`
+	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:MinLength=1
+	Name string `json:"name,omitempty"`
+	// +kubebuilder:validation:MaxItems=500
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:UniqueItems=false
+	Knights []string `json:"knights,omitempty"`
+	Winner  bool     `json:"winner,omitempty"`
+	// +kubebuilder:validation:Enum=Lion,Wolf,Dragon
+	Alias string `json:"alias,omitempty"`
+	// +kubebuilder:validation:Enum=1,2,3
+	Rank    int    `json:"rank"`
+	Comment []byte `json:"comment,omitempty"`
 }
 
 // TestKindStatus defines the observed state of TestKind

--- a/test/projects/validations/test/hack/install.yaml
+++ b/test/projects/validations/test/hack/install.yaml
@@ -23,11 +23,49 @@ spec:
           type: object
         spec:
           properties:
+            alias:
+              enum:
+              - Lion
+              - Wolf
+              - Dragon
+              type: string
+            bricks:
+              format: int32
+              type: integer
+            comment:
+              format: byte
+              type: string
             count:
               format: int64
               type: integer
+            knights:
+              items:
+                type: string
+              maxItems: 500
+              minItems: 1
+              type: array
+            name:
+              maxLength: 15
+              minLength: 1
+              type: string
+            power:
+              exclusiveMinimum: true
+              format: float
+              maximum: 100
+              minimum: 1
+              type: number
+            rank:
+              enum:
+              - 1
+              - 2
+              - 3
+              format: int64
+              type: integer
+            winner:
+              type: boolean
           required:
           - count
+          - rank
           type: object
         status:
           type: object

--- a/test_existing_projects.sh
+++ b/test_existing_projects.sh
@@ -14,5 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-go test -v ./test/projects/memcached-api-server
-go test -v ./test/projects/validations
+for p in ./test/projects/*
+do
+    if [[ -d "$p" ]]; then
+        go test -v "$p"
+    fi
+done


### PR DESCRIPTION
- Move annotation tests into test projects.
- Modified `test_existing_projects.sh`. Run all projects tests in loop, so that no need to maintain this scripts.