### PR TITLE
Use gofmt, not goimports

### DIFF
--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -19,6 +19,7 @@ package scaffold
 import (
 	"bytes"
 	"fmt"
+	"go/format"
 	"io"
 	"io/ioutil"
 	"log"
@@ -27,7 +28,6 @@ import (
 	"strings"
 	"text/template"
 
-	"golang.org/x/tools/imports"
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/project"
@@ -289,7 +289,7 @@ func (s *Scaffold) doTemplate(i input.Input, e input.File) ([]byte, error) {
 
 	// gofmt the imports
 	if filepath.Ext(i.Path) == ".go" {
-		b, err = imports.Process(i.Path, b, nil)
+		b, err = format.Source(b)
 		if err != nil {
 			fmt.Printf("%s\n", out.Bytes())
 			return nil, err

--- a/pkg/scaffold/v1/controller/controller.go
+++ b/pkg/scaffold/v1/controller/controller.go
@@ -119,6 +119,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 
@@ -134,6 +135,7 @@ var log = logf.Log.WithName("{{ lower .Resource.Kind }}-controller")
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 {{ end -}}

--- a/pkg/scaffold/v1/controller/controller.go
+++ b/pkg/scaffold/v1/controller/controller.go
@@ -103,14 +103,12 @@ package {{ lower .Resource.Kind }}
 
 import (
 {{ if .Resource.CreateExampleReconcileBody }}	"context"
-	"log"
 	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -129,6 +127,7 @@ var log = logf.Log.WithName("{{ lower .Resource.Kind }}-controller")
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/pkg/scaffold/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/v1/controller/controllersuitetest.go
@@ -59,6 +59,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	"{{ .Repo }}/pkg/apis"
 )
 

--- a/pkg/scaffold/v1/controller/controllertest.go
+++ b/pkg/scaffold/v1/controller/controllertest.go
@@ -85,6 +85,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 

--- a/pkg/scaffold/v1/manager/cmd.go
+++ b/pkg/scaffold/v1/manager/cmd.go
@@ -46,14 +46,15 @@ import (
 	"flag"
 	"os"
 
+	"{{ .Repo }}/pkg/apis"
+	"{{ .Repo }}/pkg/controller"
+	"{{ .Repo }}/pkg/webhook"
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	"{{ .Repo }}/pkg/apis"
-	"{{ .Repo }}/pkg/controller"
-	"{{ .Repo }}/pkg/webhook"
 )
 
 func main() {

--- a/pkg/scaffold/v1/manager/cmd.go
+++ b/pkg/scaffold/v1/manager/cmd.go
@@ -46,15 +46,15 @@ import (
 	"flag"
 	"os"
 
-	"{{ .Repo }}/pkg/apis"
-	"{{ .Repo }}/pkg/controller"
-	"{{ .Repo }}/pkg/webhook"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"{{ .Repo }}/pkg/apis"
+	"{{ .Repo }}/pkg/controller"
+	"{{ .Repo }}/pkg/webhook"
 )
 
 func main() {

--- a/pkg/scaffold/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/v1/webhook/admissionbuilder.go
@@ -81,6 +81,7 @@ package {{ .Type }}
 
 import (
 	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
+
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
 )

--- a/pkg/scaffold/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/v1/webhook/admissionbuilder.go
@@ -80,10 +80,10 @@ const admissionWebhookBuilderTemplate = `{{ .Boilerplate }}
 package {{ .Type }}
 
 import (
-	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/pkg/scaffold/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/v1/webhook/admissionhandler.go
@@ -83,7 +83,7 @@ import (
 	"net/http"
 
 	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"

--- a/pkg/scaffold/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/v1/webhook/admissionhandler.go
@@ -82,11 +82,11 @@ import (
 	"context"
 	"net/http"
 
-	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -92,10 +92,14 @@ const (
 package {{ .Resource.Version }}
 
 import (
+{{ if or .Validating .Defaulting }}
 	"k8s.io/apimachinery/pkg/runtime"
+{{ end -}}
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+{{- if or .Validating .Defaulting }}
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+{{ end }}
 )
 
 // log is for logging in this package.

--- a/testdata/gopath/src/project/cmd/manager/main.go
+++ b/testdata/gopath/src/project/cmd/manager/main.go
@@ -20,15 +20,15 @@ import (
 	"flag"
 	"os"
 
-	"project/pkg/apis"
-	"project/pkg/controller"
-	"project/pkg/webhook"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"project/pkg/apis"
+	"project/pkg/controller"
+	"project/pkg/webhook"
 )
 
 func main() {

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	crewv1 "project/pkg/apis/crew/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -35,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 var log = logf.Log.WithName("firstmate-controller")

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"reflect"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	crewv1 "project/pkg/apis/crew/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_suite_test.go
@@ -23,11 +23,10 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_suite_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 	"time"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	crewv1 "project/pkg/apis/crew/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_test.go
@@ -26,10 +26,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	crewv1 "project/pkg/apis/crew/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller.go
@@ -19,11 +19,10 @@ package frigate
 import (
 	"context"
 
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller.go
@@ -22,13 +22,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_suite_test.go
@@ -23,11 +23,10 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_suite_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 	"time"
 
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_test.go
@@ -25,10 +25,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
@@ -22,13 +22,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
@@ -19,11 +19,10 @@ package healthcheckpolicy
 import (
 	"context"
 
-	policyv1beta1 "project/pkg/apis/policy/v1beta1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_suite_test.go
@@ -23,11 +23,10 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_suite_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 	"time"
 
-	policyv1beta1 "project/pkg/apis/policy/v1beta1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_test.go
@@ -25,10 +25,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller.go
@@ -22,13 +22,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller.go
@@ -19,11 +19,10 @@ package kraken
 import (
 	"context"
 
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_suite_test.go
@@ -23,11 +23,10 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_suite_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 	"time"
 
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_test.go
@@ -25,10 +25,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_suite_test.go
@@ -23,11 +23,10 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_suite_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"project/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_test.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/create_update_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/create_update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mutating
 
 import (
-	crewv1 "project/pkg/apis/crew/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/delete_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/delete_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mutating
 
 import (
-	crewv1 "project/pkg/apis/crew/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_create_update_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_create_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_delete_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_delete_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/frigate_update_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/frigate_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/update_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package validating
 
 import (
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/create_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/create_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package validating
 
 import (
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/kraken_create_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/kraken_create_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/namespace_update_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/namespace_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/namespace_update_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/namespace_update_handler.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"

--- a/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/update_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mutating
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/update_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/namespace/mutating/update_webhook.go
@@ -17,8 +17,9 @@ limitations under the License.
 package mutating
 
 import (
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
 )
 


### PR DESCRIPTION
goimports is slower, should not be necessary (we don't want to add
other imports), and the order of import declarations is no longer
consistent, because goimport groups them alphabetically.

goimports also means that the behaviour of kubebuilder depends on what
is on the GOPATH.

However, goimports will also respect existing import blocks, so we
remain compatible with goimports.