### PR TITLE
make webhook scaffolding work with old project

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
+	"sigs.k8s.io/kubebuilder/pkg/scaffold/manager"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/webhook"
 )
@@ -58,6 +59,7 @@ Scaffolds webhook handlers based on group, version, kind and other user inputs.
 			}
 
 			err := (&scaffold.Scaffold{}).Execute(input.Options{},
+				&manager.Webhook{},
 				&webhook.AdmissionHandler{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
 				&webhook.AdmissionWebhookBuilder{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
 				&webhook.AdmissionWebhooks{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/kubernetes-sigs/kubebuilder/issues/505#issuecomment-447173482.
`pkg/webhook.go` is only generated by `kubebuilder init` with version v1.0.5+. If the project was generated by an older kubebuilder, missing `pkg/webhook.go` will cause it failed to compile.
This PR ensure it always exist each time running `kubebuilder alpha webhook` command. If not exist, generate it.