### PR TITLE
Kustomize and Snapshot Go Links

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,9 +9,6 @@ This Quick Start guide will cover:
 
 ## Installation
 
-Install [kustomize](https://sigs.k8s.io/kustomize).
-
-
 Install [kubebuilder](https://sigs.k8s.io/kubebuilder):
 
 ```bash
@@ -25,6 +22,16 @@ curl -sL https://go.kubebuilder.io/dl/2.0.0/${os}/${arch} | tar -xz -C /tmp/kube
 # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
 sudo mv /tmp/kubebuilder/kubebuilder_2.0.0_${os}_${arch} /user/local/kubebuilder
 export PATH=$PATH:/usr/local/kubebuilder/bin
+```
+
+Install [kustomize](https://sigs.k8s.io/kustomize):
+
+```bash
+os=$(go env GOOS)
+arch=$(go env GOARCH)
+
+# download kustomize to the kubebuilder assets folder
+curl -o /usr/local/kubebuilder/bin/kustomize -sL https://go.kubebuilder.io/dl/latest/${os}/${arch}
 ```
 
 ## Create a Project

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -24,6 +24,9 @@ sudo mv /tmp/kubebuilder/kubebuilder_2.0.0_${os}_${arch} /user/local/kubebuilder
 export PATH=$PATH:/usr/local/kubebuilder/bin
 ```
 
+You can also install a KubeBuilder master snapshot from
+`https://go.kubebuilder.io/dl/latest/${os}/${arch}`.
+
 Install [kustomize](https://sigs.k8s.io/kustomize):
 
 ```bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -44,13 +44,32 @@
     force = true
 
 [[redirects]]
+    from = "https://go.kubebuilder.io/releases/latest/:os"
+    to = "https://go.kubebuilder.io/releases/latest/:os/amd64"
+    status = 302
+    force = true
+
+[[redirects]]
     from = "https://go.kubebuilder.io/releases/:version/:os"
     to = "https://go.kubebuilder.io/releases/:version/:os/amd64"
     status = 302
     force = true
 
 [[redirects]]
+    from = "https://go.kubebuilder.io/releases/latest/:os/:arch"
+    to = "https://storage.googleapis.com/kubebuilder-release/kubebuilder_master_:os_:arch.tar.gz"
+    status = 302
+    force = true
+
+[[redirects]]
     from = "https://go.kubebuilder.io/releases/:version/:os/:arch"
     to = "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v:version/kubebuilder_:version_:os_:arch.tar.gz"
+    status = 302
+    force = true
+
+# TODO(directxman12): change this to standard kustomize when the next version is released (2.1.0) 
+[[redirects]]
+    from = "https://go.kubebuilder.io/kustomize/:os/:arch"
+    to = "https://storage.googleapis.com/kubebuilder-kustomize/kustomize_:os_:arch"
     status = 302
     force = true


### PR DESCRIPTION
This adds go links for kustomize and the snapshot builds, and updates the docs to mention Kustomize installation and the snapshot builds.