### PR TITLE
:warning: Copy all files in Dockerfile

### DIFF
--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -47,10 +47,8 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
+# Copy the sources
+COPY ./ ./
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/testdata/project-v2/Dockerfile
+++ b/testdata/project-v2/Dockerfile
@@ -9,10 +9,8 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
-# Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
+# Copy the sources
+COPY ./ ./
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
This PR fixes an issue where the user Dockerfile might not work if they create packages outside `api/` or `controllers/` folders. 

With the preference for Kubebuilder v2 controller to abandon the `pkg/` directory, in [Cluster API](https://github.com/kubernetes-sigs/cluster-api) we've moved all our main packages outside of the `pkg/` folder and made it available for other repositories to use them. 