### PR TITLE
:running: Add shortlinks to releases via go.kubebuilder.io

### DIFF
--- a/docs/book/_redirects
+++ b/docs/book/_redirects
@@ -1,3 +1,4 @@
 https://kubebuilder.netlify.com/* https://book.kubebuilder.io/:splat 301!
 http://kubebuilder.netlify.com/* http://book.kubebuilder.io/:splat 301!
-
+https://go.kubebuilder.io/releases/* https://github.com/kubernetes-sigs/kubebuilder/releases/:splat 302!
+http://go.kubebuilder.io/releases/* https://github.com/kubernetes-sigs/kubebuilder/releases/:splat 302!


### PR DESCRIPTION
This adds https://go.kubebuilder.io/releases/* as a vanity url for the
github releases page.

DNS may take a bit to propagate