### PR TITLE
fix the example validation for minimum length of string type

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -57,7 +57,7 @@ the fields.
 
 // CronJobSpec defines the desired state of CronJob
 type CronJobSpec struct {
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:MinLength=0
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	Schedule string `json:"schedule"`


### PR DESCRIPTION
Fixes #855 