### PR TITLE
Add bash installation script for macos or linux users

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#
+# This file will be  fetched as: curl -L https://git.io/getLatestKubebuilder | sh -
+# so it should be pure bourne shell, not bash (and not reference other scripts)
+#
+# The script fetches the latest kubebuilder release candidate and untars it.
+# It lets users to do curl -L https://git.io//getLatestKubebuilder | KUBEBUILDER_VERSION=1.0.5 sh -
+# for instance to change the version fetched.
+
+OS="$(uname)"
+if [ "x${OS}" = "xDarwin" ] ; then
+  OSEXT="darwin"
+else
+  OSEXT="linux"
+fi
+ARCH=amd64
+
+if [ "x${KUBEBUILDER_VERSION}" = "x" ] ; then
+  KUBEBUILDER_VERSION=$(curl -L -s https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases/latest | \
+                  grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/")
+fi
+
+KUBEBUILDER_VERSION=${KUBEBUILDER_VERSION#"v"}
+KUBEBUILDER_VERSION_NAME="kubebuilder_${KUBEBUILDER_VERSION}"
+URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}.tar.gz"
+echo "Downloading ${KUBEBUILDER_VERSION_NAME} from $URL ..."
+curl -L "$URL" | tar xz
+
+echo "Downloaded these executable files into $NAME: "
+ls "${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}/bin"
+mv ${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH} kubebuilder && sudo mv -f kubebuilder /usr/local/
+RETVAL=$?
+
+if [ $RETVAL -eq 0 ]; then
+  echo "Add kubebuilder to your path; e.g copy paste in your shell and/or ~/.profile:"
+  echo "export PATH=\$PATH:/usr/local/kubebuilder/bin"
+else
+  echo "\n/usr/local/kubebuilder folder is not empty. Please delete or backup it before to install ${KUBEBUILDER_VERSION_NAME}"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # This file will be  fetched as: curl -L https://git.io/getLatestKubebuilder | sh -
@@ -8,13 +8,13 @@
 # It lets users to do curl -L https://git.io//getLatestKubebuilder | KUBEBUILDER_VERSION=1.0.5 sh -
 # for instance to change the version fetched.
 
-OS="$(uname)"
-if [ "x${OS}" = "xDarwin" ] ; then
-  OSEXT="darwin"
-else
-  OSEXT="linux"
-fi
-ARCH=amd64
+# Check if the program is installed, otherwise exit
+function command_exists () {
+  if ! [ -x "$(command -v $1)" ]; then
+    echo "Error: $1 program is not installed." >&2
+    exit 1
+  fi
+}
 
 if [ "x${KUBEBUILDER_VERSION}" = "x" ] ; then
   KUBEBUILDER_VERSION=$(curl -L -s https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases/latest | \
@@ -23,18 +23,56 @@ fi
 
 KUBEBUILDER_VERSION=${KUBEBUILDER_VERSION#"v"}
 KUBEBUILDER_VERSION_NAME="kubebuilder_${KUBEBUILDER_VERSION}"
-URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}.tar.gz"
-echo "Downloading ${KUBEBUILDER_VERSION_NAME} from $URL ..."
-curl -L "$URL" | tar xz
+KUBEBUILDER_DIR=/usr/local/kubebuilder
 
-echo "Downloaded these executable files into $NAME: "
-ls "${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}/bin"
-mv ${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH} kubebuilder && sudo mv -f kubebuilder /usr/local/
-RETVAL=$?
-
-if [ $RETVAL -eq 0 ]; then
-  echo "Add kubebuilder to your path; e.g copy paste in your shell and/or ~/.profile:"
-  echo "export PATH=\$PATH:/usr/local/kubebuilder/bin"
-else
-  echo "\n/usr/local/kubebuilder folder is not empty. Please delete or backup it before to install ${KUBEBUILDER_VERSION_NAME}"
+# Check if folder containing kubebuilder executable exists and is not empty
+if [ -d "$KUBEBUILDER_DIR" ]; then
+  if [ "$(ls -A $KUBEBUILDER_DIR)" ]; then
+    echo "\n/usr/local/kubebuilder folder is not empty. Please delete or backup it before to install ${KUBEBUILDER_VERSION_NAME}"
+    exit 1
+  fi
 fi
+
+# Check if curl, tar commands/programs exist
+command_exists curl
+command_exists tar
+
+# Determine OS
+OS="$(uname)"
+case $OS in
+  Darwin)
+    OSEXT="darwin"
+    ;;
+  Linux)
+    OSEXT="linux"
+    ;;
+  *)
+    echo "Only OSX and Linux OS are supported !"
+    exit 1
+    ;;
+esac
+
+HW=$(uname -m)
+case $HW in
+    x86_64)
+      ARCH=amd64 ;;
+    *)
+      echo "Only x86_64 machines are supported !"
+      exit 1
+      ;;
+esac
+
+TMP_DIR=$(mktemp -d)
+
+# Downloading Kuberbuilder compressed file using curl program
+URL="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}.tar.gz"
+echo "Downloading ${KUBEBUILDER_VERSION_NAME}\nfrom $URL\n"
+curl -L "$URL"| tar xz -C $TMP_DIR
+
+echo "Downloaded executable files"
+ls "$TMP_DIR/${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}/bin"
+
+echo "Moving files to $KUBEBUILDER_DIR folder\n"
+mv $TMP_DIR/${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH} $TMP_DIR/kubebuilder && sudo mv -f $TMP_DIR/kubebuilder /usr/local/
+
+rm -rf $TMP_DIR


### PR DESCRIPTION
- Add bash installation script for macos or linux users.
- Download latest version of kuberbuilder or specify the version, untar it and move project under /usr/local/bin/kubebuilder if it is empty. Otherwise exit
- Fix #482