### PR TITLE
:bug: added multigroup check while creating resource

### DIFF
--- a/pkg/scaffold/input/input.go
+++ b/pkg/scaffold/input/input.go
@@ -169,4 +169,29 @@ type ProjectFile struct {
 
 	// Repo is the go package name of the project root
 	Repo string `yaml:"repo,omitempty"`
+
+	// Resources tracks scaffolded resources in the project. This info is
+	// tracked only in project with version 2.
+	Resources []Resource `yaml:"resources,omitempty"`
+}
+
+// ResourceGroups returns unique groups of scaffolded resources in the project.
+func (pf *ProjectFile) ResourceGroups() []string {
+	groupSet := map[string]struct{}{}
+	for _, r := range pf.Resources {
+		groupSet[r.Group] = struct{}{}
+	}
+
+	groups := []string{}
+	for g, _ := range groupSet {
+		groups = append(groups, g)
+	}
+	return groups
+}
+
+// Resource contains information about scaffolded resources.
+type Resource struct {
+	Group   string `yaml:"group,omitempty"`
+	Version string `yaml:"version,omitempty"`
+	Kind    string `yaml:"kind,omitempty"`
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -105,6 +105,19 @@ func LoadProjectFile(path string) (input.ProjectFile, error) {
 	return p, nil
 }
 
+// saveProjectFile saves the given ProjectFile at the given path.
+func saveProjectFile(path string, project *input.ProjectFile) error {
+	content, err := yaml.Marshal(project)
+	if err != nil {
+		return fmt.Errorf("error marshalling project info %v", err)
+	}
+	err = ioutil.WriteFile(path, content, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to save project file at %s %v", path, err)
+	}
+	return nil
+}
+
 // GetBoilerplate reads the boilerplate file
 func getBoilerplate(path string) (string, error) {
 	b, err := ioutil.ReadFile(path) // nolint: gosec

--- a/testdata/project-v2/PROJECT
+++ b/testdata/project-v2/PROJECT
@@ -1,3 +1,10 @@
 version: "2"
 domain: testproject.org
 repo: sigs.k8s.io/kubebuilder/testdata/project-v2
+resources:
+- group: crew
+  version: v1
+  kind: Captain
+- group: crew
+  version: v1
+  kind: FirstMate


### PR DESCRIPTION
This change does the following:
  - introduces book-keeping of scaffolded resources in PROJECT file
  - Validates if new resource belong to existing scaffolded groups

fixes #739 