### PR TITLE
:sparkles: Update cert-manager group and version to match 0.11 change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,23 @@ os:
 go:
 - "1.12"
 
+# A build matix defines the K8s versions to use for e2e tests. Travis runs these in parrellel
 env:
+  - KIND_K8S_VERSION="v1.16.2" GOPROXY=https://proxy.golang.org/
+  - KIND_K8S_VERSION="v1.15.3" GOPROXY=https://proxy.golang.org/
+  - KIND_K8S_VERSION="v1.14.1" GOPROXY=https://proxy.golang.org/
   - GOPROXY=https://proxy.golang.org/
+# As OSX isn't running KIND e2e tests exlude it from the matrix
+matrix:
+  exclude:
+  - os: osx
+    env: KIND_K8S_VERSION="v1.16.2" GOPROXY=https://proxy.golang.org/
+  - os: osx
+    env: KIND_K8S_VERSION="v1.15.3" GOPROXY=https://proxy.golang.org/
+  - os: osx
+    env: KIND_K8S_VERSION="v1.14.1" GOPROXY=https://proxy.golang.org/
+  - os: linux
+    env: GOPROXY=https://proxy.golang.org/
 
 git:
   depth: 3
@@ -26,7 +41,7 @@ services:
 before_install:
 # NOTE: The latest version of dep requires go 1.13
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p /Users/travis/gopath/bin; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then GO111MODULE=on scripts/install_and_setup.sh; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then GO111MODULE=on scripts/install_and_setup.sh $KIND_K8S_VERSION; fi
 - GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.2
 - GO111MODULE=on go get sigs.k8s.io/kustomize/kustomize/v3@v3.2.1
 

--- a/pkg/scaffold/v2/certmanager/certificate.go
+++ b/pkg/scaffold/v2/certmanager/certificate.go
@@ -38,7 +38,8 @@ func (p *CertManager) GetInput() (input.Input, error) {
 
 var certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -46,15 +47,15 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
-  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer

--- a/pkg/scaffold/v2/certmanager/kustomizeconfig.go
+++ b/pkg/scaffold/v2/certmanager/kustomizeconfig.go
@@ -39,17 +39,17 @@ func (p *KustomizeConfig) GetInput() (input.Input, error) {
 var kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames
 `

--- a/pkg/scaffold/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/v2/crd/enablecainjection_patch.go
@@ -57,6 +57,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: {{ .Resource.Resource }}.{{ .Resource.Group }}.{{ .Domain }}
 `

--- a/pkg/scaffold/v2/kustomize.go
+++ b/pkg/scaffold/v2/kustomize.go
@@ -102,16 +102,16 @@ vars:
 #- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:
 #    kind: Certificate
-#    group: certmanager.k8s.io
-#    version: v1alpha1
+#    group: cert-manager.io
+#    version: v1alpha2
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
 #- name: CERTIFICATE_NAME
 #  objref:
 #    kind: Certificate
-#    group: certmanager.k8s.io
-#    version: v1alpha1
+#    group: cert-manager.io
+#    version: v1alpha2
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:

--- a/pkg/scaffold/v2/types.go
+++ b/pkg/scaffold/v2/types.go
@@ -66,6 +66,9 @@ import (
 type {{.Resource.Kind}}Spec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// Foo is an example field of {{.Resource.Kind}}. Edit {{.Resource.Kind}}_types.go to remove/update
+	Foo string ` + "`" + `json:"foo,omitempty"` + "`" + `
 }
 
 // {{.Resource.Kind}}Status defines the observed state of {{.Resource.Kind}}

--- a/pkg/scaffold/v2/webhook/enablecainection_patch.go
+++ b/pkg/scaffold/v2/webhook/enablecainection_patch.go
@@ -46,12 +46,12 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 `

--- a/scripts/install_and_setup.sh
+++ b/scripts/install_and_setup.sh
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+K8S_VERSION=$1
+
 export GO111MODULE=on
 
 go get sigs.k8s.io/kind@v0.5.1
 
 # You can use --image flag to specify the cluster version you want, e.g --image=kindest/node:v1.13.6, the supported version are listed at https://hub.docker.com/r/kindest/node/tags
-kind create cluster --config test/kind-config.yaml --image=kindest/node:v1.14.1
+kind create cluster --config test/kind-config.yaml --image=kindest/node:$K8S_VERSION

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -26,8 +26,8 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-const certmanagerVersion = "v0.10.1"
-const prometheusOperatorVersion= "0.33"
+const certmanagerVersion = "v0.11.0"
+const prometheusOperatorVersion = "0.33"
 
 // KBTestContext specified to run e2e tests
 type KBTestContext struct {
@@ -88,10 +88,7 @@ func (kc *KBTestContext) InstallCertManager() error {
 	if _, err := kc.Kubectl.Command("create", "namespace", "cert-manager"); err != nil {
 		return err
 	}
-	if _, err := kc.Kubectl.Command("label", "namespace", "cert-manager", "certmanager.k8s.io/disable-validation=true"); err != nil {
-		return err
-	}
-	_, err := kc.Kubectl.Apply(false, "-f", fmt.Sprintf("https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml", certmanagerVersion))
+	_, err := kc.Kubectl.Apply(false, "-f", fmt.Sprintf("https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml", certmanagerVersion), "--validate=false")
 	return err
 }
 

--- a/test/e2e/v2/e2e_suite.go
+++ b/test/e2e/v2/e2e_suite.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"sigs.k8s.io/kubebuilder/test/e2e/utils"
 	"strconv"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/kubebuilder/test/e2e/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -123,16 +124,16 @@ var _ = Describe("kubebuilder", func() {
 				`#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:
 #    kind: Certificate
-#    group: certmanager.k8s.io
-#    version: v1alpha1
+#    group: cert-manager.io
+#    version: v1alpha2
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
 #- name: CERTIFICATE_NAME
 #  objref:
 #    kind: Certificate
-#    group: certmanager.k8s.io
-#    version: v1alpha1
+#    group: cert-manager.io
+#    version: v1alpha2
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:
@@ -211,7 +212,7 @@ var _ = Describe("kubebuilder", func() {
 				true,
 				"ServiceMonitor")
 			Expect(err).NotTo(HaveOccurred())
-			
+
 			By("validate the mutating|validating webhooks have the CA injected")
 			verifyCAInjection := func() error {
 				mwhOutput, err := kbc.Kubectl.Get(

--- a/testdata/project-v2/api/v1/admiral_types.go
+++ b/testdata/project-v2/api/v1/admiral_types.go
@@ -27,6 +27,9 @@ import (
 type AdmiralSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// Foo is an example field of Admiral. Edit Admiral_types.go to remove/update
+	Foo string `json:"foo,omitempty"`
 }
 
 // AdmiralStatus defines the observed state of Admiral

--- a/testdata/project-v2/api/v1/captain_types.go
+++ b/testdata/project-v2/api/v1/captain_types.go
@@ -27,6 +27,9 @@ import (
 type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// Foo is an example field of Captain. Edit Captain_types.go to remove/update
+	Foo string `json:"foo,omitempty"`
 }
 
 // CaptainStatus defines the observed state of Captain

--- a/testdata/project-v2/api/v1/firstmate_types.go
+++ b/testdata/project-v2/api/v1/firstmate_types.go
@@ -27,6 +27,9 @@ import (
 type FirstMateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// Foo is an example field of FirstMate. Edit FirstMate_types.go to remove/update
+	Foo string `json:"foo,omitempty"`
 }
 
 // FirstMateStatus defines the observed state of FirstMate

--- a/testdata/project-v2/config/certmanager/certificate.yaml
+++ b/testdata/project-v2/config/certmanager/certificate.yaml
@@ -1,6 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,15 +9,15 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
-  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer

--- a/testdata/project-v2/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v2/config/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -33,6 +33,11 @@ spec:
           type: object
         spec:
           description: AdmiralSpec defines the desired state of Admiral
+          properties:
+            foo:
+              description: Foo is an example field of Admiral. Edit Admiral_types.go
+                to remove/update
+              type: string
           type: object
         status:
           description: AdmiralStatus defines the observed state of Admiral

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
@@ -33,6 +33,11 @@ spec:
           type: object
         spec:
           description: CaptainSpec defines the desired state of Captain
+          properties:
+            foo:
+              description: Foo is an example field of Captain. Edit Captain_types.go
+                to remove/update
+              type: string
           type: object
         status:
           description: CaptainStatus defines the observed state of Captain

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -33,6 +33,11 @@ spec:
           type: object
         spec:
           description: FirstMateSpec defines the desired state of FirstMate
+          properties:
+            foo:
+              description: Foo is an example field of FirstMate. Edit FirstMate_types.go
+                to remove/update
+              type: string
           type: object
         status:
           description: FirstMateStatus defines the observed state of FirstMate

--- a/testdata/project-v2/config/crd/patches/cainjection_in_admirals.yaml
+++ b/testdata/project-v2/config/crd/patches/cainjection_in_admirals.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: admirals.crew.testproject.org

--- a/testdata/project-v2/config/crd/patches/cainjection_in_captains.yaml
+++ b/testdata/project-v2/config/crd/patches/cainjection_in_captains.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: captains.crew.testproject.org

--- a/testdata/project-v2/config/crd/patches/cainjection_in_firstmates.yaml
+++ b/testdata/project-v2/config/crd/patches/cainjection_in_firstmates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: firstmates.crew.testproject.org

--- a/testdata/project-v2/config/default/kustomization.yaml
+++ b/testdata/project-v2/config/default/kustomization.yaml
@@ -49,16 +49,16 @@ vars:
 #- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:
 #    kind: Certificate
-#    group: certmanager.k8s.io
-#    version: v1alpha1
+#    group: cert-manager.io
+#    version: v1alpha2
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
 #- name: CERTIFICATE_NAME
 #  objref:
 #    kind: Certificate
-#    group: certmanager.k8s.io
-#    version: v1alpha1
+#    group: cert-manager.io
+#    version: v1alpha2
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:

--- a/testdata/project-v2/config/default/webhookcainjection_patch.yaml
+++ b/testdata/project-v2/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
This PR updates the `group` and `version` references to `cert-manager` to function correctly with `v0.11`.

>The v0.11 release marks the removal of the v1alpha1 API that was used in previous versions of cert-manager, as well as our API group changing to be cert-manager.io instead of certmanager.k8s.io.

https://docs.cert-manager.io/en/latest/tasks/upgrading/upgrading-0.10-0.11.html

Fixes #1093 

Todo:

- [x] Fix up tests. I've attempted to follow the `contribute.md` guide but failed and ended up with 5k+ file changes so think I must have gone wrong. 