### PR TITLE
changed book.kubebuilder.com to book.kubebuilder.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the Kubebuilder [book](http://book.kubebuilder.io).
 
 ## Resources
 
-- GitBook: [book.kubebuilder.com](http://book.kubebuilder.io)
+- GitBook: [book.kubebuilder.io](http://book.kubebuilder.io)
 - GitHub Repo: [kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
 - Slack channel: [#kubebuilder](http://slack.k8s.io/#kubebuilder)
 - Google Group: [kubebuilder@googlegroups.com](https://groups.google.com/forum/#!forum/kubebuilder)


### PR DESCRIPTION
the link worked, but the text over the link was wrong and caused a 404 on my mobile phone