### PR TITLE
:bug: fix missing add-to-scheme calls on new API version

### DIFF
--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -212,15 +212,21 @@ func (api *API) scaffoldV2() error {
 			return fmt.Errorf("error scaffolding controller: %v", err)
 		}
 
-		err = ctrlScaffolder.UpdateMain("main.go")
-		if err != nil {
-			return fmt.Errorf("error updating main.go with reconciler code: %v", err)
-		}
-
-		err = testsuiteScaffolder.UpdateTestSuite()
+		err = testsuiteScaffolder.Update()
 		if err != nil {
 			return fmt.Errorf("error updating suite_test.go under controllers pkg: %v", err)
 		}
+	}
+
+	err := (&resourcev2.Main{}).Update(
+		&resourcev2.MainUpdateOptions{
+			Project:        api.project,
+			WireResource:   api.DoResource,
+			WireController: api.DoController,
+			Resource:       r,
+		})
+	if err != nil {
+		return fmt.Errorf("error updating main.go: %v", err)
 	}
 
 	return nil

--- a/pkg/scaffold/v2/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller_suitetest.go
@@ -125,9 +125,9 @@ var _ = AfterSuite(func() {
 })
 `
 
-// UpdateTestSuite updates given file (suite_test.go) with code fragments required for
+// Update updates given file (suite_test.go) with code fragments required for
 // adding import paths and code setup for new types.
-func (a *ControllerSuiteTest) UpdateTestSuite() error {
+func (a *ControllerSuiteTest) Update() error {
 
 	a.ResourcePackage, a.GroupDomain = getResourceInfo(a.Resource, a.Input)
 	if a.Plural == "" {
@@ -146,9 +146,10 @@ Expect(err).NotTo(HaveOccurred())
 `, a.Resource.Group, a.Resource.Version)
 
 	err := internal.InsertStringsInFile(a.Path,
-		apiPkgImportScaffoldMarker, ctrlImportCodeFragment,
-		apiPkgImportScaffoldMarker, apiImportCodeFragment,
-		apiSchemeScaffoldMarker, addschemeCodeFragment)
+		map[string][]string{
+			apiPkgImportScaffoldMarker: []string{ctrlImportCodeFragment, apiImportCodeFragment},
+			apiSchemeScaffoldMarker:    []string{addschemeCodeFragment},
+		})
 	if err != nil {
 		return err
 	}

--- a/pkg/scaffold/v2/crd/kustomization.go
+++ b/pkg/scaffold/v2/crd/kustomization.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	kustomizeResourceScaffoldMarker = "+kubebuilder:scaffold:kustomizeresource"
-	kustomizePatchScaffoldMarker    = "+kubebuilder:scaffold:kustomizepatch"
+	kustomizeResourceScaffoldMarker = "# +kubebuilder:scaffold:kustomizeresource"
+	kustomizePatchScaffoldMarker    = "# +kubebuilder:scaffold:kustomizepatch"
 )
 
 var _ input.File = &Kustomization{}
@@ -67,19 +67,21 @@ func (c *Kustomization) Update() error {
 	kustomizePatchCodeFragment := fmt.Sprintf("#- patches/webhook_in_%s.yaml\n", plural)
 
 	return internal.InsertStringsInFile(c.Path,
-		kustomizeResourceScaffoldMarker, kustomizeResourceCodeFragment,
-		kustomizePatchScaffoldMarker, kustomizePatchCodeFragment)
+		map[string][]string{
+			kustomizeResourceScaffoldMarker: []string{kustomizeResourceCodeFragment},
+			kustomizePatchScaffoldMarker:    []string{kustomizePatchCodeFragment},
+		})
 }
 
 var kustomizationTemplate = fmt.Sprintf(`# This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-# %s
+%s
 
 patches:
 # patches here are for enabling the conversion webhook for each CRD
-# %s
+%s
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/pkg/scaffold/v2/internal/string_utils_test.go
+++ b/pkg/scaffold/v2/internal/string_utils_test.go
@@ -22,11 +22,10 @@ import (
 )
 
 type insertStrTest struct {
-	input    string
-	marker   string
-	str      string
-	expected string
-	got      string
+	input         string
+	markerNValues map[string][]string
+	expected      string
+	got           string
 }
 
 func TestInsertStrBelowMarker(t *testing.T) {
@@ -37,11 +36,14 @@ func TestInsertStrBelowMarker(t *testing.T) {
 v1beta1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
-			marker: "+kubebuilder:scaffold:apis-add-scheme",
-			str:    "v1.AddToScheme(scheme)\n",
+			markerNValues: map[string][]string{
+				"// +kubebuilder:scaffold:apis-add-scheme": []string{
+					"v1.AddToScheme(scheme)\n", "somefunc()\n"},
+			},
 			expected: `
 v1beta1.AddToScheme(scheme)
 v1.AddToScheme(scheme)
+somefunc()
 // +kubebuilder:scaffold:apis-add-scheme
 `,
 		},
@@ -50,10 +52,13 @@ v1.AddToScheme(scheme)
 v1beta1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
-			marker: "+kubebuilder:scaffold:apis-add-scheme",
-			str:    "v1beta1.AddToScheme(scheme)\n",
+			markerNValues: map[string][]string{
+				"// +kubebuilder:scaffold:apis-add-scheme": []string{
+					"v1beta1.AddToScheme(scheme)\n", "v1.AddToScheme(scheme)\n"},
+			},
 			expected: `
 v1beta1.AddToScheme(scheme)
+v1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
 		},
@@ -63,9 +68,9 @@ v1beta1.AddToScheme(scheme)
 v1beta1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
-			marker: "+kubebuilder:scaffold:apis-add-scheme",
-			str: `v1.AddToScheme(scheme)
-`,
+			markerNValues: map[string][]string{
+				"// +kubebuilder:scaffold:apis-add-scheme": []string{`v1.AddToScheme(scheme)
+`}},
 			expected: `
 v1beta1.AddToScheme(scheme)
 v1.AddToScheme(scheme)
@@ -75,7 +80,7 @@ v1.AddToScheme(scheme)
 	}
 
 	for _, test := range tests {
-		result, err := insertStrings(bytes.NewBufferString(test.input), test.marker, test.str)
+		result, err := insertStrings(bytes.NewBufferString(test.input), test.markerNValues)
 		if err != nil {
 			t.Errorf("error %v", err)
 		}
@@ -89,5 +94,4 @@ v1.AddToScheme(scheme)
 			t.Errorf("got: %s and wanted: %s", string(b), test.expected)
 		}
 	}
-
 }

--- a/testdata/project-v2/controllers/suite_test.go
+++ b/testdata/project-v2/controllers/suite_test.go
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
 	cfg, err := testEnv.Start()


### PR DESCRIPTION
The change improves the logic for updating the main.go when
new API/Controller is added to the project.

fixes #740