### PR TITLE
:sparkles: add a flag for the leader election feature

### DIFF
--- a/pkg/scaffold/v2/main.go
+++ b/pkg/scaffold/v2/main.go
@@ -140,15 +140,18 @@ func init() {
 
 func main() {
 	var metricsAddr string
+	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                  scheme,
-		MetricsBindAddress:      metricsAddr,
-		LeaderElection:          true,
+		Scheme:             scheme,
+		MetricsBindAddress: metricsAddr,
+		LeaderElection:     enableLeaderElection,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/scaffold/v2/manager/config.go
+++ b/pkg/scaffold/v2/manager/config.go
@@ -67,6 +67,8 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - --enable-leader-election
         image: {{ .Image }}
         name: manager
         resources:

--- a/testdata/project-v2/config/manager/manager.yaml
+++ b/testdata/project-v2/config/manager/manager.yaml
@@ -25,6 +25,8 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - --enable-leader-election
         image: controller:latest
         name: manager
         resources:

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -44,7 +44,10 @@ func init() {
 
 func main() {
 	var metricsAddr string
+	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
@@ -52,7 +55,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		LeaderElection:     true,
+		LeaderElection:     enableLeaderElection,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
The leader election feature is disabled when running locally using `make
run`, while it is enabled by default when running in a k8s cluster.
