### PR TITLE
Support mixed case Kind

### DIFF
--- a/pkg/model/resource/options.go
+++ b/pkg/model/resource/options.go
@@ -126,9 +126,17 @@ func (opts *Options) Validate() error {
 			"version must match %s (was %s)", versionPattern, opts.Version)
 	}
 
-	// Check if the Kind is PascalCase
-	if opts.Kind != flect.Pascalize(opts.Kind) {
-		return fmt.Errorf("kind must be PascalCase (expected %s was %s)", flect.Pascalize(opts.Kind), opts.Kind)
+	validationErrors := []string{}
+
+	// require Kind to start with an uppercase character
+	if string(opts.Kind[0]) == strings.ToLower(string(opts.Kind[0])) {
+		validationErrors = append(validationErrors, "Kind must start with an uppercase character")
+	}
+
+	validationErrors = append(validationErrors, isDNS1035Label(strings.ToLower(opts.Kind))...)
+
+	if len(validationErrors) != 0 {
+		return fmt.Errorf("Invalid Kind: %#v", validationErrors)
 	}
 
 	// TODO: validate plural strings if provided

--- a/pkg/model/resource/validation.go
+++ b/pkg/model/resource/validation.go
@@ -33,9 +33,17 @@ const (
 
 	// dns1123SubdomainMaxLength is a subdomain's max length in DNS (RFC 1123)
 	dns1123SubdomainMaxLength int = 253
+
+	dns1035LabelFmt    string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+	dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', " +
+		"start with an alphabetic character, and end with an alphanumeric character"
+
+	// DNS1035LabelMaxLength is a label's max length in DNS (RFC 1035)
+	dns1035LabelMaxLength int = 63
 )
 
 var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
+var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
 
 // IsDNS1123Subdomain tests for a string that conforms to the definition of a
 // subdomain in DNS (RFC 1123).
@@ -46,6 +54,17 @@ func IsDNS1123Subdomain(value string) []string {
 	}
 	if !dns1123SubdomainRegexp.MatchString(value) {
 		errs = append(errs, regexError(dns1123SubdomainErrorMsg, dns1123SubdomainFmt, "example.com"))
+	}
+	return errs
+}
+
+func isDNS1035Label(value string) []string {
+	var errs []string
+	if len(value) > dns1035LabelMaxLength {
+		errs = append(errs, maxLenError(dns1035LabelMaxLength))
+	}
+	if !dns1035LabelRegexp.MatchString(value) {
+		errs = append(errs, regexError(dns1035LabelErrMsg, dns1035LabelFmt, "my-name", "abc-123"))
 	}
 	return errs
 }


### PR DESCRIPTION
This PR should address issues https://github.com/kubernetes-sigs/kubebuilder/issues/1019 and https://github.com/kubernetes-sigs/kubebuilder/issues/1091.

The implementation uses the validation logic that runs against `Kind` in
apimachinery; i.e. allows any `Kind` value that, when converted to
lowercase, is a valid DNS-1035 label.

Reusing that logic instead of reimplementing it helps with ensuring that
the two (i.e. `Kind` validation in core Kubernetes and `Kind` validation
in kubebuilder) are as similar as possible.

Would love feedback on:
* The choice to use [`k8s.io/apimachinery` logic](https://github.com/kubernetes/kubernetes/blob/b3b15a9e260ac65edfa14dd80add9046f3fa9b1f/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go#L549-L582) vs continuing to extend the validation logic [in kubebuilder](https://github.com/kubernetes-sigs/kubebuilder/blob/702b272f9c73c723d0aec3569489ffcf79d6d1b9/pkg/scaffold/v1/resource/resource.go#L82).
* If the above does sound like a good idea, is it worth refactoring [`Validate()`](https://github.com/kubernetes-sigs/kubebuilder/blob/702b272f9c73c723d0aec3569489ffcf79d6d1b9/pkg/scaffold/v1/resource/resource.go#L56) more broadly, to use available logic in `k8s.io/apimachinery`?
* There were more changes than I expected in go.mod 😅 I'll take an extra look at that.

Remaining work in this PR:
(once the approach seems reasonable)
* Refactor tests to describe successful & failed validation more succinctly (at the moment there's duplication and missing test cases while the PR is in progress)
* Ensure any logging and error messages are descriptive of the validation that takes place.