### PR TITLE
Ship arm64 and ppc64le binaries

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -9,6 +9,13 @@ builds:
    - linux
   goarch:
    - amd64
+   - arm64
+   - ppc64le
+  ignore:
+   - goos: darwin
+     goarch: arm64
+   - goos: darwin
+     goarch: ppc64le
   env:
    - CGO_ENABLED=0
    - GO111MODULE=on


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kubebuilder/issues/966