### PR TITLE
add RBAC annotation for status subresource

### DIFF
--- a/pkg/scaffold/controller/controller.go
+++ b/pkg/scaffold/controller/controller.go
@@ -194,8 +194,10 @@ type Reconcile{{ .Resource.Kind }} struct {
 {{ if .Resource.CreateExampleReconcileBody -}}
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 {{ end -}}
 // +kubebuilder:rbac:groups={{.GroupDomain}},resources={{ .Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{.GroupDomain}},resources={{ .Plural }}/status,verbs=get;update;patch
 func (r *Reconcile{{ .Resource.Kind }}) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the {{ .Resource.Kind }} instance
 	instance := &{{ .Resource.Group}}{{ .Resource.Version }}.{{ .Resource.Kind }}{}

--- a/test/project/config/rbac/rbac_role.yaml
+++ b/test/project/config/rbac/rbac_role.yaml
@@ -17,6 +17,14 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - crew.testproject.org
   resources:
   - firstmates
@@ -28,6 +36,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - firstmates/status
+  verbs:
+  - get
+  - update
+  - patch
 - apiGroups:
   - ship.testproject.org
   resources:
@@ -41,6 +57,14 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - ship.testproject.org
+  resources:
+  - frigates/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - policy.testproject.org
   resources:
   - healthcheckpolicies
@@ -52,6 +76,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - policy.testproject.org
+  resources:
+  - healthcheckpolicies/status
+  verbs:
+  - get
+  - update
+  - patch
 - apiGroups:
   - creatures.testproject.org
   resources:
@@ -65,6 +97,14 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - creatures.testproject.org
+  resources:
+  - krakens/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - ""
   resources:
   - namespaces
@@ -76,6 +116,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
+  verbs:
+  - get
+  - update
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/test/project/pkg/controller/firstmate/firstmate_controller.go
+++ b/test/project/pkg/controller/firstmate/firstmate_controller.go
@@ -94,7 +94,9 @@ type ReconcileFirstMate struct {
 // a Deployment as an example
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 func (r *ReconcileFirstMate) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the FirstMate instance
 	instance := &crewv1.FirstMate{}

--- a/test/project/pkg/controller/frigate/frigate_controller.go
+++ b/test/project/pkg/controller/frigate/frigate_controller.go
@@ -87,6 +87,7 @@ type ReconcileFrigate struct {
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
 func (r *ReconcileFrigate) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Frigate instance
 	instance := &shipv1beta1.Frigate{}

--- a/test/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
+++ b/test/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
@@ -87,6 +87,7 @@ type ReconcileHealthCheckPolicy struct {
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
 // +kubebuilder:rbac:groups=policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
 func (r *ReconcileHealthCheckPolicy) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the HealthCheckPolicy instance
 	instance := &policyv1beta1.HealthCheckPolicy{}

--- a/test/project/pkg/controller/kraken/kraken_controller.go
+++ b/test/project/pkg/controller/kraken/kraken_controller.go
@@ -87,6 +87,7 @@ type ReconcileKraken struct {
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
 // +kubebuilder:rbac:groups=creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
 func (r *ReconcileKraken) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Kraken instance
 	instance := &creaturesv2alpha1.Kraken{}

--- a/test/project/pkg/controller/namespace/namespace_controller.go
+++ b/test/project/pkg/controller/namespace/namespace_controller.go
@@ -87,6 +87,7 @@ type ReconcileNamespace struct {
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
 func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Namespace instance
 	instance := &corev1.Namespace{}


### PR DESCRIPTION
While testing status subresources, I discovered that we are not generating RBAC permissions for status sub resource. This PR addresses that.