### PR TITLE
Adding the GO111MODULE environment variable

### DIFF
--- a/scripts/install_and_setup.sh
+++ b/scripts/install_and_setup.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export GO111MODULE=on
+
 go get sigs.k8s.io/kind@v0.4.0
 go get sigs.k8s.io/kustomize/v3/cmd/kustomize@v3.0.1
 


### PR DESCRIPTION
Added  `export GO111MODULE=on` to the install_and_setup.sh 

Without this environment variable, running this script will produce the following error: 

```
go get: warning: modules disabled by GO111MODULE=auto in GOPATH/src;
	ignoring ../go.mod;
	see 'go help modules'
go: cannot use path@version syntax in GOPATH mode
```
