### PR TITLE
fix typo/invalid link in the book

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -192,7 +192,7 @@ make deploy IMG=<some-registry>/<project-name>:tag
 <h1>RBAC errors</h1>
 
 If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin. See [Prerequisites for using Kubernetes RBAC on GKE cluster v1.11.x and older][pre-rbc-gke] which may can be your case.  
+privileges or be logged in as admin. See [Prerequisites for using Kubernetes RBAC on GKE cluster v1.11.x and older][pre-rbc-gke] which may be your case.  
 
 </aside> 
 

--- a/docs/book/src/reference/writing-tests.md
+++ b/docs/book/src/reference/writing-tests.md
@@ -3,7 +3,7 @@
 Testing Kubernetes controller is a big subject, and the boilerplate testing
 files generated for you by kubebuilder are fairly minimal.
 
-[Writing and Running Integration Tests](/reference/testing/integration.md) documents steps to consider when writing integration steps for your controllers, and available options for configuring your test control plane using [`envtest`](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/envtest).
+[Writing and Running Integration Tests](/reference/testing/envtest.md) documents steps to consider when writing integration steps for your controllers, and available options for configuring your test control plane using [`envtest`](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/envtest).
 
 Until more documentation has been written, your best bet to get started is to look at some
 existing examples, such as:


### PR DESCRIPTION
The envtest link was incorrect -- it should point to /reference/testing/envtest