### PR TITLE
:sparkles: cache go module cache in docker

### DIFF
--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -40,14 +40,17 @@ var dockerfileTemplate = `# Build the manager binary
 FROM golang:1.12.5 as builder
 
 WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/testdata/project-v2/Dockerfile
+++ b/testdata/project-v2/Dockerfile
@@ -2,14 +2,17 @@
 FROM golang:1.12.5 as builder
 
 WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
Before: every time you change your source file, the downloaded go module cache are invalidated.
After: the downloaded go module cache are always reused.
fixes: #755