### PR TITLE
Put the manager binary into /, instead of /root/

### DIFF
--- a/pkg/scaffold/manager/config.go
+++ b/pkg/scaffold/manager/config.go
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
       - command:
-        - /root/manager
+        - /manager
         image: {{ .Image }}
         imagePullPolicy: Always
         name: manager

--- a/pkg/scaffold/manager/dockerfile.go
+++ b/pkg/scaffold/manager/dockerfile.go
@@ -50,7 +50,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager {{ .Repo }}/cmd
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
-WORKDIR /root/
+WORKDIR /
 COPY --from=builder /go/src/{{ .Repo }}/manager .
-ENTRYPOINT ["./manager"]
+ENTRYPOINT ["/manager"]
 `

--- a/test/project/Dockerfile
+++ b/test/project/Dockerfile
@@ -12,6 +12,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/kub
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
-WORKDIR /root/
+WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/kubebuilder/test/project/manager .
-ENTRYPOINT ["./manager"]
+ENTRYPOINT ["/manager"]

--- a/test/project/config/manager/manager.yaml
+++ b/test/project/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - command:
-        - /root/manager
+        - /manager
         image: controller:latest
         imagePullPolicy: Always
         name: manager


### PR DESCRIPTION
/root/ encourages use of the root user, and / is more the pattern I've
seen for thin containers.