### PR TITLE
Fix position of envtest reference in book ToC

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -69,9 +69,10 @@
   - [controller-gen CLI](./reference/controller-gen.md)
   - [Artifacts](./reference/artifacts.md)
   - [Writing controller tests](./reference/writing-tests.md)
-  - [Metrics](./reference/metrics.md)
 
     - [Using envtest in integration tests](./reference/testing/envtest.md)
+
+  - [Metrics](./reference/metrics.md)
 
 ---
 


### PR DESCRIPTION
A bad merge or something screwed up the order of the ToC wrt to the
envtest reference section.  This fixes it.

/kind bug
/kind documentation