### PR TITLE
Add existing k8s types to new scheme

### DIFF
--- a/pkg/scaffold/v2/main.go
+++ b/pkg/scaffold/v2/main.go
@@ -130,11 +130,12 @@ import (
 )
 
 var (
-	scheme   = clientgoscheme.Scheme
-    setupLog = ctrl.Log.WithName("setup")
+	scheme = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
 
 	%s
 }
@@ -160,7 +161,7 @@ func main() {
 	}
 
 
-    %s
+	%s
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,11 +32,12 @@ import (
 )
 
 var (
-	scheme   = clientgoscheme.Scheme
+	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
 
 	_ = crewv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)


### PR DESCRIPTION
It's generally not good practice to modify someone else's scheme, so we
add k8s types to our new scheme instead.

(re) fixes #797