### PR TITLE
solve issue with groups with '.' as example.com

### DIFF
--- a/pkg/scaffold/resource/resource.go
+++ b/pkg/scaffold/resource/resource.go
@@ -73,6 +73,7 @@ func (r *Resource) Validate() error {
 	}
 
 	r.GroupImportSafe = strings.Replace(r.Group, "-", "", -1)
+	r.GroupImportSafe = strings.Replace(r.GroupImportSafe, ".", "", -1)
 
 	versionMatch := regexp.MustCompile("^v\\d+(alpha\\d+|beta\\d+)?$")
 	if !versionMatch.MatchString(r.Version) {

--- a/pkg/scaffold/resource/resource_test.go
+++ b/pkg/scaffold/resource/resource_test.go
@@ -117,6 +117,12 @@ var _ = Describe("Resource", func() {
 			Expect(instance.GroupImportSafe).To(Equal("myproject"))
 		})
 
+		It("should allow dots in group names", func() {
+			instance := &Resource{Group: "example.com", Kind: "Cat", Version: "v1"}
+			Expect(instance.Validate()).To(Succeed())
+			Expect(instance.GroupImportSafe).To(Equal("examplecom"))
+		})
+
 		It("should keep the Resource if specified", func() {
 			instance := &Resource{Group: "crew", Kind: "FirstMate", Version: "v1", Resource: "myresource"}
 			Expect(instance.Validate()).To(Succeed())


### PR DESCRIPTION
**Description**
- solve the scaffolding issue with groups with `.` as example.com by doing the same fix that is done with `-`

**Motivation**
Closes: #1138