### PR TITLE
Allow group names with dash

### DIFF
--- a/pkg/scaffold/v1/resource/resource.go
+++ b/pkg/scaffold/v1/resource/resource.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gobuffalo/flect"
 )
 
+const GroupMatchRegex = "^[a-z-]+$"
+
 // Resource contains the information required to scaffold files for a resource.
 type Resource struct {
 	// Namespaced is true if the resource is namespaced
@@ -64,9 +66,9 @@ func (r *Resource) Validate() error {
 		r.Resource = flect.Pluralize(strings.ToLower(r.Kind))
 	}
 
-	groupMatch := regexp.MustCompile("^[a-z]+$")
+	groupMatch := regexp.MustCompile(GroupMatchRegex)
 	if !groupMatch.MatchString(r.Group) {
-		return fmt.Errorf("group must match ^[a-z]+$ (was %s)", r.Group)
+		return fmt.Errorf("group must match %s (was %s)", GroupMatchRegex, r.Group)
 	}
 
 	versionMatch := regexp.MustCompile("^v\\d+(alpha\\d+|beta\\d+)?$")

--- a/pkg/scaffold/v1/resource/resource_test.go
+++ b/pkg/scaffold/v1/resource/resource_test.go
@@ -30,13 +30,13 @@ var _ = Describe("Resource", func() {
 		It("should fail if the Group is not all lowercase", func() {
 			instance := &resource.Resource{Group: "Crew", Version: "v1", Kind: "FirstMate"}
 			Expect(instance.Validate()).NotTo(Succeed())
-			Expect(instance.Validate().Error()).To(ContainSubstring("group must match ^[a-z]+$ (was Crew)"))
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was Crew)", resource.GroupMatchRegex))
 		})
 
 		It("should fail if the Group contains non-alpha characters", func() {
 			instance := &resource.Resource{Group: "crew1", Version: "v1", Kind: "FirstMate"}
 			Expect(instance.Validate()).NotTo(Succeed())
-			Expect(instance.Validate().Error()).To(ContainSubstring("group must match ^[a-z]+$ (was crew1)"))
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was crew1)", resource.GroupMatchRegex))
 		})
 
 		It("should fail if the Version is not specified", func() {


### PR DESCRIPTION
## Motivation:
- https://github.com/kubernetes-sigs/kubebuilder/issues/954

## What 
allow the usage of dash in the group names

## Why 

Allow users to create API's with a group name like `mypapp-operator.example.com`. Note that the controller allows it.  