### PR TITLE
typo correction

### DIFF
--- a/docs/book/beyond_basics/controller_watches.md
+++ b/docs/book/beyond_basics/controller_watches.md
@@ -68,7 +68,7 @@ correct RBAC rules are in place and informers have been started.
 
 ```go
 // Annotation to generate RBAC roles to watch and update Pods
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;watch;list,create,update,delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;watch;list;create;update;delete
 ```
 
 {% sample lang="go" %}


### PR DESCRIPTION
otherwise we got
```
2019/03/20 16:12:57 // +kubebuilder:rbac: tags must be key value pairs.  Expected keys [groups=<group1;group2>,resources=<resource1;resource2>,verbs=<verb1;verb2>] Got string: [groups="",resources=pods,verbs=get;watch;list,create,update,delete]
```