### PR TITLE
:bug: Change makefile in v2 scaffolding to use ./...

### DIFF
--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -59,7 +59,7 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	go test ./api/... ./controllers/... -coverprofile cover.out
+	go test ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet
@@ -92,7 +92,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
+	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
 docker-build: test

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -15,7 +15,7 @@ all: manager
 
 # Run tests
 test: generate fmt vet manifests
-	go test ./api/... ./controllers/... -coverprofile cover.out
+	go test ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet
@@ -48,7 +48,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
+	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
 docker-build: test


### PR DESCRIPTION
Previously, we had some spots where we were using `./api/...` and
`./controllers/...` specifically.  Using `./...` instead allows us to
handle cases where we're lacking `api/`, and should otherwise be fine
since we don't have a vendor directory.

Ref #925 