### PR TITLE
Add webhook scaffolding to docs

### DIFF
--- a/docs/book/src/cronjob-tutorial/webhook-implementation.md
+++ b/docs/book/src/cronjob-tutorial/webhook-implementation.md
@@ -11,4 +11,12 @@ Kubebuilder takes care of the rest for you, such as
 1. Creating handlers for your webhooks.
 1. Registering each handler with a path in your server.
 
+First, let's scaffold the webhooks for our CRD (CronJob). We’ll need to run the following command with the `--defaulting` and `--programmatic-validation` flags (since our test project will use defaulting and validating webhooks):
+
+```bash
+kubebuilder create webhook --group batch --version v1 --kind CronJob --defaulting --programmatic-validation
+```
+
+This will scaffold the webhook functions and register your webhook with the manager in your `main.go` for you.
+
 {{#literatego ./testdata/project/api/v1/cronjob_webhook.go}}

--- a/docs/book/src/reference/markers/webhook.md
+++ b/docs/book/src/reference/markers/webhook.md
@@ -1,6 +1,6 @@
 # Webhook
 
-These markers describe how [webhook configuration](/TODO.md) is generated.
+These markers describe how [webhook configuration](../webhook-overview.md) is generated.
 Use these to keep the description of your webhooks close to the code that
 implements them.
 


### PR DESCRIPTION
Adds the command to scaffold out webhooks to the docs. It was in the migration guide, but the main docs were incomplete. If you didn't run the scaffolding and just satisfy the validator/defaulter interfaces as mentioned, you would not actually be calling `SetupWebhookWithManager()` in your main and you might be confused why the thing that it says automatically happens does not in fact automatically happen.