### PR TITLE
:sparkles: set preserveUnknownFields in crd conversion patch

### DIFF
--- a/pkg/scaffold/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/v2/crd/enablewebhook_patch.go
@@ -68,4 +68,7 @@ spec:
         namespace: system
         name: webhook-service
         path: /convert
+  # With conversion webhook promoted to Beta in Kubernetes 1.15, it requires setting preserveUnknownFields to false.
+  # Refer to https://github.com/kubernetes/kubernetes/pull/78426 for details.
+  preserveUnknownFields: false
 `

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -34,6 +34,7 @@ spec:
           description: AdmiralStatus defines the observed state of Admiral
           type: object
       type: object
+  version: v1
   versions:
   - name: v1
     served: true

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
@@ -34,6 +34,7 @@ spec:
           description: CaptainStatus defines the observed state of Captain
           type: object
       type: object
+  version: v1
   versions:
   - name: v1
     served: true

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -34,6 +34,7 @@ spec:
           description: FirstMateStatus defines the observed state of FirstMate
           type: object
       type: object
+  version: v1
   versions:
   - name: v1
     served: true

--- a/testdata/project-v2/config/crd/patches/webhook_in_admirals.yaml
+++ b/testdata/project-v2/config/crd/patches/webhook_in_admirals.yaml
@@ -15,3 +15,6 @@ spec:
         namespace: system
         name: webhook-service
         path: /convert
+  # With conversion webhook promoted to Beta in Kubernetes 1.15, it requires setting preserveUnknownFields to false.
+  # Refer to https://github.com/kubernetes/kubernetes/pull/78426 for details.
+  preserveUnknownFields: false

--- a/testdata/project-v2/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v2/config/crd/patches/webhook_in_captains.yaml
@@ -15,3 +15,6 @@ spec:
         namespace: system
         name: webhook-service
         path: /convert
+  # With conversion webhook promoted to Beta in Kubernetes 1.15, it requires setting preserveUnknownFields to false.
+  # Refer to https://github.com/kubernetes/kubernetes/pull/78426 for details.
+  preserveUnknownFields: false

--- a/testdata/project-v2/config/crd/patches/webhook_in_firstmates.yaml
+++ b/testdata/project-v2/config/crd/patches/webhook_in_firstmates.yaml
@@ -15,3 +15,6 @@ spec:
         namespace: system
         name: webhook-service
         path: /convert
+  # With conversion webhook promoted to Beta in Kubernetes 1.15, it requires setting preserveUnknownFields to false.
+  # Refer to https://github.com/kubernetes/kubernetes/pull/78426 for details.
+  preserveUnknownFields: false


### PR DESCRIPTION
With Kubernetes 1.15, CRD conversion support went Beta and it requires
setting preserveUnknownFields to false. Refer to this PR
https://github.com/kubernetes/kubernetes/pull/7842 for details.