### PR TITLE
fix enable-leader-election overriden by patch.

### DIFF
--- a/pkg/scaffold/v2/metricsauth/kustomize_auth_proxy_patch.go
+++ b/pkg/scaffold/v2/metricsauth/kustomize_auth_proxy_patch.go
@@ -64,4 +64,5 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
 `

--- a/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
@@ -22,3 +22,4 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"


### PR DESCRIPTION
when `manager_auth_proxy_patch` is enabled, the
`--enable-leader-election` arg inside `manager/manager.yaml` will be
overriden.