### PR TITLE
:book: Marker Docs

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -10,3 +10,6 @@ curly-quotes = true
 
 [preprocessor.literatego]
 command = "./litgo.sh"
+
+[preprocessor.markerdocs]
+command = "./markerdocs.sh"

--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -1,11 +1,54 @@
 #!/bin/bash
 
+set -e
+
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
+# translate arch to rust's conventions (if we can)
+if [[ ${arch} == "amd64" ]]; then
+    arch="x86_64"
+elif [[ ${arch} == "x86" ]]; then
+    arch="i686"
+fi
+
+# translate os to rust's conventions (if we can)
+ext="tar.gz"
+cmd="tar -C /tmp -xzvf"
+case ${os} in
+    windows)
+        target="pc-windows-msvc"
+        ext="zip"
+        cmd="unzip -d /tmp"
+        ;;
+    darwin)
+        target="apple-darwin"
+        ;;
+    linux)
+        # works for linux, too
+        target="unknown-${os}-gnu"
+        ;;
+    *)
+        target="unknown-${os}"
+        ;;
+esac
+
 # grab mdbook
-# mdbook's deploy got borked by a CI move, so grab our build till that gets
-# fixed (https://github.com/rust-lang-nursery/mdBook/issues/904).
-curl -sL -o /tmp/mdbook https://storage.googleapis.com/kubebuilder-build-tools/mdbook-0.2.3-${os}-${arch}
+# we hardcode linux/amd64 since rust uses a different naming scheme and it's a pain to tran
+echo "downloading mdBook-v0.3.1-${arch}-${target}.${ext}"
+set -x
+curl -sL -o /tmp/mdbook.${ext} https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdBook-v0.3.1-${arch}-${target}.${ext}
+${cmd} /tmp/mdbook.${ext}
 chmod +x /tmp/mdbook
+
+echo "grabbing the latest released controller-gen"
+# TODO(directxman12): remove the @v0.2.0-beta.4 once get v0.2.0 released,
+# so that we actually get the latest version
+go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.4
+
+# make sure we add the go bin directory to our path
+gobin=$(go env GOBIN)
+gobin=${GOBIN:-$(go env GOPATH)/bin}  # GOBIN won't always be set :-/
+
+export PATH=${gobin}:$PATH
 /tmp/mdbook build

--- a/docs/book/litgo.sh
+++ b/docs/book/litgo.sh
@@ -4,7 +4,7 @@ set -ex
 
 (
     pushd ./utils
-    go build -o ../../../bin/literate-go ./literate.go
+    go build -o ../../../bin/literate-go ./litgo
     popd
 ) &>/dev/null
 

--- a/docs/book/markerdocs.sh
+++ b/docs/book/markerdocs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+(
+    pushd ./utils
+    go build -o ../../../bin/marker-docs ./markerdocs
+    popd
+) &>/dev/null
+
+../../bin/marker-docs "$@"

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -42,6 +42,14 @@
   - [Kind cluster](reference/kind.md)
   - [What's a webhook?](reference/webhook-overview.md)
     - [Admission webhook](reference/admission-webhook.md)
+  - [Markers for Config/Code Generation](./reference/markers.md)
+
+      - [CRD Generation](./reference/markers/crd.md)
+      - [CRD Validation](./reference/markers/crd-validation.md)
+      - [Webhook](./reference/markers/webhook.md)
+      - [Object/DeepCopy](./reference/markers/object.md)
+      - [RBAC](./reference/markers/rbac.md)
+
 ---
 
 [Appendix: The TODO Landing Page](./TODO.md)

--- a/docs/book/src/cronjob-tutorial/epilogue.md
+++ b/docs/book/src/cronjob-tutorial/epilogue.md
@@ -3,5 +3,4 @@
 Things left to do:
 
 - Write custom printer columns
-- Discuss webhooks
 - Use different watches

--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -44,9 +44,10 @@ type CronJobReconciler struct {
 }
 
 /*
-Most controllers eventually end up running on the cluster, so they need RBAC permissions.
-These are the bare minimum permissions needed to run.  As we add more functionality, we'll
-need to revisit these.
+Most controllers eventually end up running on the cluster, so they need RBAC
+permissions, which we specify using controller-tools [RBAC
+markers](/reference/markers/rbac.md).  These are the bare minimum permissions
+needed to run.  As we add more functionality, we'll need to revisit these.
 */
 
 // +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete

--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -58,9 +58,11 @@ At this point, our main function is fairly simple:
 
 - We set up some basic flags for metrics.
 
-- We instantiate a [*manager*](../TODO.md), which keeps track of running all of
-our controllers, as well as setting up shared caches and clients to the API
-server (notice we tell the manager about our Scheme).
+- We instantiate a
+[*manager*](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/manager#Manager),
+which keeps track of running all of our controllers, as well as setting up
+shared caches and clients to the API server (notice we tell the manager about
+our Scheme).
 
 - We run our manager, which in turn runs all of our controllers and webhooks.
 The manager is set up to run until it receives a graceful shutdown signal.

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -50,9 +50,9 @@ func (r *CronJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 /*
 Notice that we use kubebuilder markers to generate webhook manifests.
-This markers is responsible for generating a mutating webhook manifest.
+This marker is responsible for generating a mutating webhook manifest.
 
-The meaning of each marker can be found [here](../TODO.md).
+The meaning of each marker can be found [here](/reference/markers/webhook.md).
 */
 
 // +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io
@@ -87,10 +87,7 @@ func (r *CronJob) Default() {
 }
 
 /*
-Notice that we use kubebuilder markers to generate webhook manifests.
-This markers is responsible for generating a validating webhook manifest.
-
-The meaning of each marker can be found [here](../TODO.md).
+This marker is responsible for generating a validating webhook manifest.
 */
 
 // +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob.kb.io
@@ -156,7 +153,7 @@ You can find kubebuilder validation markers (prefixed
 with `// +kubebuilder:validation`) in the [API](api-design.md)
 You can find all of the kubebuilder supported markers for
 declaring validation by running `controller-gen crd -w`,
-or [here](../TODO.md).
+or [here](/reference/markers/crd-validation.md).
 */
 
 func (r *CronJob) validateCronJobSpec() *field.Error {

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -87,7 +87,8 @@ func ignoreNotFound(err error) error {
 
 /*
 Notice that we need a few more RBAC permissions -- since we're creating and
-managing jobs now, we'll need permissions for those.
+managing jobs now, we'll need permissions for those, which means adding
+a couple more [markers](/reference/markers/rbac.md).
 */
 
 // +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete

--- a/docs/book/src/multiversion-tutorial/api-implementation.md
+++ b/docs/book/src/multiversion-tutorial/api-implementation.md
@@ -154,7 +154,7 @@ Let's take a quick look at the `api/v1/disk_webhook.go` file.
 
 If you look at `main.go`, you will notice the following snippet that invokes the
 SetupWebhook method.
-```Go
+```go
 	.....
 
 	if err = (&infrav1.Disk{}).SetupWebhookWithManager(mgr); err != nil {
@@ -176,7 +176,14 @@ CRD_OPTIONS ?= "crd:trivialVersions=false"
 ```
 
 Run `make manifests` to ensure that CRD manifests gets generated under `config/crd/bases/` directory.
-[TODO](../TODO.md) embed a compressed form of the generated CRD `testdata/project/config/crd`
+
+<details><summary>`infra.kubebuilder.io_disks.yaml`: the generated CRD YAML</summary>
+
+```yaml
+{{#include ./testdata/project/config/crd/bases/infra.kubebuilder.io_disks.yaml}}
+```
+
+</details>
 
 ### Manifests Generation
 

--- a/docs/book/src/multiversion-tutorial/deployment.md
+++ b/docs/book/src/multiversion-tutorial/deployment.md
@@ -34,7 +34,7 @@ kubectl get disks.v2.infra.kubebuilder.io/disk-sample -o yaml
 ```
 
 ```yaml
-apiVersion: infra.kubebuilder.io/v2 <-- note the v2 version
+apiVersion: infra.kubebuilder.io/v2 # <-- note the v2 version
 kind: Disk
 metadata:
   name: disk-sample
@@ -54,7 +54,7 @@ status: {}
 kubectl get disks.v3.infra.kubebuilder.io/disk-sample -o yaml
 ```
 ```yaml
-apiVersion: infra.kubebuilder.io/v3 <-- note the v3 version
+apiVersion: infra.kubebuilder.io/v3 # <-- note the v3 version
 kind: Disk
 metadata:
   name: disk-sample
@@ -62,7 +62,7 @@ metadata:
   uid: 0e9be0fd-a284-11e9-bbbe-42010a8001af <-- note the same uid as v2
   ....
 spec:
-  pricePerGB: <-- note the pricePerGB name of the field
+  pricePerGB: # <-- note the pricePerGB name of the field
     amount: 10
     currency: USD
 status: {}

--- a/docs/book/src/reference/markers.md
+++ b/docs/book/src/reference/markers.md
@@ -1,0 +1,84 @@
+# Markers for Config/Code Generation
+
+KubeBuilder makes use of a tool called `controller-gen` (from
+[controller-tools](https://godoc.org/sigs.k8s.io/controller-tools)) for
+generating utility code and Kubernetes YAML.  This code and config
+generation is controlled by the presenence of special "marker comments" in
+Go code.
+
+Markers are single-line comments that start with a plus, followed by
+a marker name, optionally followed by some marker specific configuration:
+
+```go
+// +kubebuilder:validation:Optional
+// +kubebuilder:validation:MaxItems=2
+// +kubebuilder:printcolumn:JSONPath=".status.replicas",name=Replicas,type=string
+```
+
+See each subsection for information about different types of code and YAML
+generation.
+
+## Generating Code & Artifacts in KubeBuilder
+
+KubeBuilder projects have two `make` targets that make use of
+controller-gen:
+
+- `make manifests` generates Kubernetes object YAML, like
+  [CustomResourceDefinitions](./markers/crd.md),
+  [WebhookConfigurations](./markers/webhook.md), and [RBAC
+  roles](./markers/rbac.md).
+
+- `make generate` generates code, like [runtime.Object/DeepCopy
+  implementations](./markers/object.md).
+
+See [Generating CRDs](./generating-crd.md) for a comprehensive overview.
+
+## Marker Syntax
+
+Exact syntax is described in the [godocs for
+controller-tools](https://godoc.org/sigs.k8s.io/controller-tools/pkg/markers).
+
+In general, markers may either be: 
+
+- **Empty** (`+kubebuilder:validation:Optional`): empty markers are like boolean flags on the command line
+  -- just specifying them enables some behavior.
+
+- **Anonymous** (`+kubebuilder:validation:MaxItems=2`): anonymous markers take
+  a single value as their argument.
+
+- **Multi-option**
+  (`+kubebuilder:printcolumn:JSONPath=".status.replicas",name=Replicas,type=string`): multi-option
+  markers take one or more named arguments.  The first argument is
+  separated from the name by a colon, and latter arguments are
+  comma-separated.  Order of arguments doesn't matter.  Some arguments may
+  be optional.
+
+Marker arguments may be strings, ints, bools, or slices thereof.  Strings,
+ints, and bools follow their Go syntax:
+
+```go
+// +kubebuilder:validation:ExclusiveMaximum=false
+// +kubebulder:validation:Format="date-time"
+// +kubebuilder:validation:Maxium=42
+```
+
+For convinience, in simple cases the quotes may be omitted from strings,
+although this is not encouraged for anything other than single-word
+strings:
+
+```go
+// +kubebuilder:validation:Type=string
+```
+
+Slices may be specified either by surrounding them with curly braces and
+separating with commas:
+
+```go
+// +kubebuilder:webhooks:Enum={"crackers, Gromit, we forgot the crackers!","not even wensleydale?"}
+```
+
+or, in simple cases, by separating with semicolons:
+
+```go
+// +kubebuilder:validation:Enum=Wallace;Gromit;Chicken
+```

--- a/docs/book/src/reference/markers/crd-validation.md
+++ b/docs/book/src/reference/markers/crd-validation.md
@@ -1,0 +1,7 @@
+# CRD Validation
+
+These markers modify how the CRD validation schema is produced for the
+types and fields they modify.  Each corresponds roughly to an OpenAPI/JSON
+schema option.
+
+{{#markerdocs CRD validation}}

--- a/docs/book/src/reference/markers/crd-validation.md
+++ b/docs/book/src/reference/markers/crd-validation.md
@@ -4,4 +4,6 @@ These markers modify how the CRD validation schema is produced for the
 types and fields they modify.  Each corresponds roughly to an OpenAPI/JSON
 schema option.
 
+See [Generating CRDs](/reference/generating-crd.md) for examples.
+
 {{#markerdocs CRD validation}}

--- a/docs/book/src/reference/markers/crd.md
+++ b/docs/book/src/reference/markers/crd.md
@@ -4,4 +4,6 @@ These markers describe how to construct a custom resource definition from
 a series of Go types and packages.  Generation of the actual validation
 schema is described by the [validation markers](./crd-validation.md).
 
+See [Generating CRDs](/reference/generating-crd.md) for examples.
+
 {{#markerdocs CRD}}

--- a/docs/book/src/reference/markers/crd.md
+++ b/docs/book/src/reference/markers/crd.md
@@ -1,0 +1,7 @@
+# CRD Generation
+
+These markers describe how to construct a custom resource definition from
+a series of Go types and packages.  Generation of the actual validation
+schema is described by the [validation markers](./crd-validation.md).
+
+{{#markerdocs CRD}}

--- a/docs/book/src/reference/markers/object.md
+++ b/docs/book/src/reference/markers/object.md
@@ -1,0 +1,6 @@
+# Object/DeepCopy
+
+These markers control when `DeepCopy` and `runtime.Object` implemention
+methods are generated.
+
+{{#markerdocs object}}

--- a/docs/book/src/reference/markers/rbac.md
+++ b/docs/book/src/reference/markers/rbac.md
@@ -1,0 +1,9 @@
+# RBAC
+
+These markers cause an [RBAC
+ClusterRole](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)
+to be generated.  This allows you to describe the permissions that your
+controller requires alongside the code that makes use of those
+permissions.
+
+{{#markerdocs RBAC}}

--- a/docs/book/src/reference/markers/webhook.md
+++ b/docs/book/src/reference/markers/webhook.md
@@ -1,0 +1,7 @@
+# Webhook
+
+These markers describe how [webhook configuration](/TODO.md) is generated.
+Use these to keep the description of your webhooks close to the code that
+implements them.
+
+{{#markerdocs Webhook}}

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -1,0 +1,355 @@
+/* Base styles and content styles */
+
+@import 'variables.css';
+
+html {
+    font-family: "Open Sans", sans-serif;
+    color: var(--fg);
+    background-color: var(--bg);
+    text-size-adjust: none;
+}
+
+body {
+    margin: 0;
+    font-size: 1rem;
+    overflow-x: hidden;
+}
+
+code {
+    font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
+    font-size: 0.875em; /* please adjust the ace font size accordingly in editor.js */
+}
+
+.left { float: left; }
+.right { float: right; }
+.hidden { display: none; }
+.play-button.hidden { display: none; }
+
+h2, h3 { margin-top: 2.5em; }
+h4, h5 { margin-top: 2em; }
+
+.header + .header h3,
+.header + .header h4,
+.header + .header h5 { 
+    margin-top: 1em;
+}
+
+a.header:target h1:before,
+a.header:target h2:before,
+a.header:target h3:before,
+a.header:target h4:before {
+    display: inline-block;
+    content: "»";
+    margin-left: -30px;
+    width: 30px;
+}
+
+.page {
+    outline: 0;
+    padding: 0 var(--page-padding);
+}
+.page-wrapper {
+    box-sizing: border-box;
+}
+.js .page-wrapper {
+    transition: margin-left 0.3s ease, transform 0.3s ease; /* Animation: slide away */
+}
+
+.content {
+    overflow-y: auto;
+    padding: 0 15px;
+    padding-bottom: 50px;
+}
+.content main {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: var(--content-max-width);
+}
+.content a { text-decoration: none; }
+.content a:hover { text-decoration: underline; }
+.content img { max-width: 100%; }
+.content .header:link,
+.content .header:visited {
+    color: var(--fg);
+}
+.content .header:link,
+.content .header:visited:hover {
+    text-decoration: none;
+}
+
+table {
+    margin: 0 auto;
+    border-collapse: collapse;
+}
+table td {
+    padding: 3px 20px;
+    border: 1px var(--table-border-color) solid;
+}
+table thead {
+    background: var(--table-header-bg);
+}
+table thead td {
+    font-weight: 700;
+    border: none;
+}
+table thead tr {
+    border: 1px var(--table-header-bg) solid;
+}
+/* Alternate background colors for rows */
+table tbody tr:nth-child(2n) {
+    background: var(--table-alternate-bg);
+}
+
+
+blockquote {
+    margin: 20px 0;
+    padding: 0 20px;
+    color: var(--fg);
+    background-color: var(--quote-bg);
+    border-top: .1em solid var(--quote-border);
+    border-bottom: .1em solid var(--quote-border);
+}
+
+
+:not(.footnote-definition) + .footnote-definition,
+.footnote-definition + :not(.footnote-definition) {
+    margin-top: 2em;
+}
+.footnote-definition {
+    font-size: 0.9em;
+    margin: 0.5em 0;
+}
+.footnote-definition p {
+    display: inline;
+}
+
+.tooltiptext {
+    position: absolute;
+    visibility: hidden;
+    color: #fff;
+    background-color: #333;
+    transform: translateX(-50%); /* Center by moving tooltip 50% of its width left */
+    left: -8px; /* Half of the width of the icon */
+    top: -35px;
+    font-size: 0.8em;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 8px;
+    margin: 5px;
+    z-index: 1000;
+}
+.tooltipped .tooltiptext {
+    visibility: visible;
+}
+
+/* From here on out is custom stuff */
+
+/* marker docs styles */
+
+/* NB(directxman12): The general gist of this is that we use semantic markup
+ * for the actual HTML as much as possible, and then use CSS to look pretty and
+ * extract the actual relevant information.  Theoretically, this'll let us do
+ * stuff like transform the information for different screen widths. */
+
+/* the marker */
+.marker {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 0.25em;
+}
+
+/* the marker name */
+.marker > dt.name::before {
+    content: '// +';
+}
+.marker > dt.name {
+    font-weight: bold;
+    order: 0; /* hack around the ::before's positioning to get it after the line */
+}
+
+/* the target blob */
+.marker::before {
+    content: "on " attr(data-target);
+    padding: 1px 6px;
+    border-radius: 20%;
+    background: var(--quote-bg);
+    margin-left: 0.5em;
+    font-weight: normal;
+    opacity: 0.75;
+    font-size: 0.75em;
+    order: 2; /* hack around the ::before's positioning to get it after the line */
+}
+
+/* deprecated markers */
+.marker.deprecated[data-target] {
+    /* use attribute marker for specificity */
+    order: 4;
+    opacity: 0.65;
+}
+
+.marker.deprecated::before {
+    content: "deprecated (on " attr(data-target) ")";
+    color: red;
+}
+.marker.deprecated:not([data-deprecated=""])::before {
+    content: "use " attr(data-deprecated) " (on " attr(data-target) ")";
+    color: red;
+}
+
+/* the summary arguments (hidden in non-summary view) */
+.marker dd.args {
+    margin-left: 0;
+    font-family: mono;
+    order: 1; /* hack around the ::before's positioning to get it after the line */
+}
+.marker dl.args.summary {
+    display: inline-block;
+    margin-bottom: 0;
+    margin-top: 0;
+}
+/* TODO(directxman12): optional */
+.marker dl.args.summary dt {
+    display: inline-block;
+    font-style: inherit;
+}
+.marker dl.args.summary dt:first-child::before {
+    content: ':';
+}
+.marker dl.args.summary dt::before {
+    content: ',';
+}
+.marker dl.args.summary dt:first-of-type:last-of-type::before {
+    content: '';
+}
+/* hide in non-summary view */
+.marker dd.args {
+    display: none
+}
+
+/* the description */
+.marker dd.description {
+    order: 3; /* hack around the ::before's positioning to get it after the line */
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+/* all arguments */
+.marker dl.args dt.argument::after {
+    content: '=';
+}
+.marker dl.args dd.type {
+    font-style: italic;
+}
+.marker .argument {
+    display: inline-block;
+    margin-left: 0;
+}
+.marker .argument.type {
+    font-size: 0.875em;
+}
+.marker .literal {
+    font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
+    font-size: 0.875em; /* please adjust the ace font size accordingly in editor.js */
+}
+.marker .argument.type::before {
+    content: '‹';
+}
+.marker .argument.type::after {
+    content: '›';
+}
+
+/* summary args */
+.marker .args.summary .argument.optional {
+    opacity: 0.75;
+}
+
+/* anonymous marker args */
+.marker.anonymous .description details {
+    order: 1;
+    flex: 1; /* don't cause arg syntax to wrap */
+}
+.marker.anonymous .description .args {
+    order: 0; /* go before the description */
+
+    /* all on a single line */
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-right: 1em;
+}
+.marker.anonymous .description {
+    flex-direction: row;
+}
+.marker .description dl.args:empty {
+    margin-top: 0;
+}
+
+.marker .type .slice::before {
+    content: '[]';
+}
+
+/* description args */
+.marker .description dt.argument.optional::before {
+    content: "opt";
+    padding: 1px 4px;
+    border-radius: 20%;
+    background: var(--quote-bg);
+    opacity: 0.5;
+    margin-left: -3em;
+    float: left;
+}
+
+/* help text */
+.marker summary.no-details {
+    list-style: none;
+}
+.marker summary.no-details::-webkit-details-marker {
+    display: none;
+}
+
+/* summary view */
+#markers-summarize:checked ~ dl > .marker dd.args {
+    display: inline-block
+}
+#markers-summarize:checked ~ dl > .marker dd.description dl.args {
+    display: none
+}
+#markers-summarize:checked ~ dl > .marker dd.description {
+    margin-bottom: 0.25em;
+}
+
+#markers-summarize {
+    display: none;
+}
+label[for="markers-summarize"]::before {
+    margin-right: 0.5em;
+    content: '\25bc';
+    display: inline-block;
+}
+#markers-summarize:checked ~ label[for="markers-summarize"]::before {
+    content: '\25b6';
+}
+
+/* misc */
+/* marker details should be indented to be in line with the summary,
+ * which is indented due to the expando
+ */
+.marker details > p {
+    margin-left: 1em;
+}
+
+/* sort by target */
+.marker[data-target="package"] {
+    order: 2;
+}
+.marker[data-target="type"] {
+    order: 1;
+}
+.marker[data-target="field"] {
+    order: 0;
+}
+.markers {
+    display: flex;
+    flex-direction: column;
+}

--- a/docs/book/utils/go.sum
+++ b/docs/book/utils/go.sum
@@ -1,0 +1,1 @@
+sigs.k8s.io/kubebuilder v1.0.8 h1:XYctSbuOICM9z1Ok0GIWChc1cj90EEEczeJQnb7ZPf0=

--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -188,21 +188,33 @@ func extractContents(contents []byte, path string) (string, error) {
 			out.WriteString("</summary>")
 		}
 		if strings.TrimSpace(pair.comment) != "" {
+			out.WriteString("\n")
 			out.WriteString(pair.comment)
 		}
 
 		if strings.TrimSpace(pair.code) != "" {
-			out.WriteString("\n```go\n")
-			out.WriteString(pair.code)
-			out.WriteString("\n```\n")
+			out.WriteString("\n\n```go")
+			out.WriteString(wrapWithNewlines(pair.code))
+			out.WriteString("```\n")
 		}
 		if pair.collapse != ""{
-			out.WriteString("</details>")
+			out.WriteString("\n</details>")
 		}
 		// TODO(directxman12): nice side-by-side sections
 	}
 
 	return out.String(), nil
+}
+
+// wrapWithNewlines ensures that we begin and end with a newline character.
+func wrapWithNewlines(src string) string {
+	if src[0] != '\n' {
+		src = "\n" + src
+	}
+	if src[len(src)-1] != '\n' {
+		src = src + "\n"
+	}
+	return src
 }
 
 func main() {

--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -23,48 +39,16 @@ import (
 type Literate struct {}
 func (_ Literate) SupportsOutput(_ string) bool { return true }
 func (_ Literate) Process(input *plugin.Input) error {
-	return plugin.EachItemInBook(&input.Book, func(chapter *plugin.BookChapter) error {
-		if chapter.Content == "" {
-			return nil
+	return plugin.EachCommand(&input.Book, "literatego", func(chapter *plugin.BookChapter, relPath string) (string, error) {
+		path := filepath.Join(input.Context.Root, input.Context.Config.Book.Src, filepath.Dir(chapter.Path), relPath)
+
+		// TODO(directxman12): don't escape root?
+		contents, err := ioutil.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("unable to import %q: %v", path, err)
 		}
 
-		// figure out all the trigger expressins
-		partsRaw := strings.Split(chapter.Content, "{{#literatego ")
-		// the first section won't start with `{{#literatego ` as per how split works
-		if len(partsRaw) < 2 {
-			return nil
-		}
-
-		var res []string
-		res = append(res, partsRaw[0])
-		for _, part := range partsRaw[1:] {
-			endDelim := strings.Index(part, "}}")
-			if endDelim < 0 {
-				return fmt.Errorf("missing end delimiter in chapter %q", chapter.Name)
-			}
-			// we need to join the path with the context root and the book's
-			// source directory, since we assume paths are relative to the
-			// given chapter file, like `{{#include}}`
-			relPath := part[:endDelim]
-			path := filepath.Join(input.Context.Root, input.Context.Config.Book.Src, filepath.Dir(chapter.Path), relPath)
-
-			// TODO(directxman12): don't escape root?
-			contents, err := ioutil.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("unable to import %q: %v", path, err)
-			}
-
-			newContents, err := extractContents(contents, path)
-			if err != nil {
-				return fmt.Errorf("unable to process %q: %v", path, err)
-			}
-
-			res = append(res, string(newContents))
-			res = append(res, part[endDelim+2:])
-		}
-
-		chapter.Content = strings.Join(res, "")
-		return nil
+		return extractContents(contents, path)
 	})
 }
 

--- a/docs/book/utils/markerdocs/doctypes.go
+++ b/docs/book/utils/markerdocs/doctypes.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// these should be kept in sync with the output from controller-tools
+
+type DetailedHelp struct {
+	Summary string `json:"summary"`
+	Details string `json:"details"`
+}
+
+type Argument struct {
+	Type string `json:"type"`
+	Optional bool `json:"optional"`
+	ItemType  *Argument `json:"itemType"`
+}
+
+type FieldHelp struct {
+	// definition
+	Name string `json:"name"`
+	Argument `json:",inline"`
+
+	// help
+
+	DetailedHelp `json:",inline"`
+}
+
+type MarkerDoc struct {
+	// definition
+
+	Name string `json:"name"`
+	Target string `json:"target"`
+
+	// help
+
+	DetailedHelp `json:",inline"`
+	Category string `json:"category"`
+	DeprecatedInFavorOf *string `json:"deprecatedInFavorOf"`
+	Fields []FieldHelp `json:"fields"`
+}
+
+type CategoryDoc struct {
+	Category string `json:"category"`
+	Markers []MarkerDoc `json:"markers"`
+}
+
+func (m MarkerDoc) Anonymous() bool {
+	return len(m.Fields) == 1 && m.Fields[0].Name == ""
+}
+

--- a/docs/book/utils/markerdocs/html.go
+++ b/docs/book/utils/markerdocs/html.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"html"
+	"io"
+
+)
+
+// NB(directxman12): we use this instead of templates to avoid
+// weird issues with whitespace in elements rendered as inline.
+// Writing with templates was getting tricky to do without
+// compromising readability.
+//
+// This isn't an amazing solution, but it's good enough™
+
+// toHTML knows how to write itself as HTML to an output.
+type toHTML interface {
+	// WriteHTML writes this as HTML to the given Writer.
+	WriteHTML(io.Writer) error
+}
+
+// Text is a chunk of text in an HTML doc.
+type Text string
+func (t Text) WriteHTML(w io.Writer) error {
+	_, err := io.WriteString(w, html.EscapeString(string(t)))
+	return err
+}
+
+// Tag is some tag with contents and attributes in an HTML doc.
+type Tag struct {
+	Name string
+	Attrs Attrs
+	Children []toHTML
+}
+func (t Tag) WriteHTML(w io.Writer) error {
+	attrsOut := ""
+	if t.Attrs != nil {
+		attrsOut = t.Attrs.ToAttrs()
+	}
+	if _, err := fmt.Fprintf(w, "<%s %s>", t.Name, attrsOut); err != nil {
+		return err
+	}
+
+	for _, child := range t.Children {
+		if err := child.WriteHTML(w); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintf(w, "</%s>", t.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Fragment is some series of tags, text, etc in an HTML doc.
+type Fragment []toHTML
+func (f Fragment) WriteHTML(w io.Writer) error {
+	for _, item := range f {
+		if err := item.WriteHTML(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Attrs knows how to convert itself to HTML attributes.
+type Attrs interface {
+	// ToAttrs returns `key1="value1" key2="value2"` etc to be placed into an HTML tag.
+	ToAttrs() string
+}
+
+// classes sets the class attribute to these class names.
+type classes []string
+func (c classes) ToAttrs() string { return fmt.Sprintf("class=%q", strings.Join(c, " ")) }
+
+// optionalClasses sets the the class attribute to these class names, if their values are true.
+type optionalClasses map[string]bool
+func (c optionalClasses) ToAttrs() string {
+	actualClasses := make([]string, 0, len(c))
+	for class, active := range c {
+		if active {
+			actualClasses = append(actualClasses, class)
+		}
+	}
+	return classes(actualClasses).ToAttrs()
+}
+
+// attrs joins together one or more Attrs.
+type attrs []Attrs
+func (a attrs) ToAttrs() string {
+	parts := make([]string, len(a))
+	for i, attr := range a {
+		parts[i] = attr.ToAttrs()
+	}
+	return strings.Join(parts, " ")
+}
+
+// dataAttr represents some `data-*` attribute.
+type dataAttr struct {
+	Name string
+	Value string
+}
+func (d dataAttr) ToAttrs() string {
+	return fmt.Sprintf("data-%s=%q", d.Name, d.Value)
+}
+
+// makeTag produces a function that makes tags of the given
+// type.
+func makeTag(name string) func(Attrs, ...toHTML) Tag {
+	return func(attrs Attrs, children ...toHTML) Tag {
+		return Tag{
+			Name: name,
+			Attrs: attrs,
+			Children: children,
+		}
+	}
+}
+
+var (
+	dd = makeTag("dd")
+	dt = makeTag("dt")
+	dl = makeTag("dl")
+	details = makeTag("details")
+	summary = makeTag("summary")
+	span = makeTag("span")
+	div = makeTag("div")
+)
+

--- a/docs/book/utils/markerdocs/main.go
+++ b/docs/book/utils/markerdocs/main.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"log"
+	"strings"
+	"os/exec"
+	"encoding/json"
+
+	"sigs.k8s.io/kubebuilder/docs/book/utils/plugin"
+)
+
+// argType produces HTML for describing an Argument's type.
+func argType(arg *Argument) toHTML {
+	if arg.Type == "slice" {
+		return span(optionalClasses{"optional": arg.Optional, "slice": true},
+			argType(arg.ItemType))
+	}
+
+	return span(classes{"optional"},
+		Text(arg.Type))
+}
+
+// maybeDetails returns HTML describing summary and
+// details if present, otherwise returning an empty fragment.
+func maybeDetails(help *DetailedHelp) toHTML {
+	if help.Summary == "" && help.Details == "" {
+		return Fragment{}
+	}
+	
+	return Fragment{
+		details(nil,
+			summary(optionalClasses{"no-details": help.Details == ""},
+				Text(help.Summary)),
+			// NB(directxman12): if we don't wrap with newlines, markdown won't be parsed
+			Text(wrapWithNewlines(help.Details)))}
+}
+
+// markerTemplate returns HTML describing the documentation for a given marker.
+func markerTemplate(marker *MarkerDoc) toHTML {
+
+	// the marker name
+	term := dt(classes{"literal", "name"},
+		Text(marker.Name))
+	
+	// the args summary (displayed in summary mode)
+	var fields []toHTML
+	for _, field := range marker.Fields {
+		fields = append(fields, Fragment{
+			dt(optionalClasses{"argument": true, "optional": field.Optional, "literal": true},
+				Text(field.Name)),
+			dd(optionalClasses{"argument": true, "type": true, "optional": field.Optional},
+				argType(&field.Argument)),
+		})
+	}
+	argsDef := dd(classes{"args"},
+		dl(classes{"args", "summary"},
+			fields...))
+	
+	// the argument details (displayed in details mode)
+	var args Fragment
+	for _, field := range marker.Fields {
+		args = append(args, Fragment{
+			dt(optionalClasses{"argument": true, "optional": field.Optional, "literal": true},
+				Text(field.Name)),
+			dd(optionalClasses{"argument": true, "type": true, "optional": field.Optional},
+				argType(&field.Argument)),
+			dd(classes{"description"},
+				maybeDetails(&field.DetailedHelp))})
+	}
+
+	// the help (displayed in both modes)
+	helpDef := dd(classes{"description"},
+		maybeDetails(&marker.DetailedHelp),
+		dl(classes{"args"},
+			args))
+		
+	// the overall wrapping marker (common classes go here to make it easier to select
+	// on certain things w/o duplication)
+	markerAttrs := attrs{
+		optionalClasses{
+			"marker": true,
+			"deprecated": marker.DeprecatedInFavorOf != nil,
+			"anonymous": marker.Anonymous(),
+		},
+		dataAttr{Name: "target", Value: marker.Target},
+	}
+	if marker.DeprecatedInFavorOf != nil {
+		markerAttrs = append(markerAttrs, dataAttr{Name: "deprecated", Value: *marker.DeprecatedInFavorOf})
+	}
+	return div(markerAttrs,
+		term, argsDef, helpDef)
+}
+
+// MarkerDocs is a plugin that autogenerates documentation
+// for markers known to controller-gen.  Generated pages
+// will be added to locations marked `{{#markerdocs category name}}`.
+// This allows us to put additional documentation in each category.
+type MarkerDocs struct {
+	// MarkerCategories contains the generators for which to query controller-tools.
+	MarkerGenerators []string
+}
+
+func (_ MarkerDocs) SupportsOutput(_ string) bool { return true }
+func (p MarkerDocs) Process(input *plugin.Input) error {
+	markerDocs, err := p.getMarkerDocs()
+	if err != nil {
+		return fmt.Errorf("unable to fetch marker docs: %v", err)
+	}
+
+	// first, find all categories...
+	markersByCategory := make(map[string][]MarkerDoc)
+	for _, cat := range markerDocs {
+		markersByCategory[cat.Category] = cat.Markers
+	}
+
+	usedCategories := make(map[string]struct{}, len(markersByCategory))
+
+	// NB(directxman12): we use existing pages instead of generating new ones so that we can add additional
+	// content to the pages (for instance, additional description of the category).
+
+	// ...then, go through the book, finding all instances of `{{#markerdocs <category>}}` and replacing them
+	// with the appropriate docs ...
+	err = plugin.EachCommand(&input.Book, "markerdocs", func(chapter *plugin.BookChapter, category string) (string, error) {
+		category = strings.TrimSpace(category)
+		markers, knownCategory := markersByCategory[category]
+		if !knownCategory {
+			return "", fmt.Errorf("unknown category %q", category)
+		}
+
+		content := new(strings.Builder)
+
+		// NB(directxman12): wrap this in a div to prevent the markdown processor from inserting extra paragraphs
+		fmt.Fprint(content, "<div><input checked type=\"checkbox\" id=\"markers-summarize\"></input><label for=\"markers-summarize\">Show Detailed Argument Help</label><dl class=\"markers\">")
+
+		// write the markers
+		for _, marker := range markers {
+			if err := markerTemplate(&marker).WriteHTML(content); err != nil {
+				return "", fmt.Errorf("unable to render documentation for marker %q: %v", marker.Name, err)
+			}
+		}
+
+		fmt.Fprintf(content, "</dl></div>")
+
+		usedCategories[category] = struct{}{}
+
+		return content.String(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// ... and finally make sure we didn't miss any
+	if len(usedCategories) != len(markersByCategory) {
+		unusedCategories := make([]string, 0, len(markersByCategory) - len(usedCategories))
+		for cat := range markersByCategory {
+			if _, ok := usedCategories[cat]; !ok {
+				unusedCategories = append(unusedCategories, cat)
+			}
+		}
+		return fmt.Errorf("unused categories %v", unusedCategories)
+	}
+
+	return nil
+}
+
+// wrapWithNewlines ensures that we begin and end with a newline character.
+// this is important to ensure that markdown is parsed inside of details elements.
+func wrapWithNewlines(src string) string {
+	if len(src) < 4 {
+		return src
+	}
+	if src[0] != '\n' {
+		src = "\n" + src
+	}
+	if src[1] != '\n' {
+		src = "\n" + src
+	}
+	if src[len(src)-1] != '\n' {
+		src = src + "\n"
+	}
+	if src[len(src)-2] != '\n' {
+		src = src + "\n"
+	}
+	return src
+}
+
+// getMarkerDocs fetches marker documentation from controller-gen
+func (p MarkerDocs) getMarkerDocs() ([]CategoryDoc, error) {
+	args := []string{"-wwww"} // wonderful-world-wide-web
+	args = append(args, p.MarkerGenerators...)
+	cmd := exec.Command("controller-gen", args...)
+	outRaw, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var res []CategoryDoc
+	if err := json.Unmarshal(outRaw, &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func main() {
+	if err := plugin.Run(MarkerDocs{
+		MarkerGenerators: []string{"crd", "webhook", "rbac:roleName=cheddar" /* role name doesn't mean anything here */, "object"},
+	}, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
+		log.Fatal(err.Error())
+	}
+}

--- a/docs/book/utils/plugin/input.go
+++ b/docs/book/utils/plugin/input.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package plugin
 
 import (

--- a/docs/book/utils/plugin/plugin.go
+++ b/docs/book/utils/plugin/plugin.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package plugin
 
 import (

--- a/docs/book/utils/plugin/utils.go
+++ b/docs/book/utils/plugin/utils.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EachCommand looks for mustache-like declarations of the form `{{#cmd args}}`
+// in each book chapter, and calls the callback for each one, substituting it
+// for the result.
+func EachCommand(book *Book, cmd string, callback func(chapter *BookChapter, args string) (string, error)) error {
+	cmdStart := fmt.Sprintf("{{#%s ", cmd)
+	return EachItemInBook(book, func(chapter *BookChapter) error {
+		if chapter.Content == "" {
+			return nil
+		}
+
+		// figure out all the trigger expressins
+		partsRaw := strings.Split(chapter.Content, cmdStart)
+		// the first section won't start with `{{#<cmd> ` as per how split works
+		if len(partsRaw) < 2 {
+			return nil
+		}
+
+		var res []string
+		res = append(res, partsRaw[0])
+		for _, part := range partsRaw[1:] {
+			endDelim := strings.Index(part, "}}")
+			if endDelim < 0 {
+				return fmt.Errorf("missing end delimiter in chapter %q", chapter.Name)
+			}
+			newContents, err := callback(chapter, part[:endDelim])
+			if err != nil {
+				return err
+			}
+			res = append(res, string(newContents))
+			res = append(res, part[endDelim+2:])
+		}
+
+		chapter.Content = strings.Join(res, "")
+		return nil
+	})
+}


### PR DESCRIPTION
This generates marker-docs using controller-gen, and then inserts them (in HTML form) into the book as part of the build process (via an mdbook plugin).

Closes #815 