### PR TITLE
Remove GitBook instructions/reference and add mdBook instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the Kubebuilder [book](https://book.kubebuilder.io).
 
 ## Resources
 
-- GitBook: [book.kubebuilder.com](https://book.kubebuilder.io)
+- Kubebuilder Book: [book.kubebuilder.io](https://book.kubebuilder.io)
 - GitHub Repo: [kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)
 - Slack channel: [#kubebuilder](https://slack.k8s.io/#kubebuilder)
 - Google Group: [kubebuilder@googlegroups.com](https://groups.google.com/forum/#!forum/kubebuilder)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
-# Running GitBook
+# Running mdBook
 
-1. Follow the instructions at [https://toolchain.gitbook.com/](https://toolchain.gitbook.com/) to
-  install gitbook.
+The kubebuilder book is served using [mdBook](https://github.com/rust-lang-nursery/mdBook). If you want to test changes to the book locally, follow these directions:
+
+1. Follow the instructions at [https://github.com/rust-lang-nursery/mdBook#installation](https://github.com/rust-lang-nursery/mdBook#installation) to
+  install mdBook.
 1. cd into the `docs/book` directory
-1. Run `gitbook install`
-1. Run `gitbook build`
-1. Run `gitbook serve`
-1. Visit `http://localhost:4000`
+1. Run `mdbook serve`
+1. Visit [http://localhost:3000](http://localhost:3000)
 
 # Steps to deploy
 


### PR DESCRIPTION
Hi there, this is a small PR to update a couple references to GitBook, which no longer seems to be in use.  I replaced the `docs/book/README.md` instructions for GitBook with mdBook instructions, for other folks who want to come in and make documentation changes.  I searched the project and didn't see any other references to GitBook.