### PR TITLE
Add version dependent questions for generating APIs

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -28,7 +28,6 @@ import (
 
 	"sigs.k8s.io/kubebuilder/cmd/util"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
-	"sigs.k8s.io/kubebuilder/pkg/scaffold/project"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/v1/resource"
 )
 
@@ -67,28 +66,15 @@ func resourceForFlags(f *flag.FlagSet) *resource.Resource {
 // APICmd represents the resource command
 func (o *apiOptions) runAddAPI() {
 	dieIfNoProject()
-	projectInfo, err := scaffold.LoadProjectFile("PROJECT")
-	if err != nil {
-		log.Fatalf("failed to read the PROJECT file: %v", err)
-	}
+
 	reader := bufio.NewReader(os.Stdin)
 	if !o.resourceFlag.Changed {
-		if projectInfo.Version == project.Version1 {
-			fmt.Println("Create Resource under pkg/apis [y/n]")
-		}
-		if projectInfo.Version == project.Version2 {
-			fmt.Println("Create Resource under api [y/n]")
-		}
+		fmt.Println("Create Resource [y/n]")
 		o.apiScaffolder.DoResource = util.Yesno(reader)
 	}
 
 	if !o.controllerFlag.Changed {
-		if projectInfo.Version == project.Version1 {
-			fmt.Println("Create Controller under pkg/controller [y/n]")
-		}
-		if projectInfo.Version == project.Version2 {
-			fmt.Println("Create Controller under controllers [y/n]")
-		}
+		fmt.Println("Create Controller [y/n]")
 		o.apiScaffolder.DoController = util.Yesno(reader)
 	}
 
@@ -139,7 +125,6 @@ After the scaffold is written, api will run make on the project.
 		Example: `	# Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
 	kubebuilder create api --group ship --version v1beta1 --kind Frigate
 	
-	# Project Version 2
 	# Edit the API Scheme
 	nano api/ship/v1beta1/frigate_types.go
 

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -28,6 +28,7 @@ import (
 
 	"sigs.k8s.io/kubebuilder/cmd/util"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/scaffold/project"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/v1/resource"
 )
 
@@ -66,15 +67,28 @@ func resourceForFlags(f *flag.FlagSet) *resource.Resource {
 // APICmd represents the resource command
 func (o *apiOptions) runAddAPI() {
 	dieIfNoProject()
-
+	projectInfo, err := scaffold.LoadProjectFile("PROJECT")
+	if err != nil {
+		log.Fatalf("failed to read the PROJECT file: %v", err)
+	}
 	reader := bufio.NewReader(os.Stdin)
 	if !o.resourceFlag.Changed {
-		fmt.Println("Create Resource under api [y/n]?")
+		if projectInfo.Version == project.Version1 {
+			fmt.Println("Create Resource under pkg/apis [y/n]")
+		}
+		if projectInfo.Version == project.Version2 {
+			fmt.Println("Create Resource under api [y/n]")
+		}
 		o.apiScaffolder.DoResource = util.Yesno(reader)
 	}
 
 	if !o.controllerFlag.Changed {
-		fmt.Println("Create Controller under controllers [y/n]?")
+		if projectInfo.Version == project.Version1 {
+			fmt.Println("Create Controller under pkg/controller [y/n]")
+		}
+		if projectInfo.Version == project.Version2 {
+			fmt.Println("Create Controller under controllers [y/n]")
+		}
 		o.apiScaffolder.DoController = util.Yesno(reader)
 	}
 
@@ -124,7 +138,8 @@ After the scaffold is written, api will run make on the project.
 `,
 		Example: `	# Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
 	kubebuilder create api --group ship --version v1beta1 --kind Frigate
-
+	
+	# Project Version 2
 	# Edit the API Scheme
 	nano api/ship/v1beta1/frigate_types.go
 


### PR DESCRIPTION
As a follow up to #728 here is a simple approach to version specific questions. Although I am not sure if this is the right way to approach this, it really seems more complex to add a helper for this. @abursavich what do you think about the `Examples`? I haven't found a proper way to make those version specific.