### PR TITLE
Update cronjob_controller.go

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -78,9 +78,9 @@ and requeuing in the mean time won't help.
 */
 func ignoreNotFound(err error) error {
 	if apierrs.IsNotFound(err) {
-		return err
+		return nil
 	}
-	return nil
+	return err
 }
 
 // +kubebuilder:docs-gen:collapse=ignoreNotFound


### PR DESCRIPTION
Fix ignoreNotFound function.  
Correct me if I'm wrong, but I Believe the request will be requeued if `err != nil`, so nil should be returned on NotFound error