### PR TITLE
deepcopy-gen sets an output base

### DIFF
--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/apis.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/apis.go
@@ -18,6 +18,7 @@ package manager
 
 import (
 	"fmt"
+	"go/build"
 	"path/filepath"
 	"strings"
 
@@ -38,6 +39,7 @@ var deepCopy = strings.Join([]string{
 	"//go:generate go run",
 	"../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go",
 	"-O zz_generated.deepcopy",
+	"-o", build.Default.GOPATH,
 	"-i ./..."}, " ")
 
 // GetInput implements input.File


### PR DESCRIPTION
When there is no GOPATH, deepcopy-gen must set the output base. Use the
build package to determine what the appropriate GOPATH is regardless.

Fixes #359