### PR TITLE
:book: add the missing scheme back

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/main.go
@@ -86,6 +86,7 @@ func main() {
 	if err = (&controllers.CronJobReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Captain"),
+		Scheme: mgr.GetScheme(), // we've added this ourselves
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Captain")
 		os.Exit(1)


### PR DESCRIPTION
Adding the scheme to the reconciler initialization accidentally got dropped during a refresh.  This restores it.

Fixes #870
