### PR TITLE
:sparkles: scheme should have all builtin types registered by default

### DIFF
--- a/pkg/scaffold/v2/main.go
+++ b/pkg/scaffold/v2/main.go
@@ -119,6 +119,7 @@ import (
 	"flag"
     "os"
 
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
     ctrl "sigs.k8s.io/controller-runtime"
     "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -129,7 +130,7 @@ import (
 )
 
 var (
-    scheme = runtime.NewScheme()
+	scheme   = clientgoscheme.Scheme
     setupLog = ctrl.Log.WithName("setup")
 )
 

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
+	scheme   = clientgoscheme.Scheme
 	setupLog = ctrl.Log.WithName("setup")
 )
 


### PR DESCRIPTION
This new scheme should make users life easier.

fixes https://github.com/kubernetes-sigs/kubebuilder/issues/797

xref: https://github.com/kubernetes-sigs/controller-runtime/issues/492