### PR TITLE
Fix kustomize go link in quickstart

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -34,7 +34,7 @@ os=$(go env GOOS)
 arch=$(go env GOARCH)
 
 # download kustomize to the kubebuilder assets folder
-curl -o /usr/local/kubebuilder/bin/kustomize -sL https://go.kubebuilder.io/dl/latest/${os}/${arch}
+curl -o /usr/local/kubebuilder/bin/kustomize -sL https://go.kubebuilder.io/kustomize/${os}/${arch}
 ```
 
 ## Create a Project


### PR DESCRIPTION
This fixes the kustomize go link to point at the actual kustomize go link, and not the latest go link.