### PR TITLE
add control-plane: controller-manager label to namespace

### DIFF
--- a/pkg/scaffold/manager/config.go
+++ b/pkg/scaffold/manager/config.go
@@ -44,6 +44,7 @@ var configTemplate = `apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: system
 ---

--- a/test/project/config/manager/manager.yaml
+++ b/test/project/config/manager/manager.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
+    control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   name: system
 ---


### PR DESCRIPTION
This will be useful for webhook to exclude the namespace where the controller-manager runs.
