### PR TITLE
Error string formatting

### DIFF
--- a/cmd/init_project.go
+++ b/cmd/init_project.go
@@ -172,7 +172,7 @@ func (o *projectOptions) validate() error {
 	}
 
 	if util.ProjectExist() {
-		return fmt.Errorf("Failed to initialize project because project is already initialized")
+		return fmt.Errorf("failed to initialize project because project is already initialized")
 	}
 
 	return nil
@@ -190,16 +190,16 @@ func fetchAndCheckGoVersion() error {
 	cmd := exec.Command("go", "version")
 	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve 'go version': %v", string(out))
+		return fmt.Errorf("failed to retrieve 'go version': %v", string(out))
 	}
 
 	split := strings.Split(string(out), " ")
 	if len(split) < 3 {
-		return fmt.Errorf("Found invalid Go version: %q", string(out))
+		return fmt.Errorf("found invalid Go version: %q", string(out))
 	}
 	goVer := split[2]
 	if err := checkGoVersion(goVer); err != nil {
-		return fmt.Errorf("Go version '%s' is incompatible because '%s'", goVer, err)
+		return fmt.Errorf("go version '%s' is incompatible because '%s'", goVer, err)
 	}
 	return nil
 }

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -265,7 +265,7 @@ func (api *API) scaffoldV2() error {
 func (api *API) validateResourceGroup(r *resource.Resource) error {
 	for _, existingGroup := range api.project.ResourceGroups() {
 		if strings.ToLower(r.Group) != strings.ToLower(existingGroup) {
-			return fmt.Errorf("Group '%s' is not same as existing group '%s'. Multiple groups are not supported yet.", r.Group, existingGroup)
+			return fmt.Errorf("group '%s' is not same as existing group '%s'. Multiple groups are not supported yet.", r.Group, existingGroup)
 		}
 	}
 	return nil


### PR DESCRIPTION
### Linter message:
> Error string should not be capitalized or end with punctuation inspection

### Linter description:
> Reports error strings format issues.
> Error strings should not be capitalized or end with punctuation mark.
> See [Code review comments: error strings](https://github.com/golang/go/wiki/CodeReviewComments#error-strings) for more details.

Closes: #1177

/kind cleanup