### PR TITLE
Rename Gopkg.toml to go.mod in help usage

### DIFF
--- a/cmd/init_project.go
+++ b/cmd/init_project.go
@@ -45,7 +45,7 @@ Writes the following files:
 - a boilerplate license file
 - a PROJECT file with the domain and repo
 - a Makefile to build the project
-- a Gopkg.toml with project dependencies
+- a go.mod with project dependencies
 - a Kustomization.yaml for customizating manifests
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics

--- a/pkg/scaffold/v2/gomod.go
+++ b/pkg/scaffold/v2/gomod.go
@@ -22,7 +22,7 @@ import (
 
 var _ input.File = &GoMod{}
 
-// GoMod writes a templatefile for Gopkg.toml
+// GoMod writes a templatefile for go.mod
 type GoMod struct {
 	input.Input
 }


### PR DESCRIPTION
Since the default project version is v2 and it relies on go modules, it makes sense to adapt the help usage accordingly.