### PR TITLE
plugins/addon: perform replacements for type and controller

### DIFF
--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -228,9 +228,13 @@ func (api *API) scaffoldV2() error {
 	if api.DoController {
 		fmt.Println(filepath.Join("controllers", fmt.Sprintf("%s_controller.go", strings.ToLower(r.Kind))))
 
+		scaffold := &Scaffold{
+			Plugins: api.Plugins,
+		}
+
 		ctrlScaffolder := &resourcev2.Controller{Resource: r}
 		testsuiteScaffolder := &resourcev2.ControllerSuiteTest{Resource: r}
-		err := (&Scaffold{}).Execute(
+		err := scaffold.Execute(
 			api.buildUniverse(),
 			input.Options{},
 			testsuiteScaffolder,

--- a/plugins/addon/channel.go
+++ b/plugins/addon/channel.go
@@ -32,8 +32,9 @@ func ExampleChannel(u *model.Universe) error {
 	m := &model.File{
 		Path:           filepath.Join("channels", "stable"),
 		Contents:       exampleChannel,
-		IfExistsAction: input.Error,
+		IfExistsAction: input.Skip,
 	}
 
-	return AddFile(u, m)
+	_, err := AddFile(u, m)
+	return err
 }

--- a/plugins/addon/controller.go
+++ b/plugins/addon/controller.go
@@ -33,17 +33,22 @@ var controllerTemplate = `{{ .Boilerplate }}
 package controllers
 
 import (
-	"context"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/addon/pkg/status"
 	"sigs.k8s.io/kubebuilder-declarative-pattern/pkg/patterns/declarative"
 
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	api "{{ .Resource.GoPackage }}/{{ .Resource.Version }}"
 )
+
+var _ reconcile.Reconciler = &{{ .Resource.Kind }}Reconciler{}
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
 type {{ .Resource.Kind }}Reconciler struct {

--- a/plugins/addon/helpers.go
+++ b/plugins/addon/helpers.go
@@ -16,21 +16,24 @@ import (
 
 type PluginFunc func(u *model.Universe) error
 
-// AddFile adds the specified file to the model, returning a file if the file already exists
-func AddFile(u *model.Universe, add *model.File) error {
+// AddFile adds the specified file to the model.
+// If the file exists the function returns false and does not modify the Universe
+// If the file does not exist, the function returns true and adds the file to the Universe
+// If there is a problem with the file the function returns an error
+func AddFile(u *model.Universe, add *model.File) (bool, error) {
 	p := add.Path
 	if p == "" {
-		return fmt.Errorf("path must be set")
+		return false, fmt.Errorf("path must be set")
 	}
 
 	for _, f := range u.Files {
 		if f.Path == p {
-			return fmt.Errorf("file already exists at path %q", p)
+			return false, nil
 		}
 	}
 
 	u.Files = append(u.Files, add)
-	return nil
+	return true, nil
 }
 
 // ReplaceFileIfExists replaces the specified file in the model by path

--- a/plugins/addon/manifest.go
+++ b/plugins/addon/manifest.go
@@ -35,10 +35,12 @@ func ExampleManifest(u *model.Universe) error {
 	m := &model.File{
 		Path:           filepath.Join("channels", "packages", packageName, exampleManifestVersion, "manifest.yaml"),
 		Contents:       exampleManifestContents,
-		IfExistsAction: input.Error,
+		IfExistsAction: input.Skip,
 	}
 
-	return AddFile(u, m)
+	_, err := AddFile(u, m)
+
+	return err
 }
 
 // getPackageName returns the (default) name of the declarative package

--- a/plugins/addon/type.go
+++ b/plugins/addon/type.go
@@ -19,7 +19,7 @@ func ReplaceTypes(u *model.Universe) error {
 	}
 
 	m := &model.File{
-		Path:           filepath.Join("controllers", strings.ToLower(u.Resource.Kind)+"_controller.go"),
+		Path:           filepath.Join("api", u.Resource.Version, strings.ToLower(u.Resource.Kind)+"_types.go"),
 		Contents:       contents,
 		IfExistsAction: input.Error,
 	}


### PR DESCRIPTION
This change adds the plumbing for plugins to act on the controller and fixes the addon pattern to output a buildable controller.

changes:
- controller runs in a second phase and needs the Plugins configured on
  the Scaffold
- fix path to the api/<version>/<resource>_type.go file for file
  replacement
- make the addon plugin work with the 2 phase run (api then controller)
  by not failing if the manifest/channel file has already been generated
- fixup import paths
