### PR TITLE
gitignore zz_generated.* files except for vendored stuff

### DIFF
--- a/pkg/scaffold/project/gitignore.go
+++ b/pkg/scaffold/project/gitignore.go
@@ -52,7 +52,7 @@ bin
 *.out
 
 # Kubernetes Generated files - skip generated files, except for vendored files
-
+**/zz_generated.*
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia


### PR DESCRIPTION
The vendor exception existed but there was a missing ignore for `**/zz_generated.*` :-)