### PR TITLE
Avoid rewriting template values, mark them as const

### DIFF
--- a/pkg/scaffold/project/authproxyrole.go
+++ b/pkg/scaffold/project/authproxyrole.go
@@ -38,7 +38,7 @@ func (r *AuthProxyRole) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var proxyRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+const proxyRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: proxy-role

--- a/pkg/scaffold/project/authproxyrolebinding.go
+++ b/pkg/scaffold/project/authproxyrolebinding.go
@@ -38,7 +38,7 @@ func (r *AuthProxyRoleBinding) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var proxyRoleBindinggTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+const proxyRoleBindinggTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: proxy-rolebinding

--- a/pkg/scaffold/project/boilerplate.go
+++ b/pkg/scaffold/project/boilerplate.go
@@ -65,7 +65,7 @@ func (c *Boilerplate) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var apache = `/*
+const apache = `/*
 {{ if .Owner }}Copyright {{ .Year }} {{ .Owner }}.
 {{ end }}
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,6 +81,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */`
 
-var none = `/*
+const none = `/*
 {{ if .Owner }}Copyright {{ .Year }} {{ .Owner }}{{ end }}.
 */`

--- a/pkg/scaffold/project/gitignore.go
+++ b/pkg/scaffold/project/gitignore.go
@@ -36,7 +36,7 @@ func (c *GitIgnore) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var gitignoreTemplate = `
+const gitignoreTemplate = `
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/pkg/scaffold/project/gopkg.go
+++ b/pkg/scaffold/project/gopkg.go
@@ -134,7 +134,7 @@ const DefaultGopkgUserContent = `required = [
 
 `
 
-var depTemplate = `{{ .UserContent }}
+const depTemplate = `{{ .UserContent }}
 # STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE.
 
 {{ range $element := .Stanzas -}}

--- a/pkg/scaffold/project/kustomize.go
+++ b/pkg/scaffold/project/kustomize.go
@@ -51,7 +51,7 @@ func (c *Kustomize) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeTemplate = `# Adds namespace to all resources.
+const kustomizeTemplate = `# Adds namespace to all resources.
 namespace: {{.Prefix}}-system
 
 # Value of this field is prepended to the

--- a/pkg/scaffold/project/kustomize_manager_base.go
+++ b/pkg/scaffold/project/kustomize_manager_base.go
@@ -39,6 +39,6 @@ func (c *KustomizeManager) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeManagerTemplate = `resources:
+const kustomizeManagerTemplate = `resources:
 - manager.yaml
 `

--- a/pkg/scaffold/project/kustomize_rbac_base.go
+++ b/pkg/scaffold/project/kustomize_rbac_base.go
@@ -39,7 +39,7 @@ func (c *KustomizeRBAC) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeRBACTemplate = `resources:
+const kustomizeRBACTemplate = `resources:
 - rbac_role.yaml
 - rbac_role_binding.yaml
   # Comment the following 3 lines if you want to disable

--- a/pkg/scaffold/project/makefile.go
+++ b/pkg/scaffold/project/makefile.go
@@ -48,7 +48,7 @@ func (c *Makefile) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var makefileTemplate = `
+const makefileTemplate = `
 # Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
 

--- a/pkg/scaffold/v1/authproxyservice.go
+++ b/pkg/scaffold/v1/authproxyservice.go
@@ -38,7 +38,7 @@ func (r *AuthProxyService) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var AuthProxyServiceTemplate = `apiVersion: v1
+const AuthProxyServiceTemplate = `apiVersion: v1
 kind: Service
 metadata:
   annotations:

--- a/pkg/scaffold/v1/controller/add.go
+++ b/pkg/scaffold/v1/controller/add.go
@@ -45,7 +45,7 @@ func (a *AddController) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var addControllerTemplate = `{{ .Boilerplate }}
+const addControllerTemplate = `{{ .Boilerplate }}
 
 package controller
 

--- a/pkg/scaffold/v1/controller/controller.go
+++ b/pkg/scaffold/v1/controller/controller.go
@@ -97,7 +97,7 @@ func getResourceInfo(coreGroups map[string]string, r *resource.Resource, in inpu
 	return path.Join(in.Repo, "pkg", "apis"), r.Group + "." + in.Domain
 }
 
-var controllerTemplate = `{{ .Boilerplate }}
+const controllerTemplate = `{{ .Boilerplate }}
 
 package {{ lower .Resource.Kind }}
 

--- a/pkg/scaffold/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/v1/controller/controllersuitetest.go
@@ -42,7 +42,7 @@ func (a *SuiteTest) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var controllerSuiteTestTemplate = `{{ .Boilerplate }}
+const controllerSuiteTestTemplate = `{{ .Boilerplate }}
 
 package {{ lower .Resource.Kind }}
 

--- a/pkg/scaffold/v1/controller/controllertest.go
+++ b/pkg/scaffold/v1/controller/controllertest.go
@@ -66,7 +66,7 @@ func (a *Test) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var controllerTestTemplate = `{{ .Boilerplate }}
+const controllerTestTemplate = `{{ .Boilerplate }}
 
 package {{ lower .Resource.Kind }}
 

--- a/pkg/scaffold/v1/crd/addtoscheme.go
+++ b/pkg/scaffold/v1/crd/addtoscheme.go
@@ -52,7 +52,7 @@ func (a *AddToScheme) Validate() error {
 // NB(directxman12): we need that package alias on the API import otherwise imports.Process
 // gets wicked (or hella, if you're feeling west-coasty) confused.
 
-var addResourceTemplate = `{{ .Boilerplate }}
+const addResourceTemplate = `{{ .Boilerplate }}
 
 package apis
 

--- a/pkg/scaffold/v1/crd/crd_sample.go
+++ b/pkg/scaffold/v1/crd/crd_sample.go
@@ -52,7 +52,7 @@ func (c *CRDSample) Validate() error {
 	return c.Resource.Validate()
 }
 
-var crdSampleTemplate = `apiVersion: {{ .Resource.Group }}.{{ .Domain }}/{{ .Resource.Version }}
+const crdSampleTemplate = `apiVersion: {{ .Resource.Group }}.{{ .Domain }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:
   labels:

--- a/pkg/scaffold/v1/crd/doc.go
+++ b/pkg/scaffold/v1/crd/doc.go
@@ -50,7 +50,7 @@ func (a *Doc) Validate() error {
 	return a.Resource.Validate()
 }
 
-var docGoTemplate = `{{ .Boilerplate }}
+const docGoTemplate = `{{ .Boilerplate }}
 
 // Package {{.Resource.Version}} contains API Schema definitions for the {{ .Resource.GroupImportSafe }} {{.Resource.Version}} API group
 // +k8s:openapi-gen=true

--- a/pkg/scaffold/v1/crd/group.go
+++ b/pkg/scaffold/v1/crd/group.go
@@ -47,7 +47,7 @@ func (g *Group) Validate() error {
 	return g.Resource.Validate()
 }
 
-var groupTemplate = `{{ .Boilerplate }}
+const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.GroupImportSafe }} contains {{ .Resource.Group }} API versions
 package {{ .Resource.GroupImportSafe }}

--- a/pkg/scaffold/v1/crd/register.go
+++ b/pkg/scaffold/v1/crd/register.go
@@ -47,7 +47,7 @@ func (r *Register) Validate() error {
 	return r.Resource.Validate()
 }
 
-var registerTemplate = `{{ .Boilerplate }}
+const registerTemplate = `{{ .Boilerplate }}
 
 // NOTE: Boilerplate only.  Ignore this file.
 

--- a/pkg/scaffold/v1/crd/types.go
+++ b/pkg/scaffold/v1/crd/types.go
@@ -51,7 +51,7 @@ func (t *Types) Validate() error {
 	return t.Resource.Validate()
 }
 
-var typesTemplate = `{{ .Boilerplate }}
+const typesTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}
 

--- a/pkg/scaffold/v1/crd/typestest.go
+++ b/pkg/scaffold/v1/crd/typestest.go
@@ -51,7 +51,7 @@ func (t *TypesTest) Validate() error {
 	return t.Resource.Validate()
 }
 
-var typesTestTemplate = `{{ .Boilerplate }}
+const typesTestTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}
 

--- a/pkg/scaffold/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/v1/crd/version_suitetest.go
@@ -49,7 +49,7 @@ func (v *VersionSuiteTest) Validate() error {
 	return v.Resource.Validate()
 }
 
-var versionSuiteTestTemplate = `{{ .Boilerplate }}
+const versionSuiteTestTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}
 

--- a/pkg/scaffold/v1/kustomize_image_patch.go
+++ b/pkg/scaffold/v1/kustomize_image_patch.go
@@ -46,7 +46,7 @@ func (c *KustomizeImagePatch) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeImagePatchTemplate = `apiVersion: apps/v1
+const kustomizeImagePatchTemplate = `apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: controller-manager

--- a/pkg/scaffold/v1/manager/apis.go
+++ b/pkg/scaffold/v1/manager/apis.go
@@ -58,7 +58,7 @@ func (a *APIs) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var apisTemplate = `{{ .Boilerplate }}
+const apisTemplate = `{{ .Boilerplate }}
 
 {{ range $line := .Comments }}{{ $line }}
 {{ end }}

--- a/pkg/scaffold/v1/manager/cmd.go
+++ b/pkg/scaffold/v1/manager/cmd.go
@@ -38,7 +38,7 @@ func (a *Cmd) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var cmdTemplate = `{{ .Boilerplate }}
+const cmdTemplate = `{{ .Boilerplate }}
 
 package main
 

--- a/pkg/scaffold/v1/manager/config.go
+++ b/pkg/scaffold/v1/manager/config.go
@@ -40,7 +40,7 @@ func (c *Config) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var configTemplate = `apiVersion: v1
+const configTemplate = `apiVersion: v1
 kind: Namespace
 metadata:
   labels:

--- a/pkg/scaffold/v1/manager/controller.go
+++ b/pkg/scaffold/v1/manager/controller.go
@@ -38,7 +38,7 @@ func (c *Controller) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var controllerTemplate = `{{ .Boilerplate }}
+const controllerTemplate = `{{ .Boilerplate }}
 
 package controller
 

--- a/pkg/scaffold/v1/manager/dockerfile.go
+++ b/pkg/scaffold/v1/manager/dockerfile.go
@@ -36,7 +36,7 @@ func (c *Dockerfile) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var dockerfileTemplate = `# Build the manager binary
+const dockerfileTemplate = `# Build the manager binary
 FROM golang:1.10.3 as builder
 
 # Copy in the go src

--- a/pkg/scaffold/v1/manager/webhook.go
+++ b/pkg/scaffold/v1/manager/webhook.go
@@ -38,7 +38,7 @@ func (c *Webhook) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var webhookTemplate = `{{ .Boilerplate }}
+const webhookTemplate = `{{ .Boilerplate }}
 
 package webhook
 

--- a/pkg/scaffold/v1/metricsauth/kustomize_auth_proxy_patch.go
+++ b/pkg/scaffold/v1/metricsauth/kustomize_auth_proxy_patch.go
@@ -40,7 +40,7 @@ func (c *KustomizeAuthProxyPatch) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
+const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
 # it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: StatefulSet

--- a/pkg/scaffold/v1/metricsauth/kustomize_metrics_patch.go
+++ b/pkg/scaffold/v1/metricsauth/kustomize_metrics_patch.go
@@ -40,7 +40,7 @@ func (c *KustomizePrometheusMetricsPatch) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizePrometheusMetricsPatchTemplate = `# This patch enables Prometheus scraping for the manager pod.
+const kustomizePrometheusMetricsPatchTemplate = `# This patch enables Prometheus scraping for the manager pod.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/pkg/scaffold/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/v1/webhook/add_admissionbuilder_handler.go
@@ -49,7 +49,7 @@ func (a *AddAdmissionWebhookBuilderHandler) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var addAdmissionWebhookBuilderHandlerTemplate = `{{ .Boilerplate }}
+const addAdmissionWebhookBuilderHandlerTemplate = `{{ .Boilerplate }}
 
 package {{ .Server }}server
 

--- a/pkg/scaffold/v1/webhook/add_server.go
+++ b/pkg/scaffold/v1/webhook/add_server.go
@@ -45,7 +45,7 @@ func (a *AddServer) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var addServerTemplate = `{{ .Boilerplate }}
+const addServerTemplate = `{{ .Boilerplate }}
 
 package webhook
 

--- a/pkg/scaffold/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/v1/webhook/admissionbuilder.go
@@ -75,7 +75,7 @@ func (a *AdmissionWebhookBuilder) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var admissionWebhookBuilderTemplate = `{{ .Boilerplate }}
+const admissionWebhookBuilderTemplate = `{{ .Boilerplate }}
 
 package {{ .Type }}
 

--- a/pkg/scaffold/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/v1/webhook/admissionhandler.go
@@ -74,7 +74,7 @@ func (a *AdmissionHandler) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var addAdmissionHandlerTemplate = `{{ .Boilerplate }}
+const addAdmissionHandlerTemplate = `{{ .Boilerplate }}
 
 package {{ .Type }}
 

--- a/pkg/scaffold/v1/webhook/admissionwebhooks.go
+++ b/pkg/scaffold/v1/webhook/admissionwebhooks.go
@@ -51,7 +51,7 @@ func (a *AdmissionWebhooks) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var webhooksTemplate = `{{ .Boilerplate }}
+const webhooksTemplate = `{{ .Boilerplate }}
 
 package {{ .Type }}
 

--- a/pkg/scaffold/v1/webhook/server.go
+++ b/pkg/scaffold/v1/webhook/server.go
@@ -45,7 +45,7 @@ func (a *Server) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var serverTemplate = `{{ .Boilerplate }}
+const serverTemplate = `{{ .Boilerplate }}
 
 package {{ .Server }}server
 

--- a/pkg/scaffold/v2/authproxyservice.go
+++ b/pkg/scaffold/v2/authproxyservice.go
@@ -38,7 +38,7 @@ func (r *AuthProxyService) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var AuthProxyServiceTemplate = `apiVersion: v1
+const AuthProxyServiceTemplate = `apiVersion: v1
 kind: Service
 metadata:
   labels:

--- a/pkg/scaffold/v2/certmanager/certificate.go
+++ b/pkg/scaffold/v2/certmanager/certificate.go
@@ -36,7 +36,7 @@ func (p *CertManager) GetInput() (input.Input, error) {
 	return p.Input, nil
 }
 
-var certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.
+const certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
 apiVersion: cert-manager.io/v1alpha2

--- a/pkg/scaffold/v2/certmanager/kustomize.go
+++ b/pkg/scaffold/v2/certmanager/kustomize.go
@@ -36,7 +36,7 @@ func (p *Kustomization) GetInput() (input.Input, error) {
 	return p.Input, nil
 }
 
-var kustomizationTemplate = `resources:
+const kustomizationTemplate = `resources:
 - certificate.yaml
 
 configurations:

--- a/pkg/scaffold/v2/certmanager/kustomizeconfig.go
+++ b/pkg/scaffold/v2/certmanager/kustomizeconfig.go
@@ -36,7 +36,7 @@ func (p *KustomizeConfig) GetInput() (input.Input, error) {
 	return p.Input, nil
 }
 
-var kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
+const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/pkg/scaffold/v2/controller.go
+++ b/pkg/scaffold/v2/controller.go
@@ -64,7 +64,7 @@ func (a *Controller) GetInput() (input.Input, error) {
 	return a.Input, nil
 }
 
-var controllerTemplate = `{{ .Boilerplate }}
+const controllerTemplate = `{{ .Boilerplate }}
 
 package controllers
 

--- a/pkg/scaffold/v2/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller_suitetest.go
@@ -61,7 +61,7 @@ func (v *ControllerSuiteTest) Validate() error {
 	return v.Resource.Validate()
 }
 
-var controllerSuiteTestTemplate = `{{ .Boilerplate }}
+const controllerSuiteTestTemplate = `{{ .Boilerplate }}
 
 package controllers
 

--- a/pkg/scaffold/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/v2/crd/enablecainjection_patch.go
@@ -51,7 +51,7 @@ func (g *EnableCAInjectionPatch) Validate() error {
 	return g.Resource.Validate()
 }
 
-var EnableCAInjectionPatchTemplate = `# The following patch adds a directive for certmanager to inject CA into the CRD
+const EnableCAInjectionPatchTemplate = `# The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/pkg/scaffold/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/v2/crd/enablewebhook_patch.go
@@ -51,7 +51,7 @@ func (g *EnableWebhookPatch) Validate() error {
 	return g.Resource.Validate()
 }
 
-var enableWebhookPatchTemplate = `# The following patch enables conversion webhook for CRD
+const enableWebhookPatchTemplate = `# The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/pkg/scaffold/v2/crd/kustomizeconfig.go
+++ b/pkg/scaffold/v2/crd/kustomizeconfig.go
@@ -39,7 +39,7 @@ func (c *KustomizeConfig) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeConfigTemplate = `# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+const kustomizeConfigTemplate = `# This file is for teaching kustomize how to substitute name and namespace reference in CRD
 nameReference:
 - kind: Service
   version: v1

--- a/pkg/scaffold/v2/crd_sample.go
+++ b/pkg/scaffold/v2/crd_sample.go
@@ -52,7 +52,7 @@ func (c *CRDSample) Validate() error {
 	return c.Resource.Validate()
 }
 
-var crdSampleTemplate = `apiVersion: {{ .Resource.Group }}.{{ .Domain }}/{{ .Resource.Version }}
+const crdSampleTemplate = `apiVersion: {{ .Resource.Group }}.{{ .Domain }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:
   name: {{ lower .Resource.Kind }}-sample

--- a/pkg/scaffold/v2/dockerfile.go
+++ b/pkg/scaffold/v2/dockerfile.go
@@ -36,7 +36,7 @@ func (c *Dockerfile) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var dockerfileTemplate = `# Build the manager binary
+const dockerfileTemplate = `# Build the manager binary
 FROM golang:1.13 as builder
 
 WORKDIR /workspace

--- a/pkg/scaffold/v2/gomod.go
+++ b/pkg/scaffold/v2/gomod.go
@@ -38,7 +38,7 @@ func (g *GoMod) GetInput() (input.Input, error) {
 	return g.Input, nil
 }
 
-var goModTemplate = `
+const goModTemplate = `
 module {{ .Repo }}
 
 go 1.13

--- a/pkg/scaffold/v2/group.go
+++ b/pkg/scaffold/v2/group.go
@@ -47,7 +47,7 @@ func (g *Group) Validate() error {
 	return g.Resource.Validate()
 }
 
-var groupTemplate = `{{ .Boilerplate }}
+const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{.Resource.Version}} contains API Schema definitions for the {{ .Resource.GroupImportSafe }} {{.Resource.Version}} API group
 // +kubebuilder:object:generate=true

--- a/pkg/scaffold/v2/kustomize.go
+++ b/pkg/scaffold/v2/kustomize.go
@@ -51,7 +51,7 @@ func (c *Kustomize) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeTemplate = `# Adds namespace to all resources.
+const kustomizeTemplate = `# Adds namespace to all resources.
 namespace: {{.Prefix}}-system
 
 # Value of this field is prepended to the

--- a/pkg/scaffold/v2/leaderelectionrole.go
+++ b/pkg/scaffold/v2/leaderelectionrole.go
@@ -38,7 +38,7 @@ func (r *LeaderElectionRole) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var leaderElectionRoleTemplate = `# permissions to do leader election.
+const leaderElectionRoleTemplate = `# permissions to do leader election.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/pkg/scaffold/v2/leaderelectionrolebinding.go
+++ b/pkg/scaffold/v2/leaderelectionrolebinding.go
@@ -38,7 +38,7 @@ func (r *LeaderElectionRoleBinding) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var leaderElectionRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+const leaderElectionRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: leader-election-rolebinding

--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -44,7 +44,7 @@ func (c *Makefile) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var makefileTemplate = `
+const makefileTemplate = `
 # Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/pkg/scaffold/v2/manager/config.go
+++ b/pkg/scaffold/v2/manager/config.go
@@ -40,7 +40,7 @@ func (c *Config) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var configTemplate = `apiVersion: v1
+const configTemplate = `apiVersion: v1
 kind: Namespace
 metadata:
   labels:

--- a/pkg/scaffold/v2/manager/kustomization.go
+++ b/pkg/scaffold/v2/manager/kustomization.go
@@ -39,6 +39,6 @@ func (c *Kustomization) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeManagerTemplate = `resources:
+const kustomizeManagerTemplate = `resources:
 - manager.yaml
 `

--- a/pkg/scaffold/v2/metricsauth/kustomize_auth_proxy_patch.go
+++ b/pkg/scaffold/v2/metricsauth/kustomize_auth_proxy_patch.go
@@ -40,7 +40,7 @@ func (c *KustomizeAuthProxyPatch) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
+const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
 # it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/scaffold/v2/mgrrolebinding.go
+++ b/pkg/scaffold/v2/mgrrolebinding.go
@@ -38,7 +38,7 @@ func (r *ManagerRoleBinding) GetInput() (input.Input, error) {
 	return r.Input, nil
 }
 
-var managerBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+const managerBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: manager-rolebinding
@@ -51,4 +51,3 @@ subjects:
   name: default
   namespace: system
 `
-

--- a/pkg/scaffold/v2/prometheus/kustomize.go
+++ b/pkg/scaffold/v2/prometheus/kustomize.go
@@ -35,7 +35,6 @@ func (p *Kustomization) GetInput() (input.Input, error) {
 	return p.Input, nil
 }
 
-var kustomizationTemplate = `resources:
+const kustomizationTemplate = `resources:
 - monitor.yaml
 `
-

--- a/pkg/scaffold/v2/prometheus/monitor.go
+++ b/pkg/scaffold/v2/prometheus/monitor.go
@@ -19,7 +19,7 @@ func (p *PrometheusServiceMonitor) GetInput() (input.Input, error) {
 	return p.Input, nil
 }
 
-var monitorTemplate = `
+const monitorTemplate = `
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/pkg/scaffold/v2/rbac.go
+++ b/pkg/scaffold/v2/rbac.go
@@ -39,7 +39,7 @@ func (c *KustomizeRBAC) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var kustomizeRBACTemplate = `resources:
+const kustomizeRBACTemplate = `resources:
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/pkg/scaffold/v2/types.go
+++ b/pkg/scaffold/v2/types.go
@@ -51,7 +51,7 @@ func (t *Types) Validate() error {
 	return t.Resource.Validate()
 }
 
-var typesTemplate = `{{ .Boilerplate }}
+const typesTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}
 

--- a/pkg/scaffold/v2/webhook/enablecainection_patch.go
+++ b/pkg/scaffold/v2/webhook/enablecainection_patch.go
@@ -39,7 +39,7 @@ func (c *InjectCAPatch) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var injectCAPatchTemplate = `# This patch add annotation to admission webhook config and
+const injectCAPatchTemplate = `# This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration

--- a/pkg/scaffold/v2/webhook/kustomization.go
+++ b/pkg/scaffold/v2/webhook/kustomization.go
@@ -39,7 +39,7 @@ func (c *Kustomization) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var KustomizeWebhookTemplate = `resources:
+const KustomizeWebhookTemplate = `resources:
 - manifests.yaml
 - service.yaml
 

--- a/pkg/scaffold/v2/webhook/kustomizeconfig.go
+++ b/pkg/scaffold/v2/webhook/kustomizeconfig.go
@@ -39,7 +39,7 @@ func (c *KustomizeConfigWebhook) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var KustomizeConfigWebhookTemplate = `# the following config is for teaching kustomize where to look at when substituting vars.
+const KustomizeConfigWebhookTemplate = `# the following config is for teaching kustomize where to look at when substituting vars.
 # It requires kustomize v2.1.0 or newer to work properly.
 nameReference:
 - kind: Service

--- a/pkg/scaffold/v2/webhook/service.go
+++ b/pkg/scaffold/v2/webhook/service.go
@@ -39,7 +39,7 @@ func (c *Service) GetInput() (input.Input, error) {
 	return c.Input, nil
 }
 
-var ServiceTemplate = `
+const ServiceTemplate = `
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -68,14 +68,15 @@ func (a *Webhook) GetInput() (input.Input, error) {
 		a.Path = filepath.Join("api", a.Resource.Version,
 			fmt.Sprintf("%s_webhook.go", strings.ToLower(a.Resource.Kind)))
 	}
+	webhookTemplate := WebhookTemplate
 	if a.Defaulting {
-		WebhookTemplate = WebhookTemplate + DefaultingWebhookTemplate
+		webhookTemplate = webhookTemplate + DefaultingWebhookTemplate
 	}
 	if a.Validating {
-		WebhookTemplate = WebhookTemplate + ValidatingWebhookTemplate
+		webhookTemplate = webhookTemplate + ValidatingWebhookTemplate
 	}
 
-	a.TemplateBody = WebhookTemplate
+	a.TemplateBody = webhookTemplate
 	a.Input.IfExistsAction = input.Error
 	return a.Input, nil
 }
@@ -85,7 +86,7 @@ func (g *Webhook) Validate() error {
 	return g.Resource.Validate()
 }
 
-var (
+const (
 	WebhookTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}

--- a/pkg/scaffold/v2/webhook_manager_patch.go
+++ b/pkg/scaffold/v2/webhook_manager_patch.go
@@ -36,7 +36,7 @@ func (p *ManagerWebhookPatch) GetInput() (input.Input, error) {
 	return p.Input, nil
 }
 
-var ManagerWebhookPatchTemplate = `apiVersion: apps/v1
+const ManagerWebhookPatchTemplate = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager

--- a/plugins/addon/controller.go
+++ b/plugins/addon/controller.go
@@ -28,7 +28,7 @@ func ReplaceController(u *model.Universe) error {
 	return nil
 }
 
-var controllerTemplate = `{{ .Boilerplate }}
+const controllerTemplate = `{{ .Boilerplate }}
 
 package controllers
 

--- a/plugins/addon/type.go
+++ b/plugins/addon/type.go
@@ -37,7 +37,7 @@ func JSONTag(tag string) string {
 
 // Resource.Resource
 
-var typesTemplate = `{{ .Boilerplate }}
+const typesTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}
 


### PR DESCRIPTION
Fix a place where we rewrote a shared template value and potentially
made it unsafe for concurrent / repeated evaluation.  Also mark the
templates as const to have the compiler help us stick to it!