### PR TITLE
Fix broken dir listing by using github URLs

### DIFF
--- a/docs/book/src/cronjob-tutorial/basic-project.md
+++ b/docs/book/src/cronjob-tutorial/basic-project.md
@@ -29,23 +29,23 @@ First up, basic infrastructure for building your project:
 ## Launch Configuration
 
 We also get launch configurations under the
-[`config/`](testdata/project/config)
+[`config/`](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cronjob-tutorial/testdata/project/config)
 directory.  Right now, it just contains
 [Kustomize](https://sigs.k8s.io/kustomize) YAML definitions required to
 launch our controller on a cluster, but once we get started writing our
 controller, it'll also hold our CustomResourceDefinitions, RBAC
 configuration, and WebhookConfigurations.
 
-[`config/default`](testdata/project/config/default) contains a [Kustomize base](../TODO.md) for launching
+[`config/default`](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cronjob-tutorial/testdata/project/config/default) contains a [Kustomize base](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml) for launching
 the controller in a standard configuration.
 
 Each other directory contains a different piece of configuration,
 refactored out into its own base:
 
-- [`config/manager`](testdata/project/config/manager): launch your controllers as pods in the
+- [`config/manager`](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cronjob-tutorial/testdata/project/config/manager): launch your controllers as pods in the
   cluster
 
-- [`config/rbac`](testdata/project/config/rbac): permissions required to run your
+- [`config/rbac`](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cronjob-tutorial/testdata/project/config/rbac): permissions required to run your
   controllers under their own service account
 
 ## The Entrypoint

--- a/docs/book/src/cronjob-tutorial/main-revisited.md
+++ b/docs/book/src/cronjob-tutorial/main-revisited.md
@@ -1,7 +1,7 @@
 # You said something about main?
 
 But first, remember how we said we'd [come back to `main.go`
-again](../TODO)?  Let's take a look and see what's changed, and what we
+again](../TODO.md)?  Let's take a look and see what's changed, and what we
 need to add.
 
 {{#literatego ./testdata/project/main.go}}


### PR DESCRIPTION
Directory trees like `testdata/project/config/default` aren't listed by mdbook, breaking links in the book. Workaround this by using the github URLs for the paths. There's going to be a better way, but at least the links will work.

I introduced it in #779 when replacing `TODO.md` with the directory