### PR TITLE
enable prometheus metrics integration

### DIFF
--- a/cmd/init_project.go
+++ b/cmd/init_project.go
@@ -52,6 +52,7 @@ Writes the following files:
 - a Gopkg.toml with project dependencies
 - a Kustomization.yaml for customizating manifests
 - a Patch file for customizing image for manager manifests
+- a Patch file for enabling prometheus metrics
 - a cmd/manager/main.go to run
 
 project will prompt the user to run 'dep ensure' after writing the project files.
@@ -141,7 +142,8 @@ func (o *projectOptions) runInit() {
 		&manager.Config{Image: imgName},
 		&project.GitIgnore{},
 		&project.Kustomize{},
-		&project.KustomizeImagePatch{})
+		&project.KustomizeImagePatch{},
+		&project.KustomizePrometheusMetricsPatch{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/scaffold/project/kustomize.go
+++ b/pkg/scaffold/project/kustomize.go
@@ -77,6 +77,7 @@ resources:
 
 patches:
 - manager_image_patch.yaml
+- manager_prometheus_metrics_patch.yaml
 
 vars:
 - name: WEBHOOK_SECRET_NAME

--- a/pkg/scaffold/project/kustomize_metrics_patch.go
+++ b/pkg/scaffold/project/kustomize_metrics_patch.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
+)
+
+var _ input.File = &KustomizePrometheusMetricsPatch{}
+
+// KustomizePrometheusMetricsPatch scaffolds the patch file for enabling
+// prometheus metrics for manager Pod.
+type KustomizePrometheusMetricsPatch struct {
+	input.Input
+}
+
+// GetInput implements input.File
+func (c *KustomizePrometheusMetricsPatch) GetInput() (input.Input, error) {
+	if c.Path == "" {
+		c.Path = filepath.Join("config", "default", "manager_prometheus_metrics_patch.yaml")
+	}
+	c.TemplateBody = kustomizePrometheusMetricsPatchTemplate
+	c.Input.IfExistsAction = input.Error
+	return c.Input, nil
+}
+
+var kustomizePrometheusMetricsPatchTemplate = `# This patch enables Prometheus scraping for the manager pod.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      # Expose the prometheus metrics on default port
+      - name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+`

--- a/pkg/scaffold/project/project_test.go
+++ b/pkg/scaffold/project/project_test.go
@@ -218,6 +218,23 @@ Copyright 2019 Example Owners.
 		})
 	})
 
+	Describe("scaffolding a Kustomize prometheus metrics patch", func() {
+		BeforeEach(func() {
+			goldenPath = filepath.Join("config", "default", "manager_prometheus_metrics_patch.yaml")
+			writeToPath = goldenPath
+		})
+		Context("with defaults ", func() {
+			It("should match the golden file", func() {
+				instance := &KustomizePrometheusMetricsPatch{}
+				instance.Repo = "sigs.k8s.io/kubebuilder/test/project"
+				Expect(s.Execute(input.Options{}, instance)).NotTo(HaveOccurred())
+
+				// Verify the contents matches the golden file.
+				Expect(result.Actual.String()).To(BeEquivalentTo(result.Golden))
+			})
+		})
+	})
+
 	Describe("scaffolding a .gitignore", func() {
 		BeforeEach(func() {
 			goldenPath = filepath.Join(".gitignore")

--- a/test/project/config/default/kustomization.yaml
+++ b/test/project/config/default/kustomization.yaml
@@ -24,6 +24,7 @@ resources:
 
 patches:
 - manager_image_patch.yaml
+- manager_prometheus_metrics_patch.yaml
 
 vars:
 - name: WEBHOOK_SECRET_NAME

--- a/test/project/config/default/manager_prometheus_metrics_patch.yaml
+++ b/test/project/config/default/manager_prometheus_metrics_patch.yaml
@@ -1,0 +1,19 @@
+# This patch enables Prometheus scraping for the manager pod.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      containers:
+      # Expose the prometheus metrics on default port
+      - name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP


### PR DESCRIPTION
Quick highlights:
 - Scaffolds a patch which enables prometheus scraping on the manager pods.  Using the most common annotations used by Stackdriver, [weaveworks](https://www.weave.works/docs/cloud/latest/tasks/monitor/configuration-k8s/)
 - Enables the patch in `kustomization.yaml` file.