### PR TITLE
:bug: end users should not have permissions to edit */status

### DIFF
--- a/pkg/scaffold/v2/crd_editor_rbac.go
+++ b/pkg/scaffold/v2/crd_editor_rbac.go
@@ -50,7 +50,7 @@ func (g *CRDEditorRole) Validate() error {
 	return g.Resource.Validate()
 }
 
-const crdRoleEditorTemplate = `# permissions to do edit {{ .Resource.Resource }}.
+const crdRoleEditorTemplate = `# permissions for end users to edit {{ .Resource.Resource }}.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -74,6 +74,4 @@ rules:
   - {{ .Resource.Resource }}/status
   verbs:
   - get
-  - patch
-  - update
 `

--- a/pkg/scaffold/v2/crd_viewer_rbac.go
+++ b/pkg/scaffold/v2/crd_viewer_rbac.go
@@ -50,7 +50,7 @@ func (g *CRDViewerRole) Validate() error {
 	return g.Resource.Validate()
 }
 
-const crdRoleViewerTemplate = `# permissions to do viewer {{ .Resource.Resource }}.
+const crdRoleViewerTemplate = `# permissions for end users to view {{ .Resource.Resource }}.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v2/config/rbac/admiral_editor_role.yaml
+++ b/testdata/project-v2/config/rbac/admiral_editor_role.yaml
@@ -1,4 +1,4 @@
-# permissions to do edit admirals.
+# permissions for end users to edit admirals.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,5 +22,3 @@ rules:
   - admirals/status
   verbs:
   - get
-  - patch
-  - update

--- a/testdata/project-v2/config/rbac/admiral_viewer_role.yaml
+++ b/testdata/project-v2/config/rbac/admiral_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions to do viewer admirals.
+# permissions for end users to view admirals.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v2/config/rbac/captain_editor_role.yaml
+++ b/testdata/project-v2/config/rbac/captain_editor_role.yaml
@@ -1,4 +1,4 @@
-# permissions to do edit captains.
+# permissions for end users to edit captains.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,5 +22,3 @@ rules:
   - captains/status
   verbs:
   - get
-  - patch
-  - update

--- a/testdata/project-v2/config/rbac/captain_viewer_role.yaml
+++ b/testdata/project-v2/config/rbac/captain_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions to do viewer captains.
+# permissions for end users to view captains.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v2/config/rbac/firstmate_editor_role.yaml
+++ b/testdata/project-v2/config/rbac/firstmate_editor_role.yaml
@@ -1,4 +1,4 @@
-# permissions to do edit firstmates.
+# permissions for end users to edit firstmates.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,5 +22,3 @@ rules:
   - firstmates/status
   verbs:
   - get
-  - patch
-  - update

--- a/testdata/project-v2/config/rbac/firstmate_viewer_role.yaml
+++ b/testdata/project-v2/config/rbac/firstmate_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions to do viewer firstmates.
+# permissions for end users to view firstmates.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
As @erictune pointed out in https://github.com/kubernetes-sigs/kubebuilder/pull/1165#discussion_r347689204, editor role is intended for end users which should not have permissions to edit `*/status`.

fixes #886 