### PR TITLE
:book: add a note for bootstrapping webhooks for pods

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -44,7 +44,7 @@ chmod +x /tmp/mdbook
 echo "grabbing the latest released controller-gen"
 # TODO(directxman12): remove the @v0.2.0-beta.4 once get v0.2.0 released,
 # so that we actually get the latest version
-go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.4
+go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.5
 
 # make sure we add the go bin directory to our path
 gobin=$(go env GOBIN)

--- a/docs/book/src/cronjob-tutorial/running-webhook.md
+++ b/docs/book/src/cronjob-tutorial/running-webhook.md
@@ -57,5 +57,15 @@ kubectl create -f config/samples/batch_v1_cronjob.yaml
 You can also try to create an invalid CronJob (e.g. use an ill-formatted
 schedule field). You should see a creation failure with a validation error.
 
-**Note**: If you are
+<aside>
+Note: If you are deploying a webhook for pods in the same cluster, be
+careful about the bootstrapping problem, since the creation request of the
+webhook pod would be sent to the webhook pod itself, which hasn't come up yet.
 
+To make it work, you can either use [namespaceSelector] if your kubernetes
+version is 1.9+ or use [objectSelector] if your kubernetes version is 1.15+ to
+skip itself.
+</aside>
+
+[namespaceSelector]: https://github.com/kubernetes/api/blob/kubernetes-1.14.5/admissionregistration/v1beta1/types.go#L189-L233
+[objectSelector]: https://github.com/kubernetes/api/blob/kubernetes-1.15.2/admissionregistration/v1beta1/types.go#L262-L274

--- a/docs/book/src/cronjob-tutorial/running-webhook.md
+++ b/docs/book/src/cronjob-tutorial/running-webhook.md
@@ -57,14 +57,18 @@ kubectl create -f config/samples/batch_v1_cronjob.yaml
 You can also try to create an invalid CronJob (e.g. use an ill-formatted
 schedule field). You should see a creation failure with a validation error.
 
-<aside>
-Note: If you are deploying a webhook for pods in the same cluster, be
+<aside class="note warning">
+
+<h1>The Bootstrapping Problem</h1>
+
+If you are deploying a webhook for pods in the same cluster, be
 careful about the bootstrapping problem, since the creation request of the
 webhook pod would be sent to the webhook pod itself, which hasn't come up yet.
 
 To make it work, you can either use [namespaceSelector] if your kubernetes
 version is 1.9+ or use [objectSelector] if your kubernetes version is 1.15+ to
 skip itself.
+
 </aside>
 
 [namespaceSelector]: https://github.com/kubernetes/api/blob/kubernetes-1.14.5/admissionregistration/v1beta1/types.go#L189-L233

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -397,3 +397,43 @@ main > details.collapse-code > summary::after {
     fill: black;
     stroke: none;
 }
+
+/* notes */
+aside.note {
+    border: 1px solid var(--searchbar-border-color);
+    border-radius: 3px;
+}
+
+aside.note > * {
+    margin-left: 1em;
+    margin-right: 1em;
+}
+
+/* note title */
+aside.note > h1 {
+    border-bottom: 1px solid var(--searchbar-border-color);
+    margin: 0;
+    padding: 0.5em 1em;
+    font-size: 100%;
+    font-weight: normal;
+}
+
+/* warning notes */
+aside.note.warning > h1 {
+    background: var(--warning-note-background-color, #fcf8f2);
+}
+aside.note.warning > h1::before {
+    /* TODO(directxman12): fill in these colors in theme.
+     * If you're good with colors, feel free to play around with this
+     * in dark mode. */
+    content: "!";
+    color: var(--warning-note-color, #f0ad4e);
+    margin-right: 1em;
+    font-size: 100%;
+    vertical-align: middle;
+    font-weight: bold;
+    padding-left: 0.6em;
+    padding-right: 0.6em;
+    border-radius: 50%;
+    border: 2px solid var(--warning-note-color, #f0ad4e);
+}


### PR DESCRIPTION
Put the note in an `<aside>` block.

fixes: #893