### PR TITLE
Support for status subresource

### DIFF
--- a/cmd/internal/codegen/parse/crd.go
+++ b/cmd/internal/codegen/parse/crd.go
@@ -80,6 +80,14 @@ func (b *APIs) parseCRDs() {
 						resource.CRD.Spec.Names.Categories = strings.Split(categoriesTag, ",")
 					}
 
+					if HasStatusSubresource(resource.Type) {
+						subresources := &v1beta1.CustomResourceSubresources{
+							Status: &v1beta1.CustomResourceSubresourceStatus{},
+						}
+						resource.CRD.Spec.Subresources = subresources
+						resource.HasStatusSubresource = true
+					}
+
 					if len(resource.ShortName) > 0 {
 						resource.CRD.Spec.Names.ShortNames = []string{resource.ShortName}
 					}
@@ -318,7 +326,7 @@ func (b *APIs) parseArrayValidation(t *types.Type, found sets.String, comments [
 
 type objectTemplateArgs struct {
 	v1beta1.JSONSchemaProps
-	Fields map[string]string
+	Fields   map[string]string
 	Required []string
 }
 
@@ -514,7 +522,7 @@ func (b *APIs) getMembers(t *types.Type, found sets.String) (map[string]v1beta1.
 
 		// Inline "inline" structs
 		if strat == "inline" {
-			m, r, re:= b.getMembers(member.Type, found)
+			m, r, re := b.getMembers(member.Type, found)
 			for n, v := range m {
 				members[n] = v
 			}

--- a/cmd/internal/codegen/parse/util.go
+++ b/cmd/internal/codegen/parse/util.go
@@ -121,6 +121,20 @@ func HasSubresource(t *types.Type) bool {
 	return false
 }
 
+// HasStatusSubresource returns true if t is an APIResource annotated with
+// +kubebuilder:subresource:status.
+func HasStatusSubresource(t *types.Type) bool {
+	if !IsAPIResource(t) {
+		return false
+	}
+	for _, c := range t.CommentLines {
+		if strings.Contains(c, "+kubebuilder:subresource:status") {
+			return true
+		}
+	}
+	return false
+}
+
 // HasCategories returns true if t is an APIResource annotated with
 // +kubebuilder:categories.
 func HasCategories(t *types.Type) bool {

--- a/cmd/internal/codegen/types.go
+++ b/cmd/internal/codegen/types.go
@@ -164,6 +164,8 @@ type APIResource struct {
 	ValidationComments string
 	// DocAnnotation is a map of annotations by name for doc. e.g. warning, notes message
 	DocAnnotation map[string]string
+	// HasStatusSubresource indicates that the resource has a status subresource
+	HasStatusSubresource bool
 }
 
 type APISubresource struct {

--- a/cmd/kubebuilder-gen/internal/resourcegen/versioned_generator.go
+++ b/cmd/kubebuilder-gen/internal/resourcegen/versioned_generator.go
@@ -136,6 +136,11 @@ var (
             Validation: &v1beta1.CustomResourceValidation{
                 OpenAPIV3Schema: &{{.Validation}},
             },
+            {{ if .HasStatusSubresource -}}
+            Subresources: &v1beta1.CustomResourceSubresources{
+                Status: &v1beta1.CustomResourceSubresourceStatus{},
+            },
+            {{ end -}}
         },
     }
     {{ end -}}

--- a/cmd/kubebuilder/create/resource/resource.go
+++ b/cmd/kubebuilder/create/resource/resource.go
@@ -26,15 +26,16 @@ import (
 )
 
 type resourceTemplateArgs struct {
-	BoilerPlate       string
-	Domain            string
-	Group             string
-	Version           string
-	Kind              string
-	Resource          string
-	Repo              string
-	PluralizedKind    string
-	NonNamespacedKind bool
+	BoilerPlate          string
+	Domain               string
+	Group                string
+	Version              string
+	Kind                 string
+	Resource             string
+	Repo                 string
+	PluralizedKind       string
+	NonNamespacedKind    bool
+	HasStatusSubresource bool
 }
 
 func doResource(dir string, args resourceTemplateArgs) bool {

--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -109,6 +109,7 @@ func createResource(boilerplate string) {
 		util.Repo,
 		inflect.NewDefaultRuleset().Pluralize(createutil.KindName),
 		nonNamespacedKind,
+		false,
 	}
 
 	dir, err := os.Getwd()

--- a/pkg/gen/apis/doc.go
+++ b/pkg/gen/apis/doc.go
@@ -23,6 +23,9 @@ const (
 	// Resource annotates a type as a resource
 	Resource = "// +kubebuilder:resource:path="
 
+	// StatusSubresource annotates a type as having a status subresource
+	StatusSubresource = "// +kubebuilder:subresource:status"
+
 	// Categories annotates a type as belonging to a comma-delimited list of
 	// categories
 	Categories = "// +kubebuilder:categories="

--- a/test.sh
+++ b/test.sh
@@ -155,7 +155,8 @@ function generate_crd_resources {
 
   header_text "editing generated files to simulate a user"
   sed -i -e '/type Bee struct/ i \
-  // +kubebuilder:categories=foo,bar
+  // +kubebuilder:categories=foo,bar\
+  // +kubebuilder:subresource:status
   ' pkg/apis/insect/v1beta1/bee_types.go
 
   sed -i -e '/type BeeController struct {/ i \
@@ -194,6 +195,8 @@ spec:
     kind: Bee
     plural: bees
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -290,6 +293,8 @@ spec:
     kind: Bee
     plural: bees
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -440,6 +445,8 @@ spec:
     kind: Bee
     plural: bees
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -534,6 +541,7 @@ function test_crd_validation {
     Comment []byte \`json:"comment,omitempty"\`\
   ' pkg/apis/got/v1beta1/house_types.go
 
+  header_text "calling kubebuilder generate"
   kubebuilder generate
   header_text "generating and testing CRD..."
   kubebuilder create config --crds --output crd-validation.yaml


### PR DESCRIPTION
Adds support for generating a CRD definition that includes a declaration of the status resource, triggered by the presence of the `+kubebuilder:subresource:status` tag.

This is needed to leverage CRD status subresources in projects created by kubebuilder