### PR TITLE
scaffold: Don't hardcode the boilerplate path in the Makefile

### DIFF
--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -94,7 +94,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
+	$(CONTROLLER_GEN) object:headerFile={{printf "%q" .BoilerplatePath}} paths="./..."
 
 # Build the docker image
 docker-build: test


### PR DESCRIPTION
init has a --path argument that specifies where the boilerplate file should be
written to. Unfortunately, the Makefile generation wasn't taking it into
account.