### PR TITLE
 📖 use real example, fix yaml in markdown

### DIFF
--- a/docs/book/src/cronjob-tutorial/running.md
+++ b/docs/book/src/cronjob-tutorial/running.md
@@ -25,7 +25,9 @@ anything just yet.
 At this point, we need a CronJob to test with.  Let's write a sample to
 `config/samples/batch_v1_cronjob.yaml`, and use that:
 
+```yaml
 {{#include ./testdata/project/config/samples/batch_v1_cronjob.yaml}}
+```
 
 ```bash
 kubectl create -f config/samples/batch_v1_cronjob.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/samples/batch_v1_cronjob.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/samples/batch_v1_cronjob.yaml
@@ -3,5 +3,18 @@ kind: CronJob
 metadata:
   name: cronjob-sample
 spec:
-  # Add fields here
-  foo: bar
+  schedule: "*/1 * * * *"
+  startingDeadlineSeconds: 60
+  concurrencyPolicy: Allow # explicitly specify, but Allow is also default.
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure


### PR DESCRIPTION
For users familiar with CronJobs, this is self-explanatory, but I thought it would be nice to have a real example. 

Also, the yaml isn't in a code block so it looks whack right now.