### PR TITLE
fix: remove tmp/vendor.v1.tgz to ensure that it will work always

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -166,10 +166,13 @@ function download_vendor_archive {
   archive_name="vendor.v1.tgz"
   archive_download_url="https://storage.googleapis.com/kubebuilder-vendor/$archive_name"
   archive_path="$tmp_root/$archive_name"
-  if [ ! -f $archive_path ]; then
-    header_text "downloading vendor archive $archive_path"
-    curl -sL ${archive_download_url} -o "$archive_path"
+  header_text "checking the path $archive_path to download the $archive_name"
+  if [ -f $archive_path ]; then
+    header_text "removing file which exists"
+    rm $archive_path
   fi
+  header_text "downloading vendor archive from $archive_download_url"
+  curl -sL ${archive_download_url} -o "$archive_path"
 }
 
 function restore_go_deps {


### PR DESCRIPTION
**Description**
Ensure that the common.sh script will be always able to download the file. 
**Motivation**
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1087 and https://github.com/kubernetes-sigs/kubebuilder/issues/1078

**Following the local tests**

<img width="982" alt="Screenshot 2019-10-11 at 20 37 49" src="https://user-images.githubusercontent.com/7708031/66679827-13d4a380-ec67-11e9-9da4-40ae86c35d14.png">

<img width="1037" alt="Screenshot 2019-10-11 at 20 39 01" src="https://user-images.githubusercontent.com/7708031/66679887-349cf900-ec67-11e9-809e-e5dfec18486c.png">
