### PR TITLE
:bug: help/version command fails when default repo is not initialized

### DIFF
--- a/cmd/init_project.go
+++ b/cmd/init_project.go
@@ -73,18 +73,19 @@ type projectOptions struct {
 	skipGoVersionCheck bool
 
 	boilerplate project.Boilerplate
-	project project.Project
+	project     project.Project
 
 	// deprecated flags
-	dep                bool
-	depFlag            *flag.Flag
-	depArgs            []string
+	dep     bool
+	depFlag *flag.Flag
+	depArgs []string
 
 	// final result
 	scaffolder scaffold.ProjectScaffolder
 }
 
 func (o *projectOptions) bindCmdlineFlags(cmd *cobra.Command) {
+
 	cmd.Flags().BoolVar(&o.skipGoVersionCheck, "skip-go-version-check", false, "if specified, skip checking the Go version")
 
 	// dependency args
@@ -103,9 +104,9 @@ func (o *projectOptions) bindCmdlineFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.boilerplate.Owner, "owner", "", "Owner to add to the copyright")
 
 	// project args
-	cmd.Flags().StringVar(&o.project.Repo, "repo", util.Repo, "name of the github repo.  "+
+	cmd.Flags().StringVar(&o.project.Repo, "repo", "", "name of the github repo.  "+
 		"defaults to the go package of the current working directory.")
-	cmd.Flags().StringVar(&o.project.Domain, "domain", "k8s.io", "domain for groups")
+	cmd.Flags().StringVar(&o.project.Domain, "domain", "my.domain", "domain for groups")
 	cmd.Flags().StringVar(&o.project.Version, "project-version", project.Version2, "project version")
 }
 
@@ -132,6 +133,13 @@ func (o *projectOptions) validate() error {
 			return err
 		}
 	}
+	if o.project.Repo == "" {
+		repoPath, err := findCurrentRepo()
+		if err != nil {
+			return fmt.Errorf("error finding current repository: %v", err)
+		}
+		o.project.Repo = repoPath
+	}
 
 	switch o.project.Version {
 	case project.Version1:
@@ -140,15 +148,15 @@ func (o *projectOptions) validate() error {
 			defEnsure = &o.dep
 		}
 		o.scaffolder = &scaffold.V1Project{
-			Project: o.project,
+			Project:     o.project,
 			Boilerplate: o.boilerplate,
 
-			DepArgs: o.depArgs,
+			DepArgs:          o.depArgs,
 			DefinitelyEnsure: defEnsure,
 		}
 	case project.Version2:
 		o.scaffolder = &scaffold.V2Project{
-			Project: o.project,
+			Project:     o.project,
 			Boilerplate: o.boilerplate,
 		}
 	default:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/go/packages"
 
-	"sigs.k8s.io/kubebuilder/cmd/util"
 	"sigs.k8s.io/kubebuilder/cmd/version"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 )
@@ -104,13 +103,6 @@ func findCurrentRepo() (string, error) {
 }
 
 func main() {
-	repoPath, err := findCurrentRepo()
-	if err != nil {
-		log.Fatal(fmt.Errorf("error finding current repository: %v", err))
-	}
-
-	util.Repo = repoPath
-
 	rootCmd := defaultCommand()
 
 	rootCmd.AddCommand(
@@ -146,7 +138,7 @@ Typical project lifecycle:
 
 - initialize a project:
 
-  kubebuilder init --domain k8s.io --license apache2 --owner "The Kubernetes authors"
+  kubebuilder init --domain example.com --license apache2 --owner "The Kubernetes authors"
 
 - create one or more a new resource APIs and add your code to them:
 

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -25,15 +25,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"text/template"
 
 	"github.com/gobuffalo/flect"
 )
-
-var Domain string
-var Repo string
 
 // writeIfNotFound returns true if the file was created and false if it already exists
 func WriteIfNotFound(path, templateName, templateValue string, data interface{}) bool {
@@ -106,20 +102,6 @@ func GetCopyright(file string) string {
 		return ""
 	}
 	return string(cr)
-}
-
-func GetDomain() string {
-	b, err := ioutil.ReadFile(filepath.Join("pkg", "apis", "doc.go"))
-	if err != nil {
-		log.Fatalf("Could not find pkg/apis/doc.go.  First run `kubebuilder init --domain <domain>`.")
-	}
-	r := regexp.MustCompile("\\+domain=(.*)")
-	l := r.FindSubmatch(b)
-	if len(l) < 2 {
-		log.Fatalf("pkg/apis/doc.go does not contain the domain (// +domain=.*)")
-	}
-	Domain = string(l[1])
-	return Domain
 }
 
 func create(path string) {


### PR DESCRIPTION
Key changes:
 - kills global variables domain and repo under utils pkg.
 - Moved code to find current repo to init-project command (thats the only place where it is needed). 

fixes #899