### PR TITLE
Add standard error handling options to test.sh / test_existing_projects.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,7 +14,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Enable tracing in this script off by setting the TRACE variable in your
 # environment to any value:

--- a/test_existing_projects.sh
+++ b/test_existing_projects.sh
@@ -14,6 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 for p in ./test/projects/*
 do
     if [[ -d "$p" ]]; then


### PR DESCRIPTION
I think otherwise a failure in test_existing_projects.sh would not
have failed CI.