### PR TITLE
:book: Links to source in tutorial & misc docs fixes

### DIFF
--- a/docs/book/src/cronjob-tutorial/basic-project.md
+++ b/docs/book/src/cronjob-tutorial/basic-project.md
@@ -7,7 +7,8 @@ basic pieces of boilerplate.
 
 First up, basic infrastructure for building your project:
 
-<details><summary>`go.mod`: A new Go module matching our project, with basic dependencies</summary>
+<details> <summary>`go.mod`: A new Go module matching our project, with
+basic dependencies</summary>
 
 ```go
 {{#include ./testdata/project/go.mod}}

--- a/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
@@ -19,6 +19,23 @@ once, seeing them to completion.
 Instead of trying to tackle rewriting the Job controller as well, we'll
 use this as an opportunity to see how to interact with external types.
 
+<aside class="note">
+
+<h1>Following Along vs Jumping Ahead</h1>
+
+Note that most of this tutorial is generated from literate Go files that
+live in the book source directory:
+[docs/book/src/cronjob-tutorial/testdata][tutorial-source].  The full,
+runnable project lives in [project][tutorial-project-source], while
+intermediate files live directly under the [testdata][tutorial-source]
+directory.
+
+[tutorial-source]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cronjob-tutorial/testdata
+
+[tutorial-project-source]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cronjob-tutorial/testdata/project
+
+</aside>
+
 ## Scaffolding Out Our Project
 
 As covered in the [quick start](../quick-start.md), we'll need to scaffold

--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -91,7 +91,6 @@ when the manager is started.
 For now, we just note that this reconciler operates on `CronJob`s.  Later,
 we'll use this to mark that we care about related objects as well.
 
-TODO: jump back to main?
 */
 
 func (r *CronJobReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/docs/book/src/multiversion-tutorial/deployment.md
+++ b/docs/book/src/multiversion-tutorial/deployment.md
@@ -84,7 +84,8 @@ respectively.  Notice that each has a different API version.
 Finally, if we wait a bit, we should notice that our CronJob continues to
 reconcile, even though our controller is written against our v1 API version.
 
-## Troubleshooting
-TODO(../TODO.md) steps for troubleshoting
+## Troubleshooting 
+
+[steps for troubleshooting](/TODO.md)
 
 [ref-multiver]: /reference/generating-crd.md#multiple-versions "Generating CRDs: Multiple Versions"

--- a/docs/book/src/multiversion-tutorial/tutorial.md
+++ b/docs/book/src/multiversion-tutorial/tutorial.md
@@ -11,7 +11,21 @@ different versions are supported by our CronJob project.
 If you haven't already, make sure you've gone through the base [CronJob
 Tutorial](/cronjob-tutorial/cronjob-tutorial.md).
 
-## Aside: Kubernetes Versions
+<aside class="note">
+
+<h1>Following Along vs Jumping Ahead</h1>
+
+Note that most of this tutorial is generated from literate Go files that
+form a runnable project, and live in the book source directory:
+[docs/book/src/multiversion-tutorial/testdata/project][tutorial-source].
+
+[tutorial-source]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/multiversion-tutorial/testdata/project
+
+</aside>
+
+<aside class="note warning">
+
+<h1>Minimum Kubernetes Versions Incoming!</h1>
 
 CRD conversion support was introduced as an alpha feature in Kubernetes
 1.13 (which means it's not on by default, and needs to be enabled via
@@ -22,6 +36,8 @@ If you're on Kubernetes 1.13-1.14, make sure to enable the feature gate.
 If you're on Kubernetes 1.12 or below, you'll need a new cluster to use
 conversion. Check out the [KinD instructions](/reference/kind.md) for
 instructions on how to set up a all-in-one cluster.
+
+</aside>
 
 Next, let's figure out what changes we want to make...
 

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -402,6 +402,7 @@ main > details.collapse-code > summary::after {
 aside.note {
     border: 1px solid var(--searchbar-border-color);
     border-radius: 3px;
+    margin-top: 1em;
 }
 
 aside.note > * {
@@ -416,6 +417,7 @@ aside.note > h1 {
     padding: 0.5em 1em;
     font-size: 100%;
     font-weight: normal;
+    background: var(--quote-bg);
 }
 
 /* warning notes */

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -439,3 +439,20 @@ aside.note.warning > h1::before {
     border-radius: 50%;
     border: 2px solid var(--warning-note-color, #f0ad4e);
 }
+
+/* literate source citations */
+cite.literate-source {
+    font-size: 75%;
+    font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
+}
+cite.literate-source::before {
+    content: "$ ";
+    font-weight: bold;
+    font-style: normal;
+}
+
+cite.literate-source > a::before {
+    content: "vim ";
+    font-style: normal;
+    color: var(--fg);
+}

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -456,3 +456,14 @@ cite.literate-source > a::before {
     font-style: normal;
     color: var(--fg);
 }
+
+/* hide the annoying "copy to clipboard" buttons */
+.literate pre > .buttons {
+    display: none;
+}
+
+/* add a bit of extra padding for readability */
+.literate pre code {
+    padding-top: 0.75em;
+    padding-bottom: 0.75em;
+}

--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -223,6 +223,8 @@ func (l Literate) extractContents(contents []byte, pathInfo filePathInfo) (strin
 
 	out := new(strings.Builder)
 
+	out.WriteString(`<div class="literate">`)
+
 	// write the source so that readers can easily find the code
 	sourcePath := pathInfo.ViewablePath(*l.BaseSourcePath)
 	prettyPath := pathInfo.chapterRelativePath
@@ -256,19 +258,15 @@ func (l Literate) extractContents(contents []byte, pathInfo filePathInfo) (strin
 		}
 		// TODO(directxman12): nice side-by-side sections
 	}
+	out.WriteString(`</div>`)
 
 	return out.String(), nil
 }
 
 // wrapWithNewlines ensures that we begin and end with a newline character.
 func wrapWithNewlines(src string) string {
-	if src[0] != '\n' {
-		src = "\n" + src
-	}
-	if src[len(src)-1] != '\n' {
-		src = src + "\n"
-	}
-	return src
+	src = strings.Trim(src, "\n") // remove newlines first to avoid too many
+	return "\n" + src + "\n"
 }
 
 func main() {

--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -245,7 +245,7 @@ func (l Literate) extractContents(contents []byte, pathInfo filePathInfo) (strin
 		}
 		if strings.TrimSpace(pair.comment) != "" {
 			out.WriteString("\n")
-			out.WriteString(pair.comment)
+			out.WriteString(removeIndent(pair.comment))
 		}
 
 		if strings.TrimSpace(pair.code) != "" {
@@ -261,6 +261,20 @@ func (l Literate) extractContents(contents []byte, pathInfo filePathInfo) (strin
 	out.WriteString(`</div>`)
 
 	return out.String(), nil
+}
+
+// removeIndent removes any initial indent that gofmt puts in place,
+// because it likes to make our lives harder.
+//
+// If we left them in place, text would turn into legacy markdown codeblocks.
+func removeIndent(comment string) string {
+	lines := strings.Split(comment, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "\t") {
+			lines[i] = line[1:]
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // wrapWithNewlines ensures that we begin and end with a newline character.

--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -26,6 +26,8 @@ import (
 	"log"
 	"strings"
 	"unicode"
+	"path"
+	"net/url"
 
 	"sigs.k8s.io/kubebuilder/docs/book/utils/plugin"
 )
@@ -36,11 +38,23 @@ import (
 // It's triggered by using the an expression like `{{#literatego ./path/to/source/file.go}}`.
 // The marker `+kubebuilder:docs-gen:collapse=<string>` can be used to collapse a description/code
 // pair into a details block with the given summary.
-type Literate struct {}
+type Literate struct {
+	// PrettyPathPrunePrefix specifies the prefix, if any to prune off of user-visible paths
+	PrettyPathPrunePrefix string
+	// BaseSourcePath specifies the base path to internet-reachable versions of the source code used
+	BaseSourcePath *url.URL
+}
 func (_ Literate) SupportsOutput(_ string) bool { return true }
-func (_ Literate) Process(input *plugin.Input) error {
+func (l Literate) Process(input *plugin.Input) error {
+	bookSrcDir := filepath.Join(input.Context.Root, input.Context.Config.Book.Src)
 	return plugin.EachCommand(&input.Book, "literatego", func(chapter *plugin.BookChapter, relPath string) (string, error) {
-		path := filepath.Join(input.Context.Root, input.Context.Config.Book.Src, filepath.Dir(chapter.Path), relPath)
+		chapterDir := filepath.Dir(chapter.Path)
+		pathInfo := filePathInfo{
+			chapterRelativePath: relPath,
+			chapterDir: chapterDir,
+			bookSrcDir: bookSrcDir,
+		}
+		path := pathInfo.FullPath()
 
 		// TODO(directxman12): don't escape root?
 		contents, err := ioutil.ReadFile(path)
@@ -48,8 +62,36 @@ func (_ Literate) Process(input *plugin.Input) error {
 			return "", fmt.Errorf("unable to import %q: %v", path, err)
 		}
 
-		return extractContents(contents, path)
+		return l.extractContents(contents, pathInfo)
 	})
+}
+
+// filePathInfo stores different paths to a file, to allow for nicely
+// displaying relative path information.
+type filePathInfo struct {
+	// chapterRelativePath is the path relative to the current chapter file
+	chapterRelativePath string
+
+	// chapterDir is the directory of the chapter, relative to bookSrcDir
+	chapterDir string
+
+	// bookSrcDir is the absoulte book source path
+	bookSrcDir string
+}
+
+// FullPath resturns the full, absolute path to the given file on the source filesystem.
+func (f filePathInfo) FullPath() string {
+	return filepath.Join(f.bookSrcDir, f.chapterDir, f.chapterRelativePath)
+}
+
+// viewablePath returns the internet-viewable path to the given source file
+func (f filePathInfo) ViewablePath(baseBookSrcURL url.URL) string {
+	relPath := filepath.ToSlash(filepath.Join(f.chapterDir, f.chapterRelativePath))
+	outURL := baseBookSrcURL
+
+	outURL.Path = path.Join(outURL.Path, relPath)
+	
+	return outURL.String()
 }
 
 // commentCodePair represents a block of code with some text before it, optionally
@@ -173,13 +215,25 @@ func extractPairs(contents []byte, path string) ([]commentCodePair, error) {
 
 // extractContents extracts comment-code pairs from the given named file
 // contents, and then renders the result to markdown.
-func extractContents(contents []byte, path string) (string, error) {
-	pairs, err := extractPairs(contents, path)
+func (l Literate) extractContents(contents []byte, pathInfo filePathInfo) (string, error) {
+	pairs, err := extractPairs(contents, pathInfo.FullPath())
 	if err != nil {
 		return "", err
 	}
 
 	out := new(strings.Builder)
+
+	// write the source so that readers can easily find the code
+	sourcePath := pathInfo.ViewablePath(*l.BaseSourcePath)
+	prettyPath := pathInfo.chapterRelativePath
+	if l.PrettyPathPrunePrefix != "" {
+		prunedPath, err := filepath.Rel(l.PrettyPathPrunePrefix, prettyPath)
+		if err != nil {
+			return "", fmt.Errorf("unable to remove path prefix %q from %q: %v", l.PrettyPathPrunePrefix, prettyPath, err)
+		}
+		prettyPath = prunedPath
+	}
+	out.WriteString(fmt.Sprintf(`<cite class="literate-source"><a href="%[1]s">%[2]s</a></cite>`, sourcePath, prettyPath))
 	
 	for _, pair := range pairs {
 		if pair.collapse != "" {
@@ -218,7 +272,15 @@ func wrapWithNewlines(src string) string {
 }
 
 func main() {
-	if err := plugin.Run(Literate{}, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
+	baseURL, err := url.Parse("https://sigs.k8s.io/kubebuilder/docs/book/src")
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	cfg := Literate{
+		PrettyPathPrunePrefix: "testdata",
+		BaseSourcePath: baseURL,
+	}
+	if err := plugin.Run(cfg, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
 		log.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
This adds links to the source for the tutorials in both a note at the start of each, and on each literate Go file when mentioned.

It also fixes a couple of code formatting issues, and hides the copy buttons on code blocks to make them flow a bit better with normal text in literate go sections.