### PR TITLE
add an install target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ all: build test
 build:
 	go build -o bin/kubebuilder ./cmd
 
+install: build
+	cp ./bin/kubebuilder $(shell go env GOPATH)/bin/kubebuilder
+
 generate:
 	./generated_golden.sh
 


### PR DESCRIPTION
This repo is slightly annoying to install from source since `main.go` is in `cmd/` instead of a `kubebuilder` directory, so I added a make target roughly equivilant to typical `go install`. Alternate options to make this easier include:
- have `main.go` be in the repo root
- have a `cmd/kubebuilder/main.go`

for either of those, `go get -u sigs.k8s.io/kubebuilder/...` would be a viable install route.

This route was the least invasive, so I started there, but I'd be up for PRing other routes if there's interest.

