### PR TITLE
designs: extensible CLI and scaffolding plugins

### DIFF
--- a/designs/extensible-cli-and-scaffolding-plugins.md
+++ b/designs/extensible-cli-and-scaffolding-plugins.md
@@ -1,0 +1,144 @@
+# Extensible CLI and Scaffolding Plugins
+
+## Overview 
+I would like for Kubebuilder to become more extensible, such that it could be imported and used as a library in other projects. Specifically, I'm looking for a way to use Kubebuilder's existing CLI and scaffolding for Go projects, but to also be able to augment Kubebuilder's project versions with other custom project versions so that I can support the Kubebuilder workflow with non-Go operators (e.g. operator-sdk's Ansible and Helm-based operators).
+
+The idea is for Kubebuilder to define one or more plugin interfaces that can be used to drive what the `init`, `create api` and `create webhooks` subcommands do and to add a new `cli` package that other projects can use to integrate out-of-tree plugins with the Kubebuilder CLI in their own projects.
+
+## Related issues and PRs
+
+* [#1148](https://github.com/kubernetes-sigs/kubebuilder/pull/1148)
+* [#1171](https://github.com/kubernetes-sigs/kubebuilder/pull/1171)
+* Possibly [#1218](https://github.com/kubernetes-sigs/kubebuilder/issues/1218)
+
+## Prototype implementation
+https://github.com/joelanford/kubebuilder-exp
+
+## Plugin interfaces
+
+### Required
+Each plugin would minimally be required to implement the `Plugin` interface.
+
+```go
+type Plugin interface {
+    // Version is the project version that this plugin implements.
+    // For example, Kubebuilder's Go v2 plugin implementation would return "2"
+    Version() string
+}
+```
+
+### Optional
+Next, a plugin could optionally implement further interfaces to declare its support for specific Kubebuilder subcommands. For example:
+* `InitPlugin` - to initialize new projects
+* `CreateAPIPlugin` - to create APIs (and possibly controllers) for existing projects
+* `CreateWebhookPlugin` - to create webhooks for existing projects
+
+Each of these interfaces would follow the same pattern (see the InitPlugin interface example below).
+
+```go
+type InitPlugin interface {
+    Plugin
+
+    // InitDescription returns a description of what this plugin initializes
+    // for a new project. It is used to display help.
+    InitDescription() string
+
+    // InitHelp returns one or more examples of the command-line usage
+    // of this plugin's project initialization support. It is used to display help.
+    InitExample() string
+
+    // BindInitFlags binds the plugin's init flags to the CLI. This allows each
+    // plugin to define its own command line flags for the `kubebuilder init`
+    // subcommand.
+    BindInitFlags(fs *pflag.FlagSet)
+
+    // Init initializes a project.
+    Init() error
+}
+```
+
+#### Deprecated Plugins
+
+To generically support deprecated project versions, we could also add a `Deprecated` interface that the CLI could use to decide when to print deprecation warnings:
+
+```go
+// Deprecated is an interface that, if implemented, informs the CLI
+// that the plugin is deprecated.  The CLI uses this to print deprecation
+// warnings when the plugin is in use.
+type Deprecated interface {
+    // DeprecationWarning returns a deprecation message that callers 
+    // can use to warn users of deprecations
+    DeprecationWarning() string
+}
+```
+
+## CLI
+
+To make the above plugin system extensible and usable by other projects, we could add a new CLI package that Kubebuilder (and other projects) could use as their entrypoint.
+
+Example Kubebuilder main.go:
+
+```go
+func main() {
+	c, err := cli.New(
+		cli.WithPlugins(
+			&golangv1.Plugin{},
+			&golangv2.Plugin{},
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := c.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+Example Operator SDK main.go:
+
+```go
+func main() {
+	c, err := cli.New(
+		cli.WithCommandName("operator-sdk"),
+		cli.WithDefaultProjectVersion("2"),
+		cli.WithExtraCommands(newCustomCobraCmd()),
+		cli.WithPlugins(
+			&golangv1.Plugin{},
+			&golangv2.Plugin{},
+			&helmv1.Plugin{},
+			&ansiblev1.Plugin{},
+		),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := c.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+## Comments & Questions
+
+### Cobra Commands
+As discussed earlier as part of [#1148](https://github.com/kubernetes-sigs/kubebuilder/pull/1148), one goal is to eliminate the use of `cobra.Command` in the exported API of Kubebuilder since that is considered an internal implementation detail. 
+
+However, at some point, projects that make use of this extensibility will likely want to integrate their own subcommands. In this proposal, `cli.WithExtraCommands()` _DOES_ expose `cobra.Command` to allow callers to pass their own subcommands to the CLI.
+
+In [#1148](https://github.com/kubernetes-sigs/kubebuilder/pull/1148), callers would use Kubebuilder's cobra commands to build their CLI. Here, control of the CLI is retained by Kubebuilder, and callers pass their subcommands to Kubebuilder. This has several benefits:
+1. Kubebuilder's CLI subcommands are never exposed except via the explicit plugin interface. This allows the Kubebuilder project to re-implement its subcommand internals without worrying about backwards compatibility of consumers of Kubebuilder's CLI.
+2. If desired, Kubebuilder could ensure that extra subcommands do not overwrite/reuse the existing Kubebuilder subcommand names. For example, only Kubebuilder gets to define the `init` subcommand
+3. The overall binary's help handling is self-contained in Kubebuilder's CLI. Callers don't have to figure out how to have a cohesive help output between the Kubebuilder CLI and their own custom subcommands.
+
+With all of that said, even this exposure of `cobra.Command` could be problematic. If Kubebuilder decides in the future to transition to a different CLI framework (or to roll its own) it has to either continue maintaining support for these extra cobra commands passed into it, or it was to break the CLI API.
+
+Are there other ideas for how to handle the following requirements?
+* Eliminate use of cobra in CLI interface
+* Allow other projects to have custom subcommands
+* Support cohesive help output
+
+### Other
+1. Should the `InitPlugin` interface methods be required of all plugins?
+2. Any other approaches or ideas?
+3. Anything I didn't cover that could use more explanation?


### PR DESCRIPTION
**Description of the change**
This PR adds a design proposal for Kubebuilder CLI and scaffolding extensibility

**Motivation for the change**
To achieve agreement on a way forward for Kubebuilder CLI and scaffolding extensibility so that the Kubernetes controller/operator communities can align on Go project layouts and enable extension points for other customizations.