### PR TITLE
Added information about how to make kustomize executable

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -37,6 +37,12 @@ arch=$(go env GOARCH)
 curl -o /usr/local/kubebuilder/bin/kustomize -sL https://go.kubebuilder.io/kustomize/${os}/${arch}
 ```
 
+Ensure that kustomize is executable:
+
+```bash
+chmod 755 /usr/local/kubebuilder/bin/kustomize
+```
+
 ## Create a Project
 
 Initialize a new project and Go module for your controllers:


### PR DESCRIPTION
Suggestion: Add documentation to ensure that kustomize is executable when users install it. 

I ran into issues when trying to deploy an image that required kustomize. It installed correctly, but was not executable and I therefore encountered errors. 