### PR TITLE
test binary and container image redirects and docs

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -67,6 +67,7 @@
       - [RBAC](./reference/markers/rbac.md)
 
   - [controller-gen CLI](./reference/controller-gen.md)
+  - [Artifacts](./reference/artifacts.md)
 
 ---
 

--- a/docs/book/src/reference/artifacts.md
+++ b/docs/book/src/reference/artifacts.md
@@ -5,10 +5,12 @@ to the main binary releases.
 
 ## Test Binaries
 
-You can find all of the test binaries at `https://go.kubebuilder.io/test`.
-You can find individual test binaries at `https://go.kubebuilder.io/test/${version}/${os}/${arch}`.
+You can find all of the test binaries at `https://go.kubebuilder.io/test-tools`.
+You can find individual test binaries at `https://go.kubebuilder.io/test-tools/${version}/${os}/${arch}`.
 
 ## Container Images
 
-You can find all container images for your os at `https://go.kubebuilder.io/images/${os}`.
-You can find individual container images at `https://go.kubebuilder.io/images/:os/:version`.
+You can find all container images for your os at `https://go.kubebuilder.io/images/${os}`
+or at `gcr.io/kubebuilder/thirdparty-${os}`.
+You can find individual container images at `https://go.kubebuilder.io/images/${os}/${version}`
+or at `gcr.io/kubebuilder/thirdparty-${os}:${version}`.

--- a/docs/book/src/reference/artifacts.md
+++ b/docs/book/src/reference/artifacts.md
@@ -1,0 +1,14 @@
+# Artifacts
+
+Kubebuilder publishes test binaries and container images in addition
+to the main binary releases.
+
+## Test Binaries
+
+You can find all of the test binaries at `https://go.kubebuilder.io/test`.
+You can find individual test binaries at `https://go.kubebuilder.io/test/${version}/${os}/${arch}`.
+
+## Container Images
+
+You can find all container images for your os at `https://go.kubebuilder.io/images/${os}`.
+You can find individual container images at `https://go.kubebuilder.io/images/:os/:version`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -67,6 +67,48 @@
     status = 302
     force = true
 
+[[redirects]]
+    from = "https://go.kubebuilder.io/test"
+    to = "https://console.cloud.google.com/storage/browser/kubebuilder-tools"
+    status = 302
+    force = true
+
+[[redirects]]
+    from = "https://go.kubebuilder.io/test/:version"
+    to = "https://console.cloud.google.com/storage/browser/kubebuilder-tools/?prefix=kubebuilder-tools-:version"
+    status = 302
+    force = true
+
+[[redirects]]
+    from = "https://go.kubebuilder.io/test/:version/:os"
+    to = "https://console.cloud.google.com/storage/browser/_details/kubebuilder-tools/kubebuilder-tools-:version-:os-amd64.tar.gz"
+    status = 302
+    force = true
+
+[[redirects]]
+    from = "https://go.kubebuilder.io/test/:version/:os/:arch"
+    to = "https://console.cloud.google.com/storage/browser/_details/kubebuilder-tools/kubebuilder-tools-:version-:os-:arch.tar.gz"
+    status = 302
+    force = true
+
+[[redirects]]
+    from = "https://go.kubebuilder.io/images"
+    to = "gcr.io/kubebuilder"
+    status = 302
+    force = true
+
+[[redirects]]
+    from = "https://go.kubebuilder.io/images/:os"
+    to = "gcr.io/kubebuilder/thirdparty-:os"
+    status = 302
+    force = true
+
+[[redirects]]
+    from = "https://go.kubebuilder.io/images/:os/:version"
+    to = "gcr.io/kubebuilder/thirdparty-:os::version"
+    status = 302
+    force = true
+
 # TODO(directxman12): change this to standard kustomize when the next version is released (2.1.0) 
 [[redirects]]
     from = "https://go.kubebuilder.io/kustomize/:os/:arch"

--- a/netlify.toml
+++ b/netlify.toml
@@ -68,25 +68,25 @@
     force = true
 
 [[redirects]]
-    from = "https://go.kubebuilder.io/test"
+    from = "https://go.kubebuilder.io/test-tools"
     to = "https://console.cloud.google.com/storage/browser/kubebuilder-tools"
     status = 302
     force = true
 
 [[redirects]]
-    from = "https://go.kubebuilder.io/test/:version"
+    from = "https://go.kubebuilder.io/test-tools/:version"
     to = "https://console.cloud.google.com/storage/browser/kubebuilder-tools/?prefix=kubebuilder-tools-:version"
     status = 302
     force = true
 
 [[redirects]]
-    from = "https://go.kubebuilder.io/test/:version/:os"
+    from = "https://go.kubebuilder.io/test-tools/:version/:os"
     to = "https://console.cloud.google.com/storage/browser/_details/kubebuilder-tools/kubebuilder-tools-:version-:os-amd64.tar.gz"
     status = 302
     force = true
 
 [[redirects]]
-    from = "https://go.kubebuilder.io/test/:version/:os/:arch"
+    from = "https://go.kubebuilder.io/test-tools/:version/:os/:arch"
     to = "https://console.cloud.google.com/storage/browser/_details/kubebuilder-tools/kubebuilder-tools-:version-:os-:arch.tar.gz"
     status = 302
     force = true


### PR DESCRIPTION
Adding `go.kubebuilder` links and documentation for published test binaries and container images.

Fixes #914 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>