### PR TITLE
Add interface validation check for missing types

### DIFF
--- a/pkg/scaffold/v1/controller/controller.go
+++ b/pkg/scaffold/v1/controller/controller.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
+var _ input.File = &Controller{}
+
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	input.Input

--- a/pkg/scaffold/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/v1/controller/controllersuitetest.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
+var _ input.File = &SuiteTest{}
+
 // SuiteTest scaffolds a SuiteTest
 type SuiteTest struct {
 	input.Input

--- a/pkg/scaffold/v1/controller/controllertest.go
+++ b/pkg/scaffold/v1/controller/controllertest.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
+var _ input.File = &Test{}
+
 // Test scaffolds a Controller Test
 type Test struct {
 	input.Input

--- a/pkg/scaffold/v2/certmanager/certificate.go
+++ b/pkg/scaffold/v2/certmanager/certificate.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
+var _ input.File = &CertManager{}
+
 // CertManager scaffolds an issuer CR and a certificate CR
 type CertManager struct {
 	input.Input

--- a/pkg/scaffold/v2/certmanager/kustomize.go
+++ b/pkg/scaffold/v2/certmanager/kustomize.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
+var _ input.File = &Kustomization{}
+
 // Kustomization scaffolds the kustomizaiton in the certmanager folder
 type Kustomization struct {
 	input.Input

--- a/pkg/scaffold/v2/certmanager/kustomizeconfig.go
+++ b/pkg/scaffold/v2/certmanager/kustomizeconfig.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
+var _ input.File = &KustomizeConfig{}
+
 // KustomizeConfig scaffolds the kustomizeconfig in the certmanager folder
 type KustomizeConfig struct {
 	input.Input

--- a/pkg/scaffold/v2/controller/controller.go
+++ b/pkg/scaffold/v2/controller/controller.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/util"
 )
 
+var _ input.File = &Controller{}
+
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	input.Input

--- a/pkg/scaffold/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/v2/crd/enablecainjection_patch.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
+var _ input.File = &EnableCAInjectionPatch{}
+
 // EnableCAInjectionPatch scaffolds a EnableCAInjectionPatch for a Resource
 type EnableCAInjectionPatch struct {
 	input.Input

--- a/pkg/scaffold/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/v2/crd/enablewebhook_patch.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 )
 
+var _ input.File = &EnableWebhookPatch{}
+
 // EnableWebhookPatch scaffolds a EnableWebhookPatch for a Resource
 type EnableWebhookPatch struct {
 	input.Input

--- a/pkg/scaffold/v2/prometheus/kustomize.go
+++ b/pkg/scaffold/v2/prometheus/kustomize.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
+var _ input.File = &Kustomization{}
+
 // Kustomization scaffolds the kustomizaiton in the prometheus folder
 type Kustomization struct {
 	input.Input

--- a/pkg/scaffold/v2/prometheus/monitor.go
+++ b/pkg/scaffold/v2/prometheus/monitor.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
+var _ input.File = &PrometheusServiceMonitor{}
+
 // PrometheusMetricsService scaffolds an issuer CR and a certificate CR
 type PrometheusServiceMonitor struct {
 	input.Input

--- a/pkg/scaffold/v2/webhook/webhook.go
+++ b/pkg/scaffold/v2/webhook/webhook.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/util"
 )
 
+var _ input.File = &Webhook{}
+
 // Webhook scaffolds a Webhook for a Resource
 type Webhook struct {
 	input.Input

--- a/pkg/scaffold/v2/webhook_manager_patch.go
+++ b/pkg/scaffold/v2/webhook_manager_patch.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 )
 
+var _ input.File = &ManagerWebhookPatch{}
+
 // CRDWebhookPatch scaffolds a CRDWebhookPatch for a Resource
 type ManagerWebhookPatch struct {
 	input.Input


### PR DESCRIPTION
### Description

Some structs that implemented `File` interface did not have the interface check that most of the structs had. This PR adds the missing ones.

### Motivation

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.

/kind cleanup
