### PR TITLE
:sparkles: replace patches with patchesStrategicMerge

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -68,4 +68,3 @@ gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-

--- a/pkg/scaffold/project/kustomize.go
+++ b/pkg/scaffold/project/kustomize.go
@@ -69,7 +69,7 @@ bases:
 - ../rbac
 - ../manager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/pkg/scaffold/v2/crd/kustomization.go
+++ b/pkg/scaffold/v2/crd/kustomization.go
@@ -81,7 +81,7 @@ var kustomizationTemplate = fmt.Sprintf(`# This kustomization.yaml is not intend
 resources:
 %s
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 %s

--- a/pkg/scaffold/v2/kustomize.go
+++ b/pkg/scaffold/v2/kustomize.go
@@ -74,7 +74,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 
-patches:
+patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.

--- a/testdata/gopath/src/project/config/default/kustomization.yaml
+++ b/testdata/gopath/src/project/config/default/kustomization.yaml
@@ -16,7 +16,7 @@ bases:
 - ../rbac
 - ../manager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/testdata/project-v2/config/crd/kustomization.yaml
+++ b/testdata/project-v2/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - bases/crew.testproject.org_admirals.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_captains.yaml

--- a/testdata/project-v2/config/default/kustomization.yaml
+++ b/testdata/project-v2/config/default/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 
-patches:
+patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.


### PR DESCRIPTION
kustomize has deprecated `patches` fields for months.
It should be replaced by `patchesStrategicMerge`.
`patches` if in old format will be auto convert to the new format in v3.0.4+. So this PR is not considering a breaking change.

Ref: https://github.com/kubernetes-sigs/kustomize/pull/1355 and kubernetes-sigs/kustomize#1363