### PR TITLE
Changing the regular expression to support numbers for groupNames

### DIFF
--- a/pkg/scaffold/v1/resource/resource.go
+++ b/pkg/scaffold/v1/resource/resource.go
@@ -24,7 +24,8 @@ import (
 	"github.com/gobuffalo/flect"
 )
 
-const GroupMatchRegex = "^[a-z-]+$"
+// GroupMatchRegex is the regex used to validate groupNames
+const GroupMatchRegex = "^[a-zA-Z0-9]+[a-zA-Z0-9-_]*[a-zA-Z0-9]+$"
 
 // Resource contains the information required to scaffold files for a resource.
 type Resource struct {

--- a/pkg/scaffold/v1/resource/resource_test.go
+++ b/pkg/scaffold/v1/resource/resource_test.go
@@ -28,16 +28,28 @@ var _ = Describe("Resource", func() {
 			Expect(instance.Validate().Error()).To(ContainSubstring("group cannot be empty"))
 		})
 
-		It("should fail if the Group is not all lowercase", func() {
-			instance := &resource.Resource{Group: "Crew", Version: "v1", Kind: "FirstMate"}
+		It("should fail if the Group starts with dash characters", func() {
+			instance := &resource.Resource{Group: "-crew1", Version: "v1", Kind: "FirstMate"}
 			Expect(instance.Validate()).NotTo(Succeed())
-			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was Crew)", resource.GroupMatchRegex))
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was -crew1)", resource.GroupMatchRegex))
 		})
 
-		It("should fail if the Group contains non-alpha characters", func() {
-			instance := &resource.Resource{Group: "crew1", Version: "v1", Kind: "FirstMate"}
+		It("should fail if the Group ends with dash characters", func() {
+			instance := &resource.Resource{Group: "crew1-", Version: "v1", Kind: "FirstMate"}
 			Expect(instance.Validate()).NotTo(Succeed())
-			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was crew1)", resource.GroupMatchRegex))
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was crew1-)", resource.GroupMatchRegex))
+		})
+
+		It("should fail if the Group starts with underscore characters", func() {
+			instance := &resource.Resource{Group: "_crew1", Version: "v1", Kind: "FirstMate"}
+			Expect(instance.Validate()).NotTo(Succeed())
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was _crew1)", resource.GroupMatchRegex))
+		})
+
+		It("should fail if the Group ends with underscore characters", func() {
+			instance := &resource.Resource{Group: "crew1_", Version: "v1", Kind: "FirstMate"}
+			Expect(instance.Validate()).NotTo(Succeed())
+			Expect(instance.Validate().Error()).To(ContainSubstring("group must match %s (was crew1_)", resource.GroupMatchRegex))
 		})
 
 		It("should fail if the Version is not specified", func() {


### PR DESCRIPTION
The current regex for `groupNames` doesn't allow for numbers for underscore which should be allowed under DNS spec.

**Correct:**
* k8s
* K8s
* k8s-rox
* k8s_rox
* k8

**Incorrect:**
* k8s.foo
* 123k8s 
* _k8s_
* -k8s-

Closes #1037 

Signed-off-by: Christopher Hein <me@chrishein.com>