### PR TITLE
Imports ordering

### DIFF
--- a/cmd/go_version_test.go
+++ b/cmd/go_version_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestCheckGoVersion(t *testing.T) {
 

--- a/cmd/vendor_update.go
+++ b/cmd/vendor_update.go
@@ -20,6 +20,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"

--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -23,9 +23,9 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -29,11 +29,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -18,13 +18,11 @@ package v1
 
 import (
 	"github.com/robfig/cron"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	validationutils "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/docs/book/src/cronjob-tutorial/testdata/project/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/main.go
@@ -25,6 +25,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
 	"tutorial.kubebuilder.io/project/controllers"
 	// +kubebuilder:scaffold:imports

--- a/docs/book/src/migration/testdata/gopath/project-v1/cmd/manager/main.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/cmd/manager/main.go
@@ -20,15 +20,15 @@ import (
 	"flag"
 	"os"
 
-	"project/pkg/apis"
-	"project/pkg/controller"
-	"project/pkg/webhook"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"project/pkg/apis"
+	"project/pkg/controller"
+	"project/pkg/webhook"
 )
 
 func main() {

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/controller/cronjob/cronjob_controller.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/controller/cronjob/cronjob_controller.go
@@ -23,9 +23,6 @@ import (
 	"time"
 
 	"github.com/robfig/cron"
-
-	batchv1 "project/pkg/apis/batch/v1"
-
 	kbatch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 var log = logf.Log.WithName("controller")

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/controller/cronjob/cronjob_controller_suite_test.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/controller/cronjob/cronjob_controller_suite_test.go
@@ -23,14 +23,14 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/mutating/create_update_webhook.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/mutating/create_update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mutating
 
 import (
-	batchv1 "project/pkg/apis/batch/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 func init() {

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/mutating/cronjob_create_update_handler.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/mutating/cronjob_create_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	batchv1 "project/pkg/apis/batch/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 func init() {

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/create_webhook.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/create_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package validating
 
 import (
-	batchv1 "project/pkg/apis/batch/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 func init() {

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/cronjob_create_handler.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/cronjob_create_handler.go
@@ -21,9 +21,6 @@ import (
 	"net/http"
 
 	"github.com/robfig/cron"
-
-	batchv1 "project/pkg/apis/batch/v1"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	validationutils "k8s.io/apimachinery/pkg/util/validation"
@@ -31,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 func init() {

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/cronjob_update_handler.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/cronjob_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	batchv1 "project/pkg/apis/batch/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 func init() {

--- a/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/update_webhook.go
+++ b/docs/book/src/migration/testdata/gopath/project-v1/pkg/webhook/default_server/cronjob/validating/update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package validating
 
 import (
-	batchv1 "project/pkg/apis/batch/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	batchv1 "project/pkg/apis/batch/v1"
 )
 
 func init() {

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -18,13 +18,11 @@ package v1
 
 import (
 	"github.com/robfig/cron"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	validationutils "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/docs/book/src/multiversion-tutorial/testdata/project/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/main.go
@@ -26,6 +26,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
 	batchv2 "tutorial.kubebuilder.io/project/api/v2"
 	"tutorial.kubebuilder.io/project/controllers"

--- a/pkg/scaffold/project/project_test.go
+++ b/pkg/scaffold/project/project_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -28,11 +28,19 @@ import (
 	"text/template"
 
 	"golang.org/x/tools/imports"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/project"
 	"sigs.k8s.io/yaml"
 )
+
+var options = imports.Options{
+	Comments:   true,
+	TabIndent:  true,
+	TabWidth:   8,
+	FormatOnly: true,
+}
 
 // Scaffold writes Templates to scaffold new files
 type Scaffold struct {
@@ -181,6 +189,10 @@ func (s *Scaffold) Execute(u *model.Universe, options input.Options, files ...in
 	if err := s.defaultOptions(&options); err != nil {
 		return err
 	}
+
+	// Set the repo as the local prefix so that it knows how to group imports
+	imports.LocalPrefix = s.Project.Repo
+
 	for _, f := range files {
 		m, err := s.buildFileModel(f)
 		if err != nil {
@@ -289,7 +301,7 @@ func (s *Scaffold) doTemplate(i input.Input, e input.File) ([]byte, error) {
 
 	// gofmt the imports
 	if filepath.Ext(i.Path) == ".go" {
-		b, err = imports.Process(i.Path, b, nil)
+		b, err = imports.Process(i.Path, b, &options)
 		if err != nil {
 			fmt.Printf("%s\n", out.Bytes())
 			return nil, err

--- a/pkg/scaffold/v1/controller/controller.go
+++ b/pkg/scaffold/v1/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/flect"
+
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
@@ -103,14 +104,11 @@ package {{ lower .Resource.Kind }}
 
 import (
 {{ if .Resource.CreateExampleReconcileBody }}	"context"
-	"log"
 	"reflect"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -126,9 +124,9 @@ import (
 
 var log = logf.Log.WithName("{{ lower .Resource.Kind }}-controller")
 {{ else }}	"context"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"

--- a/pkg/scaffold/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/v1/controller/controllersuitetest.go
@@ -52,7 +52,6 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/scaffold/v1/controller/controllertest.go
+++ b/pkg/scaffold/v1/controller/controllertest.go
@@ -73,7 +73,6 @@ package {{ lower .Resource.Kind }}
 import (
 	"testing"
 	"time"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	{{ if .Resource.CreateExampleReconcileBody -}}

--- a/pkg/scaffold/v1/crd/typestest.go
+++ b/pkg/scaffold/v1/crd/typestest.go
@@ -57,7 +57,6 @@ package {{ .Resource.Version }}
 
 import (
 	"testing"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/scaffold/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/v1/crd/version_suitetest.go
@@ -58,7 +58,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/scaffold/v1/manager/cmd.go
+++ b/pkg/scaffold/v1/manager/cmd.go
@@ -45,7 +45,6 @@ package main
 import (
 	"flag"
 	"os"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/pkg/scaffold/v1/manager/manager_test.go
+++ b/pkg/scaffold/v1/manager/manager_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/scaffoldtest"

--- a/pkg/scaffold/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/v1/webhook/add_admissionbuilder_handler.go
@@ -55,7 +55,6 @@ package {{ .Server }}server
 
 import (
 	"fmt"
-
 	"{{ .Repo }}/pkg/webhook/{{ .Server }}_server/{{ lower .Resource.Kind }}/{{ .Type }}"
 )
 

--- a/pkg/scaffold/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/v1/webhook/admissionbuilder.go
@@ -77,9 +77,9 @@ const admissionWebhookBuilderTemplate = `{{ .Boilerplate }}
 package {{ .Type }}
 
 import (
-	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/pkg/scaffold/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/v1/webhook/admissionhandler.go
@@ -78,12 +78,10 @@ package {{ .Type }}
 import (
 	"context"
 	"net/http"
-
-	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+	{{ .Resource.Group}}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Group}}/{{ .Resource.Version }}"
 )
 
 func init() {

--- a/pkg/scaffold/v1/webhook/server.go
+++ b/pkg/scaffold/v1/webhook/server.go
@@ -48,7 +48,6 @@ package {{ .Server }}server
 import (
 	"fmt"
 	"os"
-
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"

--- a/pkg/scaffold/v1/webhook/webhook_test.go
+++ b/pkg/scaffold/v1/webhook/webhook_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"

--- a/pkg/scaffold/v2/controller.go
+++ b/pkg/scaffold/v2/controller.go
@@ -70,12 +70,10 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	{{ .Resource.GroupImportSafe }}{{ .Resource.Version }} "{{ .ResourcePackage }}/{{ .Resource.Version }}"
 )
 

--- a/pkg/scaffold/v2/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller_suitetest.go
@@ -57,17 +57,14 @@ package controllers
 import (
 	"path/filepath"
 	"testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/scaffold/v2/main.go
+++ b/pkg/scaffold/v2/main.go
@@ -131,13 +131,11 @@ package main
 import (
 	"flag"
 	"os"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	%s
 )
 

--- a/pkg/scaffold/v2/prometheus/kustomize.go
+++ b/pkg/scaffold/v2/prometheus/kustomize.go
@@ -18,6 +18,7 @@ package prometheus
 
 import (
 	"path/filepath"
+
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 

--- a/pkg/scaffold/v2/prometheus/monitor.go
+++ b/pkg/scaffold/v2/prometheus/monitor.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"path/filepath"
+
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -89,10 +89,12 @@ const (
 package {{ .Resource.Version }}
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	{{- if or .Validating .Defaulting }}
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	{{- end }}
 )
 
 // log is for logging in this package.

--- a/plugins/addon/helpers.go
+++ b/plugins/addon/helpers.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	"github.com/gobuffalo/flect"
+
 	"sigs.k8s.io/kubebuilder/pkg/model"
 )
 

--- a/test/e2e/v1/e2e_suite.go
+++ b/test/e2e/v1/e2e_suite.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
-	"sigs.k8s.io/kubebuilder/test/e2e/utils"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/test/e2e/utils"
 )
 
 var _ = Describe("kubebuilder", func() {

--- a/test/e2e/v2/e2e_suite.go
+++ b/test/e2e/v2/e2e_suite.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/kubebuilder/test/e2e/utils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/test/e2e/utils"
 )
 
 var _ = Describe("kubebuilder", func() {

--- a/testdata/gopath/src/project/cmd/manager/main.go
+++ b/testdata/gopath/src/project/cmd/manager/main.go
@@ -20,15 +20,15 @@ import (
 	"flag"
 	"os"
 
-	"project/pkg/apis"
-	"project/pkg/controller"
-	"project/pkg/webhook"
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"project/pkg/apis"
+	"project/pkg/controller"
+	"project/pkg/webhook"
 )
 
 func main() {

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"reflect"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 var log = logf.Log.WithName("firstmate-controller")

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_suite_test.go
@@ -23,14 +23,14 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/firstmate/firstmate_controller_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller.go
@@ -19,8 +19,6 @@ package frigate
 import (
 	"context"
 
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_suite_test.go
@@ -23,14 +23,14 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/frigate/frigate_controller_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller.go
@@ -19,8 +19,6 @@ package healthcheckpolicy
 import (
 	"context"
 
-	policyv1beta1 "project/pkg/apis/policy/v1beta1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_suite_test.go
@@ -23,14 +23,14 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/healthcheckpolicy/healthcheckpolicy_controller_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	policyv1beta1 "project/pkg/apis/policy/v1beta1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	policyv1beta1 "project/pkg/apis/policy/v1beta1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller.go
@@ -19,8 +19,6 @@ package kraken
 import (
 	"context"
 
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 /**

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_suite_test.go
@@ -23,14 +23,14 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_test.go
+++ b/testdata/gopath/src/project/pkg/controller/kraken/kraken_controller_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -30,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 var c client.Client

--- a/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_suite_test.go
+++ b/testdata/gopath/src/project/pkg/controller/namespace/namespace_controller_suite_test.go
@@ -23,14 +23,14 @@ import (
 	"sync"
 	"testing"
 
-	"project/pkg/apis"
-
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"project/pkg/apis"
 )
 
 var cfg *rest.Config

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/create_update_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/create_update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mutating
 
 import (
-	crewv1 "project/pkg/apis/crew/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/delete_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/delete_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mutating
 
 import (
-	crewv1 "project/pkg/apis/crew/v1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_create_update_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_create_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_delete_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/firstmate/mutating/firstmate_delete_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	crewv1 "project/pkg/apis/crew/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	crewv1 "project/pkg/apis/crew/v1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/frigate_update_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/frigate_update_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/update_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/frigate/validating/update_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package validating
 
 import (
-	shipv1beta1 "project/pkg/apis/ship/v1beta1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	shipv1beta1 "project/pkg/apis/ship/v1beta1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/create_webhook.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/create_webhook.go
@@ -17,10 +17,10 @@ limitations under the License.
 package validating
 
 import (
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 func init() {

--- a/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/kraken_create_handler.go
+++ b/testdata/gopath/src/project/pkg/webhook/default_server/kraken/validating/kraken_create_handler.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"net/http"
 
-	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
-
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	creaturesv2alpha1 "project/pkg/apis/creatures/v2alpha1"
 )
 
 func init() {

--- a/testdata/project-v2/controllers/namespace_controller.go
+++ b/testdata/project-v2/controllers/namespace_controller.go
@@ -20,11 +20,10 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // NamespaceReconciler reconciles a Namespace object

--- a/testdata/project-v2/controllers/suite_test.go
+++ b/testdata/project-v2/controllers/suite_test.go
@@ -22,14 +22,15 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	corev1 "k8s.io/api/core/v1"
+
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2/api/v1"
 	// +kubebuilder:scaffold:imports
 )

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -20,12 +20,14 @@ import (
 	"flag"
 	"os"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	corev1 "k8s.io/api/core/v1"
+
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v2/controllers"
 	// +kubebuilder:scaffold:imports


### PR DESCRIPTION
Imports have been grouped and sorted in the whole project. Two different schemas have been followed.

For kubebuilder source files, the imports have been split into three groups according to the current policy: standard library are placed first, followed by packages non related to k8s and at the end k8s packages.
```
import (
    std

    non-k8s

    k8s
)
```

Scaffolded files use the schema that go formatting tools (`golang.org/x/tools/imports`) implement: standard library first, followed by external packages and at the bottom imports from the current repository.
```
import (
    std

    external

    repository
)
```

Template strings for scaffolded files need to keep imports in a single group and `imports.Process` wil handle the divission.

### Linter message:
> Unsorted imports inspection

### Linter description:
> Reports unsorted imports.

### References:
- [Imports](https://github.com/golang/go/wiki/CodeReviewComments#imports)

Note: despite being the de facto standard, couldn't find a CodeReviewComments or Effective Go section that talks about the order of imports in each group, but you can see in the example how this rule is being followed.

Closes: #1183

/kind cleanup
