### PR TITLE
Basic Project docs: Add blank lines before code blocks to fix formatting

### DIFF
--- a/docs/book/src/cronjob-tutorial/basic-project.md
+++ b/docs/book/src/cronjob-tutorial/basic-project.md
@@ -15,12 +15,14 @@ First up, basic infrastructure for building your project:
 </details>
 
 <details><summary>`Makefile`: Make targets for building and deploying your controller</summary>
+
 ```makefile
 {{#include ./testdata/project/Makefile}}
 ```
 </details>
 
 <details><summary>`PROJECT`: Kubebuilder metadata for scaffolding new components</summary>
+
 ```yaml
 {{#include ./testdata/project/PROJECT}}
 ```


### PR DESCRIPTION
- The Makefile snippet in particular weren't very readable. :-)