### PR TITLE
:running: bump up k8s tools to 1.15.5

### DIFF
--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -25,18 +25,18 @@ steps:
   args: [fetch, --tags, --depth=100]
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/linux_amd64"]
-- name: "gcr.io/kubebuilder/thirdparty-linux:1.14.1"
+- name: "gcr.io/kubebuilder/thirdparty-linux:1.15.5"
   args: ["tar", "-xzvf", "/kubebuilder_linux_amd64.tar.gz"]
   dir: "_output/linux_amd64"
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/darwin_amd64"]
-- name: "gcr.io/kubebuilder/thirdparty-darwin:1.14.1"
+- name: "gcr.io/kubebuilder/thirdparty-darwin:1.15.5"
   args: ["tar", "-xzvf", "/kubebuilder_darwin_amd64.tar.gz"]
   dir: "_output/darwin_amd64"
 - name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh"]
   env:
-   - 'KUBERNETES_VERSION=1.14.1'
+   - 'KUBERNETES_VERSION=1.15.5'
   secretEnv: ['GITHUB_TOKEN']
 secrets:
 - kmsKeyName: projects/kubebuilder/locations/global/keyRings/kubebuilder-gh-tokens/cryptoKeys/gh-release-token

--- a/build/cloudbuild_local.yaml
+++ b/build/cloudbuild_local.yaml
@@ -23,15 +23,15 @@
 steps:
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/linux_amd64"]
-- name: "gcr.io/kubebuilder/thirdparty-linux:1.14.1"
+- name: "gcr.io/kubebuilder/thirdparty-linux:1.15.5"
   args: ["tar", "-xzvf", "/kubebuilder_linux_amd64.tar.gz"]
   dir: "_output/linux_amd64"
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/darwin_amd64"]
-- name: "gcr.io/kubebuilder/thirdparty-darwin:1.14.1"
+- name: "gcr.io/kubebuilder/thirdparty-darwin:1.15.5"
   args: ["tar", "-xzvf", "/kubebuilder_darwin_amd64.tar.gz"]
   dir: "_output/darwin_amd64"
 - name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh", "--snapshot"]
   env:
-   - 'KUBERNETES_VERSION=1.14.1'
+   - 'KUBERNETES_VERSION=1.15.5'

--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -23,18 +23,18 @@
 steps:
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/linux_amd64"]
-- name: "gcr.io/kubebuilder/thirdparty-linux:1.14.1"
+- name: "gcr.io/kubebuilder/thirdparty-linux:1.15.5"
   args: ["tar", "-xzvf", "/kubebuilder_linux_amd64.tar.gz"]
   dir: "_output/linux_amd64"
 - name: "ubuntu"
   args: ["mkdir", "-p", "/workspace/_output/darwin_amd64"]
-- name: "gcr.io/kubebuilder/thirdparty-darwin:1.14.1"
+- name: "gcr.io/kubebuilder/thirdparty-darwin:1.15.5"
   args: ["tar", "-xzvf", "/kubebuilder_darwin_amd64.tar.gz"]
   dir: "_output/darwin_amd64"
 - name: "gcr.io/kubebuilder/goreleaser_with_go_1.12.5:0.0.1"
   args: ["bash", "build/build_kubebuilder.sh", "--snapshot"]
   env:
-   - 'KUBERNETES_VERSION=1.14.1'
+   - 'KUBERNETES_VERSION=1.15.5'
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['-h', 'Content-Type:application/gzip', 'cp', 'dist/kubebuilder_master_linux_amd64.tar.gz', 'gs://kubebuilder-release/kubebuilder_master_linux_amd64.tar.gz']
 - name: 'gcr.io/cloud-builders/gsutil'

--- a/common.sh
+++ b/common.sh
@@ -53,8 +53,7 @@ if [ -z $go_workspace ]; then
   exit 1
 fi
 
-# k8s_version=1.11.0
-k8s_version=1.14.1
+k8s_version=1.15.5
 goarch=amd64
 goos="unknown"
 


### PR DESCRIPTION
Changes:
 - Use Kubernetes 1.15.5 binaries in tests
 - Use Kubernetes 1.15.5 in release bundle
