### PR TITLE
Unused exported functions removal

### DIFF
--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -17,137 +17,14 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
-	"fmt"
-	"go/format"
-	"io/ioutil"
-	"log"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"text/template"
-
-	"github.com/gobuffalo/flect"
 )
 
-// writeIfNotFound returns true if the file was created and false if it already exists
-func WriteIfNotFound(path, templateName, templateValue string, data interface{}) bool {
-	// Make sure the directory exists
-	os.MkdirAll(filepath.Dir(path), 0700)
-
-	// Don't create the doc.go if it exists
-	if _, err := os.Stat(path); err == nil {
-		return false
-	} else if !os.IsNotExist(err) {
-		log.Fatalf("Could not stat %s: %v", path, err)
-	}
-
-	return Write(path, templateName, templateValue, data)
-}
-
-func Write(path, templateName, templateValue string, data interface{}) bool {
-	t := template.Must(template.New(templateName).Funcs(
-		template.FuncMap{
-			"title":  strings.Title,
-			"lower":  strings.ToLower,
-			"plural": flect.Pluralize,
-		},
-	).Parse(templateValue))
-
-	var tmp bytes.Buffer
-	err := t.Execute(&tmp, data)
-	if err != nil {
-		log.Fatalf("Failed to render template %s: %v", templateName, err)
-	}
-
-	content := tmp.Bytes()
-	if filepath.Ext(path) == ".go" {
-		content, err = format.Source(content)
-		if err != nil {
-			log.Fatalf("Failed to format template %s: %v", templateName, err)
-		}
-	}
-
-	WriteString(path, string(content))
-
-	return true
-}
-
-func WriteString(path, value string) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		create(path)
-	}
-
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
-	if err != nil {
-		log.Fatalf("Failed to create %s: %v", path, err)
-	}
-	defer f.Close()
-
-	_, err = f.WriteString(value)
-	if err != nil {
-		log.Fatalf("Failed to write %s: %v", path, err)
-	}
-}
-
-// GetCopyright will return the contents of the copyright file if it exists.
-// if the file cannot be read, will return the empty string.
-func GetCopyright(file string) string {
-	if len(file) == 0 {
-		file = filepath.Join("hack", "boilerplate.go.txt")
-	}
-	cr, err := ioutil.ReadFile(file)
-	if err != nil {
-		return ""
-	}
-	return string(cr)
-}
-
-func create(path string) {
-	f, err := os.Create(path)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	defer f.Close()
-}
-
-func DoCmd(cmd string, args ...string) {
-	c := exec.Command(cmd, args...)
-	c.Stderr = os.Stderr
-	c.Stdout = os.Stdout
-	log.Printf("%s\n", strings.Join(c.Args, " "))
-	err := c.Run()
-	if err != nil {
-		log.Fatalf("command failed %v", err)
-	}
-}
-
-func IsNewVersion() bool {
+func ProjectExist() bool {
 	_, err := os.Stat("PROJECT")
 	if err != nil {
 		return false
 	}
 
-	return true
-}
-
-func ProjectExist() bool {
-	return IsNewVersion()
-}
-
-func IsProjectNotInitialized() bool {
-	dirs := []string{
-		"cmd",
-		"hack",
-		"pkg",
-		"vendor",
-	}
-	for _, dir := range dirs {
-		if _, err := os.Stat(dir); err == nil {
-			return false
-		}
-	}
 	return true
 }


### PR DESCRIPTION
Evaluate and remove non-needed exported functions or at least make them non-exported to reduce the API surface.

### Linter message:
> Unused exported function inspection

### Linter description:
> Reports unused exported functions.

Closes: #1178

/kind cleanup