### PR TITLE
Improve Dockerfile template such that copying vendor dir is cached.

### DIFF
--- a/pkg/scaffold/manager/dockerfile.go
+++ b/pkg/scaffold/manager/dockerfile.go
@@ -41,9 +41,9 @@ FROM golang:1.10.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/{{ .Repo }}
-COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
+COPY pkg/    pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager {{ .Repo }}/cmd/manager

--- a/test/project/Dockerfile
+++ b/test/project/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:1.10.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/kubebuilder/test/project
-COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
+COPY pkg/    pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/kubebuilder/test/project/cmd/manager


### PR DESCRIPTION
The vendor directory is rarely changed during development and is big.
So, moving its copy to lower layer in docker build can make docker builds faster.