### PR TITLE
Solve name collision and document why version strings can not be const

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,8 +116,8 @@ func main() {
 		version.NewVersionCmd(),
 	)
 
-	foundProject, version := getProjectVersion()
-	if foundProject && version == project.Version1 {
+	foundProject, projectVersion := getProjectVersion()
+	if foundProject && projectVersion == project.Version1 {
 		printV1DeprecationWarning()
 
 		rootCmd.AddCommand(

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// var needs to be used instead of const as ldflags is used to fill this
+// information in the release process
 var (
 	kubeBuilderVersion      = "unknown"
 	kubernetesVendorVersion = "unknown"
@@ -41,7 +43,7 @@ type Version struct {
 	GoArch             string `json:"goArch"`
 }
 
-func GetVersion() Version {
+func getVersion() Version {
 	return Version{
 		kubeBuilderVersion,
 		kubernetesVendorVersion,
@@ -67,5 +69,5 @@ func NewVersionCmd() *cobra.Command {
 }
 
 func runVersion(_ *cobra.Command, _ []string) {
-	GetVersion().Print()
+	getVersion().Print()
 }


### PR DESCRIPTION
Change list:
- Avoid variable and package name collision
- Stop exporting get version function
- Document why version strings cannot be constants

/kind cleanup