### PR TITLE
Added the missing link for controller reference

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -68,7 +68,7 @@ This will create the files `api/v1/guestbook_types.go` and
 
 **Optional:** Edit the API definition or the reconciliation business logic.
 For more on this see [What is
-a Controller](TODO.md) and [What is
+a Controller](cronjob-tutorial/controller-overview.html) and [What is
 a Resource](TODO.md)
 
 ## Test It Out Locally


### PR DESCRIPTION
Added Missing link for controller reference on the [quick start page ](https://book.kubebuilder.io/quick-start.html)

Partially fixes issue #773 