### PR TITLE
Typo: CronJobSpec StartingDeadlineSeconds should be int32

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -67,7 +67,7 @@ type CronJobSpec struct {
 	// Optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
 	// +optional
-	StartingDeadlineSeconds *int64 `json:"startingDeadlineSeconds,omitempty"`
+	StartingDeadlineSeconds *int32 `json:"startingDeadlineSeconds,omitempty"`
 
 	// Specifies how to treat concurrent executions of a Job.
 	// Valid values are:


### PR DESCRIPTION
Offering a fix to the issue I opened #921 921