### PR TITLE
Fix installation procedure in getting started

### DIFF
--- a/docs/book/getting_started/installation_and_setup.md
+++ b/docs/book/getting_started/installation_and_setup.md
@@ -19,7 +19,7 @@ curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${v
 
 # extract the archive
 tar -zxvf kubebuilder_${version}_darwin_${arch}.tar.gz
-sudo mv kubebuilder_${version}_darwin_${arch} /usr/local/kubebuilder
+mv kubebuilder_${version}_darwin_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
 
 # update your PATH to include /usr/local/kubebuilder/bin
 export PATH=$PATH:/usr/local/kubebuilder/bin
@@ -35,7 +35,7 @@ curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${v
 
 # extract the archive
 tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
-sudo mv kubebuilder_${version}_linux_${arch} /usr/local/kubebuilder
+mv kubebuilder_${version}_linux_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
 
 # update your PATH to include /usr/local/kubebuilder/bin
 export PATH=$PATH:/usr/local/kubebuilder/bin
@@ -59,7 +59,7 @@ curl -L -O https://storage.googleapis.com/kubebuilder-release/kubebuilder_master
 
 # extract the archive
 tar -zxvf kubebuilder_master_darwin_${arch}.tar.gz
-sudo mv kubebuilder_master_darwin_${arch} /usr/local/kubebuilder
+mv kubebuilder_master_darwin_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
 
 # update your PATH to include /usr/local/kubebuilder/bin
 export PATH=$PATH:/usr/local/kubebuilder/bin
@@ -73,7 +73,7 @@ curl -L -O https://storage.googleapis.com/kubebuilder-release/kubebuilder_master
 
 # extract the archive
 tar -zxvf kubebuilder_master_linux_${arch}.tar.gz
-sudo mv kubebuilder_master_linux_${arch} /usr/local/kubebuilder
+mv kubebuilder_master_linux_${arch} kubebuilder && sudo mv kubebuilder /usr/local/
 
 # update your PATH to include /usr/local/kubebuilder/bin
 export PATH=$PATH:/usr/local/kubebuilder/bin


### PR DESCRIPTION
Since the directroy name by which archive is extracted is not kubebuilder,
kubebuilder binary copied into /usr/local/kubebuilder/kubebuilder_${version}_${os}_${arch}.
This patch fixes it.