### PR TITLE
:running: remove git-lfs usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-testdata/*.tgz filter=lfs diff=lfs merge=lfs -text

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ go:
 
 git:
   depth: 3
-  lfs_skip_smudge: true
 
 go_import_path: sigs.k8s.io/kubebuilder
 
@@ -23,12 +22,9 @@ services:
 
 before_install:
 - go get -u github.com/golang/dep/cmd/dep
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -sL https://github.com/git-lfs/git-lfs/releases/download/v2.7.2/git-lfs-darwin-amd64-v2.7.2.tar.gz | tar -xz git-lfs; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then GO111MODULE=on scripts/install_and_setup.sh; fi
 
 before_script:
-- git lfs install
-- git lfs pull
 
 # Install must be set to prevent default `go get` to run.
 # The dependencies have already been vendored by `dep` so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ Kubernetes projects require that you sign a Contributor License Agreement (CLA) 
 Please see https://git.k8s.io/community/CLA.md for more info.
 
 ## Contributing steps
-1. Setup [Git LFS plugin](https://git-lfs.github.com/)
 1. Submit an issue describing your proposed change to the repo in question.
 1. The [repo owners](OWNERS) will respond to your issue promptly.
 1. If your proposed change is accepted, and you haven't already done so, sign a Contributor License Agreement (see details above).
@@ -16,13 +15,9 @@ Please see https://git.k8s.io/community/CLA.md for more info.
 
 ## How to build kubebuilder locally
 
-1. Setup Git LFS
-Install the git-lfs plugin using the instructions from [git-lfs](https://git-lfs.github.com/) page.
-Once installed, run `git lfs install` in your repo to setup git lfs hooks.
-
 1. Build
 ```sh
-$ go build -o /output/path/kubebuilder ./cmd
+$ make build
 ```
 
 1. Test

--- a/common.sh
+++ b/common.sh
@@ -160,9 +160,22 @@ function setup_envs {
   export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 }
 
+# download_vendor_archive downloads vendor tarball for v1 projects. It skips the
+# download if tarball exists.
+function download_vendor_archive {
+  archive_name="vendor.v1.tgz"
+  archive_download_url="https://storage.googleapis.com/kubebuilder-vendor/$archive_name"
+  archive_path="$tmp_root/$archive_name"
+  if [ ! -f $archive_path ]; then
+    header_text "downloading vendor archive $archive_path"
+    curl -sL ${archive_download_url} -o "$archive_path"
+  fi
+}
+
 function restore_go_deps {
   header_text "restoring Go dependencies"
-  tar -zxf ${go_workspace}/src/sigs.k8s.io/kubebuilder/testdata/vendor.v1.tgz
+  download_vendor_archive
+  tar -zxf $tmp_root/vendor.v1.tgz
 }
 
 function cache_project {

--- a/generated_golden.sh
+++ b/generated_golden.sh
@@ -43,7 +43,8 @@ scaffold_test_project() {
 		export GO111MODULE=auto
 		export GOPATH=$(pwd)/../.. # go ignores vendor under testdata, so fake out a gopath
 		# untar Gopkg.lock and vendor directory for appropriate project version
-		tar -zxf $testdata_dir/vendor.v$version.tgz
+		download_vendor_archive
+		tar -zxf $tmp_root/vendor.v$version.tgz
 
 		$kb init --project-version $version --domain testproject.org --license apache2 --owner "The Kubernetes authors" --dep=false
 		$kb create api --group crew --version v1 --kind FirstMate --controller=true --resource=true --make=false
@@ -79,12 +80,6 @@ scaffold_test_project() {
 }
 
 set -e
-
-if ! git lfs > /dev/null 2>&1 ; then
-    echo "this project requires git-lfs, see: https://git-lfs.github.com/"
-    echo "after installing, you'll need to git checkout ./testdata/*tgz"
-    exit 1
-fi
 
 build_kb
 scaffold_test_project gopath/src/project 1

--- a/test.sh
+++ b/test.sh
@@ -85,17 +85,6 @@ y
 EOF
 }
 
-# download_vendor_archive downloads vendor tarball for v1 projects. It skips the
-# download if tarball exists.
-function download_vendor_archive {
-  archive_name="vendor.v1.tgz"
-  archive_download_url="https://storage.googleapis.com/kubebuilder-vendor/$archive_name"
-  archive_path="$tmp_root/$archive_name"
-  if [ ! -f $archive_path ]; then
-    header_text "downloading vendor archive $archive_path"
-    curl -sL ${archive_download_url} -o "$archive_path"
-  fi
-}
 
 function test_project {
   project_dir=$1

--- a/test/e2e/e2e_v1.go
+++ b/test/e2e/e2e_v1.go
@@ -53,9 +53,16 @@ var _ = Describe("kubebuilder", func() {
 
 		It("should generate a runnable project", func() {
 			// prepare v1 vendor
-			By("untar the vendor tarball")
-			cmd := exec.Command("tar", "-zxf", "../../../testdata/vendor.v1.tgz")
+			By("downloading the vendor tarball")
+			cmd := exec.Command("wget",
+				"https://storage.googleapis.com/kubebuilder-vendor/vendor.v1.tgz",
+				"-O", "/tmp/vendor.v1.tgz")
 			_, err := kbc.Run(cmd)
+			Expect(err).Should(Succeed())
+
+			By("untar the vendor tarball")
+			cmd = exec.Command("tar", "-zxf", "/tmp/vendor.v1.tgz")
+			_, err = kbc.Run(cmd)
 			Expect(err).Should(Succeed())
 
 			var controllerPodName string

--- a/testdata/vendor.v1.tgz
+++ b/testdata/vendor.v1.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79d1af743339638e1dff3a0412418791d3c536c8248597e4597c90852e71bf7f
-size 30389729


### PR DESCRIPTION
We no longer use git-lfs due to bandwidth quota issues. This removes remaining git-lfs usage from test scripts.