### PR TITLE
Unification of receiver names

### DIFF
--- a/pkg/scaffold/project/authproxyrole.go
+++ b/pkg/scaffold/project/authproxyrole.go
@@ -30,12 +30,12 @@ type AuthProxyRole struct {
 }
 
 // GetInput implements input.File
-func (r *AuthProxyRole) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "auth_proxy_role.yaml")
+func (f *AuthProxyRole) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_role.yaml")
 	}
-	r.TemplateBody = proxyRoleTemplate
-	return r.Input, nil
+	f.TemplateBody = proxyRoleTemplate
+	return f.Input, nil
 }
 
 const proxyRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/scaffold/project/authproxyrolebinding.go
+++ b/pkg/scaffold/project/authproxyrolebinding.go
@@ -30,12 +30,12 @@ type AuthProxyRoleBinding struct {
 }
 
 // GetInput implements input.File
-func (r *AuthProxyRoleBinding) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "auth_proxy_role_binding.yaml")
+func (f *AuthProxyRoleBinding) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_role_binding.yaml")
 	}
-	r.TemplateBody = proxyRoleBindinggTemplate
-	return r.Input, nil
+	f.TemplateBody = proxyRoleBindinggTemplate
+	return f.Input, nil
 }
 
 const proxyRoleBindinggTemplate = `apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/scaffold/project/boilerplate.go
+++ b/pkg/scaffold/project/boilerplate.go
@@ -41,28 +41,28 @@ type Boilerplate struct {
 }
 
 // GetInput implements input.File
-func (c *Boilerplate) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("hack", "boilerplate.go.txt")
+func (f *Boilerplate) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("hack", "boilerplate.go.txt")
 	}
 
 	// Boilerplate given
-	if len(c.Boilerplate) > 0 {
-		c.TemplateBody = c.Boilerplate
-		return c.Input, nil
+	if len(f.Boilerplate) > 0 {
+		f.TemplateBody = f.Boilerplate
+		return f.Input, nil
 	}
 
 	// Pick a template boilerplate option
-	if c.Year == "" {
-		c.Year = fmt.Sprintf("%v", time.Now().Year())
+	if f.Year == "" {
+		f.Year = fmt.Sprintf("%v", time.Now().Year())
 	}
-	switch c.License {
+	switch f.License {
 	case "", "apache2":
-		c.TemplateBody = apache
+		f.TemplateBody = apache
 	case "none":
-		c.TemplateBody = none
+		f.TemplateBody = none
 	}
-	return c.Input, nil
+	return f.Input, nil
 }
 
 const apache = `/*

--- a/pkg/scaffold/project/gitignore.go
+++ b/pkg/scaffold/project/gitignore.go
@@ -28,12 +28,12 @@ type GitIgnore struct {
 }
 
 // GetInput implements input.File
-func (c *GitIgnore) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = ".gitignore"
+func (f *GitIgnore) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = ".gitignore"
 	}
-	c.TemplateBody = gitignoreTemplate
-	return c.Input, nil
+	f.TemplateBody = gitignoreTemplate
+	return f.Input, nil
 }
 
 const gitignoreTemplate = `

--- a/pkg/scaffold/project/gopkg.go
+++ b/pkg/scaffold/project/gopkg.go
@@ -60,40 +60,40 @@ type Stanza struct {
 }
 
 // GetInput implements input.File
-func (g *GopkgToml) GetInput() (input.Input, error) {
-	if g.Path == "" {
-		g.Path = "Gopkg.toml"
+func (f *GopkgToml) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "Gopkg.toml"
 	}
-	if g.ManagedHeader == "" {
-		g.ManagedHeader = DefaultGopkgHeader
+	if f.ManagedHeader == "" {
+		f.ManagedHeader = DefaultGopkgHeader
 	}
 
 	// Set the user content to be used if the Gopkg.toml doesn't exist
-	if g.DefaultUserContent == "" {
-		g.DefaultUserContent = DefaultGopkgUserContent
+	if f.DefaultUserContent == "" {
+		f.DefaultUserContent = DefaultGopkgUserContent
 	}
 
 	// Set the user owned content from the last Gopkg.toml file - e.g. everything before the header
-	lastBytes, err := ioutil.ReadFile(g.Path)
+	lastBytes, err := ioutil.ReadFile(f.Path)
 	if err != nil {
-		g.UserContent = g.DefaultUserContent
-	} else if g.UserContent, err = g.getUserContent(lastBytes); err != nil {
+		f.UserContent = f.DefaultUserContent
+	} else if f.UserContent, err = f.getUserContent(lastBytes); err != nil {
 		return input.Input{}, err
 	}
 
-	g.Input.IfExistsAction = input.Overwrite
-	g.TemplateBody = depTemplate
-	return g.Input, nil
+	f.Input.IfExistsAction = input.Overwrite
+	f.TemplateBody = depTemplate
+	return f.Input, nil
 }
 
-func (g *GopkgToml) getUserContent(b []byte) (string, error) {
+func (f *GopkgToml) getUserContent(b []byte) (string, error) {
 	// Keep the users lines
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	userLines := []string{}
 	found := false
 	for scanner.Scan() {
 		l := scanner.Text()
-		if l == g.ManagedHeader {
+		if l == f.ManagedHeader {
 			found = true
 			break
 		}

--- a/pkg/scaffold/project/kustomize.go
+++ b/pkg/scaffold/project/kustomize.go
@@ -35,21 +35,21 @@ type Kustomize struct {
 }
 
 // GetInput implements input.File
-func (c *Kustomize) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "kustomization.yaml")
+func (f *Kustomize) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "kustomization.yaml")
 	}
-	if c.Prefix == "" {
+	if f.Prefix == "" {
 		// use directory name as prefix
 		dir, err := os.Getwd()
 		if err != nil {
 			return input.Input{}, err
 		}
-		c.Prefix = strings.ToLower(filepath.Base(dir))
+		f.Prefix = strings.ToLower(filepath.Base(dir))
 	}
-	c.TemplateBody = kustomizeTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeTemplate = `# Adds namespace to all resources.

--- a/pkg/scaffold/project/kustomize_manager_base.go
+++ b/pkg/scaffold/project/kustomize_manager_base.go
@@ -30,13 +30,13 @@ type KustomizeManager struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeManager) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "manager", "kustomization.yaml")
+func (f *KustomizeManager) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "kustomization.yaml")
 	}
-	c.TemplateBody = kustomizeManagerTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeManagerTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeManagerTemplate = `resources:

--- a/pkg/scaffold/project/kustomize_rbac_base.go
+++ b/pkg/scaffold/project/kustomize_rbac_base.go
@@ -30,13 +30,13 @@ type KustomizeRBAC struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeRBAC) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "rbac", "kustomization.yaml")
+func (f *KustomizeRBAC) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "kustomization.yaml")
 	}
-	c.TemplateBody = kustomizeRBACTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeRBACTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeRBACTemplate = `resources:

--- a/pkg/scaffold/project/makefile.go
+++ b/pkg/scaffold/project/makefile.go
@@ -33,19 +33,19 @@ type Makefile struct {
 }
 
 // GetInput implements input.File
-func (c *Makefile) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = "Makefile"
+func (f *Makefile) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "Makefile"
 	}
-	if c.Image == "" {
-		c.Image = "controller:latest"
+	if f.Image == "" {
+		f.Image = "controller:latest"
 	}
-	if c.ControllerToolsPath == "" {
-		c.ControllerToolsPath = "vendor/sigs.k8s.io/controller-tools"
+	if f.ControllerToolsPath == "" {
+		f.ControllerToolsPath = "vendor/sigs.k8s.io/controller-tools"
 	}
-	c.TemplateBody = makefileTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = makefileTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const makefileTemplate = `

--- a/pkg/scaffold/project/project.go
+++ b/pkg/scaffold/project/project.go
@@ -40,29 +40,29 @@ type Project struct {
 }
 
 // GetInput implements input.File
-func (c *Project) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = "PROJECT"
+func (f *Project) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "PROJECT"
 	}
-	if c.Version == "" {
-		c.Version = Version1
+	if f.Version == "" {
+		f.Version = Version1
 	}
-	if c.Repo == "" {
+	if f.Repo == "" {
 		return input.Input{}, fmt.Errorf("must specify repository")
 	}
 
-	out, err := yaml.Marshal(c.ProjectFile)
+	out, err := yaml.Marshal(f.ProjectFile)
 	if err != nil {
 		return input.Input{}, err
 	}
 
 	return input.Input{
-		Path:           c.Path,
+		Path:           f.Path,
 		TemplateBody:   string(out),
-		Repo:           c.Repo,
-		Version:        c.Version,
-		Domain:         c.Domain,
-		MultiGroup:     c.MultiGroup,
+		Repo:           f.Repo,
+		Version:        f.Version,
+		Domain:         f.Domain,
+		MultiGroup:     f.MultiGroup,
 		IfExistsAction: input.Error,
 	}, nil
 }

--- a/pkg/scaffold/v1/authproxyservice.go
+++ b/pkg/scaffold/v1/authproxyservice.go
@@ -30,12 +30,12 @@ type AuthProxyService struct {
 }
 
 // GetInput implements input.File
-func (r *AuthProxyService) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "auth_proxy_service.yaml")
+func (f *AuthProxyService) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_service.yaml")
 	}
-	r.TemplateBody = AuthProxyServiceTemplate
-	return r.Input, nil
+	f.TemplateBody = AuthProxyServiceTemplate
+	return f.Input, nil
 }
 
 const AuthProxyServiceTemplate = `apiVersion: v1

--- a/pkg/scaffold/v1/controller/add.go
+++ b/pkg/scaffold/v1/controller/add.go
@@ -36,13 +36,13 @@ type AddController struct {
 }
 
 // GetInput implements input.File
-func (a *AddController) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "controller", fmt.Sprintf(
-			"add_%s.go", strings.ToLower(a.Resource.Kind)))
+func (f *AddController) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "controller", fmt.Sprintf(
+			"add_%s.go", strings.ToLower(f.Resource.Kind)))
 	}
-	a.TemplateBody = addControllerTemplate
-	return a.Input, nil
+	f.TemplateBody = addControllerTemplate
+	return f.Input, nil
 }
 
 const addControllerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/controller/controller.go
+++ b/pkg/scaffold/v1/controller/controller.go
@@ -47,7 +47,7 @@ type Controller struct {
 }
 
 // GetInput implements input.File
-func (a *Controller) GetInput() (input.Input, error) {
+func (f *Controller) GetInput() (input.Input, error) {
 	// Use the k8s.io/api package for core resources
 	coreGroups := map[string]string{
 		"apps":                  "",
@@ -65,20 +65,20 @@ func (a *Controller) GetInput() (input.Input, error) {
 		"storage":               "k8s.io",
 	}
 
-	a.ResourcePackage, a.GroupDomain = getResourceInfo(coreGroups, a.Resource, a.Input)
+	f.ResourcePackage, f.GroupDomain = getResourceInfo(coreGroups, f.Resource, f.Input)
 
-	if a.Plural == "" {
-		a.Plural = flect.Pluralize(strings.ToLower(a.Resource.Kind))
+	if f.Plural == "" {
+		f.Plural = flect.Pluralize(strings.ToLower(f.Resource.Kind))
 	}
 
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "controller",
-			strings.ToLower(a.Resource.Kind),
-			strings.ToLower(a.Resource.Kind)+"_controller.go")
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "controller",
+			strings.ToLower(f.Resource.Kind),
+			strings.ToLower(f.Resource.Kind)+"_controller.go")
 	}
-	a.TemplateBody = controllerTemplate
-	a.Input.IfExistsAction = input.Error
-	return a.Input, nil
+	f.TemplateBody = controllerTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 func getResourceInfo(coreGroups map[string]string, r *resource.Resource, in input.Input) (resourcePackage, groupDomain string) {

--- a/pkg/scaffold/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/v1/controller/controllersuitetest.go
@@ -33,13 +33,13 @@ type SuiteTest struct {
 }
 
 // GetInput implements input.File
-func (a *SuiteTest) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "controller",
-			strings.ToLower(a.Resource.Kind), strings.ToLower(a.Resource.Kind)+"_controller_suite_test.go")
+func (f *SuiteTest) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "controller",
+			strings.ToLower(f.Resource.Kind), strings.ToLower(f.Resource.Kind)+"_controller_suite_test.go")
 	}
-	a.TemplateBody = controllerSuiteTestTemplate
-	return a.Input, nil
+	f.TemplateBody = controllerSuiteTestTemplate
+	return f.Input, nil
 }
 
 const controllerSuiteTestTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/controller/controllertest.go
+++ b/pkg/scaffold/v1/controller/controllertest.go
@@ -36,10 +36,10 @@ type Test struct {
 }
 
 // GetInput implements input.File
-func (a *Test) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "controller",
-			strings.ToLower(a.Resource.Kind), strings.ToLower(a.Resource.Kind)+"_controller_test.go")
+func (f *Test) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "controller",
+			strings.ToLower(f.Resource.Kind), strings.ToLower(f.Resource.Kind)+"_controller_test.go")
 	}
 
 	// Use the k8s.io/api package for core resources
@@ -59,11 +59,11 @@ func (a *Test) GetInput() (input.Input, error) {
 		"storage":               "k8s.io",
 	}
 
-	a.ResourcePackage, _ = getResourceInfo(coreGroups, a.Resource, a.Input)
+	f.ResourcePackage, _ = getResourceInfo(coreGroups, f.Resource, f.Input)
 
-	a.TemplateBody = controllerTestTemplate
-	a.Input.IfExistsAction = input.Error
-	return a.Input, nil
+	f.TemplateBody = controllerTestTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const controllerTestTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/crd/addtoscheme.go
+++ b/pkg/scaffold/v1/crd/addtoscheme.go
@@ -35,18 +35,18 @@ type AddToScheme struct {
 }
 
 // GetInput implements input.File
-func (a *AddToScheme) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "apis", fmt.Sprintf(
-			"addtoscheme_%s_%s.go", a.Resource.Group, a.Resource.Version))
+func (f *AddToScheme) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", fmt.Sprintf(
+			"addtoscheme_%s_%s.go", f.Resource.Group, f.Resource.Version))
 	}
-	a.TemplateBody = addResourceTemplate
-	return a.Input, nil
+	f.TemplateBody = addResourceTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (a *AddToScheme) Validate() error {
-	return a.Resource.Validate()
+func (f *AddToScheme) Validate() error {
+	return f.Resource.Validate()
 }
 
 // NB(directxman12): we need that package alias on the API import otherwise imports.Process

--- a/pkg/scaffold/v1/crd/crd_sample.go
+++ b/pkg/scaffold/v1/crd/crd_sample.go
@@ -36,20 +36,20 @@ type CRDSample struct {
 }
 
 // GetInput implements input.File
-func (c *CRDSample) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "samples", fmt.Sprintf(
-			"%s_%s_%s.yaml", c.Resource.Group, c.Resource.Version, strings.ToLower(c.Resource.Kind)))
+func (f *CRDSample) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "samples", fmt.Sprintf(
+			"%s_%s_%s.yaml", f.Resource.Group, f.Resource.Version, strings.ToLower(f.Resource.Kind)))
 	}
 
-	c.IfExistsAction = input.Error
-	c.TemplateBody = crdSampleTemplate
-	return c.Input, nil
+	f.IfExistsAction = input.Error
+	f.TemplateBody = crdSampleTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (c *CRDSample) Validate() error {
-	return c.Resource.Validate()
+func (f *CRDSample) Validate() error {
+	return f.Resource.Validate()
 }
 
 const crdSampleTemplate = `apiVersion: {{ .Resource.Group }}.{{ .Domain }}/{{ .Resource.Version }}

--- a/pkg/scaffold/v1/crd/doc.go
+++ b/pkg/scaffold/v1/crd/doc.go
@@ -34,17 +34,17 @@ type Doc struct {
 }
 
 // GetInput implements input.File
-func (a *Doc) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "apis", a.Resource.Group, a.Resource.Version, "doc.go")
+func (f *Doc) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.Group, f.Resource.Version, "doc.go")
 	}
-	a.TemplateBody = docGoTemplate
-	return a.Input, nil
+	f.TemplateBody = docGoTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (a *Doc) Validate() error {
-	return a.Resource.Validate()
+func (f *Doc) Validate() error {
+	return f.Resource.Validate()
 }
 
 const docGoTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/crd/group.go
+++ b/pkg/scaffold/v1/crd/group.go
@@ -34,17 +34,17 @@ type Group struct {
 }
 
 // GetInput implements input.File
-func (g *Group) GetInput() (input.Input, error) {
-	if g.Path == "" {
-		g.Path = filepath.Join("pkg", "apis", g.Resource.Group, "group.go")
+func (f *Group) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.Group, "group.go")
 	}
-	g.TemplateBody = groupTemplate
-	return g.Input, nil
+	f.TemplateBody = groupTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *Group) Validate() error {
-	return g.Resource.Validate()
+func (f *Group) Validate() error {
+	return f.Resource.Validate()
 }
 
 const groupTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/crd/register.go
+++ b/pkg/scaffold/v1/crd/register.go
@@ -34,17 +34,17 @@ type Register struct {
 }
 
 // GetInput implements input.File
-func (r *Register) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("pkg", "apis", r.Resource.Group, r.Resource.Version, "register.go")
+func (f *Register) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.Group, f.Resource.Version, "register.go")
 	}
-	r.TemplateBody = registerTemplate
-	return r.Input, nil
+	f.TemplateBody = registerTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (r *Register) Validate() error {
-	return r.Resource.Validate()
+func (f *Register) Validate() error {
+	return f.Resource.Validate()
 }
 
 const registerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/crd/types.go
+++ b/pkg/scaffold/v1/crd/types.go
@@ -36,19 +36,19 @@ type Types struct {
 }
 
 // GetInput implements input.File
-func (t *Types) GetInput() (input.Input, error) {
-	if t.Path == "" {
-		t.Path = filepath.Join("pkg", "apis", t.Resource.GroupImportSafe, t.Resource.Version,
-			fmt.Sprintf("%s_types.go", strings.ToLower(t.Resource.Kind)))
+func (f *Types) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupImportSafe, f.Resource.Version,
+			fmt.Sprintf("%s_types.go", strings.ToLower(f.Resource.Kind)))
 	}
-	t.TemplateBody = typesTemplate
-	t.IfExistsAction = input.Error
-	return t.Input, nil
+	f.TemplateBody = typesTemplate
+	f.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (t *Types) Validate() error {
-	return t.Resource.Validate()
+func (f *Types) Validate() error {
+	return f.Resource.Validate()
 }
 
 const typesTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/crd/typestest.go
+++ b/pkg/scaffold/v1/crd/typestest.go
@@ -36,19 +36,19 @@ type TypesTest struct {
 }
 
 // GetInput implements input.File
-func (t *TypesTest) GetInput() (input.Input, error) {
-	if t.Path == "" {
-		t.Path = filepath.Join("pkg", "apis", t.Resource.Group, t.Resource.Version,
-			fmt.Sprintf("%s_types_test.go", strings.ToLower(t.Resource.Kind)))
+func (f *TypesTest) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.Group, f.Resource.Version,
+			fmt.Sprintf("%s_types_test.go", strings.ToLower(f.Resource.Kind)))
 	}
-	t.TemplateBody = typesTestTemplate
-	t.IfExistsAction = input.Error
-	return t.Input, nil
+	f.TemplateBody = typesTestTemplate
+	f.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (t *TypesTest) Validate() error {
-	return t.Resource.Validate()
+func (f *TypesTest) Validate() error {
+	return f.Resource.Validate()
 }
 
 const typesTestTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/v1/crd/version_suitetest.go
@@ -35,18 +35,18 @@ type VersionSuiteTest struct {
 }
 
 // GetInput implements input.File
-func (v *VersionSuiteTest) GetInput() (input.Input, error) {
-	if v.Path == "" {
-		v.Path = filepath.Join("pkg", "apis", v.Resource.GroupImportSafe, v.Resource.Version,
-			fmt.Sprintf("%s_suite_test.go", v.Resource.Version))
+func (f *VersionSuiteTest) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupImportSafe, f.Resource.Version,
+			fmt.Sprintf("%s_suite_test.go", f.Resource.Version))
 	}
-	v.TemplateBody = versionSuiteTestTemplate
-	return v.Input, nil
+	f.TemplateBody = versionSuiteTestTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (v *VersionSuiteTest) Validate() error {
-	return v.Resource.Validate()
+func (f *VersionSuiteTest) Validate() error {
+	return f.Resource.Validate()
 }
 
 const versionSuiteTestTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/kustomize_image_patch.go
+++ b/pkg/scaffold/v1/kustomize_image_patch.go
@@ -34,16 +34,16 @@ type KustomizeImagePatch struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeImagePatch) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "manager_image_patch.yaml")
+func (f *KustomizeImagePatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_image_patch.yaml")
 	}
-	if c.ImageURL == "" {
-		c.ImageURL = "IMAGE_URL"
+	if f.ImageURL == "" {
+		f.ImageURL = "IMAGE_URL"
 	}
-	c.TemplateBody = kustomizeImagePatchTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeImagePatchTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeImagePatchTemplate = `apiVersion: apps/v1

--- a/pkg/scaffold/v1/manager/apis.go
+++ b/pkg/scaffold/v1/manager/apis.go
@@ -41,21 +41,21 @@ var deepCopy = strings.Join([]string{
 	"-i ./..."}, " ")
 
 // GetInput implements input.File
-func (a *APIs) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "apis", "apis.go")
+func (f *APIs) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", "apis.go")
 	}
 
-	b, err := filepath.Rel(filepath.Join(a.Input.ProjectPath, "pkg", "apis"), a.BoilerplatePath)
+	relPath, err := filepath.Rel(filepath.Join(f.Input.ProjectPath, "pkg", "apis"), f.BoilerplatePath)
 	if err != nil {
 		return input.Input{}, err
 	}
-	if len(a.Comments) == 0 {
-		a.Comments = append(a.Comments,
-			"// Generate deepcopy for apis", fmt.Sprintf("%s -h %s", deepCopy, filepath.ToSlash(b)))
+	if len(f.Comments) == 0 {
+		f.Comments = append(f.Comments,
+			"// Generate deepcopy for apis", fmt.Sprintf("%s -h %s", deepCopy, filepath.ToSlash(relPath)))
 	}
-	a.TemplateBody = apisTemplate
-	return a.Input, nil
+	f.TemplateBody = apisTemplate
+	return f.Input, nil
 }
 
 const apisTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/manager/cmd.go
+++ b/pkg/scaffold/v1/manager/cmd.go
@@ -30,12 +30,12 @@ type Cmd struct {
 }
 
 // GetInput implements input.File
-func (a *Cmd) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("cmd", "manager", "main.go")
+func (f *Cmd) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("cmd", "manager", "main.go")
 	}
-	a.TemplateBody = cmdTemplate
-	return a.Input, nil
+	f.TemplateBody = cmdTemplate
+	return f.Input, nil
 }
 
 const cmdTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/manager/config.go
+++ b/pkg/scaffold/v1/manager/config.go
@@ -32,12 +32,12 @@ type Config struct {
 }
 
 // GetInput implements input.File
-func (c *Config) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "manager", "manager.yaml")
+func (f *Config) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "manager.yaml")
 	}
-	c.TemplateBody = configTemplate
-	return c.Input, nil
+	f.TemplateBody = configTemplate
+	return f.Input, nil
 }
 
 const configTemplate = `apiVersion: v1

--- a/pkg/scaffold/v1/manager/controller.go
+++ b/pkg/scaffold/v1/manager/controller.go
@@ -30,12 +30,12 @@ type Controller struct {
 }
 
 // GetInput implements input.File
-func (c *Controller) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("pkg", "controller", "controller.go")
+func (f *Controller) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "controller", "controller.go")
 	}
-	c.TemplateBody = controllerTemplate
-	return c.Input, nil
+	f.TemplateBody = controllerTemplate
+	return f.Input, nil
 }
 
 const controllerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/manager/dockerfile.go
+++ b/pkg/scaffold/v1/manager/dockerfile.go
@@ -28,12 +28,12 @@ type Dockerfile struct {
 }
 
 // GetInput implements input.File
-func (c *Dockerfile) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = "Dockerfile"
+func (f *Dockerfile) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "Dockerfile"
 	}
-	c.TemplateBody = dockerfileTemplate
-	return c.Input, nil
+	f.TemplateBody = dockerfileTemplate
+	return f.Input, nil
 }
 
 const dockerfileTemplate = `# Build the manager binary

--- a/pkg/scaffold/v1/manager/webhook.go
+++ b/pkg/scaffold/v1/manager/webhook.go
@@ -30,12 +30,12 @@ type Webhook struct {
 }
 
 // GetInput implements input.File
-func (c *Webhook) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("pkg", "webhook", "webhook.go")
+func (f *Webhook) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook", "webhook.go")
 	}
-	c.TemplateBody = webhookTemplate
-	return c.Input, nil
+	f.TemplateBody = webhookTemplate
+	return f.Input, nil
 }
 
 const webhookTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/metricsauth/kustomize_auth_proxy_patch.go
+++ b/pkg/scaffold/v1/metricsauth/kustomize_auth_proxy_patch.go
@@ -31,13 +31,13 @@ type KustomizeAuthProxyPatch struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeAuthProxyPatch) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
+func (f *KustomizeAuthProxyPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
 	}
-	c.TemplateBody = kustomizeAuthProxyPatchTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeAuthProxyPatchTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the controller manager,

--- a/pkg/scaffold/v1/metricsauth/kustomize_metrics_patch.go
+++ b/pkg/scaffold/v1/metricsauth/kustomize_metrics_patch.go
@@ -31,13 +31,13 @@ type KustomizePrometheusMetricsPatch struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizePrometheusMetricsPatch) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "manager_prometheus_metrics_patch.yaml")
+func (f *KustomizePrometheusMetricsPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_prometheus_metrics_patch.yaml")
 	}
-	c.TemplateBody = kustomizePrometheusMetricsPatchTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizePrometheusMetricsPatchTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizePrometheusMetricsPatchTemplate = `# This patch enables Prometheus scraping for the manager pod.

--- a/pkg/scaffold/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/v1/webhook/add_admissionbuilder_handler.go
@@ -38,15 +38,15 @@ type AddAdmissionWebhookBuilderHandler struct {
 }
 
 // GetInput implements input.File
-func (a *AddAdmissionWebhookBuilderHandler) GetInput() (input.Input, error) {
-	a.Server = strings.ToLower(a.Server)
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", a.Server),
-			fmt.Sprintf("add_%s_%s.go", a.Type, strings.ToLower(a.Resource.Kind)))
+func (f *AddAdmissionWebhookBuilderHandler) GetInput() (input.Input, error) {
+	f.Server = strings.ToLower(f.Server)
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", f.Server),
+			fmt.Sprintf("add_%s_%s.go", f.Type, strings.ToLower(f.Resource.Kind)))
 	}
-	a.TemplateBody = addAdmissionWebhookBuilderHandlerTemplate
-	return a.Input, nil
+	f.TemplateBody = addAdmissionWebhookBuilderHandlerTemplate
+	return f.Input, nil
 }
 
 const addAdmissionWebhookBuilderHandlerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/webhook/add_server.go
+++ b/pkg/scaffold/v1/webhook/add_server.go
@@ -33,12 +33,12 @@ type AddServer struct {
 }
 
 // GetInput implements input.File
-func (a *AddServer) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("add_%s_server.go", a.Server))
+func (f *AddServer) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("add_%s_server.go", f.Server))
 	}
-	a.TemplateBody = addServerTemplate
-	return a.Input, nil
+	f.TemplateBody = addServerTemplate
+	return f.Input, nil
 }
 
 const addServerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/v1/webhook/admissionbuilder.go
@@ -47,29 +47,29 @@ type AdmissionWebhookBuilder struct {
 }
 
 // GetInput implements input.File
-func (a *AdmissionWebhookBuilder) GetInput() (input.Input, error) {
-	a.ResourcePackage = getResourceInfo(coreGroups, a.Resource, a.Input)
+func (f *AdmissionWebhookBuilder) GetInput() (input.Input, error) {
+	f.ResourcePackage = getResourceInfo(coreGroups, f.Resource, f.Input)
 
-	if a.Type == "mutating" {
-		a.Mutating = true
+	if f.Type == "mutating" {
+		f.Mutating = true
 	}
-	a.Type = strings.ToLower(a.Type)
-	a.BuilderName = builderName(a.Config, strings.ToLower(a.Resource.Kind))
-	ops := make([]string, len(a.Operations))
-	for i, op := range a.Operations {
+	f.Type = strings.ToLower(f.Type)
+	f.BuilderName = builderName(f.Config, strings.ToLower(f.Resource.Kind))
+	ops := make([]string, len(f.Operations))
+	for i, op := range f.Operations {
 		ops[i] = "admissionregistrationv1beta1." + strings.Title(op)
 	}
-	a.OperationsParameterString = strings.Join(ops, ", ")
+	f.OperationsParameterString = strings.Join(ops, ", ")
 
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", a.Server),
-			strings.ToLower(a.Resource.Kind),
-			a.Type,
-			fmt.Sprintf("%s_webhook.go", strings.Join(a.Operations, "_")))
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", f.Server),
+			strings.ToLower(f.Resource.Kind),
+			f.Type,
+			fmt.Sprintf("%s_webhook.go", strings.Join(f.Operations, "_")))
 	}
-	a.TemplateBody = admissionWebhookBuilderTemplate
-	return a.Input, nil
+	f.TemplateBody = admissionWebhookBuilderTemplate
+	return f.Input, nil
 }
 
 const admissionWebhookBuilderTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/v1/webhook/admissionhandler.go
@@ -47,28 +47,28 @@ type AdmissionHandler struct {
 }
 
 // GetInput implements input.File
-func (a *AdmissionHandler) GetInput() (input.Input, error) {
-	a.ResourcePackage = getResourceInfo(coreGroups, a.Resource, a.Input)
-	a.Type = strings.ToLower(a.Type)
-	if a.Type == "mutating" {
-		a.Mutate = true
+func (f *AdmissionHandler) GetInput() (input.Input, error) {
+	f.ResourcePackage = getResourceInfo(coreGroups, f.Resource, f.Input)
+	f.Type = strings.ToLower(f.Type)
+	if f.Type == "mutating" {
+		f.Mutate = true
 	}
-	a.BuilderName = builderName(a.Config, strings.ToLower(a.Resource.Kind))
-	ops := make([]string, len(a.Operations))
-	for i, op := range a.Operations {
+	f.BuilderName = builderName(f.Config, strings.ToLower(f.Resource.Kind))
+	ops := make([]string, len(f.Operations))
+	for i, op := range f.Operations {
 		ops[i] = strings.Title(op)
 	}
-	a.OperationsString = strings.Join(ops, "")
+	f.OperationsString = strings.Join(ops, "")
 
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", a.Server),
-			strings.ToLower(a.Resource.Kind),
-			a.Type,
-			fmt.Sprintf("%s_%s_handler.go", strings.ToLower(a.Resource.Kind), strings.Join(a.Operations, "_")))
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", f.Server),
+			strings.ToLower(f.Resource.Kind),
+			f.Type,
+			fmt.Sprintf("%s_%s_handler.go", strings.ToLower(f.Resource.Kind), strings.Join(f.Operations, "_")))
 	}
-	a.TemplateBody = addAdmissionHandlerTemplate
-	return a.Input, nil
+	f.TemplateBody = addAdmissionHandlerTemplate
+	return f.Input, nil
 }
 
 const addAdmissionHandlerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/webhook/admissionwebhooks.go
+++ b/pkg/scaffold/v1/webhook/admissionwebhooks.go
@@ -38,17 +38,17 @@ type AdmissionWebhooks struct {
 }
 
 // GetInput implements input.File
-func (a *AdmissionWebhooks) GetInput() (input.Input, error) {
-	a.Server = strings.ToLower(a.Server)
-	a.Type = strings.ToLower(a.Type)
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", a.Server),
-			strings.ToLower(a.Resource.Kind),
-			a.Type, "webhooks.go")
+func (f *AdmissionWebhooks) GetInput() (input.Input, error) {
+	f.Server = strings.ToLower(f.Server)
+	f.Type = strings.ToLower(f.Type)
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook",
+			fmt.Sprintf("%s_server", f.Server),
+			strings.ToLower(f.Resource.Kind),
+			f.Type, "webhooks.go")
 	}
-	a.TemplateBody = webhooksTemplate
-	return a.Input, nil
+	f.TemplateBody = webhooksTemplate
+	return f.Input, nil
 }
 
 const webhooksTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v1/webhook/server.go
+++ b/pkg/scaffold/v1/webhook/server.go
@@ -33,12 +33,12 @@ type Server struct {
 }
 
 // GetInput implements input.File
-func (a *Server) GetInput() (input.Input, error) {
-	if a.Path == "" {
-		a.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("%s_server", a.Server), "server.go")
+func (f *Server) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("%s_server", f.Server), "server.go")
 	}
-	a.TemplateBody = serverTemplate
-	return a.Input, nil
+	f.TemplateBody = serverTemplate
+	return f.Input, nil
 }
 
 const serverTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v2/authproxyservice.go
+++ b/pkg/scaffold/v2/authproxyservice.go
@@ -30,12 +30,12 @@ type AuthProxyService struct {
 }
 
 // GetInput implements input.File
-func (r *AuthProxyService) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "auth_proxy_service.yaml")
+func (f *AuthProxyService) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_service.yaml")
 	}
-	r.TemplateBody = AuthProxyServiceTemplate
-	return r.Input, nil
+	f.TemplateBody = AuthProxyServiceTemplate
+	return f.Input, nil
 }
 
 const AuthProxyServiceTemplate = `apiVersion: v1

--- a/pkg/scaffold/v2/certmanager/certificate.go
+++ b/pkg/scaffold/v2/certmanager/certificate.go
@@ -28,12 +28,12 @@ type CertManager struct {
 }
 
 // GetInput implements input.File
-func (p *CertManager) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		p.Path = filepath.Join("config", "certmanager", "certificate.yaml")
+func (f *CertManager) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "certmanager", "certificate.yaml")
 	}
-	p.TemplateBody = certManagerTemplate
-	return p.Input, nil
+	f.TemplateBody = certManagerTemplate
+	return f.Input, nil
 }
 
 const certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.

--- a/pkg/scaffold/v2/certmanager/kustomize.go
+++ b/pkg/scaffold/v2/certmanager/kustomize.go
@@ -28,12 +28,12 @@ type Kustomization struct {
 }
 
 // GetInput implements input.File
-func (p *Kustomization) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		p.Path = filepath.Join("config", "certmanager", "kustomization.yaml")
+func (f *Kustomization) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "certmanager", "kustomization.yaml")
 	}
-	p.TemplateBody = kustomizationTemplate
-	return p.Input, nil
+	f.TemplateBody = kustomizationTemplate
+	return f.Input, nil
 }
 
 const kustomizationTemplate = `resources:

--- a/pkg/scaffold/v2/certmanager/kustomizeconfig.go
+++ b/pkg/scaffold/v2/certmanager/kustomizeconfig.go
@@ -28,12 +28,12 @@ type KustomizeConfig struct {
 }
 
 // GetInput implements input.File
-func (p *KustomizeConfig) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		p.Path = filepath.Join("config", "certmanager", "kustomizeconfig.yaml")
+func (f *KustomizeConfig) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "certmanager", "kustomizeconfig.yaml")
 	}
-	p.TemplateBody = kustomizeConfigTemplate
-	return p.Input, nil
+	f.TemplateBody = kustomizeConfigTemplate
+	return f.Input, nil
 }
 
 const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 

--- a/pkg/scaffold/v2/controller/controller.go
+++ b/pkg/scaffold/v2/controller/controller.go
@@ -45,28 +45,28 @@ type Controller struct {
 }
 
 // GetInput implements input.File
-func (a *Controller) GetInput() (input.Input, error) {
+func (f *Controller) GetInput() (input.Input, error) {
 
-	a.ResourcePackage, a.GroupDomain = util.GetResourceInfo(a.Resource, a.Repo, a.Domain, a.MultiGroup)
+	f.ResourcePackage, f.GroupDomain = util.GetResourceInfo(f.Resource, f.Repo, f.Domain, f.MultiGroup)
 
-	if a.Plural == "" {
-		a.Plural = flect.Pluralize(strings.ToLower(a.Resource.Kind))
+	if f.Plural == "" {
+		f.Plural = flect.Pluralize(strings.ToLower(f.Resource.Kind))
 	}
 
-	if a.Path == "" {
-		if a.MultiGroup {
-			a.Path = filepath.Join("controllers",
-				a.Resource.Group,
-				strings.ToLower(a.Resource.Kind)+"_controller.go")
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("controllers",
+				f.Resource.Group,
+				strings.ToLower(f.Resource.Kind)+"_controller.go")
 		} else {
-			a.Path = filepath.Join("controllers",
-				strings.ToLower(a.Resource.Kind)+"_controller.go")
+			f.Path = filepath.Join("controllers",
+				strings.ToLower(f.Resource.Kind)+"_controller.go")
 		}
 	}
-	a.TemplateBody = controllerTemplate
+	f.TemplateBody = controllerTemplate
 
-	a.Input.IfExistsAction = input.Error
-	return a.Input, nil
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const controllerTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller/controller_suitetest.go
@@ -38,26 +38,23 @@ type ControllerSuiteTest struct {
 }
 
 // GetInput implements input.File
-func (v *ControllerSuiteTest) GetInput() (input.Input, error) {
+func (f *ControllerSuiteTest) GetInput() (input.Input, error) {
 
-	if v.Path == "" {
-		if v.MultiGroup {
-			v.Path = filepath.Join("controllers",
-				v.Resource.Group,
-				"suite_test.go")
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("controllers", f.Resource.Group, "suite_test.go")
 		} else {
-			v.Path = filepath.Join("controllers", "suite_test.go")
-			v.Input.IfExistsAction = input.Error
+			f.Path = filepath.Join("controllers", "suite_test.go")
 		}
 	}
 
-	v.TemplateBody = controllerSuiteTestTemplate
-	return v.Input, nil
+	f.TemplateBody = controllerSuiteTestTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (v *ControllerSuiteTest) Validate() error {
-	return v.Resource.Validate()
+func (f *ControllerSuiteTest) Validate() error {
+	return f.Resource.Validate()
 }
 
 const controllerSuiteTestTemplate = `{{ .Boilerplate }}
@@ -124,21 +121,21 @@ var _ = AfterSuite(func() {
 
 // Update updates given file (suite_test.go) with code fragments required for
 // adding import paths and code setup for new types.
-func (a *ControllerSuiteTest) Update() error {
+func (f *ControllerSuiteTest) Update() error {
 
-	resourcePackage, _ := util.GetResourceInfo(a.Resource, a.Repo, a.Domain, a.MultiGroup)
+	resourcePackage, _ := util.GetResourceInfo(f.Resource, f.Repo, f.Domain, f.MultiGroup)
 
 	ctrlImportCodeFragment := fmt.Sprintf(`"%s/controllers"
-`, a.Repo)
+`, f.Repo)
 	apiImportCodeFragment := fmt.Sprintf(`%s%s "%s/%s"
-`, a.Resource.GroupImportSafe, a.Resource.Version, resourcePackage, a.Resource.Version)
+`, f.Resource.GroupImportSafe, f.Resource.Version, resourcePackage, f.Resource.Version)
 
 	addschemeCodeFragment := fmt.Sprintf(`err = %s%s.AddToScheme(scheme.Scheme)
 Expect(err).NotTo(HaveOccurred())
 
-`, a.Resource.GroupImportSafe, a.Resource.Version)
+`, f.Resource.GroupImportSafe, f.Resource.Version)
 
-	err := internal.InsertStringsInFile(a.Path,
+	err := internal.InsertStringsInFile(f.Path,
 		map[string][]string{
 			scaffoldv2.ApiPkgImportScaffoldMarker: []string{ctrlImportCodeFragment, apiImportCodeFragment},
 			scaffoldv2.ApiSchemeScaffoldMarker:    []string{addschemeCodeFragment},

--- a/pkg/scaffold/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/v2/crd/enablecainjection_patch.go
@@ -36,19 +36,19 @@ type EnableCAInjectionPatch struct {
 }
 
 // GetInput implements input.File
-func (p *EnableCAInjectionPatch) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		plural := flect.Pluralize(strings.ToLower(p.Resource.Kind))
-		p.Path = filepath.Join("config", "crd", "patches",
+func (f *EnableCAInjectionPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		plural := flect.Pluralize(strings.ToLower(f.Resource.Kind))
+		f.Path = filepath.Join("config", "crd", "patches",
 			fmt.Sprintf("cainjection_in_%s.yaml", plural))
 	}
-	p.TemplateBody = EnableCAInjectionPatchTemplate
-	return p.Input, nil
+	f.TemplateBody = EnableCAInjectionPatchTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *EnableCAInjectionPatch) Validate() error {
-	return g.Resource.Validate()
+func (f *EnableCAInjectionPatch) Validate() error {
+	return f.Resource.Validate()
 }
 
 const EnableCAInjectionPatchTemplate = `# The following patch adds a directive for certmanager to inject CA into the CRD

--- a/pkg/scaffold/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/v2/crd/enablewebhook_patch.go
@@ -36,19 +36,19 @@ type EnableWebhookPatch struct {
 }
 
 // GetInput implements input.File
-func (p *EnableWebhookPatch) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		plural := flect.Pluralize(strings.ToLower(p.Resource.Kind))
-		p.Path = filepath.Join("config", "crd", "patches",
+func (f *EnableWebhookPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		plural := flect.Pluralize(strings.ToLower(f.Resource.Kind))
+		f.Path = filepath.Join("config", "crd", "patches",
 			fmt.Sprintf("webhook_in_%s.yaml", plural))
 	}
-	p.TemplateBody = enableWebhookPatchTemplate
-	return p.Input, nil
+	f.TemplateBody = enableWebhookPatchTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *EnableWebhookPatch) Validate() error {
-	return g.Resource.Validate()
+func (f *EnableWebhookPatch) Validate() error {
+	return f.Resource.Validate()
 }
 
 const enableWebhookPatchTemplate = `# The following patch enables conversion webhook for CRD

--- a/pkg/scaffold/v2/crd/kustomization.go
+++ b/pkg/scaffold/v2/crd/kustomization.go
@@ -45,29 +45,29 @@ type Kustomization struct {
 }
 
 // GetInput implements input.File
-func (c *Kustomization) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "crd", "kustomization.yaml")
+func (f *Kustomization) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
 	}
-	c.TemplateBody = kustomizationTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizationTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
-func (c *Kustomization) Update() error {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "crd", "kustomization.yaml")
+func (f *Kustomization) Update() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
 	}
 
 	// TODO(directxman12): not technically valid if something changes from the default
 	// (we'd need to parse the markers)
-	plural := flect.Pluralize(strings.ToLower(c.Resource.Kind))
+	plural := flect.Pluralize(strings.ToLower(f.Resource.Kind))
 
-	kustomizeResourceCodeFragment := fmt.Sprintf("- bases/%s.%s_%s.yaml\n", c.Resource.Group, c.Domain, plural)
+	kustomizeResourceCodeFragment := fmt.Sprintf("- bases/%s.%s_%s.yaml\n", f.Resource.Group, f.Domain, plural)
 	kustomizeWebhookPatchCodeFragment := fmt.Sprintf("#- patches/webhook_in_%s.yaml\n", plural)
 	kustomizeCAInjectionPatchCodeFragment := fmt.Sprintf("#- patches/cainjection_in_%s.yaml\n", plural)
 
-	return internal.InsertStringsInFile(c.Path,
+	return internal.InsertStringsInFile(f.Path,
 		map[string][]string{
 			kustomizeResourceScaffoldMarker:         {kustomizeResourceCodeFragment},
 			kustomizeWebhookPatchScaffoldMarker:     {kustomizeWebhookPatchCodeFragment},

--- a/pkg/scaffold/v2/crd/kustomizeconfig.go
+++ b/pkg/scaffold/v2/crd/kustomizeconfig.go
@@ -30,13 +30,13 @@ type KustomizeConfig struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeConfig) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "crd", "kustomizeconfig.yaml")
+func (f *KustomizeConfig) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "kustomizeconfig.yaml")
 	}
-	c.TemplateBody = kustomizeConfigTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeConfigTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeConfigTemplate = `# This file is for teaching kustomize how to substitute name and namespace reference in CRD

--- a/pkg/scaffold/v2/crd_editor_rbac.go
+++ b/pkg/scaffold/v2/crd_editor_rbac.go
@@ -36,18 +36,18 @@ type CRDEditorRole struct {
 }
 
 // GetInput implements input.File
-func (g *CRDEditorRole) GetInput() (input.Input, error) {
-	if g.Path == "" {
-		g.Path = filepath.Join("config", "rbac", fmt.Sprintf("%s_editor_role.yaml", strings.ToLower(g.Resource.Kind)))
+func (f *CRDEditorRole) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", fmt.Sprintf("%s_editor_role.yaml", strings.ToLower(f.Resource.Kind)))
 	}
 
-	g.TemplateBody = crdRoleEditorTemplate
-	return g.Input, nil
+	f.TemplateBody = crdRoleEditorTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *CRDEditorRole) Validate() error {
-	return g.Resource.Validate()
+func (f *CRDEditorRole) Validate() error {
+	return f.Resource.Validate()
 }
 
 const crdRoleEditorTemplate = `# permissions for end users to edit {{ .Resource.Resource }}.

--- a/pkg/scaffold/v2/crd_sample.go
+++ b/pkg/scaffold/v2/crd_sample.go
@@ -36,20 +36,20 @@ type CRDSample struct {
 }
 
 // GetInput implements input.File
-func (c *CRDSample) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "samples", fmt.Sprintf(
-			"%s_%s_%s.yaml", c.Resource.Group, c.Resource.Version, strings.ToLower(c.Resource.Kind)))
+func (f *CRDSample) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "samples", fmt.Sprintf(
+			"%s_%s_%s.yaml", f.Resource.Group, f.Resource.Version, strings.ToLower(f.Resource.Kind)))
 	}
 
-	c.IfExistsAction = input.Error
-	c.TemplateBody = crdSampleTemplate
-	return c.Input, nil
+	f.IfExistsAction = input.Error
+	f.TemplateBody = crdSampleTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (c *CRDSample) Validate() error {
-	return c.Resource.Validate()
+func (f *CRDSample) Validate() error {
+	return f.Resource.Validate()
 }
 
 const crdSampleTemplate = `apiVersion: {{ .Resource.Group }}.{{ .Domain }}/{{ .Resource.Version }}

--- a/pkg/scaffold/v2/crd_viewer_rbac.go
+++ b/pkg/scaffold/v2/crd_viewer_rbac.go
@@ -36,18 +36,18 @@ type CRDViewerRole struct {
 }
 
 // GetInput implements input.File
-func (g *CRDViewerRole) GetInput() (input.Input, error) {
-	if g.Path == "" {
-		g.Path = filepath.Join("config", "rbac", fmt.Sprintf("%s_viewer_role.yaml", strings.ToLower(g.Resource.Kind)))
+func (f *CRDViewerRole) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", fmt.Sprintf("%s_viewer_role.yaml", strings.ToLower(f.Resource.Kind)))
 	}
 
-	g.TemplateBody = crdRoleViewerTemplate
-	return g.Input, nil
+	f.TemplateBody = crdRoleViewerTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *CRDViewerRole) Validate() error {
-	return g.Resource.Validate()
+func (f *CRDViewerRole) Validate() error {
+	return f.Resource.Validate()
 }
 
 const crdRoleViewerTemplate = `# permissions for end users to view {{ .Resource.Resource }}.

--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -28,12 +28,12 @@ type Dockerfile struct {
 }
 
 // GetInput implements input.File
-func (c *Dockerfile) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = "Dockerfile"
+func (f *Dockerfile) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "Dockerfile"
 	}
-	c.TemplateBody = dockerfileTemplate
-	return c.Input, nil
+	f.TemplateBody = dockerfileTemplate
+	return f.Input, nil
 }
 
 const dockerfileTemplate = `# Build the manager binary

--- a/pkg/scaffold/v2/gomod.go
+++ b/pkg/scaffold/v2/gomod.go
@@ -29,13 +29,13 @@ type GoMod struct {
 }
 
 // GetInput implements input.File
-func (g *GoMod) GetInput() (input.Input, error) {
-	if g.Path == "" {
-		g.Path = "go.mod"
+func (f *GoMod) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "go.mod"
 	}
-	g.Input.IfExistsAction = input.Overwrite
-	g.TemplateBody = goModTemplate
-	return g.Input, nil
+	f.Input.IfExistsAction = input.Overwrite
+	f.TemplateBody = goModTemplate
+	return f.Input, nil
 }
 
 const goModTemplate = `

--- a/pkg/scaffold/v2/group.go
+++ b/pkg/scaffold/v2/group.go
@@ -34,21 +34,21 @@ type Group struct {
 }
 
 // GetInput implements input.File
-func (g *Group) GetInput() (input.Input, error) {
-	if g.Path == "" {
-		if g.MultiGroup {
-			g.Path = filepath.Join("apis", g.Resource.Group, g.Resource.Version, "groupversion_info.go")
+func (f *Group) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("apis", f.Resource.Group, f.Resource.Version, "groupversion_info.go")
 		} else {
-			g.Path = filepath.Join("api", g.Resource.Version, "groupversion_info.go")
+			f.Path = filepath.Join("api", f.Resource.Version, "groupversion_info.go")
 		}
 	}
-	g.TemplateBody = groupTemplate
-	return g.Input, nil
+	f.TemplateBody = groupTemplate
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *Group) Validate() error {
-	return g.Resource.Validate()
+func (f *Group) Validate() error {
+	return f.Resource.Validate()
 }
 
 const groupTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v2/kustomize.go
+++ b/pkg/scaffold/v2/kustomize.go
@@ -35,21 +35,21 @@ type Kustomize struct {
 }
 
 // GetInput implements input.File
-func (c *Kustomize) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "kustomization.yaml")
+func (f *Kustomize) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "kustomization.yaml")
 	}
-	if c.Prefix == "" {
+	if f.Prefix == "" {
 		// use directory name as prefix
 		dir, err := os.Getwd()
 		if err != nil {
 			return input.Input{}, err
 		}
-		c.Prefix = strings.ToLower(filepath.Base(dir))
+		f.Prefix = strings.ToLower(filepath.Base(dir))
 	}
-	c.TemplateBody = kustomizeTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeTemplate = `# Adds namespace to all resources.

--- a/pkg/scaffold/v2/leaderelectionrole.go
+++ b/pkg/scaffold/v2/leaderelectionrole.go
@@ -30,12 +30,12 @@ type LeaderElectionRole struct {
 }
 
 // GetInput implements input.File
-func (r *LeaderElectionRole) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "leader_election_role.yaml")
+func (f *LeaderElectionRole) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "leader_election_role.yaml")
 	}
-	r.TemplateBody = leaderElectionRoleTemplate
-	return r.Input, nil
+	f.TemplateBody = leaderElectionRoleTemplate
+	return f.Input, nil
 }
 
 const leaderElectionRoleTemplate = `# permissions to do leader election.

--- a/pkg/scaffold/v2/leaderelectionrolebinding.go
+++ b/pkg/scaffold/v2/leaderelectionrolebinding.go
@@ -30,12 +30,12 @@ type LeaderElectionRoleBinding struct {
 }
 
 // GetInput implements input.File
-func (r *LeaderElectionRoleBinding) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "leader_election_role_binding.yaml")
+func (f *LeaderElectionRoleBinding) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "leader_election_role_binding.yaml")
 	}
-	r.TemplateBody = leaderElectionRoleBindingTemplate
-	return r.Input, nil
+	f.TemplateBody = leaderElectionRoleBindingTemplate
+	return f.Input, nil
 }
 
 const leaderElectionRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/scaffold/v2/main.go
+++ b/pkg/scaffold/v2/main.go
@@ -40,17 +40,17 @@ type Main struct {
 }
 
 // GetInput implements input.File
-func (m *Main) GetInput() (input.Input, error) {
-	if m.Path == "" {
-		m.Path = filepath.Join("main.go")
+func (f *Main) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("main.go")
 	}
-	m.TemplateBody = mainTemplate
-	return m.Input, nil
+	f.TemplateBody = mainTemplate
+	return f.Input, nil
 }
 
 // Update updates main.go with code fragments required to wire a new
 // resource/controller.
-func (m *Main) Update(opts *MainUpdateOptions) error {
+func (f *Main) Update(opts *MainUpdateOptions) error {
 	path := "main.go"
 
 	resPkg, _ := util.GetResourceInfo(opts.Resource, opts.Project.Repo, opts.Project.Domain, opts.Project.MultiGroup)

--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -32,16 +32,16 @@ type Makefile struct {
 }
 
 // GetInput implements input.File
-func (c *Makefile) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = "Makefile"
+func (f *Makefile) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = "Makefile"
 	}
-	if c.Image == "" {
-		c.Image = "controller:latest"
+	if f.Image == "" {
+		f.Image = "controller:latest"
 	}
-	c.TemplateBody = makefileTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = makefileTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const makefileTemplate = `

--- a/pkg/scaffold/v2/manager/config.go
+++ b/pkg/scaffold/v2/manager/config.go
@@ -32,12 +32,12 @@ type Config struct {
 }
 
 // GetInput implements input.File
-func (c *Config) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "manager", "manager.yaml")
+func (f *Config) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "manager.yaml")
 	}
-	c.TemplateBody = configTemplate
-	return c.Input, nil
+	f.TemplateBody = configTemplate
+	return f.Input, nil
 }
 
 const configTemplate = `apiVersion: v1

--- a/pkg/scaffold/v2/manager/kustomization.go
+++ b/pkg/scaffold/v2/manager/kustomization.go
@@ -30,13 +30,13 @@ type Kustomization struct {
 }
 
 // GetInput implements input.File
-func (c *Kustomization) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "manager", "kustomization.yaml")
+func (f *Kustomization) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "kustomization.yaml")
 	}
-	c.TemplateBody = kustomizeManagerTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeManagerTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeManagerTemplate = `resources:

--- a/pkg/scaffold/v2/metricsauth/kustomize_auth_proxy_patch.go
+++ b/pkg/scaffold/v2/metricsauth/kustomize_auth_proxy_patch.go
@@ -31,13 +31,13 @@ type KustomizeAuthProxyPatch struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeAuthProxyPatch) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
+func (f *KustomizeAuthProxyPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
 	}
-	c.TemplateBody = kustomizeAuthProxyPatchTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeAuthProxyPatchTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the controller manager,

--- a/pkg/scaffold/v2/mgrrolebinding.go
+++ b/pkg/scaffold/v2/mgrrolebinding.go
@@ -30,12 +30,12 @@ type ManagerRoleBinding struct {
 }
 
 // GetInput implements input.File
-func (r *ManagerRoleBinding) GetInput() (input.Input, error) {
-	if r.Path == "" {
-		r.Path = filepath.Join("config", "rbac", "role_binding.yaml")
+func (f *ManagerRoleBinding) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "role_binding.yaml")
 	}
-	r.TemplateBody = managerBindingTemplate
-	return r.Input, nil
+	f.TemplateBody = managerBindingTemplate
+	return f.Input, nil
 }
 
 const managerBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/scaffold/v2/prometheus/kustomize.go
+++ b/pkg/scaffold/v2/prometheus/kustomize.go
@@ -28,12 +28,12 @@ type Kustomization struct {
 }
 
 // GetInput implements input.File
-func (p *Kustomization) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		p.Path = filepath.Join("config", "prometheus", "kustomization.yaml")
+func (f *Kustomization) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus", "kustomization.yaml")
 	}
-	p.TemplateBody = kustomizationTemplate
-	return p.Input, nil
+	f.TemplateBody = kustomizationTemplate
+	return f.Input, nil
 }
 
 const kustomizationTemplate = `resources:

--- a/pkg/scaffold/v2/prometheus/monitor.go
+++ b/pkg/scaffold/v2/prometheus/monitor.go
@@ -28,12 +28,12 @@ type PrometheusServiceMonitor struct {
 }
 
 // GetInput implements input.File
-func (p *PrometheusServiceMonitor) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		p.Path = filepath.Join("config", "prometheus", "monitor.yaml")
+func (f *PrometheusServiceMonitor) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus", "monitor.yaml")
 	}
-	p.TemplateBody = monitorTemplate
-	return p.Input, nil
+	f.TemplateBody = monitorTemplate
+	return f.Input, nil
 }
 
 const monitorTemplate = `

--- a/pkg/scaffold/v2/rbac.go
+++ b/pkg/scaffold/v2/rbac.go
@@ -30,13 +30,13 @@ type KustomizeRBAC struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeRBAC) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "rbac", "kustomization.yaml")
+func (f *KustomizeRBAC) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "kustomization.yaml")
 	}
-	c.TemplateBody = kustomizeRBACTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = kustomizeRBACTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const kustomizeRBACTemplate = `resources:

--- a/pkg/scaffold/v2/types.go
+++ b/pkg/scaffold/v2/types.go
@@ -36,19 +36,19 @@ type Types struct {
 }
 
 // GetInput implements input.File
-func (t *Types) GetInput() (input.Input, error) {
-	if t.Path == "" {
-		t.Path = filepath.Join("pkg", "apis", t.Resource.Group, t.Resource.Version,
-			fmt.Sprintf("%s_types.go", strings.ToLower(t.Resource.Kind)))
+func (f *Types) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("pkg", "apis", f.Resource.Group, f.Resource.Version,
+			fmt.Sprintf("%s_types.go", strings.ToLower(f.Resource.Kind)))
 	}
-	t.TemplateBody = typesTemplate
-	t.IfExistsAction = input.Error
-	return t.Input, nil
+	f.TemplateBody = typesTemplate
+	f.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (t *Types) Validate() error {
-	return t.Resource.Validate()
+func (f *Types) Validate() error {
+	return f.Resource.Validate()
 }
 
 const typesTemplate = `{{ .Boilerplate }}

--- a/pkg/scaffold/v2/webhook/enablecainection_patch.go
+++ b/pkg/scaffold/v2/webhook/enablecainection_patch.go
@@ -30,13 +30,13 @@ type InjectCAPatch struct {
 }
 
 // GetInput implements input.File
-func (c *InjectCAPatch) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "default", "webhookcainjection_patch.yaml")
+func (f *InjectCAPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "webhookcainjection_patch.yaml")
 	}
-	c.TemplateBody = injectCAPatchTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = injectCAPatchTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const injectCAPatchTemplate = `# This patch add annotation to admission webhook config and

--- a/pkg/scaffold/v2/webhook/kustomization.go
+++ b/pkg/scaffold/v2/webhook/kustomization.go
@@ -30,13 +30,13 @@ type Kustomization struct {
 }
 
 // GetInput implements input.File
-func (c *Kustomization) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "webhook", "kustomization.yaml")
+func (f *Kustomization) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "webhook", "kustomization.yaml")
 	}
-	c.TemplateBody = KustomizeWebhookTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = KustomizeWebhookTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const KustomizeWebhookTemplate = `resources:

--- a/pkg/scaffold/v2/webhook/kustomizeconfig.go
+++ b/pkg/scaffold/v2/webhook/kustomizeconfig.go
@@ -30,13 +30,13 @@ type KustomizeConfigWebhook struct {
 }
 
 // GetInput implements input.File
-func (c *KustomizeConfigWebhook) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "webhook", "kustomizeconfig.yaml")
+func (f *KustomizeConfigWebhook) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "webhook", "kustomizeconfig.yaml")
 	}
-	c.TemplateBody = KustomizeConfigWebhookTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = KustomizeConfigWebhookTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const KustomizeConfigWebhookTemplate = `# the following config is for teaching kustomize where to look at when substituting vars.

--- a/pkg/scaffold/v2/webhook/service.go
+++ b/pkg/scaffold/v2/webhook/service.go
@@ -30,13 +30,13 @@ type Service struct {
 }
 
 // GetInput implements input.File
-func (c *Service) GetInput() (input.Input, error) {
-	if c.Path == "" {
-		c.Path = filepath.Join("config", "webhook", "service.yaml")
+func (f *Service) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "webhook", "service.yaml")
 	}
-	c.TemplateBody = ServiceTemplate
-	c.Input.IfExistsAction = input.Error
-	return c.Input, nil
+	f.TemplateBody = ServiceTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 const ServiceTemplate = `

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -51,40 +51,40 @@ type Webhook struct {
 }
 
 // GetInput implements input.File
-func (a *Webhook) GetInput() (input.Input, error) {
+func (f *Webhook) GetInput() (input.Input, error) {
 
-	_, a.GroupDomain = util.GetResourceInfo(a.Resource, a.Repo, a.Domain, a.MultiGroup)
+	_, f.GroupDomain = util.GetResourceInfo(f.Resource, f.Repo, f.Domain, f.MultiGroup)
 
-	a.GroupDomainWithDash = strings.Replace(a.GroupDomain, ".", "-", -1)
+	f.GroupDomainWithDash = strings.Replace(f.GroupDomain, ".", "-", -1)
 
-	if a.Plural == "" {
-		a.Plural = flect.Pluralize(strings.ToLower(a.Resource.Kind))
+	if f.Plural == "" {
+		f.Plural = flect.Pluralize(strings.ToLower(f.Resource.Kind))
 	}
 
-	if a.Path == "" {
-		if a.MultiGroup {
-			a.Path = filepath.Join("apis", a.Resource.Group, a.Resource.Version, fmt.Sprintf("%s_webhook.go", strings.ToLower(a.Resource.Kind)))
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("apis", f.Resource.Group, f.Resource.Version, fmt.Sprintf("%s_webhook.go", strings.ToLower(f.Resource.Kind)))
 		} else {
-			a.Path = filepath.Join("api", a.Resource.Version, fmt.Sprintf("%s_webhook.go", strings.ToLower(a.Resource.Kind)))
+			f.Path = filepath.Join("api", f.Resource.Version, fmt.Sprintf("%s_webhook.go", strings.ToLower(f.Resource.Kind)))
 		}
 	}
 
 	webhookTemplate := WebhookTemplate
-	if a.Defaulting {
+	if f.Defaulting {
 		webhookTemplate = webhookTemplate + DefaultingWebhookTemplate
 	}
-	if a.Validating {
+	if f.Validating {
 		webhookTemplate = webhookTemplate + ValidatingWebhookTemplate
 	}
 
-	a.TemplateBody = webhookTemplate
-	a.Input.IfExistsAction = input.Error
-	return a.Input, nil
+	f.TemplateBody = webhookTemplate
+	f.Input.IfExistsAction = input.Error
+	return f.Input, nil
 }
 
 // Validate validates the values
-func (g *Webhook) Validate() error {
-	return g.Resource.Validate()
+func (f *Webhook) Validate() error {
+	return f.Resource.Validate()
 }
 
 const (

--- a/pkg/scaffold/v2/webhook_manager_patch.go
+++ b/pkg/scaffold/v2/webhook_manager_patch.go
@@ -28,12 +28,12 @@ type ManagerWebhookPatch struct {
 }
 
 // GetInput implements input.File
-func (p *ManagerWebhookPatch) GetInput() (input.Input, error) {
-	if p.Path == "" {
-		p.Path = filepath.Join("config", "default", "manager_webhook_patch.yaml")
+func (f *ManagerWebhookPatch) GetInput() (input.Input, error) {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_webhook_patch.yaml")
 	}
-	p.TemplateBody = ManagerWebhookPatchTemplate
-	return p.Input, nil
+	f.TemplateBody = ManagerWebhookPatchTemplate
+	return f.Input, nil
 }
 
 const ManagerWebhookPatchTemplate = `apiVersion: apps/v1


### PR DESCRIPTION
Linter is reporting different receiver names (i.e., methods of same struct with different receiver names) as if they were generic. Additionally most of the files use generic receivers such as `a`. Tiis PR changes all receiver names for implementations fo the `File` interface to `f` as a mnemonic of `file`.

### Linter message:
> Receiver has generic name inspection

### Lister description:
> Reports receiver names like me, this, self or different from other receiver names for this type.
> See [Code review comments: receiver names](https://github.com/golang/go/wiki/CodeReviewComments#receiver-names) for details.

Closes: #1182

/kind cleanup