### PR TITLE
[WIP]change group validation regex to DNS subdomain

### DIFF
--- a/pkg/scaffold/resource/resource.go
+++ b/pkg/scaffold/resource/resource.go
@@ -65,9 +65,9 @@ func (r *Resource) Validate() error {
 		r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
 	}
 
-	groupMatch := regexp.MustCompile("^[a-z]+$")
+	groupMatch := regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
 	if !groupMatch.MatchString(r.Group) {
-		return fmt.Errorf("group must match ^[a-z]+$ (was %s)", r.Group)
+		return fmt.Errorf("group must match ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ (was %s)", r.Group)
 	}
 
 	versionMatch := regexp.MustCompile("^v\\d+(alpha\\d+|beta\\d+)?$")

--- a/pkg/scaffold/resource/resource_test.go
+++ b/pkg/scaffold/resource/resource_test.go
@@ -26,16 +26,15 @@ var _ = Describe("Resource", func() {
 			Expect(instance.Validate().Error()).To(ContainSubstring("group cannot be empty"))
 		})
 
+		It("should succeed if the Group is valid DNS subdomain", func() {
+			instance := &Resource{Group: "crew-1.k8s.example.com", Version: "v1", Kind: "FirstMate"}
+			Expect(instance.Validate()).To(Succeed())
+		})
+
 		It("should fail if the Group is not all lowercase", func() {
 			instance := &Resource{Group: "Crew", Version: "v1", Kind: "FirstMate"}
 			Expect(instance.Validate()).NotTo(Succeed())
-			Expect(instance.Validate().Error()).To(ContainSubstring("group must match ^[a-z]+$ (was Crew)"))
-		})
-
-		It("should fail if the Group contains non-alpha characters", func() {
-			instance := &Resource{Group: "crew1", Version: "v1", Kind: "FirstMate"}
-			Expect(instance.Validate()).NotTo(Succeed())
-			Expect(instance.Validate().Error()).To(ContainSubstring("group must match ^[a-z]+$ (was crew1)"))
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ (was Crew)"))
 		})
 
 		It("should fail if the Version is not specified", func() {


### PR DESCRIPTION
Fix #298 
Changes done:
1. change the group validation regex to the one used by kubernetes: [DNS subdomain](https://github.com/kubernetes/kubernetes/blob/6902f3112d98eb6bd0894886ff9cd3fbd03a7f79/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L137)