### PR TITLE
Add support for the resource scope marker

### DIFF
--- a/generated_golden.sh
+++ b/generated_golden.sh
@@ -64,6 +64,7 @@ scaffold_test_project() {
 		$kb init --project-version $version --domain testproject.org --license apache2 --owner "The Kubernetes authors"
 		$kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false
 		$kb create api --group crew --version v1 --kind FirstMate --controller=true --resource=true --make=false
+		$kb create api --group crew --version v1 --kind Admiral --controller=true --resource=true --namespaced=false --make=false
 		# TODO(droot): Adding a second group is a valid test case and kubebuilder is expected to report an error in this case. It
 		# doesn't do that currently so leaving it commented so that we can enable it later.
 		# $kb create api --group ship --version v1beta1 --kind Frigate --example=false --controller=true --resource=true --make=false

--- a/pkg/scaffold/v2/types.go
+++ b/pkg/scaffold/v2/types.go
@@ -75,6 +75,9 @@ type {{.Resource.Kind}}Status struct {
 }
 
 // +kubebuilder:object:root=true
+{{ if not .Resource.Namespaced }}
+// +kubebuilder:resource:scope=Cluster
+{{ end }}
 
 // {{.Resource.Kind}} is the Schema for the {{ .Resource.Resource }} API
 type {{.Resource.Kind}} struct {


### PR DESCRIPTION
This enables generation of cluster-scoped types.

Depends on https://github.com/kubernetes-sigs/controller-tools/pull/220.

TODO:
- [x] Update controller-tools version to include https://github.com/kubernetes-sigs/controller-tools/pull/220
- [ ] Test(s)
