### PR TITLE
:running: use k8s 1.14.1 in test scripts

### DIFF
--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
 - name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh"]
   env:
-   - 'KUBERNETES_VERSION=1.13.1'
+   - 'KUBERNETES_VERSION=1.14.1'
   secretEnv: ['GITHUB_TOKEN']
 secrets:
 - kmsKeyName: projects/kubebuilder/locations/global/keyRings/kubebuilder-gh-tokens/cryptoKeys/gh-release-token

--- a/build/cloudbuild_local.yaml
+++ b/build/cloudbuild_local.yaml
@@ -34,4 +34,4 @@ steps:
 - name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh", "--snapshot"]
   env:
-   - 'KUBERNETES_VERSION=1.13.1'
+   - 'KUBERNETES_VERSION=1.14.1'

--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -34,7 +34,7 @@ steps:
 - name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh", "--snapshot"]
   env:
-   - 'KUBERNETES_VERSION=1.13.1'
+   - 'KUBERNETES_VERSION=1.14.1'
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['-h', 'Content-Type:application/gzip', 'cp', 'dist/kubebuilder_master_linux_amd64.tar.gz', 'gs://kubebuilder-release/kubebuilder_master_linux_amd64.tar.gz']
 - name: 'gcr.io/cloud-builders/gsutil'

--- a/common.sh
+++ b/common.sh
@@ -54,7 +54,7 @@ if [ -z $go_workspace ]; then
 fi
 
 # k8s_version=1.11.0
-k8s_version=1.13.1
+k8s_version=1.14.1
 goarch=amd64
 goos="unknown"
 


### PR DESCRIPTION
This change ensures our test scripts are using k8s 1.14.1 binaries.