### PR TITLE
:running: Fix netlify redirects for v1 book

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,16 @@
     command = "gitbook install && gitbook build"
     publish = "docs/book/_book"
 
+# HTTP-to-HTTPS rules
+[[redirects]]
+    from = "http://v1.book.kubebuilder.io/*"
+    to = "https://v1.book.kubebuilder.io/:splat"
+    status = 301
+    force = true
+
+# Book v1
+[[redirects]]
+    from = "https://v1.book.kubebuilder.io/*"
+    to = "https://book-v1.book.kubebuilder.io/:splat"
+    status = 301
+    force = true


### PR DESCRIPTION
This fixes the redirects for the book-v1 branch so that they properly
evaluate the alias v1.book --> book-v1.book.