### PR TITLE
wip: adding alpha command for webhook scaffolding

### DIFF
--- a/cmd/Gopkg.lock
+++ b/cmd/Gopkg.lock
@@ -256,7 +256,7 @@
   revision = "fdcf9f9480fdd5bf2b3c3df9bf4ecd22b25b87e2"
 
 [[projects]]
-  digest = "1:384789cb768e13fec37c3a15613e21cde8d32ff945d8d4ec4bcef87a2ee41ff4"
+  digest = "1:3dd9fd3c03ed863564e0abf62ed9927d51c1607684c80ee033c7deb8b02efcfc"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "pkg/scaffold",
@@ -265,11 +265,12 @@
     "pkg/scaffold/manager",
     "pkg/scaffold/project",
     "pkg/scaffold/resource",
+    "pkg/scaffold/webhook",
     "pkg/util",
   ]
   pruneopts = "NT"
-  revision = "bfd3eefb7f22ed714b2acd38730c36992ee6af70"
-  version = "v0.1.5"
+  revision = "38b2f3f497ed6b8ea5d2844ecf00c28ac4b5c2c4"
+  version = "v0.1.6"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -303,6 +304,7 @@
     "sigs.k8s.io/controller-tools/pkg/scaffold/manager",
     "sigs.k8s.io/controller-tools/pkg/scaffold/project",
     "sigs.k8s.io/controller-tools/pkg/scaffold/resource",
+    "sigs.k8s.io/controller-tools/pkg/scaffold/webhook",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/kubebuilder/v1/commands.go
+++ b/cmd/kubebuilder/v1/commands.go
@@ -24,6 +24,7 @@ func AddCmds(cmd *cobra.Command) {
 	AddAPICommand(cmd)
 	cmd.AddCommand(vendorUpdateCmd())
 	cmd.AddCommand(docsCmd())
+	cmd.AddCommand(newAlphaCommand())
 
 	cmd.Example = `# Initialize your project
     kubebuilder init --domain example.com --license apache2 --owner "The Kubernetes authors"
@@ -68,4 +69,23 @@ the schema for a Resource without writing a Controller, select "n" for Controlle
 
 After the scaffold is written, api will run make on the project.
 	`
+}
+
+// newAlphaCommand returns alpha subcommand which will be mounted
+// at the root command by the caller.
+func newAlphaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alpha",
+		Short: "Exposes commands which are in experimental or early stages of development",
+		Long:  `Command group for commands which are either experimental or in early stages of development`,
+		Example: `
+# scaffolds webhook server
+kubebuilder alpha webhook <params>
+`,
+	}
+
+	cmd.AddCommand(
+		newWebhookCmd(),
+	)
+	return cmd
 }

--- a/cmd/kubebuilder/v1/webhook.go
+++ b/cmd/kubebuilder/v1/webhook.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-tools/pkg/scaffold"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/webhook"
+)
+
+func newWebhookCmd() *cobra.Command {
+	o := webhookOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "webhook",
+		Short:   "Scaffold a webhook server",
+		Long:    `Scaffold a webhook server`,
+		Example: `webhook example: TBD`,
+		Run: func(cmd *cobra.Command, args []string) {
+			dieIfNoProject()
+
+			fmt.Println("Writing scaffold for you to edit...")
+
+			if len(o.res.Resource) == 0 {
+				gvr, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{
+					Group: o.res.Group, Version: o.res.Version, Kind: o.res.Kind})
+				o.res.Resource = gvr.Resource
+			}
+
+			err := (&scaffold.Scaffold{}).Execute(input.Options{},
+				&webhook.AdmissionHandler{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.AdmissionWebhookBuilder{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.AdmissionWebhooks{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.AddAdmissionWebhookBuilderHandler{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.Server{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.AddServer{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+			)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			if o.doMake {
+				fmt.Println("Running make...")
+				cm := exec.Command("make") // #nosec
+				cm.Stderr = os.Stderr
+				cm.Stdout = os.Stdout
+				if err := cm.Run(); err != nil {
+					log.Fatal(err)
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVar(&o.server, "server", "default",
+		"name of the server")
+	cmd.Flags().StringVar(&o.webhookType, "type", "",
+		"webhook type, e.g. mutating or validating")
+	cmd.Flags().StringSliceVar(&o.operations, "operations", []string{"create"},
+		"the operations that the webhook will intercept, e.g. create, update, delete and connect")
+	cmd.Flags().BoolVar(&o.doMake, "make", true,
+		"if true, run make after generating files")
+	o.res = gvkForFlags(cmd.Flags())
+	return cmd
+}
+
+// webhookOptions represents commandline options for scaffolding a webhook.
+type webhookOptions struct {
+	res         *resource.Resource
+	operations  []string
+	server      string
+	webhookType string
+	doMake      bool
+}
+
+// gvkForFlags registers flags for Resource fields and returns the Resource
+func gvkForFlags(f *flag.FlagSet) *resource.Resource {
+	r := &resource.Resource{}
+	f.StringVar(&r.Group, "group", "", "resource Group")
+	f.StringVar(&r.Version, "version", "", "resource Version")
+	f.StringVar(&r.Kind, "kind", "", "resource Kind")
+	f.StringVar(&r.Resource, "resource", "", "resource Resource")
+	return r
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/cmd/controller-scaffold/cmd/project.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/cmd/controller-scaffold/cmd/project.go
@@ -91,6 +91,7 @@ controller-scaffold project --domain k8s.io --license apache2 --owner "The Kuber
 			dkr,
 			&manager.APIs{},
 			&manager.Controller{},
+			&manager.Webhook{},
 			&manager.Config{Image: imgName},
 			&project.GitIgnore{},
 			&project.Kustomize{},

--- a/cmd/vendor/sigs.k8s.io/controller-tools/cmd/controller-scaffold/cmd/webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/cmd/controller-scaffold/cmd/webhook.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-tools/pkg/scaffold"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/webhook"
+)
+
+var res *resource.Resource
+var operations []string
+var server string
+var webhookType string
+
+// WebhookCmd represents the webhook command
+var WebhookCmd = &cobra.Command{
+	Use:     "webhook",
+	Short:   "Scaffold a webhook server",
+	Long:    `Scaffold a webhook server`,
+	Example: `webhook example: TBD`,
+	Run: func(cmd *cobra.Command, args []string) {
+		DieIfNoProject()
+
+		fmt.Println("Writing scaffold for you to edit...")
+
+		if len(res.Resource) == 0 {
+			gvr, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{
+				Group: res.Group, Version: res.Version, Kind: res.Kind})
+			res.Resource = gvr.Resource
+		}
+
+		err := (&scaffold.Scaffold{}).Execute(input.Options{},
+			&webhook.AdmissionHandler{Resource: res, Config: webhook.Config{Server: server, Type: webhookType, Operations: operations}},
+			&webhook.AdmissionWebhookBuilder{Resource: res, Config: webhook.Config{Server: server, Type: webhookType, Operations: operations}},
+			&webhook.AdmissionWebhooks{Resource: res, Config: webhook.Config{Server: server, Type: webhookType, Operations: operations}},
+			&webhook.AddAdmissionWebhookBuilderHandler{Resource: res, Config: webhook.Config{Server: server, Type: webhookType, Operations: operations}},
+			&webhook.Server{Resource: res, Config: webhook.Config{Server: server, Type: webhookType, Operations: operations}},
+			&webhook.AddServer{Resource: res, Config: webhook.Config{Server: server, Type: webhookType, Operations: operations}},
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if doMake {
+			fmt.Println("Running make...")
+			cm := exec.Command("make") // #nosec
+			cm.Stderr = os.Stderr
+			cm.Stdout = os.Stdout
+			if err := cm.Run(); err != nil {
+				log.Fatal(err)
+			}
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(WebhookCmd)
+	WebhookCmd.Flags().StringVar(&server, "server", "default",
+		"name of the server")
+	WebhookCmd.Flags().StringVar(&webhookType, "type", "",
+		"webhook type, e.g. mutating or validating")
+	WebhookCmd.Flags().StringSliceVar(&operations, "operations", []string{"create"},
+		"the operations that the webhook will intercept, e.g. create, update, delete and connect")
+	WebhookCmd.Flags().BoolVar(&doMake, "make", true,
+		"if true, run make after generating files")
+	res = gvkForFlags(WebhookCmd.Flags())
+}
+
+// gvkForFlags registers flags for Resource fields and returns the Resource
+func gvkForFlags(f *flag.FlagSet) *resource.Resource {
+	r := &resource.Resource{}
+	f.StringVar(&r.Group, "group", "", "resource Group")
+	f.StringVar(&r.Version, "version", "", "resource Version")
+	f.StringVar(&r.Kind, "kind", "", "resource Kind")
+	f.StringVar(&r.Resource, "resource", "", "resource Resource")
+	return r
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/cmd.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/cmd.go
@@ -43,44 +43,66 @@ var cmdTemplate = `{{ .Boilerplate }}
 package main
 
 import (
-	"log"
+	"flag"
+	"os"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 	"{{ .Repo }}/pkg/apis"
 	"{{ .Repo }}/pkg/controller"
+	"{{ .Repo }}/pkg/webhook"
 )
 
 func main() {
+	logf.SetLogger(logf.ZapLogger(false))
+	log := logf.Log.WithName("entrypoint")
+
 	// Get a config to talk to the apiserver
+	log.Info("setting up client for manager")
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable to set up client config")
+		os.Exit(1)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
+	log.Info("setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable to set up overall controller manager")
+		os.Exit(1)
 	}
 
-	log.Printf("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
+	log.Info("setting up scheme")
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable add APIs to scheme")
+		os.Exit(1)
 	}
 
 	// Setup all Controllers
+	log.Info("Setting up controller")
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable to register controllers to the manager")
+		os.Exit(1)
 	}
 
-	log.Printf("Starting the Cmd.")
+	log.Info("setting up webhooks")
+	if err := webhook.AddToManager(mgr); err != nil {
+		log.Error(err, "unable to register webhooks to the manager")
+		os.Exit(1)
+	}
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	log.Info("Starting the Cmd.")
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "unable to run the manager")
+		os.Exit(1)
+	}
 }
 `

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/config.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/config.go
@@ -86,7 +86,15 @@ spec:
       - command:
         - /root/manager
         image: {{ .Image }}
+        imagePullPolicy: Always
         name: manager
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SECRET_NAME
+            value: $(WEBHOOK_SECRET_NAME)
         resources:
           limits:
             cpu: 100m
@@ -94,5 +102,24 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-secret
+  namespace: system
 `

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/manager/webhook.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+)
+
+var _ input.File = &Webhook{}
+
+// Webhook scaffolds a webhook.go to add webhook server(s) to a manager.Cmd
+type Webhook struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *Webhook) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = filepath.Join("pkg", "webhook", "webhook.go")
+	}
+	c.TemplateBody = webhookTemplate
+	return c.Input, nil
+}
+
+var webhookTemplate = `{{ .Boilerplate }}
+
+package webhook
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// AddToManagerFuncs is a list of functions to add all Controllers to the Manager
+var AddToManagerFuncs []func(manager.Manager) error
+
+// AddToManager adds all Controllers to the Manager
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+func AddToManager(m manager.Manager) error {
+	for _, f := range AddToManagerFuncs {
+		if err := f(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/kustomize.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/project/kustomize.go
@@ -77,4 +77,11 @@ resources:
 
 patches:
 - manager_image_patch.yaml
+
+vars:
+- name: WEBHOOK_SECRET_NAME
+  objref:
+    kind: Secret
+    name: webhook-server-secret
+    apiVersion: v1
 `

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/add_admissionbuilder_handler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/add_admissionbuilder_handler.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &AddAdmissionWebhookBuilderHandler{}
+
+// AddAdmissionWebhookBuilderHandler scaffolds adds a new admission webhook builder.
+type AddAdmissionWebhookBuilderHandler struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	Config
+}
+
+// GetInput implements input.File
+func (a *AddAdmissionWebhookBuilderHandler) GetInput() (input.Input, error) {
+	a.Server = strings.ToLower(a.Server)
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", a.Server),
+			fmt.Sprintf("add_%s_%s.go", a.Type, strings.ToLower(a.Resource.Kind)))
+	}
+	a.TemplateBody = addAdmissionWebhookBuilderHandlerTemplate
+	return a.Input, nil
+}
+
+var addAdmissionWebhookBuilderHandlerTemplate = `{{ .Boilerplate }}
+
+package {{ .Server }}server
+
+import (
+	"fmt"
+
+	"{{ .Repo }}/pkg/webhook/{{ .Server }}_server/{{ .Resource.Resource }}/{{ .Type }}"
+)
+
+func init() {
+	for k, v := range {{ .Type }}.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range {{ .Type }}.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/add_server.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/add_server.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &AddServer{}
+
+// AddServer scaffolds adds a new webhook server.
+type AddServer struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	Config
+}
+
+// GetInput implements input.File
+func (a *AddServer) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("add_%s_server.go", a.Server))
+	}
+	a.TemplateBody = addServerTemplate
+	return a.Input, nil
+}
+
+var addServerTemplate = `{{ .Boilerplate }}
+
+package webhook
+
+import (
+	server "{{ .Repo }}/pkg/webhook/{{ .Server }}_server"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create webhook servers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, server.Add)
+}
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/admissionbuilder.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/admissionbuilder.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &AdmissionWebhookBuilder{}
+
+// AdmissionWebhookBuilder scaffolds adds a new webhook server.
+type AdmissionWebhookBuilder struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	// ResourcePackage is the package of the Resource
+	ResourcePackage string
+
+	// GroupDomain is the Group + "." + Domain for the Resource
+	GroupDomain string
+
+	Config
+
+	BuilderName string
+
+	OperationsParameterString string
+
+	Mutating bool
+}
+
+// GetInput implements input.File
+func (a *AdmissionWebhookBuilder) GetInput() (input.Input, error) {
+	a.ResourcePackage, a.GroupDomain = getResourceInfo(coreGroups, a.Resource, a.Input)
+
+	if a.Type == "mutating" {
+		a.Mutating = true
+	}
+	a.Type = strings.ToLower(a.Type)
+	a.BuilderName = builderName(a.Config, a.Resource.Resource)
+	ops := make([]string, len(a.Operations))
+	for i, op := range a.Operations {
+		ops[i] = "admissionregistrationv1beta1." + strings.Title(op)
+	}
+	a.OperationsParameterString = strings.Join(ops, ", ")
+
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", a.Server),
+			a.Resource.Resource,
+			a.Type,
+			fmt.Sprintf("%s_webhook.go", strings.Join(a.Operations, "_")))
+	}
+	a.TemplateBody = admissionWebhookBuilderTemplate
+	return a.Input, nil
+}
+
+var admissionWebhookBuilderTemplate = `{{ .Boilerplate }}
+
+package {{ .Type }}
+
+import (
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+func init() {
+	builderName := "{{ .BuilderName }}"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName + ".{{ .Domain }}").
+		Path("/" + builderName).
+{{ if .Mutating }}	Mutating().
+{{ else }}	Validating().
+{{ end }}
+		Operations({{ .OperationsParameterString }}).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{})
+}
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/admissionhandler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/admissionhandler.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &AddAdmissionWebhookBuilderHandler{}
+
+// AdmissionHandler scaffolds an admission handler
+type AdmissionHandler struct {
+	input.Input
+
+	// ResourcePackage is the package of the Resource
+	ResourcePackage string
+
+	// GroupDomain is the Group + "." + Domain for the Resource
+	GroupDomain string
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	Config
+
+	BuilderName string
+
+	OperationsString string
+
+	Mutate bool
+}
+
+// GetInput implements input.File
+func (a *AdmissionHandler) GetInput() (input.Input, error) {
+	a.ResourcePackage, a.GroupDomain = getResourceInfo(coreGroups, a.Resource, a.Input)
+	a.Type = strings.ToLower(a.Type)
+	if a.Type == "mutating" {
+		a.Mutate = true
+	}
+	a.BuilderName = builderName(a.Config, a.Resource.Resource)
+	ops := make([]string, len(a.Operations))
+	for i, op := range a.Operations {
+		ops[i] = strings.Title(op)
+	}
+	a.OperationsString = strings.Join(ops, "")
+
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", a.Server),
+			a.Resource.Resource,
+			a.Type,
+			fmt.Sprintf("%s_%s_handler.go", a.Resource.Resource, strings.Join(a.Operations, "_")))
+	}
+	a.TemplateBody = addAdmissionHandlerTemplate
+	return a.Input, nil
+}
+
+var addAdmissionHandlerTemplate = `{{ .Boilerplate }}
+
+package {{ .Type }}
+
+import (
+	"context"
+	"net/http"
+
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+func init() {
+	webhookName := "{{ .BuilderName }}"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &{{ .Resource.Kind }}{{ .OperationsString }}Handler{})
+}
+
+// {{ .Resource.Kind }}{{ .OperationsString }}Handler handles {{ .Resource.Kind }}
+type {{ .Resource.Kind }}{{ .OperationsString }}Handler struct {
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+{{ if .Mutate }}
+func (h *{{ .Resource.Kind }}{{ .OperationsString }}Handler) {{ .Type }}{{ .Resource.Kind }}Fn(ctx context.Context, obj *{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}) error {
+	// TODO(user): implement your admission logic
+	return nil
+}
+{{ else }}
+func (h *{{ .Resource.Kind }}{{ .OperationsString }}Handler) {{ .Type }}{{ .Resource.Kind }}Fn(ctx context.Context, obj *{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}) (bool, string, error) {
+	// TODO(user): implement your admission logic
+	return true, "allowed to be admitted", nil
+}
+{{ end }}
+var _ admission.Handler = &{{ .Resource.Kind }}{{ .OperationsString }}Handler{}
+{{ if .Mutate }}
+// Handle handles admission requests.
+func (h *{{ .Resource.Kind }}{{ .OperationsString }}Handler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	copy := obj.DeepCopy()
+
+	err = h.{{ .Type }}{{ .Resource.Kind }}Fn(ctx, copy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(obj, copy)
+}
+{{ else }}
+// Handle handles admission requests.
+func (h *{{ .Resource.Kind }}{{ .OperationsString }}Handler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := h.{{ .Type }}{{ .Resource.Kind }}Fn(ctx, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+{{ end }}
+//var _ inject.Client = &{{ .Resource.Kind }}{{ .OperationsString }}Handler{}
+//
+//// InjectClient injects the client into the {{ .Resource.Kind }}{{ .OperationsString }}Handler
+//func (h *{{ .Resource.Kind }}{{ .OperationsString }}Handler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &{{ .Resource.Kind }}{{ .OperationsString }}Handler{}
+
+// InjectDecoder injects the decoder into the {{ .Resource.Kind }}{{ .OperationsString }}Handler
+func (h *{{ .Resource.Kind }}{{ .OperationsString }}Handler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/admissionwebhooks.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/admissionwebhooks.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &Server{}
+
+// AdmissionWebhooks scaffolds how to construct a webhook server and register webhooks.
+type AdmissionWebhooks struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	Config
+}
+
+// GetInput implements input.File
+func (a *AdmissionWebhooks) GetInput() (input.Input, error) {
+	a.Server = strings.ToLower(a.Server)
+	a.Type = strings.ToLower(a.Type)
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", a.Server),
+			strings.ToLower(a.Resource.Resource),
+			a.Type, "webhooks.go")
+	}
+	a.TemplateBody = webhooksTemplate
+	return a.Input, nil
+}
+
+var webhooksTemplate = `{{ .Boilerplate }}
+
+package {{ .Type }}
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/config.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/config.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+// Config contains the information required to scaffold files for a webhook.
+type Config struct {
+	// Server is the name of the server.
+	Server string
+	// Type is the type of the webhook.
+	Type string
+	// Operations that the webhook will intercept, e.g. create, update, delete, connect
+	Operations []string
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/server.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/server.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+var _ input.File = &Server{}
+
+// Server scaffolds how to construct a webhook server and register webhooks.
+type Server struct {
+	input.Input
+
+	// Resource is a resource in the API group
+	Resource *resource.Resource
+
+	Config
+}
+
+// GetInput implements input.File
+func (a *Server) GetInput() (input.Input, error) {
+	if a.Path == "" {
+		a.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("%s_server", a.Server), "server.go")
+	}
+	a.TemplateBody = serverTemplate
+	return a.Input, nil
+}
+
+var serverTemplate = `{{ .Boilerplate }}
+
+package {{ .Server }}server
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	log        = logf.Log.WithName("{{ .Server }}_server")
+	builderMap = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains all admission webhook handlers.
+	HandlerMap = map[string][]admission.Handler{}
+)
+
+// Add adds itself to the manager
+func Add(mgr manager.Manager) error {
+	ns := os.Getenv("POD_NAMESPACE")
+	if len(ns) == 0 {
+		ns = "default"
+	}
+	secretName := os.Getenv("SECRET_NAME")
+	if len(secretName) == 0 {
+		secretName = "webhook-server-secret"
+	}
+
+	svr, err := webhook.NewServer("foo-admission-server", mgr, webhook.ServerOptions{
+		// TODO(user): change the configuration of ServerOptions based on your need.
+		Port:    9876,
+		CertDir: "/tmp/cert",
+		BootstrapOptions: &webhook.BootstrapOptions{
+			Secret: &types.NamespacedName{
+				Namespace: ns,
+				Name:      secretName,
+			},
+
+			Service: &webhook.Service{
+				Namespace: ns,
+				Name:      "webhook-server-service",
+				// Selectors should select the pods that runs this webhook server.
+				Selectors: map[string]string{
+					"control-plane": "controller-manager",
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	var webhooks []webhook.Webhook
+	for k, builder := range builderMap {
+		handlers, ok := HandlerMap[k]
+		if !ok {
+			log.V(1).Info(fmt.Sprintf("can't find handlers for builder: %v", k))
+			handlers = []admission.Handler{}
+		}
+		wh, err := builder.
+			Handlers(handlers...).
+			WithManager(mgr).
+			Build()
+		if err != nil {
+			return err
+		}
+		webhooks = append(webhooks, wh)
+	}
+
+	return svr.Register(webhooks...)
+}
+`

--- a/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/util.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/pkg/scaffold/webhook/util.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-tools/pkg/scaffold/input"
+	"sigs.k8s.io/controller-tools/pkg/scaffold/resource"
+)
+
+// Use the k8s.io/api package for core resources
+var coreGroups = map[string]string{
+	"apps":                  "",
+	"admissionregistration": "k8s.io",
+	"apiextensions":         "k8s.io",
+	"authentication":        "k8s.io",
+	"autoscaling":           "",
+	"batch":                 "",
+	"certificates":          "k8s.io",
+	"core":                  "",
+	"extensions":            "",
+	"metrics":               "k8s.io",
+	"policy":                "",
+	"rbac.authorization":    "k8s.io",
+	"storage":               "k8s.io",
+}
+
+func builderName(config Config, resource string) string {
+	opsStr := strings.Join(config.Operations, "-")
+	return fmt.Sprintf("%s-%s-%s", config.Type, opsStr, resource)
+}
+
+func getResourceInfo(coreGroups map[string]string, r *resource.Resource, in input.Input) (resourcePackage, groupDomain string) {
+	resourcePath := filepath.Join("pkg", "apis", r.Group, r.Version,
+		fmt.Sprintf("%s_types.go", strings.ToLower(r.Kind)))
+	if _, err := os.Stat(resourcePath); os.IsNotExist(err) {
+		if domain, found := coreGroups[r.Group]; found {
+			resourcePackage := path.Join("k8s.io", "api")
+			groupDomain = r.Group
+			if domain != "" {
+				groupDomain = r.Group + "." + domain
+			}
+			return resourcePackage, groupDomain
+		}
+		// TODO: need to support '--resource-pkg-path' flag for specifying resourcePath
+	}
+	return path.Join(in.Repo, "pkg", "apis"), r.Group + "." + in.Domain
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/cmd/manager/main.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/cmd/manager/main.go
@@ -17,43 +17,64 @@ limitations under the License.
 package main
 
 import (
-	"log"
+	"os"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 	"sigs.k8s.io/controller-tools/test/pkg/apis"
 	"sigs.k8s.io/controller-tools/test/pkg/controller"
+	"sigs.k8s.io/controller-tools/test/pkg/webhook"
 )
 
 func main() {
+	logf.SetLogger(logf.ZapLogger(false))
+	log := logf.Log.WithName("entrypoint")
+
 	// Get a config to talk to the apiserver
+	log.Info("setting up client for manager")
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable to set up client config")
+		os.Exit(1)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
+	log.Info("setting up manager")
 	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable to set up overall controller manager")
+		os.Exit(1)
 	}
 
-	log.Printf("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
+	log.Info("setting up scheme")
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable add APIs to scheme")
+		os.Exit(1)
 	}
 
 	// Setup all Controllers
+	log.Info("Setting up controller")
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Fatal(err)
+		log.Error(err, "unable to register controllers to the manager")
+		os.Exit(1)
 	}
 
-	log.Printf("Starting the Cmd.")
+	log.Info("setting up webhooks")
+	if err := webhook.AddToManager(mgr); err != nil {
+		log.Error(err, "unable to register webhooks to the manager")
+		os.Exit(1)
+	}
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	log.Info("Starting the Cmd.")
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "unable to run the manager")
+		os.Exit(1)
+	}
 }

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/add_default_server.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/add_default_server.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	server "sigs.k8s.io/controller-tools/test/pkg/webhook/default_server"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create webhook servers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, server.Add)
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_mutating_firstmate.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_mutating_firstmate.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating"
+)
+
+func init() {
+	for k, v := range mutating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range mutating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_mutating_namespace.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_mutating_namespace.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating"
+)
+
+func init() {
+	for k, v := range mutating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range mutating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_validating_frigate.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_validating_frigate.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating"
+)
+
+func init() {
+	for k, v := range validating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range validating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_validating_kraken.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/add_validating_kraken.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating"
+)
+
+func init() {
+	for k, v := range validating.Builders {
+		_, found := builderMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in builder map: %v", k))
+		}
+		builderMap[k] = v
+	}
+	for k, v := range validating.HandlerMap {
+		_, found := HandlerMap[k]
+		if found {
+			log.V(1).Info(fmt.Sprintf(
+				"conflicting webhook builder names in handler map: %v", k))
+		}
+		_, found = builderMap[k]
+		if !found {
+			log.V(1).Info(fmt.Sprintf(
+				"can't find webhook builder name %q in builder map", k))
+			continue
+		}
+		HandlerMap[k] = v
+	}
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/create_update_webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/create_update_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	crewv1 "sigs.k8s.io/controller-tools/test/pkg/apis/crew/v1"
+)
+
+func init() {
+	builderName := "mutating-create-update-firstmates"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName+".testproject.org").
+		Path("/"+builderName).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&crewv1.FirstMate{})
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/delete_webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/delete_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	crewv1 "sigs.k8s.io/controller-tools/test/pkg/apis/crew/v1"
+)
+
+func init() {
+	builderName := "mutating-delete-firstmates"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName + ".testproject.org").
+		Path("/" + builderName).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Delete).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&crewv1.FirstMate{})
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/firstmates_create_update_handler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/firstmates_create_update_handler.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+	crewv1 "sigs.k8s.io/controller-tools/test/pkg/apis/crew/v1"
+)
+
+func init() {
+	webhookName := "mutating-create-update-firstmates"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &FirstMateCreateUpdateHandler{})
+}
+
+// FirstMateCreateUpdateHandler handles FirstMate
+type FirstMateCreateUpdateHandler struct {
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *FirstMateCreateUpdateHandler) mutatingFirstMateFn(ctx context.Context, obj *crewv1.FirstMate) error {
+	// TODO(user): implement your admission logic
+	return nil
+}
+
+var _ admission.Handler = &FirstMateCreateUpdateHandler{}
+
+// Handle handles admission requests.
+func (h *FirstMateCreateUpdateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &crewv1.FirstMate{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	copy := obj.DeepCopy()
+
+	err = h.mutatingFirstMateFn(ctx, copy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(obj, copy)
+}
+
+//var _ inject.Client = &FirstMateCreateUpdateHandler{}
+//
+//// InjectClient injects the client into the FirstMateCreateUpdateHandler
+//func (h *FirstMateCreateUpdateHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &FirstMateCreateUpdateHandler{}
+
+// InjectDecoder injects the decoder into the FirstMateCreateUpdateHandler
+func (h *FirstMateCreateUpdateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/firstmates_delete_handler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/firstmates_delete_handler.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+	crewv1 "sigs.k8s.io/controller-tools/test/pkg/apis/crew/v1"
+)
+
+func init() {
+	webhookName := "mutating-delete-firstmates"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &FirstMateDeleteHandler{})
+}
+
+// FirstMateDeleteHandler handles FirstMate
+type FirstMateDeleteHandler struct {
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *FirstMateDeleteHandler) mutatingFirstMateFn(ctx context.Context, obj *crewv1.FirstMate) error {
+	// TODO(user): implement your admission logic
+	return nil
+}
+
+var _ admission.Handler = &FirstMateDeleteHandler{}
+
+// Handle handles admission requests.
+func (h *FirstMateDeleteHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &crewv1.FirstMate{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	copy := obj.DeepCopy()
+
+	err = h.mutatingFirstMateFn(ctx, copy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(obj, copy)
+}
+
+//var _ inject.Client = &FirstMateDeleteHandler{}
+//
+//// InjectClient injects the client into the FirstMateDeleteHandler
+//func (h *FirstMateDeleteHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &FirstMateDeleteHandler{}
+
+// InjectDecoder injects the decoder into the FirstMateDeleteHandler
+func (h *FirstMateDeleteHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/webhooks.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/firstmates/mutating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating/frigates_update_handler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating/frigates_update_handler.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+	shipv1beta1 "sigs.k8s.io/controller-tools/test/pkg/apis/ship/v1beta1"
+)
+
+func init() {
+	webhookName := "validating-update-frigates"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &FrigateUpdateHandler{})
+}
+
+// FrigateUpdateHandler handles Frigate
+type FrigateUpdateHandler struct {
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *FrigateUpdateHandler) validatingFrigateFn(ctx context.Context, obj *shipv1beta1.Frigate) (bool, string, error) {
+	// TODO(user): implement your admission logic
+	return true, "allowed to be admitted", nil
+}
+
+var _ admission.Handler = &FrigateUpdateHandler{}
+
+// Handle handles admission requests.
+func (h *FrigateUpdateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &shipv1beta1.Frigate{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := h.validatingFrigateFn(ctx, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+
+//var _ inject.Client = &FrigateUpdateHandler{}
+//
+//// InjectClient injects the client into the FrigateUpdateHandler
+//func (h *FrigateUpdateHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &FrigateUpdateHandler{}
+
+// InjectDecoder injects the decoder into the FrigateUpdateHandler
+func (h *FrigateUpdateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating/update_webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating/update_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	shipv1beta1 "sigs.k8s.io/controller-tools/test/pkg/apis/ship/v1beta1"
+)
+
+func init() {
+	builderName := "validating-update-frigates"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName + ".testproject.org").
+		Path("/" + builderName).
+		Validating().
+		Operations(admissionregistrationv1beta1.Update).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&shipv1beta1.Frigate{})
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating/webhooks.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/frigates/validating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating/create_webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating/create_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	creaturesv2alpha1 "sigs.k8s.io/controller-tools/test/pkg/apis/creatures/v2alpha1"
+)
+
+func init() {
+	builderName := "validating-create-krakens"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName + ".testproject.org").
+		Path("/" + builderName).
+		Validating().
+		Operations(admissionregistrationv1beta1.Create).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&creaturesv2alpha1.Kraken{})
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating/krakens_create_handler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating/krakens_create_handler.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"context"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+	creaturesv2alpha1 "sigs.k8s.io/controller-tools/test/pkg/apis/creatures/v2alpha1"
+)
+
+func init() {
+	webhookName := "validating-create-krakens"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &KrakenCreateHandler{})
+}
+
+// KrakenCreateHandler handles Kraken
+type KrakenCreateHandler struct {
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *KrakenCreateHandler) validatingKrakenFn(ctx context.Context, obj *creaturesv2alpha1.Kraken) (bool, string, error) {
+	// TODO(user): implement your admission logic
+	return true, "allowed to be admitted", nil
+}
+
+var _ admission.Handler = &KrakenCreateHandler{}
+
+// Handle handles admission requests.
+func (h *KrakenCreateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &creaturesv2alpha1.Kraken{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	allowed, reason, err := h.validatingKrakenFn(ctx, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.ValidationResponse(allowed, reason)
+}
+
+//var _ inject.Client = &KrakenCreateHandler{}
+//
+//// InjectClient injects the client into the KrakenCreateHandler
+//func (h *KrakenCreateHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &KrakenCreateHandler{}
+
+// InjectDecoder injects the decoder into the KrakenCreateHandler
+func (h *KrakenCreateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating/webhooks.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/krakens/validating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating/namespaces_update_handler.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating/namespaces_update_handler.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+func init() {
+	webhookName := "mutating-update-namespaces"
+	if HandlerMap[webhookName] == nil {
+		HandlerMap[webhookName] = []admission.Handler{}
+	}
+	HandlerMap[webhookName] = append(HandlerMap[webhookName], &NamespaceUpdateHandler{})
+}
+
+// NamespaceUpdateHandler handles Namespace
+type NamespaceUpdateHandler struct {
+	// Client  client.Client
+
+	// Decoder decodes objects
+	Decoder types.Decoder
+}
+
+func (h *NamespaceUpdateHandler) mutatingNamespaceFn(ctx context.Context, obj *corev1.Namespace) error {
+	// TODO(user): implement your admission logic
+	return nil
+}
+
+var _ admission.Handler = &NamespaceUpdateHandler{}
+
+// Handle handles admission requests.
+func (h *NamespaceUpdateHandler) Handle(ctx context.Context, req types.Request) types.Response {
+	obj := &corev1.Namespace{}
+
+	err := h.Decoder.Decode(req, obj)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+	copy := obj.DeepCopy()
+
+	err = h.mutatingNamespaceFn(ctx, copy)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponse(obj, copy)
+}
+
+//var _ inject.Client = &NamespaceUpdateHandler{}
+//
+//// InjectClient injects the client into the NamespaceUpdateHandler
+//func (h *NamespaceUpdateHandler) InjectClient(c client.Client) error {
+//	h.Client = c
+//	return nil
+//}
+
+var _ inject.Decoder = &NamespaceUpdateHandler{}
+
+// InjectDecoder injects the decoder into the NamespaceUpdateHandler
+func (h *NamespaceUpdateHandler) InjectDecoder(d types.Decoder) error {
+	h.Decoder = d
+	return nil
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating/update_webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating/update_webhook.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+func init() {
+	builderName := "mutating-update-namespaces"
+	Builders[builderName] = builder.
+		NewWebhookBuilder().
+		Name(builderName + ".testproject.org").
+		Path("/" + builderName).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Update).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		ForType(&corev1.Namespace{})
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating/webhooks.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/namespaces/mutating/webhooks.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	// Builders contain admission webhook builders
+	Builders = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string][]admission.Handler{}
+)

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/server.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/default_server/server.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultserver
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+)
+
+var (
+	log        = logf.Log.WithName("default_server")
+	builderMap = map[string]*builder.WebhookBuilder{}
+	// HandlerMap contains all admission webhook handlers.
+	HandlerMap = map[string][]admission.Handler{}
+)
+
+// Add adds itself to the manager
+func Add(mgr manager.Manager) error {
+	ns := os.Getenv("POD_NAMESPACE")
+	if len(ns) == 0 {
+		ns = "default"
+	}
+	secretName := os.Getenv("SECRET_NAME")
+	if len(secretName) == 0 {
+		secretName = "webhook-server-secret"
+	}
+
+	svr, err := webhook.NewServer("foo-admission-server", mgr, webhook.ServerOptions{
+		// TODO(user): change the configuration of ServerOptions based on your need.
+		Port:    9876,
+		CertDir: "/tmp/cert",
+		BootstrapOptions: &webhook.BootstrapOptions{
+			Secret: &types.NamespacedName{
+				Namespace: ns,
+				Name:      secretName,
+			},
+
+			Service: &webhook.Service{
+				Namespace: ns,
+				Name:      "webhook-server-service",
+				// Selectors should select the pods that runs this webhook server.
+				Selectors: map[string]string{
+					"control-plane": "controller-manager",
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	var webhooks []webhook.Webhook
+	for k, builder := range builderMap {
+		handlers, ok := HandlerMap[k]
+		if !ok {
+			log.V(1).Info(fmt.Sprintf("can't find handlers for builder: %v", k))
+			handlers = []admission.Handler{}
+		}
+		wh, err := builder.
+			Handlers(handlers...).
+			WithManager(mgr).
+			Build()
+		if err != nil {
+			return err
+		}
+		webhooks = append(webhooks, wh)
+	}
+
+	return svr.Register(webhooks...)
+}

--- a/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/webhook.go
+++ b/cmd/vendor/sigs.k8s.io/controller-tools/test/pkg/webhook/webhook.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// AddToManagerFuncs is a list of functions to add all Controllers to the Manager
+var AddToManagerFuncs []func(manager.Manager) error
+
+// AddToManager adds all Controllers to the Manager
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+func AddToManager(m manager.Manager) error {
+	for _, f := range AddToManagerFuncs {
+		if err := f(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Note: This is work in progress, so pl. do not merge it. (I will add appropriate labels to prevent it from merging)

PR adds `alpha` command group with first command for webhook scaffolding. While testing I discovered following issues, which still need to be resolved.

- project init fails because of the issue --> "cmd/manager/main.go:23:2: cannot find package "github.com/droot/testp/pkg/webhook"". That is because we start using `webhook` pkg in manager/main.go without scaffolding the webhook pkg structure
- After adding a webhook, I ran in to another issue --> "pkg/webhook/add_default_server.go:24:2: undefined: AddToManagerFuncs"

/cc @mengqiy 