### PR TITLE
Support for scale subresource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -641,6 +641,19 @@
   revision = "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 
 [[projects]]
+  branch = "master"
+  name = "sigs.k8s.io/controller-tools"
+  packages = [
+    "pkg/scaffold",
+    "pkg/scaffold/controller",
+    "pkg/scaffold/input",
+    "pkg/scaffold/manager",
+    "pkg/scaffold/project",
+    "pkg/scaffold/resource"
+  ]
+  revision = "ebc6b604ffe8679ebc52cb1e67b76139ad7a7599"
+
+[[projects]]
   name = "sigs.k8s.io/testing_frameworks"
   packages = [
     "integration",
@@ -651,6 +664,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "524af08cf1c0a5425c47e202bed17e8788dbf8342454090dd3b60eaf7cd6b047"
+  inputs-digest = "dda0c88f30af8ca0c996dbf225dd5ae157fef09d6edb2249e9bc3b732441ff59"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/internal/codegen/parse/crd.go
+++ b/cmd/internal/codegen/parse/crd.go
@@ -90,6 +90,13 @@ func (b *APIs) parseCRDs() {
 						resource.HasStatusSubresource = true
 					}
 
+					if HasScaleSubresource(resource.Type) {
+						subresources := &v1beta1.CustomResourceSubresourceScale{}
+
+						resource.CRD.Spec.Subresources.Scale = subresources
+						resource.HasScaleSubresource = true
+					}
+
 					if len(resource.ShortName) > 0 {
 						resource.CRD.Spec.Names.ShortNames = []string{resource.ShortName}
 					}
@@ -342,7 +349,7 @@ var objectTemplate = template.Must(template.New("object-template").Parse(
     },
     {{if .Required}}Required: []string{
         {{ range $k, $v := .Required -}}
-        "{{ $v }}", 
+        "{{ $v }}",
         {{ end -}}
     },{{ end -}}
 }`))

--- a/cmd/internal/codegen/parse/util.go
+++ b/cmd/internal/codegen/parse/util.go
@@ -135,6 +135,20 @@ func HasStatusSubresource(t *types.Type) bool {
 	return false
 }
 
+// HasScaleSubresource returns true if t is an APIResource annotated with
+// +kubebuilder:subresource:scale.
+func HasScaleSubresource(t *types.Type) bool {
+	if !IsAPIResource(t) {
+		return false
+	}
+	for _, c := range t.CommentLines {
+		if strings.Contains(c, "+kubebuilder:subresource:scale") {
+			return true
+		}
+	}
+	return false
+}
+
 // HasCategories returns true if t is an APIResource annotated with
 // +kubebuilder:categories.
 func HasCategories(t *types.Type) bool {

--- a/cmd/internal/codegen/types.go
+++ b/cmd/internal/codegen/types.go
@@ -166,6 +166,8 @@ type APIResource struct {
 	DocAnnotation map[string]string
 	// HasStatusSubresource indicates that the resource has a status subresource
 	HasStatusSubresource bool
+	// HasScaleSubresource indicates that the resource has a scale subresource
+	HasScaleSubresource bool
 	// Categories is a list of categories the resource is part of.
 	Categories []string
 }

--- a/cmd/kubebuilder/create/resource/resource.go
+++ b/cmd/kubebuilder/create/resource/resource.go
@@ -36,6 +36,7 @@ type resourceTemplateArgs struct {
 	PluralizedKind       string
 	NonNamespacedKind    bool
 	HasStatusSubresource bool
+	HasScaleSubresource  bool
 	Categories           []string
 }
 

--- a/cmd/kubebuilder/create/resource/run.go
+++ b/cmd/kubebuilder/create/resource/run.go
@@ -110,6 +110,7 @@ func createResource(boilerplate string) {
 		inflect.NewDefaultRuleset().Pluralize(createutil.KindName),
 		nonNamespacedKind,
 		false,
+		false,
 		nil,
 	}
 

--- a/pkg/gen/apis/doc.go
+++ b/pkg/gen/apis/doc.go
@@ -26,6 +26,9 @@ const (
 	// StatusSubresource annotates a type as having a status subresource
 	StatusSubresource = "// +kubebuilder:subresource:status"
 
+	// ScaleSubresource annotates a type as having a scale subresource
+	ScaleSubresource = "// +kubebuilder:subresource:scale"
+
 	// Categories annotates a type as belonging to a comma-delimited list of
 	// categories
 	Categories = "// +kubebuilder:categories="

--- a/testv0.sh
+++ b/testv0.sh
@@ -29,7 +29,8 @@ function generate_crd_resources {
   header_text "editing generated files to simulate a user"
   sed -i -e '/type Bee struct/ i \
   // +kubebuilder:categories=foo,bar\
-  // +kubebuilder:subresource:status
+  // +kubebuilder:subresource:status\
+  // +kubebuilder:subresource:scale
   ' pkg/apis/insect/v1beta1/bee_types.go
 
   sed -i -e '/type BeeController struct {/ i \
@@ -69,6 +70,9 @@ spec:
     plural: bees
   scope: Namespaced
   subresources:
+    scale:
+      specReplicasPath: ""
+      statusReplicasPath: ""
     status: {}
   validation:
     openAPIV3Schema:
@@ -167,6 +171,9 @@ spec:
     plural: bees
   scope: Namespaced
   subresources:
+    scale:
+      specReplicasPath: ""
+      statusReplicasPath: ""
     status: {}
   validation:
     openAPIV3Schema:
@@ -319,6 +326,9 @@ spec:
     plural: bees
   scope: Namespaced
   subresources:
+    scale:
+      specReplicasPath: ""
+      statusReplicasPath: ""
     status: {}
   validation:
     openAPIV3Schema:

--- a/vendor/sigs.k8s.io/controller-tools/LICENSE
+++ b/vendor/sigs.k8s.io/controller-tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/add.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/add.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &AddController{}
+
+// AddController scaffolds adds a new Controller.
+type AddController struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+}
+
+// GetInput implements input.File
+func (a *AddController) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "controller", fmt.Sprintf(
+			"add_%s.go", strings.ToLower(a.Resource.Kind)))
+	}
+	a.TemplateBody = addControllerTemplate
+	return a.Input, nil
+}
+
+var addControllerTemplate = `{{ .Boilerplate }}
+
+package controller
+
+import (
+	"{{ .Repo }}/pkg/controller/{{ lower .Resource.Kind }}"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, {{ lower .Resource.Kind }}.Add)
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/controller.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/controller.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+// Controller scaffolds a Controller for a Resource
+type Controller struct {
+	input.Input
+
+	// Resource is the Resource to make the Controller for
+	Resource *resource.Resource
+
+	// ResourcePackage is the package of the Resource
+	ResourcePackage string
+
+	// Is the Group + "." + Domain for the Resource
+	GroupDomain string
+}
+
+// GetInput implements input.File
+func (a *Controller) GetInput() (input.Input, error) {
+	// Use the k8s.io/api package for core resources
+	coreGroups := map[string]string{
+		"apps":                  "",
+		"admissionregistration": "k8s.io",
+		"apiextensions":         "k8s.io",
+		"authentication":        "k8s.io",
+		"autoscaling":           "",
+		"batch":                 "",
+		"certificates":          "k8s.io",
+		"core":                  "",
+		"extensions":            "",
+		"metrics":               "k8s.io",
+		"policy":                "",
+		"rbac.authorization":    "k8s.io",
+		"storage":               "k8s.io",
+	}
+	if domain, found := coreGroups[a.Resource.Group]; found {
+		a.ResourcePackage = path.Join("k8s.io", "api")
+		a.GroupDomain = a.Resource.Group
+		if domain != "" {
+			a.GroupDomain = a.Resource.Group + "." + domain
+		}
+	} else {
+		a.ResourcePackage = path.Join(a.Repo, "pkg", "apis")
+		a.GroupDomain = a.Resource.Group + "." + a.Domain
+	}
+
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "controller",
+			strings.ToLower(a.Resource.Kind),
+			strings.ToLower(a.Resource.Kind)+"_controller.go")
+	}
+	a.TemplateBody = controllerTemplate
+	a.Input.IfExistsAction = input.Error
+	return a.Input, nil
+}
+
+var controllerTemplate = `{{ .Boilerplate }}
+
+package {{ lower .Resource.Kind }}
+
+import (
+{{ if .Resource.CreateExampleReconcileBody }}	"context"
+	"log"
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
+{{ else }}	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
+{{ end -}}
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new {{ .Resource.Kind }} Controller and adds it to the Manager.  The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+// USER ACTION REQUIRED: update cmd/manager/main.go to call this {{ .Resource.Group}}.Add(mgr) to install this Controller
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &Reconcile{{ .Resource.Kind }}{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("{{ lower .Resource.Kind }}-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to {{ .Resource.Kind }}
+	err = c.Watch(&source.Kind{Type: &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create
+	// Uncomment watch a Deployment created by {{ .Resource.Kind }} - change this for objects you create
+	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &Reconcile{{ .Resource.Kind }}{}
+
+// Reconcile{{ .Resource.Kind }} reconciles a {{ .Resource.Kind }} object
+type Reconcile{{ .Resource.Kind }} struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a {{ .Resource.Kind }} object and makes changes based on the state read
+// and what is in the {{ .Resource.Kind }}.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
+// a Deployment as an example
+{{ if .Resource.CreateExampleReconcileBody -}}
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+// +rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+{{ end -}}
+func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the {{ .Resource.Kind }} instance
+	instance := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+	err := r.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	{{ if .Resource.CreateExampleReconcileBody -}}
+	// TODO(user): Change this to be the object type created by your controller
+	// Define the desired Deployment object
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name + "-deployment",
+			Namespace: {{ if .Resource.Namespaced}}instance.Namespace{{ else }}"default"{{ end }},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"deployment": instance.Name + "-deployment"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"deployment": instance.Name + "-deployment"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := controllerutil.SetControllerReference(instance, deploy, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// TODO(user): Change this for the object type created by your controller
+	// Check if the Deployment already exists
+	found := &appsv1.Deployment{}
+	err = r.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		log.Printf("Creating Deployment %s/%s\n", deploy.Namespace, deploy.Name)
+		err = r.Create(context.TODO(), deploy)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// TODO(user): Change this for the object type created by your controller
+	// Update the found object and write the result back if there are any changes
+	if !reflect.DeepEqual(deploy.Spec, found.Spec) {
+		found.Spec = deploy.Spec
+		log.Printf("Updating Deployment %s/%s\n", deploy.Namespace, deploy.Name)
+		err = r.Update(context.TODO(), found)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	{{ end -}}
+
+	return reconcile.Result{}, nil
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/controllersuitetest.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/controllersuitetest.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+// SuiteTest scaffolds a SuiteTest
+type SuiteTest struct {
+	input.Input
+
+	// Resource is the Resource to make the Controller for
+	Resource *resource.Resource
+}
+
+// GetInput implements input.File
+func (a *SuiteTest) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "controller",
+			strings.ToLower(a.Resource.Kind), strings.ToLower(a.Resource.Kind)+"_controller_suite_test.go")
+	}
+	a.TemplateBody = controllerSuiteTestTemplate
+	return a.Input, nil
+}
+
+var controllerSuiteTestTemplate = `{{ .Boilerplate }}
+
+package {{ lower .Resource.Kind }}
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"{{ .Repo }}/pkg/apis"
+)
+
+var cfg *rest.Config
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+	}
+	apis.AddToScheme(scheme.Scheme)
+
+	var err error
+	if cfg, err = t.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	code := m.Run()
+	t.Stop()
+	os.Exit(code)
+}
+
+// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
+// writes the request to requests after Reconcile is finished.
+func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
+	requests := make(chan reconcile.Request)
+	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
+		result, err := inner.Reconcile(req)
+		requests <- req
+		return result, err
+	})
+	return fn, requests
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) chan struct{} {
+	stop := make(chan struct{})
+	go func() {
+		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
+	}()
+	return stop
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/controllertest.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/controller/controllertest.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+// Test scaffolds a Controller Test
+type Test struct {
+	input.Input
+
+	// Resource is the Resource to make the Controller for
+	Resource *resource.Resource
+
+	// ResourcePackage is the package of the Resource
+	ResourcePackage string
+}
+
+// GetInput implements input.File
+func (a *Test) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "controller",
+			strings.ToLower(a.Resource.Kind), strings.ToLower(a.Resource.Kind)+"_controller_test.go")
+	}
+
+	// Use the k8s.io/api package for core resources
+	coreGroups := map[string]string{
+		"apps":                  "",
+		"admissionregistration": "k8s.io",
+		"apiextensions":         "k8s.io",
+		"authentication":        "k8s.io",
+		"autoscaling":           "",
+		"batch":                 "",
+		"certificates":          "k8s.io",
+		"core":                  "",
+		"extensions":            "",
+		"metrics":               "k8s.io",
+		"policy":                "",
+		"rbac.authorization":    "k8s.io",
+		"storage":               "k8s.io",
+	}
+	if _, found := coreGroups[a.Resource.Group]; found {
+		a.ResourcePackage = path.Join("k8s.io", "api")
+	} else {
+		a.ResourcePackage = path.Join(a.Repo, "pkg", "apis")
+	}
+
+	a.TemplateBody = controllerTestTemplate
+	a.Input.IfExistsAction = input.Error
+	return a.Input, nil
+}
+
+var controllerTestTemplate = `{{ .Boilerplate }}
+
+package {{ lower .Resource.Kind }}
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	{{ if .Resource.CreateExampleReconcileBody -}}
+	appsv1 "k8s.io/api/apps/v1"
+	{{ end -}}
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
+)
+
+var c client.Client
+
+var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo"{{ if .Resource.Namespaced }}, Namespace: "default"{{end}}}}
+{{ if .Resource.CreateExampleReconcileBody }}var depKey = types.NamespacedName{Name: "foo-deployment"{{ if .Resource.Namespaced }}, Namespace: "default"{{end}}}
+{{ end }}
+const timeout = time.Second * 5
+
+func TestReconcile(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	instance := &{{ .Resource.Group }}{{ .Resource.Version }}.{{ .Resource.Kind }}{ObjectMeta: metav1.ObjectMeta{Name: "foo"{{ if .Resource.Namespaced }}, Namespace: "default"{{end}}}}
+
+	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+	// channel when it is finished.
+	mgr, err := manager.New(cfg, manager.Options{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	c = mgr.GetClient()
+
+	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+	defer close(StartTestManager(mgr, g))
+
+	// Create the {{ .Resource.Kind }} object and expect the Reconcile{{ if .Resource.CreateExampleReconcileBody }} and Deployment to be created{{ end }}
+	g.Expect(c.Create(context.TODO(), instance)).To(gomega.Succeed())
+	defer c.Delete(context.TODO(), instance)
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
+{{ if .Resource.CreateExampleReconcileBody }}
+	deploy := &appsv1.Deployment{}
+	g.Eventually(func() error { return c.Get(context.TODO(), depKey, deploy) }, timeout).
+		Should(gomega.Succeed())
+
+	// Delete the Deployment and expect Reconcile to be called for Deployment deletion
+	g.Expect(c.Delete(context.TODO(), deploy)).NotTo(gomega.HaveOccurred())
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
+	g.Eventually(func() error { return c.Get(context.TODO(), depKey, deploy) }, timeout).
+		Should(gomega.Succeed())
+
+	// Manually delete Deployment since GC isn't enabled in the test control plane
+	g.Expect(c.Delete(context.TODO(), deploy)).To(gomega.Succeed())
+{{ end }}
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package scaffold contains libraries for scaffolding code to use with controller-runtime
+package scaffold

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/input/input.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/input/input.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package input
+
+// IfExistsAction determines what to do if the scaffold file already exists
+type IfExistsAction int
+
+const (
+	// Skip skips the file and moves to the next one
+	Skip IfExistsAction = iota
+
+	// Error returns an error and stops processing
+	Error
+
+	// Overwrite truncates and overwrites the existing file
+	Overwrite
+)
+
+// Input is the input for scaffoldig a file
+type Input struct {
+	// Path is the file to write
+	Path string
+
+	// IfExistsAction determines what to do if the file exists
+	IfExistsAction IfExistsAction
+
+	// TemplateBody is the template body to execute
+	TemplateBody string
+
+	// Boilerplate is the contents of a Boilerplate go header file
+	Boilerplate string
+
+	// BoilerplatePath is the path to a Boilerplate go header file
+	BoilerplatePath string
+
+	// Version is the project version
+	Version string
+
+	// Domain is the domain for the APIs
+	Domain string
+
+	// Repo is the go project package
+	Repo string
+
+	// ProjectPath is the relative path to the project root
+	ProjectPath string
+}
+
+// Domain allows a domain to be set on an object
+type Domain interface {
+	// SetDomain sets the domain
+	SetDomain(string)
+}
+
+// SetDomain sets the domain
+func (i *Input) SetDomain(d string) {
+	if i.Domain == "" {
+		i.Domain = d
+	}
+}
+
+// Repo allows a repo to be set on an object
+type Repo interface {
+	// SetRepo sets the repo
+	SetRepo(string)
+}
+
+// SetRepo sets the repo
+func (i *Input) SetRepo(r string) {
+	if i.Repo == "" {
+		i.Repo = r
+	}
+}
+
+// Boilerplate allows boilerplate text to be set on an object
+type Boilerplate interface {
+	// SetBoilerplate sets the boilerplate text
+	SetBoilerplate(string)
+}
+
+// SetBoilerplate sets the boilerplate text
+func (i *Input) SetBoilerplate(b string) {
+	if i.Boilerplate == "" {
+		i.Boilerplate = b
+	}
+}
+
+// BoilerplatePath allows boilerplate file path to be set on an object
+type BoilerplatePath interface {
+	// SetBoilerplatePath sets the boilerplate file path
+	SetBoilerplatePath(string)
+}
+
+// SetBoilerplatePath sets the boilerplate file path
+func (i *Input) SetBoilerplatePath(bp string) {
+	if i.BoilerplatePath == "" {
+		i.BoilerplatePath = bp
+	}
+}
+
+// Version allows the project version to be set on an object
+type Version interface {
+	// SetVersion sets the project version
+	SetVersion(string)
+}
+
+// SetVersion sets the project version
+func (i *Input) SetVersion(v string) {
+	if i.Version == "" {
+		i.Version = v
+	}
+}
+
+// ProjecPath allows the project path to be set on an object
+type ProjecPath interface {
+	// SetProjectPath sets the project file location
+	SetProjectPath(string)
+}
+
+// SetProjectPath sets the project path
+func (i *Input) SetProjectPath(p string) {
+	if i.ProjectPath == "" {
+		i.ProjectPath = p
+	}
+}
+
+// File is a scaffoldable file
+type File interface {
+	// GetInput returns the Input for creating a scaffold file
+	GetInput() (Input, error)
+}
+
+// Validate validates input
+type Validate interface {
+	// Validate returns true if the template has valid values
+	Validate() error
+}
+
+// Options are the options for executing scaffold templates
+type Options struct {
+	// BoilerplatePath is the path to the boilerplate file
+	BoilerplatePath string
+
+	// Path is the path to the project
+	ProjectPath string
+}
+
+// ProjectFile is deserialized into a PROJECT file
+type ProjectFile struct {
+	// Version is the project version - defaults to "2"
+	Version string `yaml:"version,omitempty"`
+
+	// Domain is the domain associated with the project and used for API groups
+	Domain string `yaml:"domain,omitempty"`
+
+	// Repo is the go package name of the project root
+	Repo string `yaml:"repo,omitempty"`
+}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/apis.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/apis.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &APIs{}
+
+// APIs scaffolds a apis.go to register types with a Scheme
+type APIs struct {
+	input.Input
+
+	// Comments is a list of comments to add to the apis.go
+	Comments []string
+}
+
+var deepCopy = strings.Join([]string{
+	"//go:generate go run",
+	"../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go",
+	"-O zz_generated.deepcopy",
+	"-i ./..."}, " ")
+
+// GetInput implements input.File
+func (a *APIs) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "apis", "apis.go")
+	}
+
+	b, err := filepath.Rel(filepath.Join(a.Input.ProjectPath, "pkg", "apis"), a.BoilerplatePath)
+	if err != nil {
+		return input.Input{}, err
+	}
+	if len(a.Comments) == 0 {
+		a.Comments = append(a.Comments,
+			"// Generate deepcopy for apis", fmt.Sprintf("%s -h %s", deepCopy, b))
+	}
+	a.TemplateBody = apisTemplate
+	return a.Input, nil
+}
+
+var apisTemplate = `{{ .Boilerplate }}
+
+{{ range $line := .Comments }}{{ $line }}
+{{ end }}
+// Package apis contains Kubernetes API groups.
+package apis
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// AddToSchemes may be used to add all resources defined in the project to a Scheme
+var AddToSchemes runtime.SchemeBuilder
+
+// AddToScheme adds all Resources to the Scheme
+func AddToScheme(s *runtime.Scheme) error {
+	return AddToSchemes.AddToScheme(s)
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/cmd.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/cmd.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Cmd{}
+
+// Cmd scaffolds a manager.go to run Controllers
+type Cmd struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (a *Cmd) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("cmd", "manager", "main.go")
+	}
+	a.TemplateBody = cmdTemplate
+	return a.Input, nil
+}
+
+var cmdTemplate = `{{ .Boilerplate }}
+
+package main
+
+import (
+	"log"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"{{ .Repo }}/pkg/apis"
+	"{{ .Repo }}/pkg/controller"
+)
+
+func main() {
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a new Cmd to provide shared dependencies and start components
+	mgr, err := manager.New(cfg, manager.Options{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Registering Components.")
+
+	// Setup Scheme for all resources
+	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatal(err)
+	}
+
+	// Setup all Controllers
+	if err := controller.AddToManager(mgr); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Starting the Cmd.")
+
+	// Start the Cmd
+	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/config.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/config.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Config{}
+
+// Config scaffolds yaml config for the manager.
+type Config struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *Config) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = filepath.Join("config", "manager", "manager.yaml")
+	}
+	c.TemplateBody = configTemplate
+	return c.Input, nil
+}
+
+var configTemplate = `apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+      controller-tools.k8s.io: "1.0"
+  name: system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-service
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  labels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: controller-manager-service
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+        command:
+        - /root/manager
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: role
+subjects:
+- kind: ServiceAccount
+  name: default
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/controller.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/controller.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Controller{}
+
+// Controller scaffolds a controller.go to add Controllers to a manager.Cmd
+type Controller struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *Controller) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = filepath.Join("pkg", "controller", "controller.go")
+	}
+	c.TemplateBody = controllerTemplate
+	return c.Input, nil
+}
+
+var controllerTemplate = `{{ .Boilerplate }}
+
+package controller
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// AddToManagerFuncs is a list of functions to add all Controllers to the Manager
+var AddToManagerFuncs []func(manager.Manager) error
+
+// AddToManager adds all Controllers to the Manager
+func AddToManager(m manager.Manager) error {
+	for _, f := range AddToManagerFuncs {
+		if err := f(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/dockerfile.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/dockerfile.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Dockerfile{}
+
+// Dockerfile scaffolds a Dockerfile for building a main
+type Dockerfile struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *Dockerfile) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = "Dockerfile"
+	}
+	c.TemplateBody = dockerfileTemplate
+	return c.Input, nil
+}
+
+var dockerfileTemplate = `# Build and test the manager binary
+FROM golang:1.9.3 as builder
+
+# Copy in the go src
+WORKDIR /go/src/{{ .Repo }}
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+COPY vendor/ vendor/
+
+# Run tests as a sanity check
+ENV TEST_ASSET_DIR /usr/local/bin
+ENV TEST_ASSET_KUBECTL $TEST_ASSET_DIR/kubectl
+ENV TEST_ASSET_KUBE_APISERVER $TEST_ASSET_DIR/kube-apiserver
+ENV TEST_ASSET_ETCD $TEST_ASSET_DIR/etcd
+ENV TEST_ASSET_URL https://storage.googleapis.com/k8s-c10s-test-binaries
+RUN curl ${TEST_ASSET_URL}/etcd-Linux-x86_64 --output $TEST_ASSET_ETCD
+RUN curl ${TEST_ASSET_URL}/kube-apiserver-Linux-x86_64 --output $TEST_ASSET_KUBE_APISERVER
+RUN curl https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubectl --output $TEST_ASSET_KUBECTL
+RUN chmod +x $TEST_ASSET_ETCD
+RUN chmod +x $TEST_ASSET_KUBE_APISERVER
+RUN chmod +x $TEST_ASSET_KUBECTL
+RUN go test ./pkg/... ./cmd/...
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager {{ .Repo }}/cmd/manager
+
+# Copy the controller-manager into a thin image
+FROM ubuntu:latest
+WORKDIR /root/
+COPY --from=builder /go/src/{{ .Repo }}/manager .
+ENTRYPOINT ["./manager"]
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/boilerplate.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/boilerplate.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Boilerplate{}
+
+// Boilerplate scaffolds a boilerplate header file.
+type Boilerplate struct {
+	input.Input
+
+	// License is the License type to write
+	License string
+
+	// Owner is the copyright owner - e.g. "The Kubernetes Authors"
+	Owner string
+
+	// Year is the copyright year
+	Year string
+}
+
+// GetInput implements input.File
+func (c *Boilerplate) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = filepath.Join("hack", "boilerplate.go.txt")
+	}
+
+	// Boilerplate given
+	if len(c.Boilerplate) > 0 {
+		c.TemplateBody = c.Boilerplate
+		return c.Input, nil
+	}
+
+	// Pick a template boilerplate option
+	if c.Year == "" {
+		c.Year = fmt.Sprintf("%v", time.Now().Year())
+	}
+	switch c.License {
+	case "", "apache2":
+		c.TemplateBody = apache
+	case "none":
+		c.TemplateBody = none
+	}
+	return c.Input, nil
+}
+
+var apache = `/*
+{{ if .Owner }}Copyright {{ .Year }} {{ .Owner }}.
+{{ end }}
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/`
+
+var none = `/*
+{{ if .Owner }}Copyright {{ .Year }} {{ .Owner }}{{ end }}.
+*/`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/gitignore.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/gitignore.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &GitIgnore{}
+
+// GitIgnore scaffolds the .gitignore file
+type GitIgnore struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *GitIgnore) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = ".gitignore"
+	}
+	c.TemplateBody = gitignoreTemplate
+	return c.Input, nil
+}
+
+var gitignoreTemplate = `
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with ` + "`go test -c`" + `
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files
+
+zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/gopkg.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/gopkg.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &GopkgToml{}
+
+// GopkgToml writes a templatefile for Gopkg.toml
+type GopkgToml struct {
+	input.Input
+
+	// ManagedHeader is the header to write after the user owned pieces and before the managed parts of the Gopkg.toml
+	ManagedHeader string
+
+	// DefaultGopkgUserContent is the default content to use for the user owned pieces
+	DefaultUserContent string
+
+	// UserContent is the content to use for the user owned pieces
+	UserContent string
+
+	// Stanzas are additional managed stanzas to add after the ManagedHeader
+	Stanzas []Stanza
+}
+
+// Stanza is a single Gopkg.toml entry
+type Stanza struct {
+	// Type will be between the'[[]]' e.g. override
+	Type string
+
+	// Name will appear after 'name=' and does not include quotes e.g. k8s.io/client-go
+	Name string
+	// Version will appear after 'version=' and does not include quotes
+	Version string
+
+	// Revision will appear after 'revsion=' and does not include quotes
+	Revision string
+}
+
+// GetInput implements input.File
+func (g *GopkgToml) GetInput() (input.Input, error) {
+	if g.Path == "" {
+		g.Path = "Gopkg.toml"
+	}
+	if g.ManagedHeader == "" {
+		g.ManagedHeader = DefaultGopkgHeader
+	}
+
+	// Set the user content to be used if the Gopkg.toml doesn't exist
+	if g.DefaultUserContent == "" {
+		g.DefaultUserContent = DefaultGopkgUserContent
+	}
+
+	// Set the user owned content from the last Gopkg.toml file - e.g. everything before the header
+	lastBytes, err := ioutil.ReadFile(g.Path)
+	if err != nil {
+		g.UserContent = g.DefaultUserContent
+	} else if g.UserContent, err = g.getUserContent(lastBytes); err != nil {
+		return input.Input{}, err
+	}
+
+	g.Input.IfExistsAction = input.Overwrite
+	g.TemplateBody = depTemplate
+	return g.Input, nil
+}
+
+func (g *GopkgToml) getUserContent(b []byte) (string, error) {
+	// Keep the users lines
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	userLines := []string{}
+	found := false
+	for scanner.Scan() {
+		l := scanner.Text()
+		if l == g.ManagedHeader {
+			found = true
+			break
+		}
+		userLines = append(userLines, l)
+	}
+
+	if !found {
+		return "", fmt.Errorf(
+			"skipping modifying Gopkg.toml - file already exists and is unmanaged")
+	}
+	return strings.Join(userLines, "\n"), nil
+}
+
+// DefaultGopkgHeader is the default header used to separate user managed lines and controller-manager managed lines
+const DefaultGopkgHeader = "# STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE."
+
+// DefaultGopkgUserContent is the default user managed lines to provide.
+const DefaultGopkgUserContent = `required = [
+    "github.com/emicklei/go-restful",
+    "github.com/onsi/ginkgo", # for test framework
+    "github.com/onsi/gomega", # for test matchers
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp", # for development against gcp
+    "k8s.io/code-generator/cmd/deepcopy-gen", # for go generate
+    "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/controller",
+    "sigs.k8s.io/controller-runtime/pkg/handler",
+    "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
+    "sigs.k8s.io/controller-runtime/pkg/source",
+    "sigs.k8s.io/testing_frameworks/integration", # for integration testing
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    ]
+
+[prune]
+  go-tests = true
+
+`
+
+var depTemplate = `{{ .UserContent }}
+# STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE.
+
+{{ range $element := .Stanzas -}}
+[[{{ .Type }}]]
+name="{{ .Name }}"
+{{ if .Version }}version="{{.Version}}"{{ end }}
+{{ if .Revision }}revision="{{.Revision}}"{{ end }}
+{{ end -}}
+
+[[override]]
+name="cloud.google.com/go"
+version="v0.21.0"
+
+[[override]]
+name="github.com/PuerkitoBio/purell"
+version="v1.1.0"
+
+[[override]]
+name="github.com/PuerkitoBio/urlesc"
+revision="de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[override]]
+name="github.com/davecgh/go-spew"
+version="v1.1.0"
+
+[[override]]
+name="github.com/emicklei/go-restful"
+version="v2.7.0"
+
+[[override]]
+name="github.com/ghodss/yaml"
+version="v1.0.0"
+
+[[override]]
+name="github.com/go-openapi/jsonpointer"
+revision="3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
+
+[[override]]
+name="github.com/go-openapi/jsonreference"
+revision="3fb327e6747da3043567ee86abd02bb6376b6be2"
+
+[[override]]
+name="github.com/go-openapi/spec"
+revision="bcff419492eeeb01f76e77d2ebc714dc97b607f5"
+
+[[override]]
+name="github.com/go-openapi/swag"
+revision="811b1089cde9dad18d4d0c2d09fbdbf28dbd27a5"
+
+[[override]]
+name="github.com/gogo/protobuf"
+version="v1.0.0"
+
+[[override]]
+name="github.com/golang/glog"
+revision="23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+
+[[override]]
+name="github.com/golang/groupcache"
+revision="66deaeb636dff1ac7d938ce666d090556056a4b0"
+
+[[override]]
+name="github.com/golang/protobuf"
+version="v1.1.0"
+
+[[override]]
+name="github.com/google/gofuzz"
+revision="24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[override]]
+name="github.com/googleapis/gnostic"
+version="v0.1.0"
+
+[[override]]
+name="github.com/hashicorp/golang-lru"
+revision="0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+
+[[override]]
+name="github.com/howeyc/gopass"
+revision="bf9dde6d0d2c004a008c27aaee91170c786f6db8"
+
+[[override]]
+name="github.com/imdario/mergo"
+version="v0.3.4"
+
+[[override]]
+name="github.com/json-iterator/go"
+version="1.1.3"
+
+[[override]]
+name="github.com/mailru/easyjson"
+revision="8b799c424f57fa123fc63a99d6383bc6e4c02578"
+
+[[override]]
+name="github.com/modern-go/concurrent"
+version="1.0.3"
+
+[[override]]
+name="github.com/modern-go/reflect2"
+version="1.0.0"
+
+[[override]]
+name="github.com/onsi/ginkgo"
+version="v1.4.0"
+
+[[override]]
+name="github.com/onsi/gomega"
+version="v1.3.0"
+
+[[override]]
+name="github.com/spf13/pflag"
+version="v1.0.1"
+
+[[override]]
+name="golang.org/x/crypto"
+revision="4ec37c66abab2c7e02ae775328b2ff001c3f025a"
+
+[[override]]
+name="golang.org/x/net"
+revision="640f4622ab692b87c2f3a94265e6f579fe38263d"
+
+[[override]]
+name="golang.org/x/oauth2"
+revision="cdc340f7c179dbbfa4afd43b7614e8fcadde4269"
+
+[[override]]
+name="golang.org/x/sys"
+revision="7db1c3b1a98089d0071c84f646ff5c96aad43682"
+
+[[override]]
+name="golang.org/x/text"
+version="v0.3.0"
+
+[[override]]
+name="golang.org/x/time"
+revision="fbb02b2291d28baffd63558aa44b4b56f178d650"
+
+[[override]]
+name="google.golang.org/appengine"
+version="v1.0.0"
+
+[[override]]
+name="gopkg.in/inf.v0"
+version="v0.9.1"
+
+[[override]]
+name="gopkg.in/yaml.v2"
+version="v2.2.1"
+
+[[override]]
+name="k8s.io/api"
+version="kubernetes-1.10.0"
+
+[[override]]
+name="k8s.io/apiextensions-apiserver"
+version="kubernetes-1.10.1"
+
+[[override]]
+name="k8s.io/apimachinery"
+version="kubernetes-1.10.0"
+
+[[override]]
+name="k8s.io/client-go"
+version="kubernetes-1.10.1"
+
+[[override]]
+name="k8s.io/kube-aggregator"
+version="kubernetes-1.10.1"
+
+[[override]]
+name="k8s.io/kube-openapi"
+revision="f08db293d3ef80052d6513ece19792642a289fea"
+
+[[override]]
+name="sigs.k8s.io/testing_frameworks"
+revision="f53464b8b84b4507805a0b033a8377b225163fea"
+
+[[override]]
+name = "github.com/thockin/logr"
+source = "https://github.com/directxman12/logr.git"
+branch = "features/structed"
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/makefile.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/makefile.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Makefile{}
+
+// Makefile scaffolds the Makefile
+type Makefile struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *Makefile) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = "Makefile"
+	}
+	c.TemplateBody = makefileTemplate
+	c.Input.IfExistsAction = input.Error
+	return c.Input, nil
+}
+
+var makefileTemplate = `
+all: test manager
+
+# Run tests
+test: generate fmt vet
+	go test ./pkg/... ./cmd/... -coverprofile cover.out
+
+# Build manager binary
+manager: generate fmt vet
+	go build -o bin/manager {{ .Repo }}/cmd/manager
+
+# Run against the configured Kubernetes cluster in ~/.kube/config
+run: generate fmt vet
+	go run ./cmd/manager/main.go
+
+# Install CRDs into a cluster
+install:
+	kubectl apply -f config/crds
+
+# Run go fmt against code
+fmt:
+	go fmt ./pkg/... ./cmd/...
+
+# Run go vet against code
+vet:
+	go vet ./pkg/... ./cmd/...
+
+# Generate code
+generate:
+	go generate ./pkg/... ./cmd/...
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/project.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/project.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Project{}
+
+// Project scaffolds the PROJECT file with project metadata
+type Project struct {
+	// Path is the output file location - defaults to PROJECT
+	Path string
+
+	input.ProjectFile
+}
+
+// GetInput implements input.File
+func (c *Project) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = "PROJECT"
+	}
+	if c.Repo == "" {
+		r, err := c.repoFromGopathAndWd(os.Getenv("GOPATH"), os.Getwd)
+		if err != nil {
+			return input.Input{}, err
+		}
+		c.Repo = r
+	}
+
+	out, err := yaml.Marshal(c.ProjectFile)
+	if err != nil {
+		return input.Input{}, err
+	}
+
+	return input.Input{
+		Path:           c.Path,
+		TemplateBody:   string(out),
+		Repo:           c.Repo,
+		Version:        c.Version,
+		Domain:         c.Domain,
+		IfExistsAction: input.Error,
+	}, nil
+}
+
+func (Project) repoFromGopathAndWd(gopath string, getwd func() (string, error)) (string, error) {
+	// Assume the working dir is the root of the repo
+	wd, err := getwd()
+	if err != nil {
+		return "", err
+	}
+
+	// Strip the GOPATH from the working dir to get the go package of the repo
+	if len(gopath) == 0 {
+		gopath = build.Default.GOPATH
+	}
+	goSrc := filepath.Join(gopath, "src")
+
+	// Make sure the GOPATH is set and the working dir is under the GOPATH
+	if !strings.HasPrefix(filepath.Dir(wd), goSrc) {
+		return "", fmt.Errorf("working directory must be a project directory under "+
+			"$GOPATH/src/<project-package>\n- GOPATH=%s\n- WD=%s", gopath, wd)
+	}
+
+	// Figure out the repo name by removing $GOPATH/src from the working directory - e.g.
+	// '$GOPATH/src/kubernetes-sigs/controller-tools' becomes 'kubernetes-sigs/controller-tools'
+	repo := ""
+	for wd != goSrc {
+		repo = filepath.Join(filepath.Base(wd), repo)
+		wd = filepath.Dir(wd)
+	}
+	return repo, nil
+}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/addtoscheme.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/addtoscheme.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &AddToScheme{}
+
+// AddToScheme scaffolds the code to add the resource to a SchemeBuilder.
+type AddToScheme struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (a *AddToScheme) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "apis", fmt.Sprintf(
+			"addtoscheme_%s_%s.go", a.Resource.Group, a.Resource.Version))
+	}
+	a.TemplateBody = addResourceTemplate
+	return a.Input, nil
+}
+
+var addResourceTemplate = `{{ .Boilerplate }}
+
+package apis
+
+import (
+	"{{ .Repo }}/pkg/apis/{{ .Resource.Group }}/{{ .Resource.Version }}"
+)
+
+func init() {
+	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+	AddToSchemes = append(AddToSchemes, {{ .Resource.Version }}.SchemeBuilder.AddToScheme)
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/crd.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/crd.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"strings"
+
+	"github.com/markbates/inflect"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &CRD{}
+
+// CRD scaffolds a CRD yaml file.
+type CRD struct {
+	input.Input
+
+	// Scope is Namespaced or Cluster
+	Scope string
+
+	// Plural is the plural lowercase of kind
+	Plural string
+
+	// Resource is a resource in the API group
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (c *CRD) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = filepath.Join("config", "crds", fmt.Sprintf(
+			"%s_%s_%s.yaml", c.Resource.Group, c.Resource.Version, strings.ToLower(c.Resource.Kind)))
+	}
+	c.Scope = "Namespaced"
+	if !c.Resource.Namespaced {
+		c.Scope = "Cluster"
+	}
+	if c.Plural == "" {
+		c.Plural = strings.ToLower(inflect.Pluralize(c.Resource.Kind))
+	}
+
+	c.IfExistsAction = input.Error
+	c.TemplateBody = crdTemplate
+	return c.Input, nil
+}
+
+var crdTemplate = `apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{ .Plural }}.{{ .Resource.Group }}.{{ .Domain }}
+spec:
+  group: {{ .Resource.Group }}.{{ .Domain }}
+  version: "{{ .Resource.Version }}"
+  names:
+    kind: {{ .Resource.Kind }}
+    plural: {{ .Plural }}
+  scope: {{ .Scope }}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/doc.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Doc{}
+
+// Doc scaffolds the pkg/apis/group/version/doc.go directory
+type Doc struct {
+	input.Input
+
+	// Resource is a resource for the API version
+	Resource *Resource
+
+	// Comments are additional lines to write to the doc.go file
+	Comments []string
+}
+
+// GetInput implements input.File
+func (a *Doc) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "apis", a.Resource.Group, a.Resource.Version, "doc.go")
+	}
+	a.TemplateBody = docGoTemplate
+	return a.Input, nil
+}
+
+var docGoTemplate = `{{ .Boilerplate }}
+
+// Package {{.Resource.Version}} contains API Schema definitions for the {{ .Resource.Group }} {{.Resource.Version}} API group
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen=package,register
+// +k8s:conversion-gen={{ .Repo }}/pkg/apis/{{ .Resource.Group }}
+// +k8s:defaulter-gen=TypeMeta
+// +groupName={{ .Resource.Group }}.{{ .Domain }}
+package {{.Resource.Version}}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/group.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/group.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Group{}
+
+// Group scaffolds the pkg/apis/group/group.go
+type Group struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (g *Group) GetInput() (input.Input, error) {
+	if g.Path == "" {
+		g.Path = filepath.Join("pkg", "apis", g.Resource.Group, "group.go")
+	}
+	g.TemplateBody = groupTemplate
+	return g.Input, nil
+}
+
+var groupTemplate = `{{ .Boilerplate }}
+
+// Package {{ .Resource.Group }} contains {{ .Resource.Group }} API versions
+package {{ .Resource.Group }}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/register.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/register.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Register{}
+
+// Register scaffolds the pkg/apis/group/version/register.go file
+type Register struct {
+	input.Input
+
+	// Resource is the resource to scaffold the types_test.go file for
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (r *Register) GetInput() (input.Input, error) {
+	if r.Path == "" {
+		r.Path = filepath.Join("pkg", "apis", r.Resource.Group, r.Resource.Version, "register.go")
+	}
+	r.TemplateBody = registerTemplate
+	return r.Input, nil
+}
+
+var registerTemplate = `{{ .Boilerplate }}
+
+// NOTE: Boilerplate only.  Ignore this file.
+
+// Package {{.Resource.Version}} contains API Schema definitions for the {{ .Resource.Group }} {{.Resource.Version}} API group
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen=package,register
+// +k8s:conversion-gen={{ .Repo }}/pkg/apis/{{ .Resource.Group }}
+// +k8s:defaulter-gen=TypeMeta
+// +groupName={{ .Resource.Group }}.{{ .Domain }}
+package {{.Resource.Version}}
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+)
+
+var (
+	// SchemeGroupVersion is group version used to register these objects
+	SchemeGroupVersion = schema.GroupVersion{Group: "{{ .Resource.Group }}.{{ .Domain }}", Version: "{{ .Resource.Version }}"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+)
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/resource.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/resource.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/markbates/inflect"
+)
+
+// Resource contains the information required to scaffold files for a resource.
+type Resource struct {
+	// Namespaced is true if the resource is namespaced
+	Namespaced bool
+
+	// Group is the API Group.  Does not contain the domain.
+	Group string
+
+	// Version is the API version - e.g. v1beta1
+	Version string
+
+	// Kind is the API Kind.
+	Kind string
+
+	// Resource is the API Resource.
+	Resource string
+
+	// ShortNames is the list of resource shortnames.
+	ShortNames []string
+
+	// CreateExampleReconcileBody will create a Deployment in the Reconcile example
+	CreateExampleReconcileBody bool
+}
+
+// Validate checks the Resource values to make sure they are valid.
+func (r *Resource) Validate() error {
+	if len(r.Group) == 0 {
+		return fmt.Errorf("group cannot be empty")
+	}
+	if len(r.Version) == 0 {
+		return fmt.Errorf("version cannot be empty")
+	}
+	if len(r.Kind) == 0 {
+		return fmt.Errorf("kind cannot be empty")
+	}
+
+	rs := inflect.NewDefaultRuleset()
+	if len(r.Resource) == 0 {
+		r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
+	}
+
+	groupMatch := regexp.MustCompile("^[a-z]+$")
+	if !groupMatch.MatchString(r.Group) {
+		return fmt.Errorf("group must match ^[a-z]+$ (was %s)", r.Group)
+	}
+
+	versionMatch := regexp.MustCompile("^v\\d+(alpha\\d+|beta\\d+)?$")
+	if !versionMatch.MatchString(r.Version) {
+		return fmt.Errorf(
+			"version must match ^v\\d+(alpha\\d+|beta\\d+)?$ (was %s)", r.Version)
+	}
+
+	if r.Kind != inflect.Camelize(r.Kind) {
+		return fmt.Errorf("Kind must be camelcase (expected %s was %s)", inflect.Camelize(r.Kind), r.Kind)
+	}
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/role.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/role.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &RoleBinding{}
+
+// Role scaffolds the config/manager/group_role_rbac.yaml file
+type Role struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (r *Role) GetInput() (input.Input, error) {
+	if r.Path == "" {
+		r.Path = filepath.Join("config", "manager", fmt.Sprintf(
+			"%s_role_rbac.yaml", r.Resource.Group))
+	}
+	r.TemplateBody = roleTemplate
+	return r.Input, nil
+}
+
+var roleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{.Resource.Group}}-role
+rules:
+- apiGroups:
+  - {{ .Resource.Group }}.{{ .Domain }}
+  resources:
+  - '*'
+  verbs:
+  - '*'
+
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/rolebinding.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/rolebinding.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &RoleBinding{}
+
+// RoleBinding scaffolds the config/manager/group_rolebinding_rbac.yaml file
+type RoleBinding struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (r *RoleBinding) GetInput() (input.Input, error) {
+	if r.Path == "" {
+		r.Path = filepath.Join("config", "manager", fmt.Sprintf(
+			"%s_rolebinding_rbac.yaml", r.Resource.Group))
+	}
+	r.TemplateBody = roleBindingTemplate
+	return r.Input, nil
+}
+
+var roleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: {{ .Resource.Group }}-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Resource.Group }}-role
+subjects:
+- kind: ServiceAccount
+  name: default
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/types.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/types.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Types{}
+
+// Types scaffolds the pkg/apis/group/version/kind_types.go file to define the schema for an API
+type Types struct {
+	input.Input
+
+	// Resource is the resource to scaffold the types_test.go file for
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (t *Types) GetInput() (input.Input, error) {
+	if t.Path == "" {
+		t.Path = filepath.Join("pkg", "apis", t.Resource.Group, t.Resource.Version,
+			fmt.Sprintf("%s_types.go", strings.ToLower(t.Resource.Kind)))
+	}
+	t.TemplateBody = typesTemplate
+	t.IfExistsAction = input.Error
+	return t.Input, nil
+}
+
+// Validate validates the values
+func (t *Types) Validate() error {
+	return t.Resource.Validate()
+}
+
+var typesTemplate = `{{ .Boilerplate }}
+
+package {{ .Resource.Version }}
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+// {{.Resource.Kind}}Spec defines the desired state of {{.Resource.Kind}}
+type {{.Resource.Kind}}Spec struct {
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "kubebuilder generate" to regenerate code after modifying this file
+}
+
+// {{.Resource.Kind}}Status defines the observed state of {{.Resource.Kind}}
+type {{.Resource.Kind}}Status struct {
+	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+	// Important: Run "kubebuilder generate" to regenerate code after modifying this file
+}
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+{{- if not .Resource.Namespaced }}
+// +genclient:nonNamespaced
+{{- end }}
+
+// {{.Resource.Kind}} is the Schema for the {{ .Resource.Resource }} API
+// +k8s:openapi-gen=true
+type {{.Resource.Kind}} struct {
+	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
+	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
+
+	Spec   {{.Resource.Kind}}Spec   ` + "`" + `json:"spec,omitempty"` + "`" + `
+	Status {{.Resource.Kind}}Status ` + "`" + `json:"status,omitempty"` + "`" + `
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+{{- if not .Resource.Namespaced }}
+// +genclient:nonNamespaced
+{{- end }}
+
+// {{.Resource.Kind}}List contains a list of {{.Resource.Kind}}
+type {{.Resource.Kind}}List struct {
+	metav1.TypeMeta ` + "`" + `json:",inline"` + "`" + `
+	metav1.ListMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
+	Items           []{{ .Resource.Kind }} ` + "`" + `json:"items"` + "`" + `
+}
+
+func init() {
+	SchemeBuilder.Register(&{{.Resource.Kind}}{}, &{{.Resource.Kind}}List{})
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/typestest.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/typestest.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &TypesTest{}
+
+// TypesTest scaffolds the pkg/apis/group/version/kind_types_test.go file to test the API schema
+type TypesTest struct {
+	input.Input
+
+	// Resource is the resource to scaffold the types_test.go file for
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (t *TypesTest) GetInput() (input.Input, error) {
+	if t.Path == "" {
+		t.Path = filepath.Join("pkg", "apis", t.Resource.Group, t.Resource.Version,
+			fmt.Sprintf("%s_types_test.go", strings.ToLower(t.Resource.Kind)))
+	}
+	t.TemplateBody = typesTestTemplate
+	t.IfExistsAction = input.Error
+	return t.Input, nil
+}
+
+// Validate validates the values
+func (t *TypesTest) Validate() error {
+	return t.Resource.Validate()
+}
+
+var typesTestTemplate = `{{ .Boilerplate }}
+
+package {{ .Resource.Version }}
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestStorage(t *testing.T) {
+	key := types.NamespacedName{Name: "foo", Namespace: "default"}
+	created := &{{ .Resource.Kind }}{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	g := gomega.NewGomegaWithT(t)
+
+	// Test Create
+	fetched := &{{ .Resource.Kind }}{}
+	g.Expect(c.Create(context.TODO(), created)).NotTo(gomega.HaveOccurred())
+
+	g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+	g.Expect(fetched).To(gomega.Equal(created))
+
+	// Test Updating the Labels
+	updated := fetched.DeepCopy()
+	updated.Labels = map[string]string{"hello": "world"}
+	g.Expect(c.Update(context.TODO(), updated)).NotTo(gomega.HaveOccurred())
+
+	g.Expect(c.Get(context.TODO(), key, fetched)).NotTo(gomega.HaveOccurred())
+	g.Expect(fetched).To(gomega.Equal(updated))
+
+	// Test Delete
+	g.Expect(c.Delete(context.TODO(), fetched)).NotTo(gomega.HaveOccurred())
+	g.Expect(c.Get(context.TODO(), key, fetched)).To(gomega.HaveOccurred())
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/version_suitetest.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/resource/version_suitetest.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &TypesTest{}
+
+// VersionSuiteTest scaffolds the version_suite_test.go file to setup the versions test
+type VersionSuiteTest struct {
+	input.Input
+
+	// Resource is the resource to scaffold the types_test.go file for
+	Resource *Resource
+}
+
+// GetInput implements input.File
+func (v *VersionSuiteTest) GetInput() (input.Input, error) {
+	if v.Path == "" {
+		v.Path = filepath.Join("pkg", "apis", v.Resource.Group, v.Resource.Version,
+			fmt.Sprintf("%s_suite_test.go", v.Resource.Version))
+	}
+	v.TemplateBody = versionSuiteTestTemplate
+	return v.Input, nil
+}
+
+var versionSuiteTestTemplate = `{{ .Boilerplate }}
+
+package {{ .Resource.Version }}
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var cfg *rest.Config
+var c client.Client
+
+func TestMain(m *testing.M) {
+	t := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
+	}
+
+	err := SchemeBuilder.AddToScheme(scheme.Scheme)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if cfg, err = t.Start(); err != nil {
+		log.Fatal(err)
+	}
+
+	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
+		log.Fatal(err)
+	}
+
+	code := m.Run()
+	t.Stop()
+	os.Exit(code)
+}
+`

--- a/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/scaffold.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/scaffold.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffold
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"fmt"
+
+	"log"
+
+	"io/ioutil"
+
+	"bytes"
+
+	"golang.org/x/tools/imports"
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+// Scaffold writes Templates to scaffold new files
+type Scaffold struct {
+	// BoilerplatePath is the path to the boilerplate file
+	BoilerplatePath string
+
+	// Boilerplate is the contents of the boilerplate file for code generation
+	Boilerplate string
+
+	BoilerplateOptional bool
+
+	// Project is the project
+	Project input.ProjectFile
+
+	ProjectOptional bool
+
+	// ProjectPath is the relative path to the project root
+	ProjectPath string
+
+	GetWriter func(path string) (io.Writer, error)
+}
+
+func (s *Scaffold) setFieldsAndValidate(t input.File) error {
+	// Set boilerplate on templates
+	if b, ok := t.(input.BoilerplatePath); ok {
+		b.SetBoilerplatePath(s.BoilerplatePath)
+	}
+	if b, ok := t.(input.Boilerplate); ok {
+		b.SetBoilerplate(s.Boilerplate)
+	}
+	if b, ok := t.(input.Domain); ok {
+		b.SetDomain(s.Project.Domain)
+	}
+	if b, ok := t.(input.Version); ok {
+		b.SetVersion(s.Project.Version)
+	}
+	if b, ok := t.(input.Repo); ok {
+		b.SetRepo(s.Project.Repo)
+	}
+	if b, ok := t.(input.ProjecPath); ok {
+		b.SetProjectPath(s.ProjectPath)
+	}
+
+	// Validate the template is ok
+	if v, ok := t.(input.Validate); ok {
+		if err := v.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetProject reads the project file and deserializes it into a Project
+func getProject(path string) (input.ProjectFile, error) {
+	in, err := ioutil.ReadFile(path)
+	if err != nil {
+		return input.ProjectFile{}, err
+	}
+	p := input.ProjectFile{}
+	err = yaml.Unmarshal(in, &p)
+	if err != nil {
+		return input.ProjectFile{}, err
+	}
+	return p, nil
+}
+
+// GetBoilerplate reads the boilerplate file
+func getBoilerplate(path string) (string, error) {
+	b, err := ioutil.ReadFile(path)
+	return string(b), err
+}
+
+func (s *Scaffold) defaultOptions(options *input.Options) error {
+	// Use the default Boilerplate path if unset
+	if options.BoilerplatePath == "" {
+		options.BoilerplatePath = filepath.Join("hack", "boilerplate.go.txt")
+	}
+
+	// Use the default Project path if unset
+	if options.ProjectPath == "" {
+		options.ProjectPath = "PROJECT"
+	}
+
+	s.BoilerplatePath = options.BoilerplatePath
+
+	var err error
+	s.Boilerplate, err = getBoilerplate(options.BoilerplatePath)
+	if !s.BoilerplateOptional && err != nil {
+		return err
+	}
+
+	s.Project, err = getProject(options.ProjectPath)
+	if !s.ProjectOptional && err != nil {
+		return err
+	}
+	return nil
+}
+
+// Execute executes scaffolding the Files
+func (s *Scaffold) Execute(options input.Options, files ...input.File) error {
+	if s.GetWriter == nil {
+		s.GetWriter = newWriteCloser
+	}
+
+	if err := s.defaultOptions(&options); err != nil {
+		return err
+	}
+	for _, f := range files {
+		if err := s.doFile(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// doFile scaffolds a single file
+func (s *Scaffold) doFile(e input.File) error {
+	// Set common fields
+	err := s.setFieldsAndValidate(e)
+	if err != nil {
+		return err
+	}
+
+	// Get the template input params
+	i, err := e.GetInput()
+	if err != nil {
+		return err
+	}
+
+	// Check if the file to write already exists
+	if _, err := os.Stat(i.Path); err == nil {
+		switch i.IfExistsAction {
+		case input.Overwrite:
+		case input.Skip:
+			return nil
+		case input.Error:
+			return fmt.Errorf("%s already exists", i.Path)
+		}
+	}
+
+	if err := s.doTemplate(i, e); err != nil {
+		return err
+	}
+	return nil
+}
+
+// doTemplate executes the template for a file using the input
+func (s *Scaffold) doTemplate(i input.Input, e input.File) error {
+	temp, err := newTemplate(e).Parse(i.TemplateBody)
+	if err != nil {
+		return err
+	}
+	f, err := s.GetWriter(i.Path)
+	if err != nil {
+		return err
+	}
+	if c, ok := f.(io.Closer); ok {
+		defer func() {
+			if err := c.Close(); err != nil {
+				log.Fatal(err)
+			}
+		}()
+	}
+
+	out := &bytes.Buffer{}
+	err = temp.Execute(out, e)
+	if err != nil {
+		return err
+	}
+	b := out.Bytes()
+
+	// gofmt the imports
+	if filepath.Ext(i.Path) == ".go" {
+		b, err = imports.Process(i.Path, b, nil)
+		if err != nil {
+			fmt.Printf("%s\n", out.Bytes())
+			return err
+		}
+	}
+
+	_, err = f.Write(b)
+	return err
+}
+
+// newWriteCloser returns a WriteCloser to write scaffold to
+func newWriteCloser(path string) (io.Writer, error) {
+	dir := filepath.Dir(path)
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	return fi, nil
+}
+
+// newTemplate a new template with common functions
+func newTemplate(t input.File) *template.Template {
+	return template.New(fmt.Sprintf("%T", t)).Funcs(template.FuncMap{
+		"title": strings.Title,
+		"lower": strings.ToLower,
+	})
+}


### PR DESCRIPTION
A follow on to #269 
Adds support for generating a CRD definition that includes a declaration of the scale resource, triggered by the presence of the +kubebuilder:subresource:scale tag.

This is needed to leverage CRD scale subresources in projects created by kubebuilder