### PR TITLE
:sparkles: Makefile: Create manifests with 'run' target

### DIFF
--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -66,7 +66,7 @@ manager: generate fmt vet
 	go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet
+run: generate fmt vet manifests
 	go run ./main.go
 
 # Install CRDs into a cluster

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -22,7 +22,7 @@ manager: generate fmt vet
 	go build -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
-run: generate fmt vet
+run: generate fmt vet manifests
 	go run ./main.go
 
 # Install CRDs into a cluster


### PR DESCRIPTION
The `manifests` makefile target isn't called as expected during the build process. This section from [the kubebuilder book](https://kubebuilder.io/reference/generating-crd.html) (specifically "If you examine the Makefile ... manifests target is also listed as prerequisite for other targets like run ...) implies a `make run` should create manifests. 

This issue was found because the yaml files in the cluster didn't match what the binary expected (with a make run).
