### PR TITLE
Setup user on docker image to run it as no root

### DIFF
--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -57,8 +57,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot 
 WORKDIR /
 COPY --from=builder /workspace/manager .
+USER nonroot:nonroot
+
 ENTRYPOINT ["/manager"]
 `

--- a/pkg/scaffold/v2/main.go
+++ b/pkg/scaffold/v2/main.go
@@ -166,6 +166,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		Port:               9443, 
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/scaffold/v2/webhook/service.go
+++ b/pkg/scaffold/v2/webhook/service.go
@@ -48,7 +48,7 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 443
+      targetPort: 9443
   selector:
     control-plane: controller-manager
 `

--- a/pkg/scaffold/v2/webhook_manager_patch.go
+++ b/pkg/scaffold/v2/webhook_manager_patch.go
@@ -47,7 +47,7 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 443
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
         volumeMounts:

--- a/testdata/project-v2/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v2/config/default/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 443
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
         volumeMounts:

--- a/testdata/project-v2/config/webhook/service.yaml
+++ b/testdata/project-v2/config/webhook/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 443
+      targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -58,6 +58,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		Port:               9843,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
## What:
- Setup user on docker image to run it as rootless

## Motivation:
- https://github.com/kubernetes-sigs/kubebuilder/issues/883
- https://jira.coreos.com/browse/OSDK-473

## Steps performed to check it locally

```
$ cd upimage/
$ kubebuilder init --domain up.image
$ kubebuilder create api --group kubeimage --version v1 --kind TestImg
$ make
$ oc login -u system:admin
$ make install
$ make docker-build docker-push IMG=cmacedo/upimage:test
$ make deploy IMG=cmacedo/upimage:test
```
Checked that it worked in Minishift/OCP as well. 

<img width="1565" alt="Screenshot 2019-09-17 at 17 03 57" src="https://user-images.githubusercontent.com/7708031/65059041-2f50d500-d96d-11e9-9e5c-36dcdeb09fde.png">
<img width="872" alt="Screenshot 2019-09-17 at 17 03 40" src="https://user-images.githubusercontent.com/7708031/65059043-2f50d500-d96d-11e9-957d-a67ea2329c32.png">
<img width="1602" alt="Screenshot 2019-09-17 at 17 03 34" src="https://user-images.githubusercontent.com/7708031/65059044-2fe96b80-d96d-11e9-8c7d-7ad54ce9ed37.png">
<img width="1185" alt="Screenshot 2019-09-17 at 17 03 27" src="https://user-images.githubusercontent.com/7708031/65059045-2fe96b80-d96d-11e9-9b0d-fc8280d1076f.png">
