### PR TITLE
Fix download links on ZSH

### DIFF
--- a/docs/book/getting_started/installation_and_setup.md
+++ b/docs/book/getting_started/installation_and_setup.md
@@ -11,7 +11,7 @@ Install kubebuilder by downloading the latest stable release from the
 
 {% sample lang="mac" %}
 ```bash
-version=1.0.6 # latest stable version
+version=1.0.7 # latest stable version
 arch=amd64
 
 # download the release
@@ -27,7 +27,7 @@ export PATH=$PATH:/usr/local/kubebuilder/bin
 
 {% sample lang="linux" %}
 ```bash
-version=1.0.6 # latest stable version
+version=1.0.7 # latest stable version
 arch=amd64
 
 # download the release

--- a/docs/book/getting_started/installation_and_setup.md
+++ b/docs/book/getting_started/installation_and_setup.md
@@ -15,7 +15,7 @@ version=1.0.6 # latest stable version
 arch=amd64
 
 # download the release
-curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz
+curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz"
 
 # extract the archive
 tar -zxvf kubebuilder_${version}_darwin_${arch}.tar.gz
@@ -31,7 +31,7 @@ version=1.0.6 # latest stable version
 arch=amd64
 
 # download the release
-curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz
+curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
 
 # extract the archive
 tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz

--- a/docs/book/quick_start.md
+++ b/docs/book/quick_start.md
@@ -17,11 +17,11 @@ This Quick Start guide will cover:
 
 {% sample lang="mac" %}
 ```bash
-version=1.0.6 # latest stable version
+version=1.0.7 # latest stable version
 arch=amd64
 
 # download the release
-curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz
+curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz"
 
 # extract the archive
 tar -zxvf kubebuilder_${version}_darwin_${arch}.tar.gz
@@ -33,11 +33,11 @@ export PATH=$PATH:/usr/local/kubebuilder/bin
 
 {% sample lang="linux" %}
 ```bash
-version=1.0.6 # latest stable version
+version=1.0.7 # latest stable version
 arch=amd64
 
 # download the release
-curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz
+curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz"
 
 # extract the archive
 tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz


### PR DESCRIPTION
`ZSH` automatically escapes links and breaks copy + paste:

```bash
# copy
curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz

# pasted
curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v$\{version\}/kubebuilder_$\{version\}_darwin_$\{arch\}.tar.gz
```

Also bumped version to `v1.0.7`

