### PR TITLE
Update deprecated output from kubebuilder create

### DIFF
--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -86,7 +86,7 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 	createResource(cr)
 	if generate {
 		fmt.Printf("Generating code for new resource...  " +
-			"Regenerate after editing resources files by running `kubebuilder build generated`.\n")
+			"Regenerate after editing resources files by running `kubebuilder generate clean; kubebuilder generate`.\n")
 		if skipRBACValidation {
 			args = append(args, "--skip-rbac-validation")
 		}


### PR DESCRIPTION
Noticed that this output says to run a deprecated command.