### PR TITLE
simplify GOPATH

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,10 +30,7 @@ import (
 )
 
 func main() {
-	gopath := os.Getenv("GOPATH")
-	if len(gopath) == 0 {
-		gopath = gobuild.Default.GOPATH
-	}
+	gopath := gobuild.Default.GOPATH
 
 	wd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
`go/build.Default.GOPATH` already has identical defaulting behavior (using `$GOPATH` if set)

https://golang.org/pkg/go/build/#Context

> Default is the default Context for builds. It uses the GOARCH, GOOS, GOROOT, and GOPATH environment variables if set, or else the compiled code's GOARCH, GOOS, and GOROOT.

