### PR TITLE
Correct the directory structure in the example provided.

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -126,7 +126,7 @@ After the scaffold is written, api will run make on the project.
 	kubebuilder create api --group ship --version v1beta1 --kind Frigate
 	
 	# Edit the API Scheme
-	nano api/ship/v1beta1/frigate_types.go
+	nano api/v1beta1/frigate_types.go
 
 	# Edit the Controller
 	nano controllers/frigate/frigate_controller.go


### PR DESCRIPTION
Fixed a minor issue in the directory structure shown in examples of kubebuilder create api --help command

Issue Addressed: [Issue 956](https://github.com/kubernetes-sigs/kubebuilder/issues/956)