### PR TITLE
🏃 task: enable running tests in prow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ services:
 before_install:
 # NOTE: The latest version of dep requires go 1.13
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p /Users/travis/gopath/bin; fi
-- GO111MODULE=on curl https://raw.githubusercontent.com/golang/dep/v0.5.1/install.sh | sh
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then GO111MODULE=on scripts/install_and_setup.sh; fi
 
 before_script:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -77,6 +77,12 @@ curl -L "$URL"| tar xz -C $TMP_DIR
 echo "Downloaded executable files"
 ls "${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH}/bin"
 
+if [[ -z "${PROW}" ]]; then 
+  MOVE="sudo mv"
+else
+  MOVE="mv"
+fi
+
 echo "Moving files to $KUBEBUILDER_DIR folder\n"
 mv ${KUBEBUILDER_VERSION_NAME}_${OSEXT}_${ARCH} kubebuilder && sudo mv -f kubebuilder /usr/local/
 

--- a/test_ci.sh
+++ b/test_ci.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export TRACE=1
+export GO111MODULE=on
+
+./test.sh


### PR DESCRIPTION
Update common.sh to fetch missing dependencies when SKIP_FETCH_TOOLS is false.

We could also build base images with the artifacts (dep, kubebuilder, etcd, api-server, v1 and v2 project tarballs) inside them. I'm not familiar with the (any?) process for publishing official images in Kubernetes projects, and we can always iterate, so I'm offering this up as an initial cut