### PR TITLE
:bug: report error if GOPATH env is missing

### DIFF
--- a/pkg/scaffold/project/makefile.go
+++ b/pkg/scaffold/project/makefile.go
@@ -89,6 +89,9 @@ vet:
 
 # Generate code
 generate:
+ifndef GOPATH
+	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
+endif
 	go generate ./pkg/... ./cmd/...
 
 # Build the docker image

--- a/test/project/Makefile
+++ b/test/project/Makefile
@@ -39,6 +39,9 @@ vet:
 
 # Generate code
 generate:
+ifndef GOPATH
+	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
+endif
 	go generate ./pkg/... ./cmd/...
 
 # Build the docker image


### PR DESCRIPTION
The root-cause of the issues we are seeing is deepcopy-gen doesn't support building/generating outside GOPATH. So for now, failing fast when we detect missing GOPATH in `generate` target can save users in this case.

fixes #531 #359

