### PR TITLE
:sparkles: scaffold ValidateDelete for validating webhook

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -90,7 +90,8 @@ func (r *CronJob) Default() {
 This marker is responsible for generating a validating webhook manifest.
 */
 
-// +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob.kb.io
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io
 
 /*
 To validate our CRD beyond what's possible with declarative validation.
@@ -103,11 +104,15 @@ schedule without making up a long regular expression.
 If `webhook.Validator` interface is implemented, a webhook will automatically be
 served that calls the validation.
 
-The `ValidateCreate` and `ValidateUpdate` methods are expected to validate that its
-receiver upon creation and update respectively. We separate out ValidateCreate
-from ValidateUpdate to allow behavior like making certain fields immutable, so
-that they can only be set on creation.
-Here, however, we just use the same shared validation.
+The `ValidateCreate`, `ValidateUpdate` and `ValidateDelete` methods are expected
+to validate that its receiver upon creation, update and deletion respectively.
+We separate out ValidateCreate from ValidateUpdate to allow behavior like making
+certain fields immutable, so that they can only be set on creation.
+ValidateDelete is also separated from ValidateUpdate to allow different
+validation behavior on deletion.
+Here, however, we just use the same shared validation for `ValidateCreate` and
+`ValidateUpdate`. And we do nothing in `ValidateDelete`, since we don't need to
+validate anything on deletion.
 */
 
 var _ webhook.Validator = &CronJob{}
@@ -124,6 +129,14 @@ func (r *CronJob) ValidateUpdate(old runtime.Object) error {
 	cronjoblog.Info("validate update", "name", r.Name)
 
 	return r.validateCronJob()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *CronJob) ValidateDelete() error {
+	cronjoblog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
 }
 
 /*

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/zz_generated.deepcopy.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/zz_generated.deepcopy.go
@@ -22,7 +22,6 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -131,8 +130,7 @@ func (in *CronJobStatus) DeepCopyInto(out *CronJobStatus) {
 	}
 	if in.LastScheduleTime != nil {
 		in, out := &in.LastScheduleTime, &out.LastScheduleTime
-		*out = new(metav1.Time)
-		(*in).DeepCopyInto(*out)
+		*out = (*in).DeepCopy()
 	}
 }
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/go.mod
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.mod
@@ -18,5 +18,5 @@ require (
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	sigs.k8s.io/controller-runtime v0.2.0-beta.5
 )

--- a/docs/book/src/cronjob-tutorial/testdata/project/go.sum
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.sum
@@ -143,8 +143,8 @@ k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 h1:VBM/0P5TWxwk+Nw6Z+lAw3DKgO76g90ETOiA6rfLV1Y=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4 h1:S1XVfRWR1MuIXZdkYx3jN8JDw+bbQxmWZroy0i87z/A=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5 h1:W2jTb239QEwQ+HejhTCF9GriFPy2zmo1I6pPmJTeEy8=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -72,7 +72,8 @@ func (r *CronJob) Default() {
 	}
 }
 
-// +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob.kb.io
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io
 
 var _ webhook.Validator = &CronJob{}
 
@@ -88,6 +89,14 @@ func (r *CronJob) ValidateUpdate(old runtime.Object) error {
 	cronjoblog.Info("validate update", "name", r.Name)
 
 	return r.validateCronJob()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *CronJob) ValidateDelete() error {
+	cronjoblog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
 }
 
 func (r *CronJob) validateCronJob() error {

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.mod
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.mod
@@ -18,5 +18,5 @@ require (
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	sigs.k8s.io/controller-runtime v0.2.0-beta.5
 )

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.sum
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.sum
@@ -143,8 +143,8 @@ k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 h1:VBM/0P5TWxwk+Nw6Z+lAw3DKgO76g90ETOiA6rfLV1Y=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4 h1:S1XVfRWR1MuIXZdkYx3jN8JDw+bbQxmWZroy0i87z/A=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5 h1:W2jTb239QEwQ+HejhTCF9GriFPy2zmo1I6pPmJTeEy8=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/pkg/scaffold/v2/gomod.go
+++ b/pkg/scaffold/v2/gomod.go
@@ -43,6 +43,6 @@ module {{ .Repo }}
 go 1.12
 
 require (
-	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	sigs.k8s.io/controller-runtime v0.2.0-beta.5
 )
 `

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -118,7 +118,8 @@ func (r *{{ .Resource.Kind }}) Default() {
 `
 
 	ValidatingWebhookTemplate = `
-// +kubebuilder:webhook:path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .GroupDomain }},resources={{ .Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .GroupDomain }},resources={{ .Plural }},versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
 
 var _ webhook.Validator = &{{ .Resource.Kind }}{}
 
@@ -135,6 +136,14 @@ func (r *{{ .Resource.Kind }}) ValidateUpdate(old runtime.Object) error {
 	{{ lower .Resource.Kind }}log.Info("validate update", "name", r.Name)
 
 	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *{{ .Resource.Kind }}) ValidateDelete() error {
+	{{ lower .Resource.Kind }}log.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }
 `

--- a/testdata/project-v2/api/v1/captain_webhook.go
+++ b/testdata/project-v2/api/v1/captain_webhook.go
@@ -45,7 +45,8 @@ func (r *Captain) Default() {
 	// TODO(user): fill in your defaulting logic.
 }
 
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,groups=crew.testproject.org,resources=captains,versions=v1,name=vcaptain.kb.io
 
 var _ webhook.Validator = &Captain{}
 
@@ -62,5 +63,13 @@ func (r *Captain) ValidateUpdate(old runtime.Object) error {
 	captainlog.Info("validate update", "name", r.Name)
 
 	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *Captain) ValidateDelete() error {
+	captainlog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
 	return nil
 }

--- a/testdata/project-v2/go.mod
+++ b/testdata/project-v2/go.mod
@@ -9,5 +9,5 @@ require (
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	sigs.k8s.io/controller-runtime v0.2.0-beta.4
+	sigs.k8s.io/controller-runtime v0.2.0-beta.5
 )

--- a/testdata/project-v2/go.sum
+++ b/testdata/project-v2/go.sum
@@ -116,8 +116,8 @@ k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c h1:3KSCztE7gPitlZmWbNwue/
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5 h1:VBM/0P5TWxwk+Nw6Z+lAw3DKgO76g90ETOiA6rfLV1Y=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4 h1:S1XVfRWR1MuIXZdkYx3jN8JDw+bbQxmWZroy0i87z/A=
-sigs.k8s.io/controller-runtime v0.2.0-beta.4/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5 h1:W2jTb239QEwQ+HejhTCF9GriFPy2zmo1I6pPmJTeEy8=
+sigs.k8s.io/controller-runtime v0.2.0-beta.5/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/pull/525 added support for validating deletion operation.
- scaffold `go.mod` with CR `v0.2.0-beta.5` and scaffold `ValidateDelete`.
- Update book to reflect the new scaffolding.