### PR TITLE
🐛 Fix subresource:status typo in gitbook

### DIFF
--- a/docs/book/src/reference/generating-crd.md
+++ b/docs/book/src/reference/generating-crd.md
@@ -106,7 +106,7 @@ the status field.
 For example:
 
 ```go
-// +kubebuilder:status:subresource
+// +kubebuilder:subresource:status
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

Fixes #941 