### PR TITLE
Use sigs.k8s.io/yaml for parsing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -89,3 +89,5 @@ gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
+sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/scaffold/input/input.go
+++ b/pkg/scaffold/input/input.go
@@ -162,17 +162,17 @@ type Options struct {
 // ProjectFile is deserialized into a PROJECT file
 type ProjectFile struct {
 	// Version is the project version - defaults to "1"
-	Version string `yaml:"version,omitempty"`
+	Version string `json:"version,omitempty"`
 
 	// Domain is the domain associated with the project and used for API groups
-	Domain string `yaml:"domain,omitempty"`
+	Domain string `json:"domain,omitempty"`
 
 	// Repo is the go package name of the project root
-	Repo string `yaml:"repo,omitempty"`
+	Repo string `json:"repo,omitempty"`
 
 	// Resources tracks scaffolded resources in the project. This info is
 	// tracked only in project with version 2.
-	Resources []Resource `yaml:"resources,omitempty"`
+	Resources []Resource `json:"resources,omitempty"`
 }
 
 // ResourceGroups returns unique groups of scaffolded resources in the project.
@@ -191,7 +191,7 @@ func (pf *ProjectFile) ResourceGroups() []string {
 
 // Resource contains information about scaffolded resources.
 type Resource struct {
-	Group   string `yaml:"group,omitempty"`
-	Version string `yaml:"version,omitempty"`
-	Kind    string `yaml:"kind,omitempty"`
+	Group   string `json:"group,omitempty"`
+	Version string `json:"version,omitempty"`
+	Kind    string `json:"kind,omitempty"`
 }

--- a/pkg/scaffold/project/project.go
+++ b/pkg/scaffold/project/project.go
@@ -19,7 +19,7 @@ package project
 import (
 	"fmt"
 
-	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -28,7 +28,7 @@ import (
 	"text/template"
 
 	"golang.org/x/tools/imports"
-	yaml "gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/project"

--- a/testdata/gopath/src/project/PROJECT
+++ b/testdata/gopath/src/project/PROJECT
@@ -1,3 +1,3 @@
-version: "1"
 domain: testproject.org
 repo: project
+version: "1"

--- a/testdata/project-v2/PROJECT
+++ b/testdata/project-v2/PROJECT
@@ -1,13 +1,13 @@
-version: "2"
 domain: testproject.org
 repo: sigs.k8s.io/kubebuilder/testdata/project-v2
 resources:
 - group: crew
-  version: v1
   kind: Captain
-- group: crew
   version: v1
+- group: crew
   kind: FirstMate
-- group: crew
   version: v1
+- group: crew
   kind: Admiral
+  version: v1
+version: "2"


### PR DESCRIPTION
This implements the `yaml` parsing using the `sigs.k8s.io/yaml` parser instead of the `gopkg.in/yaml.v2` libraries.

This was motivated by trying to keep all dependencies within sig/k8s owned projects.

closes #1166
