### PR TITLE
Add controller-gen CLI options to book

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -66,6 +66,8 @@
       - [Object/DeepCopy](./reference/markers/object.md)
       - [RBAC](./reference/markers/rbac.md)
 
+  - [controller-gen CLI](./reference/controller-gen.md)
+
 ---
 
 [Appendix: The TODO Landing Page](./TODO.md)

--- a/docs/book/src/reference/controller-gen.md
+++ b/docs/book/src/reference/controller-gen.md
@@ -1,0 +1,72 @@
+# controller-gen CLI
+
+KubeBuilder makes use of a tool called
+[controller-gen](https://sigs.k8s.io/controller-tools/cmd/controller-gen)
+for generating utility code and Kubernetes YAML.  This code and config
+generation is controlled by the presence of special ["marker
+comments"](/reference/markers.md) in Go code.
+
+controller-gen is built out of different "generators" (which specify what
+to generate) and "output rules" (which specify how and where to write the
+results).
+
+Both are configured through command line options specified in [marker
+format](/reference/markers.md).
+
+For instance,
+
+```shell
+controller-gen paths=./... crd:trivialVersions=true rbac:roleName=controller-perms output:crd:artifacts:config=config/crd/bases
+```
+
+generates CRDs and RBAC, and specifically stores the generated CRD YAML in
+`config/crd/bases`.  For the RBAC, it uses the default output rules
+(`config/rbac`).  It considers every package in the current directory tree
+(as per the normal rules of the go `...` wildcard).
+
+## Generators
+
+Each different generator is configured through a CLI option.  Multiple
+generators may be used in a single invocation of `controller-gen`.
+
+{{#markerdocs CLI: generators}}
+
+## Output Rules
+
+Output rules configure how a given generator outputs its results. There is
+always one global "fallback" output rule (specified as `output:<rule>`),
+plus per-generator overrides (specified as `output:<generator>:<rule>`).
+
+<aside class="note">
+
+<h1>Default Rules</h1>
+
+When no fallback rule is specified manually, a set of default
+per-generator rules are used which result in YAML going to
+`config/<generator>`, and code staying where it belongs.
+
+The default rules are equivalent to
+`output:<generator>:artifacts:config=config/<generator>` for each
+generator.
+
+When a "fallback" rule is specified, that'll be used instead of the
+default rules.
+
+For example, if you specify `crd rbac:roleName=controller-perms
+output:crd:stdout`, you'll get CRDs on standard out, and rbac in a file in
+`config/rbac`. If you were to add in a global rule instead, like `crd
+rbac:roleName=controller-perms output:crd:stdout output:none`, you'd get
+CRDs to standard out, and everything else to /dev/null, because we've
+explicitly specified a fallback.
+
+</aside>
+
+For brevity, the per-generator output rules (`output:<generator>:<rule>`)
+are omitted below.  They are equivalent to the global fallback options
+listed here.
+
+{{#markerdocs CLI: output rules (optionally as output:<generator>:...)}}
+
+## Other Options
+
+{{#markerdocs CLI: generic}}

--- a/docs/book/src/reference/markers.md
+++ b/docs/book/src/reference/markers.md
@@ -1,7 +1,7 @@
 # Markers for Config/Code Generation
 
-KubeBuilder makes use of a tool called `controller-gen` (from
-[controller-tools](https://godoc.org/sigs.k8s.io/controller-tools)) for
+KubeBuilder makes use of a tool called
+[controller-gen](/reference/controller-gen.md) for
 generating utility code and Kubernetes YAML.  This code and config
 generation is controlled by the presence of special "marker comments" in
 Go code.

--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -219,9 +219,6 @@ blockquote {
 .marker dl.args.summary dt::before {
     content: ',';
 }
-.marker dl.args.summary dt:first-of-type:last-of-type::before {
-    content: '';
-}
 /* hide in non-summary view */
 .marker dd.args {
     display: none
@@ -309,25 +306,25 @@ blockquote {
 }
 
 /* summary view */
-#markers-summarize:checked ~ dl > .marker dd.args {
+.markers-summarize:checked ~ dl > .marker dd.args {
     display: inline-block
 }
-#markers-summarize:checked ~ dl > .marker dd.description dl.args {
+.markers-summarize:checked ~ dl > .marker dd.description dl.args {
     display: none
 }
-#markers-summarize:checked ~ dl > .marker dd.description {
+.markers-summarize:checked ~ dl > .marker dd.description {
     margin-bottom: 0.25em;
 }
 
-#markers-summarize {
+input.markers-summarize {
     display: none;
 }
-label[for="markers-summarize"]::before {
+label.markers-summarize::before {
     margin-right: 0.5em;
     content: '\25bc';
     display: inline-block;
 }
-#markers-summarize:checked ~ label[for="markers-summarize"]::before {
+input.markers-summarize:checked ~ label.markers-summarize::before {
     content: '\25b6';
 }
 


### PR DESCRIPTION
This documents the controller-gen CLI options in the book, with the help
of the markerdocs mdbook plugin.

Fixes kubernetes-sigs/controller-tools#292