### PR TITLE
:sparkles: fix webhook related scaffolding

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,11 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
-	"log"
-	"encoding/json"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/go/packages"
@@ -77,7 +77,7 @@ func findCurrentRepo() (string, error) {
 
 	// next, check if we've got a package in the current directory
 	pkgCfg := &packages.Config{
-		Mode: packages.NeedName,  // name gives us path as well
+		Mode: packages.NeedName, // name gives us path as well
 	}
 	pkgs, err := packages.Load(pkgCfg, ".")
 	if err == nil && len(pkgs) > 0 {

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -43,10 +43,11 @@ func newWebhookCmd() *cobra.Command {
 		Short: "Scaffold a webhook server",
 		Long: `Scaffold a webhook server if there is no existing server.
 Scaffolds webhook handlers based on group, version, kind and other user inputs.
+This command is only available for v1 scaffolding project.
 `,
 		Example: `	# Create webhook for CRD of group crew, version v1 and kind FirstMate.
 	# Set type to be mutating and operations to be create and update.
-	kubebuilder webhook --group crew --version v1 --kind FirstMate --type=mutating --operations=create,update
+	kubebuilder alpha webhook --group crew --version v1 --kind FirstMate --type=mutating --operations=create,update
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			dieIfNoProject()

--- a/generated_golden.sh
+++ b/generated_golden.sh
@@ -64,13 +64,10 @@ scaffold_test_project() {
 		$kb init --project-version $version --domain testproject.org --license apache2 --owner "The Kubernetes authors"
 		$kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false
 		$kb create api --group crew --version v1 --kind FirstMate --controller=true --resource=true --make=false
-		$kb alpha webhook --group crew --version v1 --kind FirstMate --type=mutating --operations=create,update --make=false
-		$kb alpha webhook --group crew --version v1 --kind FirstMate --type=mutating --operations=delete --make=false
 		# TODO(droot): Adding a second group is a valid test case and kubebuilder is expected to report an error in this case. It
 		# doesn't do that currently so leaving it commented so that we can enable it later.
 		# $kb create api --group ship --version v1beta1 --kind Frigate --example=false --controller=true --resource=true --make=false
 		$kb create api --group core --version v1 --kind Namespace --example=false --controller=true --resource=false --namespaced=false --make=false
-		$kb alpha webhook --group core --version v1 --kind Namespace --type=mutating --operations=update --make=false
 		# $kb create api --group policy --version v1beta1 --kind HealthCheckPolicy --example=false --controller=true --resource=true --namespaced=false --make=false
 	fi
 	make all test # v2 doesn't test by default

--- a/pkg/scaffold/project.go
+++ b/pkg/scaffold/project.go
@@ -17,21 +17,21 @@ limitations under the License.
 package scaffold
 
 import (
+	"bufio"
+	"fmt"
 	"os"
 	"os/exec"
-	"fmt"
 	"strings"
-	"bufio"
 
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/project"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/v1/manager"
 
+	"sigs.k8s.io/kubebuilder/cmd/util"
 	scaffoldv2 "sigs.k8s.io/kubebuilder/pkg/scaffold/v2"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/v2/certmanager"
 	managerv2 "sigs.k8s.io/kubebuilder/pkg/scaffold/v2/manager"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/v2/webhook"
-	"sigs.k8s.io/kubebuilder/cmd/util"
 )
 
 type ProjectScaffolder interface {
@@ -41,10 +41,10 @@ type ProjectScaffolder interface {
 }
 
 type V1Project struct {
-	Project project.Project
+	Project     project.Project
 	Boilerplate project.Boilerplate
 
-	DepArgs []string
+	DepArgs          []string
 	DefinitelyEnsure *bool
 }
 
@@ -129,7 +129,7 @@ func (p *V1Project) Scaffold() error {
 }
 
 type V2Project struct {
-	Project project.Project
+	Project     project.Project
 	Boilerplate project.Boilerplate
 }
 

--- a/pkg/scaffold/v2/certmanager/kustomize.go
+++ b/pkg/scaffold/v2/certmanager/kustomize.go
@@ -39,6 +39,7 @@ func (p *Kustomization) GetInput() (input.Input, error) {
 var kustomizationTemplate = `resources:
 - certificate.yaml
 
+# the following config is for teaching kustomize how to do var substitution
 vars:
 - name: CERTIFICATENAME
   objref:
@@ -46,6 +47,14 @@ vars:
     group: certmanager.k8s.io
     version: v1alpha1
     name: serving-cert # this name should match the one in certificate.yaml
+- name: CERTIFICATENAMESPACE
+  objref:
+    kind: Certificate
+    group: certmanager.k8s.io
+    version: v1alpha1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
 
 configurations:
 - kustomizeconfig.yaml

--- a/pkg/scaffold/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/v2/crd/enablewebhook_patch.go
@@ -62,7 +62,7 @@ spec:
     webhookClientConfig:
       # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
       # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: XG4= 
+      caBundle: Cg==
       service:
         namespace: $(NAMESPACE)
         name: webhook-service

--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -54,7 +54,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]

--- a/pkg/scaffold/v2/kustomize.go
+++ b/pkg/scaffold/v2/kustomize.go
@@ -69,9 +69,10 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# - ../webhook
-# Comment the next line if you want to disable cert-manager
-# - ../certmanager
+# [WEBHOOK] Uncomment all the sections with [WEBHOOK] prefix to enable webhook.
+#- ../webhook
+# [CERTMANAGER] Uncomment next line to enable cert-manager
+#- ../certmanager
 
 patches:
 - manager_image_patch.yaml
@@ -86,9 +87,10 @@ patches:
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
 
-# Uncomment the following patch to enable the CA injection in the admission webhooks.
-#- webhookcainjection_patch.yaml
-
-# Uncomment the following patch to enable the webhook for the manager.
+# [WEBHOOK] Uncomment all the sections with [WEBHOOK] prefix to enable webhook.
 #- manager_webhook_patch.yaml
+
+# [CAINJECTION] Uncomment next line to enable the CA injection in the admission webhooks. [CERTMANAGER] needs to be
+# enabled to use ca injection
+#- webhookcainjection_patch.yaml
 `

--- a/pkg/scaffold/v2/manager/config.go
+++ b/pkg/scaffold/v2/manager/config.go
@@ -98,9 +98,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-        ports:
-        - containerPort: 9876
-          name: webhook-server
-          protocol: TCP
       terminationGracePeriodSeconds: 10
 `

--- a/pkg/scaffold/v2/webhook/enablecainection_patch.go
+++ b/pkg/scaffold/v2/webhook/enablecainection_patch.go
@@ -46,12 +46,12 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    certmanager.k8s.io/inject-ca-from: $(CERTIFICATENAMESPACE)/$(CERTIFICATENAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    certmanager.k8s.io/inject-ca-from: $(CERTIFICATENAMESPACE)/$(CERTIFICATENAME)
 `

--- a/pkg/scaffold/v2/webhook/kustomization.go
+++ b/pkg/scaffold/v2/webhook/kustomization.go
@@ -40,8 +40,24 @@ func (c *Kustomization) GetInput() (input.Input, error) {
 }
 
 var KustomizeWebhookTemplate = `resources:
-- webhookmanifests.yaml  # disabled till v2 has webhook support
+- webhookmanifests.yaml
+- service.yaml
 
 configurations:
 - kustomizeconfig.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+- name: NAMESPACE
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICENAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
 `

--- a/pkg/scaffold/v2/webhook/service.go
+++ b/pkg/scaffold/v2/webhook/service.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package manager
+package webhook
 
 import (
 	"path/filepath"
@@ -22,23 +22,31 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
-var _ input.File = &Kustomization{}
+var _ input.File = &Service{}
 
-// Kustomization scaffolds the Kustomization file in manager folder.
-type Kustomization struct {
+// Service scaffolds the Service file in manager folder.
+type Service struct {
 	input.Input
 }
 
 // GetInput implements input.File
-func (c *Kustomization) GetInput() (input.Input, error) {
+func (c *Service) GetInput() (input.Input, error) {
 	if c.Path == "" {
-		c.Path = filepath.Join("config", "manager", "kustomization.yaml")
+		c.Path = filepath.Join("config", "webhook", "service.yaml")
 	}
-	c.TemplateBody = kustomizeManagerTemplate
+	c.TemplateBody = ServiceTemplate
 	c.Input.IfExistsAction = input.Error
 	return c.Input, nil
 }
 
-var kustomizeManagerTemplate = `resources:
-- manager.yaml
+var ServiceTemplate = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      targetPort: 443
 `

--- a/pkg/scaffold/v2/webhook_manager_patch.go
+++ b/pkg/scaffold/v2/webhook_manager_patch.go
@@ -18,6 +18,7 @@ package v2
 
 import (
 	"path/filepath"
+
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
@@ -50,22 +51,12 @@ spec:
           name: webhook-server
           protocol: TCP
         volumeMounts:
-        - mountPath: /tmp/cert
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
       volumes:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-secret
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: webhook-service
-  namespace: system
-spec:
-  ports:
-  - port: 443
-    targetPort: 443
+          secretName: webhook-server-cert
 `

--- a/testdata/project-v2/Dockerfile
+++ b/testdata/project-v2/Dockerfile
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 ENTRYPOINT ["/manager"]

--- a/testdata/project-v2/config/certmanager/kustomization.yaml
+++ b/testdata/project-v2/config/certmanager/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - certificate.yaml
 
+# the following config is for teaching kustomize how to do var substitution
 vars:
 - name: CERTIFICATENAME
   objref:
@@ -8,6 +9,14 @@ vars:
     group: certmanager.k8s.io
     version: v1alpha1
     name: serving-cert # this name should match the one in certificate.yaml
+- name: CERTIFICATENAMESPACE
+  objref:
+    kind: Certificate
+    group: certmanager.k8s.io
+    version: v1alpha1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
 
 configurations:
 - kustomizeconfig.yaml

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/testdata/project-v2/config/crd/patches/webhook_in_captain.yaml
+++ b/testdata/project-v2/config/crd/patches/webhook_in_captain.yaml
@@ -11,7 +11,7 @@ spec:
     webhookClientConfig:
       # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
       # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: XG4= 
+      caBundle: Cg==
       service:
         namespace: $(NAMESPACE)
         name: webhook-service

--- a/testdata/project-v2/config/crd/patches/webhook_in_firstmate.yaml
+++ b/testdata/project-v2/config/crd/patches/webhook_in_firstmate.yaml
@@ -11,7 +11,7 @@ spec:
     webhookClientConfig:
       # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
       # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: XG4= 
+      caBundle: Cg==
       service:
         namespace: $(NAMESPACE)
         name: webhook-service

--- a/testdata/project-v2/config/default/kustomization.yaml
+++ b/testdata/project-v2/config/default/kustomization.yaml
@@ -16,9 +16,10 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# - ../webhook
-# Comment the next line if you want to disable cert-manager
-# - ../certmanager
+# [WEBHOOK] Uncomment all the sections with [WEBHOOK] prefix to enable webhook.
+#- ../webhook
+# [CERTMANAGER] Uncomment next line to enable cert-manager
+#- ../certmanager
 
 patches:
 - manager_image_patch.yaml
@@ -33,8 +34,9 @@ patches:
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
 
-# Uncomment the following patch to enable the CA injection in the admission webhooks.
-#- webhookcainjection_patch.yaml
-
-# Uncomment the following patch to enable the webhook for the manager.
+# [WEBHOOK] Uncomment all the sections with [WEBHOOK] prefix to enable webhook.
 #- manager_webhook_patch.yaml
+
+# [CAINJECTION] Uncomment next line to enable the CA injection in the admission webhooks. [CERTMANAGER] needs to be
+# enabled to use ca injection
+#- webhookcainjection_patch.yaml

--- a/testdata/project-v2/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v2/config/default/manager_webhook_patch.yaml
@@ -13,21 +13,11 @@ spec:
           name: webhook-server
           protocol: TCP
         volumeMounts:
-        - mountPath: /tmp/cert
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
       volumes:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-secret
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: webhook-service
-  namespace: system
-spec:
-  ports:
-  - port: 443
-    targetPort: 443
+          secretName: webhook-server-cert

--- a/testdata/project-v2/config/default/webhookcainjection_patch.yaml
+++ b/testdata/project-v2/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    certmanager.k8s.io/inject-ca-from: $(CERTIFICATENAMESPACE)/$(CERTIFICATENAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(NAMESPACE)/$(CERTIFICATENAME)
+    certmanager.k8s.io/inject-ca-from: $(CERTIFICATENAMESPACE)/$(CERTIFICATENAME)

--- a/testdata/project-v2/config/manager/kustomization.yaml
+++ b/testdata/project-v2/config/manager/kustomization.yaml
@@ -1,17 +1,2 @@
 resources:
 - manager.yaml
-
-# the following config is for teaching kustomize how to do var substitution 
-# vars:
-# - name: NAMESPACE
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: SERVICENAME
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service

--- a/testdata/project-v2/config/manager/manager.yaml
+++ b/testdata/project-v2/config/manager/manager.yaml
@@ -56,8 +56,4 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-        ports:
-        - containerPort: 9876
-          name: webhook-server
-          protocol: TCP
       terminationGracePeriodSeconds: 10

--- a/testdata/project-v2/config/rbac/role.yaml
+++ b/testdata/project-v2/config/rbac/role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v2/config/webhook/kustomization.yaml
+++ b/testdata/project-v2/config/webhook/kustomization.yaml
@@ -1,5 +1,21 @@
 resources:
-- webhookmanifests.yaml  # disabled till v2 has webhook support
+- webhookmanifests.yaml
+- service.yaml
 
 configurations:
 - kustomizeconfig.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+- name: NAMESPACE
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICENAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service


### PR DESCRIPTION
- remove dead code in `generated_golden.sh`
- fix broken webhook related scaffolding due to name or path change.
- split `NAMESPACE` into 2 different kustomize config, so `webhook` base can be used w/o `certmanager`.

- use `distroless/static`
