### PR TITLE
Fix URL for the Gitbook

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -39,7 +39,7 @@ Including:
 
 ## Resources
 
-GitBook: [book.kubebuilder.com](http://book.kubebuilder.com)
+GitBook: [book.kubebuilder.io](http://book.kubebuilder.io)
 GitHub Repo: [kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
 Slack channel: [#kubeuilder](http://slack.k8s.io/#kubebuilder)
 Google Group: [kubebuilder@googlegroups.com](https://groups.google.com/forum/#!forum/kubebuilder)


### PR DESCRIPTION
The URL is .io, not .com