### PR TITLE
Update kubebuilder book for typos and repaired links

### DIFF
--- a/docs/book/src/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial.md
@@ -2,7 +2,7 @@
 
 Too many tutorials start out with some really contrived setup, or some toy
 application that gets the basics across, and then stalls out on the more
-complicated suff.  Instead, this tutorial should take you through (almost)
+complicated stuff.  Instead, this tutorial should take you through (almost)
 the full gamut of complexity with Kubebuilder, starting off simple and
 building up to something pretty full-featured.
 
@@ -32,5 +32,5 @@ project:
 kubebuilder init --domain tutorial.kubebuilder.io
 ```
 
-Now that we've got've a project in place, let's take a look at what
+Now that we've got a project in place, let's take a look at what
 Kubebuilder has scaffolded for us so far...

--- a/docs/book/src/cronjob-tutorial/basic-project.md
+++ b/docs/book/src/cronjob-tutorial/basic-project.md
@@ -28,24 +28,24 @@ First up, basic infrastructure for building your project:
 
 ## Launch Configuration
 
-We also get launch configuration under the
-[`config/`](https://sigs.k8s.io/kubebuilder.io/docs/book/cronjob-tutorial/testdata/project/config)
+We also get launch configurations under the
+[`config/`](testdata/project/config)
 directory.  Right now, it just contains
 [Kustomize](https://sigs.k8s.io/kustomize) YAML definitions required to
 launch our controller on a cluster, but once we get started writing our
 controller, it'll also hold our CustomResourceDefinitions, RBAC
 configuration, and WebhookConfigurations.
 
-[`config/default`](../TODO.md) contains a [Kustomize base](../TODO.md) for launching
+[`config/default`](testdata/project/config/default) contains a [Kustomize base](../TODO.md) for launching
 the controller in a standard configuration.
 
 Each other directory contains a different piece of configuration,
 refactored out into its own base:
 
-- [`config/manager`](../TODO.md): launch your controllers as pods in the
+- [`config/manager`](testdata/project/config/manager): launch your controllers as pods in the
   cluster
 
-- [`config/rbac`](../TODO.md): permissions required to run your
+- [`config/rbac`](testdata/project/config/rbac): permissions required to run your
   controllers under their own service account
 
 ## The Entrypoint

--- a/docs/book/src/cronjob-tutorial/basic-project.md
+++ b/docs/book/src/cronjob-tutorial/basic-project.md
@@ -5,7 +5,7 @@ basic pieces of boilerplate.
 
 ## Build Infrastructure
 
-First up, basic infrastructure for building you project:
+First up, basic infrastructure for building your project:
 
 <details><summary>`go.mod`: A new Go module matching our project, with basic dependencies</summary>
 


### PR DESCRIPTION
I'm going through the book and found a couple of typos to fix. The links in basic-project are quite broken and I took a guess at their correct relative urls. Let me know if those match your expectations.

I was unable to find a match for `Kustomize base`, it is unresolved.