### PR TITLE
Remove duplicate code

### DIFF
--- a/pkg/scaffold/output.go
+++ b/pkg/scaffold/output.go
@@ -52,9 +52,6 @@ func (fw *FileWriter) WriteCloser(path string) (io.Writer, error) {
 
 // WriteFile write given content to the file path
 func (fw *FileWriter) WriteFile(filePath string, content []byte) error {
-	if fw.Fs == nil {
-		fw.Fs = afero.NewOsFs()
-	}
 	f, err := fw.WriteCloser(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %v", filePath, err)


### PR DESCRIPTION
Tiny PR that removes the filesystem creation if it is `nil` as that is already being done at the start of `WriteCloser` method that is called right away.

/kind cleanup