### PR TITLE
improve contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,10 @@
 ## Sign the CLA
 
 Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests.
-Please see https://git.k8s.io/community/CLA.md for more info
 
-### Contributing A Patch
+Please see https://git.k8s.io/community/CLA.md for more info.
+
+## Contributing steps
 
 1. Submit an issue describing your proposed change to the repo in question.
 1. The [repo owners](OWNERS) will respond to your issue promptly.
@@ -15,31 +16,29 @@ Please see https://git.k8s.io/community/CLA.md for more info
 
 ## How to build kubebuilder locally
 
-Setup:
+1. Setup tools
+    1. Download and setup [gcloud](https://cloud.google.com/sdk/docs/downloads-interactive) 
+    1. Install `cloud-build-local` via `gcloud` 
+        ```bash
+        $ gcloud install cloud-build-local
+        ```
+1. Build
+    1. Export `OUTPUT` to a location to write the directory containing the final build artifacts
+        ```sh
+        $ export OUTPUT=/tmp/kubebuilder
+        ```
+    2. Run container-builder:
+        ```sh
+        $ cloud-build-local --config=build/cloudbuild_local.yaml --dryrun=false \
+          --write-workspace=$OUTPUT .
+        ```
+    1. Extract `tar.gz` from $OUTPUT to /usr/local
+1. Test
+    ```sh
+    go test ./pkg/...
+    ```
 
-- Download [google container builder](https://cloud.google.com/container-builder/docs/build-debug-locally)
-- Export `OUTPUT` to a location to write the directory containing the final build artifacts
-
-```sh
-export OUTPUT=/tmp/kubebuilder
-```
-
-Run container-builder:
-
-```sh
-container-builder-local --config=build/cloudbuild_local.yaml --dryrun=false \
-  --write-workspace=$OUTPUT .
-```
-
-Extract `tar.gz` from $OUTPUT to /usr/local
-
-## Running kubebuilder tests
-
-```sh
-go test ./pkg/...
-```
-
-## Community, discussion, contribution, and support
+## Community, discussion and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
 
@@ -48,8 +47,6 @@ You can reach the maintainers of this project at:
 - [Slack](http://slack.k8s.io/)
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-kubebuilder)
 
-### Code of conduct
+## Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
-
-[google container builder]: https://github.com/kubernetes-sigs/container-builder-local


### PR DESCRIPTION
Improve https://github.com/kubernetes-sigs/kubebuilder/issues/350

1. use `cloud-build-local` instead of `container-builder-local` (deprecated).
1. clarify setup tools step.
1. refine some words/sections

Thanks for reivew.