### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/test/internal/e2e/kubebuildertest.go
+++ b/test/internal/e2e/kubebuildertest.go
@@ -201,7 +201,7 @@ func (kt *KubebuilderTest) RunKubectlCommand(cmdOptions []string) (string, error
 	return string(output), err
 }
 
-// RunKubectlCommand is a general func to run kubectl commands
+// RunKubectlCommandWithInput is a general func to run kubectl commands
 func (kt *KubebuilderTest) RunKubectlCommandWithInput(cmdOptions []string, stdinInput string) (string, error) {
 	cmd := exec.Command("kubectl", cmdOptions...)
 	stdin, err := cmd.StdinPipe()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?