### PR TITLE
Named arguments for path formatting

### DIFF
--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -17,6 +17,9 @@ limitations under the License.
 package resource
 
 import (
+	"fmt"
+	"strings"
+
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 )
 
@@ -61,4 +64,20 @@ func (r *Resource) GVK() config.GVK {
 		Version: r.Version,
 		Kind:    r.Kind,
 	}
+}
+
+func wrapKey(key string) string {
+	return fmt.Sprintf("%%[%s]", key)
+}
+
+func (r Resource) Replacer() *strings.Replacer {
+	var replacements []string
+
+	replacements = append(replacements, wrapKey("group"), r.Group)
+	replacements = append(replacements, wrapKey("group-package-name"), r.GroupPackageName)
+	replacements = append(replacements, wrapKey("version"), r.Version)
+	replacements = append(replacements, wrapKey("kind"), strings.ToLower(r.Kind))
+	replacements = append(replacements, wrapKey("plural"), strings.ToLower(r.Plural))
+
+	return strings.NewReplacer(replacements...)
 }

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -18,8 +18,6 @@ package scaffold
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/model"
@@ -90,11 +88,6 @@ func (s *apiScaffolder) newUniverse() *model.Universe {
 
 func (s *apiScaffolder) scaffoldV1() error {
 	if s.doResource {
-		fmt.Println(filepath.Join("pkg", "apis", s.resource.GroupPackageName, s.resource.Version,
-			fmt.Sprintf("%s_types.go", strings.ToLower(s.resource.Kind))))
-		fmt.Println(filepath.Join("pkg", "apis", s.resource.GroupPackageName, s.resource.Version,
-			fmt.Sprintf("%s_types_test.go", strings.ToLower(s.resource.Kind))))
-
 		if err := machinery.NewScaffold().Execute(
 			s.newUniverse(),
 			&crdv1.Register{},
@@ -117,11 +110,6 @@ func (s *apiScaffolder) scaffoldV1() error {
 	}
 
 	if s.doController {
-		fmt.Println(filepath.Join("pkg", "controller", strings.ToLower(s.resource.Kind),
-			fmt.Sprintf("%s_controller.go", strings.ToLower(s.resource.Kind))))
-		fmt.Println(filepath.Join("pkg", "controller", strings.ToLower(s.resource.Kind),
-			fmt.Sprintf("%s_controller_test.go", strings.ToLower(s.resource.Kind))))
-
 		if err := machinery.NewScaffold().Execute(
 			s.newUniverse(),
 			&controllerv1.Controller{},
@@ -143,14 +131,6 @@ func (s *apiScaffolder) scaffoldV2() error {
 			if err := s.config.Save(); err != nil {
 				return fmt.Errorf("error updating project file with resource information : %v", err)
 			}
-		}
-
-		if s.config.MultiGroup {
-			fmt.Println(filepath.Join("apis", s.resource.Group, s.resource.Version,
-				fmt.Sprintf("%s_types.go", strings.ToLower(s.resource.Kind))))
-		} else {
-			fmt.Println(filepath.Join("api", s.resource.Version,
-				fmt.Sprintf("%s_types.go", strings.ToLower(s.resource.Kind))))
 		}
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
@@ -183,14 +163,6 @@ func (s *apiScaffolder) scaffoldV2() error {
 	}
 
 	if s.doController {
-		if s.config.MultiGroup {
-			fmt.Println(filepath.Join("controllers", s.resource.Group,
-				fmt.Sprintf("%s_controller.go", strings.ToLower(s.resource.Kind))))
-		} else {
-			fmt.Println(filepath.Join("controllers",
-				fmt.Sprintf("%s_controller.go", strings.ToLower(s.resource.Kind))))
-		}
-
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),
 			&controllerv2.SuiteTest{},

--- a/pkg/scaffold/internal/templates/v1/controller/add.go
+++ b/pkg/scaffold/internal/templates/v1/controller/add.go
@@ -17,9 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -37,9 +35,9 @@ type AddController struct {
 // SetTemplateDefaults implements input.Template
 func (f *AddController) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "controller", fmt.Sprintf(
-			"add_%s.go", strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("pkg", "controller", "add_%[kind].go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = addControllerTemplate
 

--- a/pkg/scaffold/internal/templates/v1/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controller.go
@@ -17,8 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -35,10 +35,10 @@ type Controller struct {
 // SetTemplateDefaults implements input.Template
 func (f *Controller) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "controller",
-			strings.ToLower(f.Resource.Kind),
-			strings.ToLower(f.Resource.Kind)+"_controller.go")
+		f.Path = filepath.Join("pkg", "controller", "%[kind]", "%[kind]_controller.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	f.TemplateBody = controllerTemplate
 

--- a/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -36,9 +35,9 @@ type SuiteTest struct {
 // SetTemplateDefaults implements input.Template
 func (f *SuiteTest) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "controller",
-			strings.ToLower(f.Resource.Kind), strings.ToLower(f.Resource.Kind)+"_controller_suite_test.go")
+		f.Path = filepath.Join("pkg", "controller", "%[kind]", "%[kind]_controller_suite_test.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = controllerSuiteTestTemplate
 

--- a/pkg/scaffold/internal/templates/v1/controller/controllertest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllertest.go
@@ -17,8 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -35,9 +35,10 @@ type Test struct {
 // SetTemplateDefaults implements input.Template
 func (f *Test) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "controller",
-			strings.ToLower(f.Resource.Kind), strings.ToLower(f.Resource.Kind)+"_controller_test.go")
+		f.Path = filepath.Join("pkg", "controller", "%[kind]", "%[kind]_controller_test.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	f.TemplateBody = controllerTestTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
+++ b/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
@@ -17,7 +17,6 @@ limitations under the License.
 package crd
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -35,9 +34,9 @@ type AddToScheme struct {
 // SetTemplateDefaults implements input.Template
 func (f *AddToScheme) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", fmt.Sprintf(
-			"addtoscheme_%s_%s.go", f.Resource.GroupPackageName, f.Resource.Version))
+		f.Path = filepath.Join("pkg", "apis", "addtoscheme_%[group-package-name]_%[version].go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = addResourceTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/crd_sample.go
+++ b/pkg/scaffold/internal/templates/v1/crd/crd_sample.go
@@ -17,9 +17,7 @@ limitations under the License.
 package crd
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -36,9 +34,9 @@ type CRDSample struct {
 // SetTemplateDefaults implements input.Template
 func (f *CRDSample) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("config", "samples", fmt.Sprintf(
-			"%s_%s_%s.yaml", f.Resource.GroupPackageName, f.Resource.Version, strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("config", "samples", "%[group-package-name]_%[version]_%[kind].yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = crdSampleTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/doc.go
+++ b/pkg/scaffold/internal/templates/v1/crd/doc.go
@@ -35,8 +35,9 @@ type Doc struct {
 // SetTemplateDefaults implements input.Template
 func (f *Doc) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupPackageName, f.Resource.Version, "doc.go")
+		f.Path = filepath.Join("pkg", "apis", "%[group-package-name]", "%[version]", "doc.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = docGoTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/group.go
+++ b/pkg/scaffold/internal/templates/v1/crd/group.go
@@ -34,8 +34,9 @@ type Group struct {
 // SetTemplateDefaults implements input.Template
 func (f *Group) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupPackageName, "group.go")
+		f.Path = filepath.Join("pkg", "apis", "%[group-package-name]", "group.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = groupTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/register.go
+++ b/pkg/scaffold/internal/templates/v1/crd/register.go
@@ -35,8 +35,9 @@ type Register struct {
 // SetTemplateDefaults implements input.Template
 func (f *Register) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupPackageName, f.Resource.Version, "register.go")
+		f.Path = filepath.Join("pkg", "apis", "%[group-package-name]", "%[version]", "register.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = registerTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/types.go
+++ b/pkg/scaffold/internal/templates/v1/crd/types.go
@@ -19,7 +19,6 @@ package crd
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -36,9 +35,10 @@ type Types struct {
 // SetTemplateDefaults implements input.Template
 func (f *Types) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupPackageName, f.Resource.Version,
-			fmt.Sprintf("%s_types.go", strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("pkg", "apis", "%[group-package-name]", "%[version]", "%[kind]_types.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	f.TemplateBody = typesTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/typestest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/typestest.go
@@ -19,7 +19,6 @@ package crd
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -36,9 +35,10 @@ type TypesTest struct {
 // SetTemplateDefaults implements input.Template
 func (f *TypesTest) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupPackageName, f.Resource.Version,
-			fmt.Sprintf("%s_types_test.go", strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("pkg", "apis", "%[group-package-name]", "%[version]", "%[kind]_types_test.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	f.TemplateBody = typesTestTemplate
 

--- a/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
@@ -17,7 +17,6 @@ limitations under the License.
 package crd
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -35,9 +34,9 @@ type VersionSuiteTest struct {
 // SetTemplateDefaults implements input.Template
 func (f *VersionSuiteTest) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "apis", f.Resource.GroupPackageName, f.Resource.Version,
-			fmt.Sprintf("%s_suite_test.go", f.Resource.Version))
+		f.Path = filepath.Join("pkg", "apis", "%[group-package-name]", "%[version]", "%[version]_suite_test.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = versionSuiteTestTemplate
 

--- a/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -39,10 +38,9 @@ type AddAdmissionWebhookBuilderHandler struct {
 // SetTemplateDefaults implements input.Template
 func (f *AddAdmissionWebhookBuilderHandler) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", f.Server),
-			fmt.Sprintf("add_%s_%s.go", f.Type, strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("pkg", "webhook", f.Server+"_server", "add_"+f.Type+"_%[kind].go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = addAdmissionWebhookBuilderHandlerTemplate
 

--- a/pkg/scaffold/internal/templates/v1/webhook/add_server.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_server.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -37,7 +36,7 @@ type AddServer struct {
 // SetTemplateDefaults implements input.Template
 func (f *AddServer) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("add_%s_server.go", f.Server))
+		f.Path = filepath.Join("pkg", "webhook", "add_"+f.Server+"_server.go")
 	}
 
 	f.TemplateBody = addServerTemplate

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -45,12 +44,10 @@ type AdmissionWebhookBuilder struct {
 // SetTemplateDefaults implements input.Template
 func (f *AdmissionWebhookBuilder) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", f.Server),
-			strings.ToLower(f.Resource.Kind),
-			f.Type,
-			fmt.Sprintf("%s_webhook.go", strings.Join(f.Operations, "_")))
+		f.Path = filepath.Join("pkg", "webhook", f.Server+"_server", "%[kind]", f.Type,
+			strings.Join(f.Operations, "_")+"_webhook.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = admissionWebhookBuilderTemplate
 

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionhandler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -44,12 +43,10 @@ type AdmissionHandler struct {
 // SetTemplateDefaults implements input.Template
 func (f *AdmissionHandler) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", f.Server),
-			strings.ToLower(f.Resource.Kind),
-			f.Type,
-			fmt.Sprintf("%s_%s_handler.go", strings.ToLower(f.Resource.Kind), strings.Join(f.Operations, "_")))
+		f.Path = filepath.Join("pkg", "webhook", f.Server+"_server", "%[kind]", f.Type,
+			"%[kind]_"+strings.Join(f.Operations, "_")+"_handler.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = addAdmissionHandlerTemplate
 

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionwebhooks.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionwebhooks.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -38,11 +37,9 @@ type AdmissionWebhooks struct {
 // SetTemplateDefaults implements input.Template
 func (f *AdmissionWebhooks) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "webhook",
-			fmt.Sprintf("%s_server", f.Server),
-			strings.ToLower(f.Resource.Kind),
-			f.Type, "webhooks.go")
+		f.Path = filepath.Join("pkg", "webhook", f.Server+"_server", "%[kind]", f.Type, "webhooks.go")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = webhooksTemplate
 

--- a/pkg/scaffold/internal/templates/v1/webhook/server.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/server.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
@@ -36,7 +35,7 @@ type Server struct {
 // SetTemplateDefaults implements input.Template
 func (f *Server) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("pkg", "webhook", fmt.Sprintf("%s_server", f.Server), "server.go")
+		f.Path = filepath.Join("pkg", "webhook", f.Server+"_server", "server.go")
 	}
 
 	f.TemplateBody = serverTemplate

--- a/pkg/scaffold/internal/templates/v1/webhook/util.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/util.go
@@ -22,6 +22,5 @@ import (
 )
 
 func builderName(config Config, resource string) string {
-	opsStr := strings.Join(config.Operations, "-")
-	return fmt.Sprintf("%s-%s-%s", config.Type, opsStr, resource)
+	return fmt.Sprintf("%s-%s-%s", config.Type, strings.Join(config.Operations, "-"), resource)
 }

--- a/pkg/scaffold/internal/templates/v2/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller.go
@@ -17,8 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -37,13 +37,13 @@ type Controller struct {
 func (f *Controller) SetTemplateDefaults() error {
 	if f.Path == "" {
 		if f.MultiGroup {
-			f.Path = filepath.Join("controllers", f.Resource.Group,
-				strings.ToLower(f.Resource.Kind)+"_controller.go")
+			f.Path = filepath.Join("controllers", "%[group]", "%[kind]_controller.go")
 		} else {
-			f.Path = filepath.Join("controllers",
-				strings.ToLower(f.Resource.Kind)+"_controller.go")
+			f.Path = filepath.Join("controllers", "%[kind]_controller.go")
 		}
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	f.TemplateBody = controllerTemplate
 

--- a/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
@@ -39,11 +39,12 @@ type SuiteTest struct {
 func (f *SuiteTest) SetTemplateDefaults() error {
 	if f.Path == "" {
 		if f.MultiGroup {
-			f.Path = filepath.Join("controllers", f.Resource.Group, "suite_test.go")
+			f.Path = filepath.Join("controllers", "%[group]", "suite_test.go")
 		} else {
 			f.Path = filepath.Join("controllers", "suite_test.go")
 		}
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = fmt.Sprintf(controllerSuiteTestTemplate,
 		file.NewMarkerFor(f.Path, importMarker),

--- a/pkg/scaffold/internal/templates/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/internal/templates/v2/crd/enablecainjection_patch.go
@@ -17,11 +17,7 @@ limitations under the License.
 package crd
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
-
-	"github.com/gobuffalo/flect"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -37,10 +33,9 @@ type EnableCAInjectionPatch struct {
 // SetTemplateDefaults implements input.Template
 func (f *EnableCAInjectionPatch) SetTemplateDefaults() error {
 	if f.Path == "" {
-		plural := flect.Pluralize(strings.ToLower(f.Resource.Kind))
-		f.Path = filepath.Join("config", "crd", "patches",
-			fmt.Sprintf("cainjection_in_%s.yaml", plural))
+		f.Path = filepath.Join("config", "crd", "patches", "cainjection_in_%[plural].yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = enableCAInjectionPatchTemplate
 

--- a/pkg/scaffold/internal/templates/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/internal/templates/v2/crd/enablewebhook_patch.go
@@ -17,11 +17,7 @@ limitations under the License.
 package crd
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
-
-	"github.com/gobuffalo/flect"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -37,10 +33,9 @@ type EnableWebhookPatch struct {
 // SetTemplateDefaults implements input.Template
 func (f *EnableWebhookPatch) SetTemplateDefaults() error {
 	if f.Path == "" {
-		plural := flect.Pluralize(strings.ToLower(f.Resource.Kind))
-		f.Path = filepath.Join("config", "crd", "patches",
-			fmt.Sprintf("webhook_in_%s.yaml", plural))
+		f.Path = filepath.Join("config", "crd", "patches", "webhook_in_%[plural].yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = enableWebhookPatchTemplate
 

--- a/pkg/scaffold/internal/templates/v2/crd/kustomization.go
+++ b/pkg/scaffold/internal/templates/v2/crd/kustomization.go
@@ -37,6 +37,7 @@ func (f *Kustomization) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = fmt.Sprintf(kustomizationTemplate,
 		file.NewMarkerFor(f.Path, resourceMarker),

--- a/pkg/scaffold/internal/templates/v2/crd_editor_rbac.go
+++ b/pkg/scaffold/internal/templates/v2/crd_editor_rbac.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v2
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -35,8 +33,9 @@ type CRDEditorRole struct {
 // SetTemplateDefaults implements input.Template
 func (f *CRDEditorRole) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("config", "rbac", fmt.Sprintf("%s_editor_role.yaml", strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("config", "rbac", "%[kind]_editor_role.yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = crdRoleEditorTemplate
 

--- a/pkg/scaffold/internal/templates/v2/crd_sample.go
+++ b/pkg/scaffold/internal/templates/v2/crd_sample.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v2
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -35,9 +33,9 @@ type CRDSample struct {
 // SetTemplateDefaults implements input.Template
 func (f *CRDSample) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("config", "samples", fmt.Sprintf(
-			"%s_%s_%s.yaml", f.Resource.Group, f.Resource.Version, strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("config", "samples", "%[group]_%[version]_%[kind].yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.IfExistsAction = file.Error
 

--- a/pkg/scaffold/internal/templates/v2/crd_viewer_rbac.go
+++ b/pkg/scaffold/internal/templates/v2/crd_viewer_rbac.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v2
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -35,8 +33,9 @@ type CRDViewerRole struct {
 // SetTemplateDefaults implements input.Template
 func (f *CRDViewerRole) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("config", "rbac", fmt.Sprintf("%s_viewer_role.yaml", strings.ToLower(f.Resource.Kind)))
+		f.Path = filepath.Join("config", "rbac", "%[kind]_viewer_role.yaml")
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = crdRoleViewerTemplate
 

--- a/pkg/scaffold/internal/templates/v2/group.go
+++ b/pkg/scaffold/internal/templates/v2/group.go
@@ -36,11 +36,12 @@ type Group struct {
 func (f *Group) SetTemplateDefaults() error {
 	if f.Path == "" {
 		if f.MultiGroup {
-			f.Path = filepath.Join("apis", f.Resource.Group, f.Resource.Version, "groupversion_info.go")
+			f.Path = filepath.Join("apis", "%[group]", "%[version]", "groupversion_info.go")
 		} else {
-			f.Path = filepath.Join("api", f.Resource.Version, "groupversion_info.go")
+			f.Path = filepath.Join("api", "%[version]", "groupversion_info.go")
 		}
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
 
 	f.TemplateBody = groupTemplate
 

--- a/pkg/scaffold/internal/templates/v2/types.go
+++ b/pkg/scaffold/internal/templates/v2/types.go
@@ -19,7 +19,6 @@ package v2
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -38,13 +37,13 @@ type Types struct {
 func (f *Types) SetTemplateDefaults() error {
 	if f.Path == "" {
 		if f.MultiGroup {
-			f.Path = filepath.Join("apis", f.Resource.Group, f.Resource.Version,
-				fmt.Sprintf("%s_types.go", strings.ToLower(f.Resource.Kind)))
+			f.Path = filepath.Join("apis", "%[group]", "%[version]", "%[kind]_types.go")
 		} else {
-			f.Path = filepath.Join("api", f.Resource.Version,
-				fmt.Sprintf("%s_types.go", strings.ToLower(f.Resource.Kind)))
+			f.Path = filepath.Join("api", "%[version]", "%[kind]_types.go")
 		}
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	f.TemplateBody = typesTemplate
 

--- a/pkg/scaffold/internal/templates/v2/webhook/webhook.go
+++ b/pkg/scaffold/internal/templates/v2/webhook/webhook.go
@@ -46,13 +46,13 @@ type Webhook struct { // nolint:maligned
 func (f *Webhook) SetTemplateDefaults() error {
 	if f.Path == "" {
 		if f.MultiGroup {
-			f.Path = filepath.Join("apis", f.Resource.Group, f.Resource.Version,
-				fmt.Sprintf("%s_webhook.go", strings.ToLower(f.Resource.Kind)))
+			f.Path = filepath.Join("apis", "%[group]", "%[version]", "%[kind]_webhook.go")
 		} else {
-			f.Path = filepath.Join("api", f.Resource.Version,
-				fmt.Sprintf("%s_webhook.go", strings.ToLower(f.Resource.Kind)))
+			f.Path = filepath.Join("api", "%[version]", "%[kind]_webhook.go")
 		}
 	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
 
 	webhookTemplate := webhookTemplate
 	if f.Defaulting {

--- a/pkg/scaffold/webhook.go
+++ b/pkg/scaffold/webhook.go
@@ -18,8 +18,6 @@ package scaffold
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
@@ -121,14 +119,6 @@ func (s *webhookScaffolder) scaffoldV1() error {
 }
 
 func (s *webhookScaffolder) scaffoldV2() error {
-	if s.config.MultiGroup {
-		fmt.Println(filepath.Join("apis", s.resource.Group, s.resource.Version,
-			fmt.Sprintf("%s_webhook.go", strings.ToLower(s.resource.Kind))))
-	} else {
-		fmt.Println(filepath.Join("api", s.resource.Version,
-			fmt.Sprintf("%s_webhook.go", strings.ToLower(s.resource.Kind))))
-	}
-
 	if s.conversion {
 		fmt.Println(`Webhook server has been set up for you.
 You need to implement the conversion.Hub and conversion.Convertible interfaces for your CRD types.`)


### PR DESCRIPTION
### Description

This PR allows the usage of named-arguments while formatting files' paths.

Resources have a `Replacer` method that returns an `strings.Replacer` that is used to format paths. The `strings.Replacer` dictionary is as follows:
  - `%[group]s`: `Resource.Group`
  - `%[group-package-name]s`: `Resource.GroupPackageName`
  - `%[version]s`: `Resource.Version`
  - `%[kind]s`: `strings.ToLower(Resource.Kind)`
  - `%[plural]s`: `strings.ToLower(Resource.Plural)`

### Motivation

Despite the fact that the path can be provided to these file structs, access to some of the fields is restricted to the default path. This formatting ("%[kind]s" getting replaced by strings.ToLower(resource.Kind)) does not only apply to default paths. Paths provided outside the GetInputfunction do also benefit from it.

For example, if you want the types file to be inside a directory of its version, this can be done in the default package because you have access to the resource, but it can't be done before that. By providing this path temnplating options paths can be configured before having access to the exact resource. This allows to provide paths **before** having access to the resource like in a flag (for implementing a flag that is in kubebuilder` but breaks the scaffolding right now, the boilerplate path.

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.