### PR TITLE
scaffold/v2/group: fix duplicate import package name and sort order

### DIFF
--- a/pkg/scaffold/v2/group.go
+++ b/pkg/scaffold/v2/group.go
@@ -55,14 +55,14 @@ var groupTemplate = `{{ .Boilerplate }}
 package {{ .Resource.Version }}
 
 import (
+	runtimeschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.Group }}.{{ .Domain }}", Version: "{{ .Resource.Version }}"}
+	GroupVersion = runtimeschema.GroupVersion{Group: "{{ .Resource.Group }}.{{ .Domain }}", Version: "{{ .Resource.Version }}"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}


### PR DESCRIPTION
Fix duplicate import package name and sort package order.

The `k8s.io/apimachinery/pkg/runtime/schema` and `sigs.k8s.io/controller-runtime/pkg/scheme` are the same package name. Fix it use the `runtimeschema` custom import package name to `k8s.io/apimachinery/pkg/runtime/schema` package.

Also, When running goimports to generated `groupversion_info.go`, will change the import order of packages that `k8s.io/apimachinery/pkg/runtime/schema` is the first.