### PR TITLE
:bugfix: fixed docker image file for v2 scaffolding

### DIFF
--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -37,21 +37,25 @@ func (c *Dockerfile) GetInput() (input.Input, error) {
 }
 
 var dockerfileTemplate = `# Build the manager binary
-FROM golang:1.10.3 as builder
+FROM golang:1.12.5 as builder
 
-# Copy in the go src
-WORKDIR /go/src/{{ .Repo }}
-COPY vendor/ vendor/
+WORKDIR /workspace
+# Copy the go source
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager {{ .Repo }}/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Copy the controller-manager into a thin image
-FROM ubuntu:latest
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/base
 WORKDIR /
-COPY --from=builder /go/src/{{ .Repo }}/manager .
+COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]
 `

--- a/testdata/project_v2/Dockerfile
+++ b/testdata/project_v2/Dockerfile
@@ -1,18 +1,22 @@
 # Build the manager binary
-FROM golang:1.10.3 as builder
+FROM golang:1.12.5 as builder
 
-# Copy in the go src
-WORKDIR /go/src/sigs.k8s.io/kubebuilder/testdata/project_v2
-COPY vendor/ vendor/
+WORKDIR /workspace
+# Copy the go source
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/kubebuilder/testdata/project_v2/
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Copy the controller-manager into a thin image
-FROM ubuntu:latest
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/base
 WORKDIR /
-COPY --from=builder /go/src/sigs.k8s.io/kubebuilder/testdata/project_v2/manager .
+COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Main changes:
  - use Go 1.12.5 with Go modules to build the manager binary
  - use distroless (stripped down image)