### PR TITLE
Handle creation of duplicate API resources

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -57,6 +57,8 @@ func (o *apiOptions) bindCmdFlags(cmd *cobra.Command) {
 		cmd.Flags().StringVar(&o.pattern, "pattern", "",
 			"generates an API following an extension pattern (addon)")
 	}
+	cmd.Flags().BoolVar(&o.apiScaffolder.Force, "force", false,
+		"attempt to create resource even if it already exists")
 	o.apiScaffolder.Resource = resourceForFlags(cmd.Flags())
 }
 


### PR DESCRIPTION
This changeset updates `create api` command logic, rejecting duplicate APIs by default, but allowing to continue with `--force` flag.

Note that it only affects v2 projects, since in v1 projects resources are not tracked by the PROJECT file.

Fixes #1110
