### PR TITLE
:running: switch to using Go modules in build tooling

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
    - amd64
   env:
    - CGO_ENABLED=0
+   - GO111MODULE=on
 archive:
   files:
     - "/workspace/_output/{{ .Os }}_{{ .Arch }}/kubebuilder/bin/*"

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
 - name: "gcr.io/kubebuilder/thirdparty-darwin:1.13.1"
   args: ["tar", "-xzvf", "/kubebuilder_darwin_amd64.tar.gz"]
   dir: "_output/darwin_amd64"
-- name: "gcr.io/kubebuilder/goreleaser_with_go_1.11:0.0.1"
+- name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh"]
   env:
    - 'KUBERNETES_VERSION=1.13.1'

--- a/build/cloudbuild_local.yaml
+++ b/build/cloudbuild_local.yaml
@@ -31,7 +31,7 @@ steps:
 - name: "gcr.io/kubebuilder/thirdparty-darwin:1.13.1"
   args: ["tar", "-xzvf", "/kubebuilder_darwin_amd64.tar.gz"]
   dir: "_output/darwin_amd64"
-- name: "gcr.io/kubebuilder/goreleaser_with_go_1.11:0.0.1"
+- name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh", "--snapshot"]
   env:
    - 'KUBERNETES_VERSION=1.13.1'

--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -31,7 +31,7 @@ steps:
 - name: "gcr.io/kubebuilder/thirdparty-darwin:1.13.1"
   args: ["tar", "-xzvf", "/kubebuilder_darwin_amd64.tar.gz"]
   dir: "_output/darwin_amd64"
-- name: "gcr.io/kubebuilder/goreleaser_with_go_1.11:0.0.1"
+- name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh", "--snapshot"]
   env:
    - 'KUBERNETES_VERSION=1.13.1'


### PR DESCRIPTION
Highlights:
 - use Goreleaser with Go 1.12.5
 - Enable Go modules