### PR TITLE
Change obsolete patches: section to patchesStrategicMerge:

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
 # +kubebuilder:scaffold:kustomizeresource
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_cronjobs.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/infra.kubebuilder.io_disks.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 - patches/webhook_in_disks.yaml

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/pkg/scaffold/project/kustomize.go
+++ b/pkg/scaffold/project/kustomize.go
@@ -69,7 +69,7 @@ bases:
 - ../rbac
 - ../manager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/pkg/scaffold/v2/crd/kustomization.go
+++ b/pkg/scaffold/v2/crd/kustomization.go
@@ -81,7 +81,7 @@ var kustomizationTemplate = fmt.Sprintf(`# This kustomization.yaml is not intend
 resources:
 %s
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 %s

--- a/pkg/scaffold/v2/kustomize.go
+++ b/pkg/scaffold/v2/kustomize.go
@@ -74,7 +74,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/testdata/gopath/src/project/config/default/kustomization.yaml
+++ b/testdata/gopath/src/project/config/default/kustomization.yaml
@@ -16,7 +16,7 @@ bases:
 - ../rbac
 - ../manager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and

--- a/testdata/project-v2/config/crd/kustomization.yaml
+++ b/testdata/project-v2/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - bases/crew.testproject.org_admirals.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_captains.yaml

--- a/testdata/project-v2/config/default/kustomization.yaml
+++ b/testdata/project-v2/config/default/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and


### PR DESCRIPTION
`patches:` was rendered obsolete in kustomize 1.0.9. The user is supposed to use `patchesStrategicMerge:` instead ([see](https://github.com/kubernetes-sigs/kustomize/blob/v1.0.9/pkg/types/kustomization.go#L124)


The problem is that the kustomize 3.0.3 is reusing `patches:` section for more extend patching. The kustomize figured that patches had been obsoleted for long enough [see](https://github.com/kubernetes-sigs/kustomize/pull/1355#pullrequestreview-262678277)

As a side effect kubebuilder would not be able to produce kustomize compliant files.

This PR is only getting kubebuilder to use the right field.