### PR TITLE
Use pointers for replicas field in the gitbook

### DIFF
--- a/docs/book/basics/simple_resource.md
+++ b/docs/book/basics/simple_resource.md
@@ -69,7 +69,7 @@ field, which may be set by autoscalers.
 // ContainerSetSpec defines the desired state of ContainerSet
 type ContainerSetSpec struct {
   // replicas is the number of replicas to maintain
-  Replicas int32 `json:"replicas,omitempty"`
+  Replicas *int32 `json:"replicas,omitempty"`
 
   // image is the container image to run.  Image must have a tag.
   // +kubebuilder:validation:Pattern=.+:.+
@@ -91,7 +91,7 @@ events to update the field.
 ```go
 // ContainerSetStatus defines the observed state of ContainerSet
 type ContainerSetStatus struct {
-  HealthyReplicas int32 `json:"healthyReplicas,omitempty"`
+  HealthyReplicas *int32 `json:"healthyReplicas,omitempty"`
 }
 ```
 {% endmethod %}


### PR DESCRIPTION
Update the replica field to use a pointer in the type definition and the controller reconciliation code.

Fixes #434 

/cc @mengqiy 