### PR TITLE
On kubebuilder init checking go.mod file before getting path

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,9 +69,11 @@ func findCurrentRepo() (string, error) {
 	}
 
 	// next easy case: existing go module
-	path, err := findGoModulePath(false)
-	if err == nil {
-		return path, nil
+	if _, err := os.Stat("go.mod"); os.IsExist(err) {
+		path, err := findGoModulePath(false)
+		if err == nil {
+			return path, nil
+		}
 	}
 
 	// next, check if we've got a package in the current directory


### PR DESCRIPTION
When running the ```kubebuilder init``` the findCurrentRepo function returns "github.com", since go edit mod tries to "guess" the directory without being in.

The solution is to check if a go.mod file exists before running go edit mod to fetch the path.