### PR TITLE
:warning: Switch default project version to v2

### DIFF
--- a/build/test.sh
+++ b/build/test.sh
@@ -29,7 +29,7 @@ export TEST_ASSET_KUBE_APISERVER=/tmp/kubebuilder/bin/kube-apiserver
 export TEST_ASSET_ETCD=/tmp/kubebuilder/bin/etcd
 
 # Run the commands
-kubebuilder init repo --domain sample.kubernetes.io
+kubebuilder init --project-version 1 repo --domain sample.kubernetes.io
 kubebuilder create resource --group insect --version v1beta1 --kind Bee
 kubebuilder create resource --group insect --version v1beta1 --kind Wasp
 kubebuilder create controller --group apps --version v1beta2 --kind Deployment --core-type

--- a/cmd/init_project.go
+++ b/cmd/init_project.go
@@ -106,7 +106,7 @@ func (o *projectOptions) bindCmdlineFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.project.Repo, "repo", util.Repo, "name of the github repo.  "+
 		"defaults to the go package of the current working directory.")
 	cmd.Flags().StringVar(&o.project.Domain, "domain", "k8s.io", "domain for groups")
-	cmd.Flags().StringVar(&o.project.Version, "project-version", project.Version1, "project version")
+	cmd.Flags().StringVar(&o.project.Version, "project-version", project.Version2, "project version")
 }
 
 func (o *projectOptions) initializeProject() {

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ source common.sh
 
 function test_init_project {
   header_text "performing init project"
-  kubebuilder init --domain example.com <<< "n"
+  kubebuilder init --project-version 1 --domain example.com <<< "n"
 }
 
 function test_make_project {


### PR DESCRIPTION
This switches the default scaffolding to v2, since we want people to use
this version.