### PR TITLE
Remove scaffolding fields that were not used

### DIFF
--- a/cmd/webhook_v1.go
+++ b/cmd/webhook_v1.go
@@ -77,8 +77,8 @@ This command is only available for v1 scaffolding project.
 				&webhook.AdmissionWebhookBuilder{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
 				&webhook.AdmissionWebhooks{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
 				&webhook.AddAdmissionWebhookBuilderHandler{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
-				&webhook.Server{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
-				&webhook.AddServer{Resource: o.res, Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.Server{Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
+				&webhook.AddServer{Config: webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}},
 			)
 			if err != nil {
 				log.Fatal(err)

--- a/pkg/scaffold/v1/crd/doc.go
+++ b/pkg/scaffold/v1/crd/doc.go
@@ -31,9 +31,6 @@ type Doc struct {
 
 	// Resource is a resource for the API version
 	Resource *resource.Resource
-
-	// Comments are additional lines to write to the doc.go file
-	Comments []string
 }
 
 // GetInput implements input.File

--- a/pkg/scaffold/v1/webhook/add_server.go
+++ b/pkg/scaffold/v1/webhook/add_server.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
-	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
 var _ input.File = &AddServer{}
@@ -29,9 +28,6 @@ var _ input.File = &AddServer{}
 // AddServer scaffolds adds a new webhook server.
 type AddServer struct {
 	input.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
 
 	Config
 }

--- a/pkg/scaffold/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/v1/webhook/admissionbuilder.go
@@ -37,9 +37,6 @@ type AdmissionWebhookBuilder struct {
 	// ResourcePackage is the package of the Resource
 	ResourcePackage string
 
-	// GroupDomain is the Group + "." + Domain for the Resource
-	GroupDomain string
-
 	Config
 
 	BuilderName string
@@ -51,7 +48,7 @@ type AdmissionWebhookBuilder struct {
 
 // GetInput implements input.File
 func (a *AdmissionWebhookBuilder) GetInput() (input.Input, error) {
-	a.ResourcePackage, a.GroupDomain = getResourceInfo(coreGroups, a.Resource, a.Input)
+	a.ResourcePackage, _ = getResourceInfo(coreGroups, a.Resource, a.Input)
 
 	if a.Type == "mutating" {
 		a.Mutating = true

--- a/pkg/scaffold/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/v1/webhook/admissionhandler.go
@@ -34,9 +34,6 @@ type AdmissionHandler struct {
 	// ResourcePackage is the package of the Resource
 	ResourcePackage string
 
-	// GroupDomain is the Group + "." + Domain for the Resource
-	GroupDomain string
-
 	// Resource is a resource in the API group
 	Resource *resource.Resource
 
@@ -51,7 +48,7 @@ type AdmissionHandler struct {
 
 // GetInput implements input.File
 func (a *AdmissionHandler) GetInput() (input.Input, error) {
-	a.ResourcePackage, a.GroupDomain = getResourceInfo(coreGroups, a.Resource, a.Input)
+	a.ResourcePackage, _ = getResourceInfo(coreGroups, a.Resource, a.Input)
 	a.Type = strings.ToLower(a.Type)
 	if a.Type == "mutating" {
 		a.Mutate = true

--- a/pkg/scaffold/v1/webhook/server.go
+++ b/pkg/scaffold/v1/webhook/server.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
-	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
 var _ input.File = &Server{}
@@ -29,9 +28,6 @@ var _ input.File = &Server{}
 // Server scaffolds how to construct a webhook server and register webhooks.
 type Server struct {
 	input.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
 
 	Config
 }

--- a/pkg/scaffold/v1/webhook/webhook_test.go
+++ b/pkg/scaffold/v1/webhook/webhook_test.go
@@ -20,7 +20,6 @@ var _ = Describe("Webhook", func() {
 	}
 
 	serverName := "default"
-	domainName := "testproject.org"
 	inputs := []*webhookTestcase{
 		{
 			Resource: resource.Resource{Group: "crew", Version: "v1", Kind: "FirstMate", Namespaced: true, CreateExampleReconcileBody: true},
@@ -74,14 +73,12 @@ var _ = Describe("Webhook", func() {
 				{
 					file: filepath.Join("pkg", "webhook", "add_default_server.go"),
 					instance: &AddServer{
-						Resource: &in.Resource,
 						Config:   in.Config,
 					},
 				},
 				{
 					file: filepath.Join("pkg", "webhook", "default_server", "server.go"),
 					instance: &Server{
-						Resource: &in.Resource,
 						Config:   in.Config,
 					},
 				},
@@ -117,7 +114,6 @@ var _ = Describe("Webhook", func() {
 					instance: &AdmissionWebhookBuilder{
 						Resource:    &in.Resource,
 						Config:      in.Config,
-						GroupDomain: domainName,
 					},
 				},
 				{
@@ -127,7 +123,6 @@ var _ = Describe("Webhook", func() {
 					instance: &AdmissionHandler{
 						Resource:    &in.Resource,
 						Config:      in.Config,
-						GroupDomain: domainName,
 					},
 				},
 			}

--- a/pkg/scaffold/v2/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller_suitetest.go
@@ -19,9 +19,7 @@ package v2
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
-	"github.com/gobuffalo/flect"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/util"
@@ -36,15 +34,6 @@ type ControllerSuiteTest struct {
 
 	// Resource is the resource to scaffold the controller_kind_test.go file for
 	Resource *resource.Resource
-
-	// ResourcePackage is the package of the Resource
-	ResourcePackage string
-
-	// Plural is the plural lowercase of kind
-	Plural string
-
-	// Is the Group + "." + Domain for the Resource
-	GroupDomain string
 }
 
 // GetInput implements input.File
@@ -130,15 +119,12 @@ var _ = AfterSuite(func() {
 // adding import paths and code setup for new types.
 func (a *ControllerSuiteTest) Update() error {
 
-	a.ResourcePackage, a.GroupDomain = util.GetResourceInfo(a.Resource, a.Repo, a.Domain)
-	if a.Plural == "" {
-		a.Plural = flect.Pluralize(strings.ToLower(a.Resource.Kind))
-	}
+	resourcePackage, _ := util.GetResourceInfo(a.Resource, a.Repo, a.Domain)
 
 	ctrlImportCodeFragment := fmt.Sprintf(`"%s/controllers"
 `, a.Repo)
 	apiImportCodeFragment := fmt.Sprintf(`%s%s "%s/%s"
-`, a.Resource.GroupImportSafe, a.Resource.Version, a.ResourcePackage, a.Resource.Version)
+`, a.Resource.GroupImportSafe, a.Resource.Version, resourcePackage, a.Resource.Version)
 
 	addschemeCodeFragment := fmt.Sprintf(`err = %s%s.AddToScheme(scheme.Scheme)
 Expect(err).NotTo(HaveOccurred())

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -35,9 +35,6 @@ type Webhook struct {
 	// Resource is the Resource to make the Webhook for
 	Resource *resource.Resource
 
-	// ResourcePackage is the package of the Resource
-	ResourcePackage string
-
 	// Plural is the plural lowercase of kind
 	Plural string
 
@@ -56,7 +53,7 @@ type Webhook struct {
 // GetInput implements input.File
 func (a *Webhook) GetInput() (input.Input, error) {
 
-	a.ResourcePackage, a.GroupDomain = util.GetResourceInfo(a.Resource, a.Repo, a.Domain)
+	_, a.GroupDomain = util.GetResourceInfo(a.Resource, a.Repo, a.Domain)
 
 	a.GroupDomainWithDash = strings.Replace(a.GroupDomain, ".", "-", -1)
 


### PR DESCRIPTION
Removes some fields that `File` structs had but are not being used.

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.

/kind cleanup
