### PR TITLE
:running: fix kubebuilder go links

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -69,25 +69,25 @@
 
 [[redirects]]
     from = "https://go.kubebuilder.io/test-tools"
-    to = "https://console.cloud.google.com/storage/browser/kubebuilder-tools"
+    to = "https://storage.googleapis.com/kubebuilder-tools"
     status = 302
     force = true
 
 [[redirects]]
     from = "https://go.kubebuilder.io/test-tools/:version"
-    to = "https://console.cloud.google.com/storage/browser/kubebuilder-tools/?prefix=kubebuilder-tools-:version"
+    to = "https://storage.googleapis.com/kubebuilder-tools/?prefix=kubebuilder-tools-:version"
     status = 302
     force = true
 
 [[redirects]]
     from = "https://go.kubebuilder.io/test-tools/:version/:os"
-    to = "https://console.cloud.google.com/storage/browser/_details/kubebuilder-tools/kubebuilder-tools-:version-:os-amd64.tar.gz"
+    to = "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-:version-:os-amd64.tar.gz"
     status = 302
     force = true
 
 [[redirects]]
     from = "https://go.kubebuilder.io/test-tools/:version/:os/:arch"
-    to = "https://console.cloud.google.com/storage/browser/_details/kubebuilder-tools/kubebuilder-tools-:version-:os-:arch.tar.gz"
+    to = "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-:version-:os-:arch.tar.gz"
     status = 302
     force = true
 


### PR DESCRIPTION
URL starting with `console.cloud.google.com` requires user to login before download anything. This defeat our purpose of making these public accessible.
This PR switch them to use `storage.googleapis.com` which doesn't require anything if the file to download is public.
