### PR TITLE
fix range value

### DIFF
--- a/pkg/scaffold/input/input.go
+++ b/pkg/scaffold/input/input.go
@@ -183,7 +183,7 @@ func (pf *ProjectFile) ResourceGroups() []string {
 	}
 
 	groups := []string{}
-	for g, _ := range groupSet {
+	for g := range groupSet {
 		groups = append(groups, g)
 	}
 	return groups


### PR DESCRIPTION
# What
* fix bug

# Why
* remove`_` because `range` that has 2 return values returns index first.
* `range` that has 1 return value returns value only.