### PR TITLE
Split injecting fields and validating files

### DIFF
--- a/pkg/scaffold/input/input.go
+++ b/pkg/scaffold/input/input.go
@@ -158,8 +158,9 @@ type File interface {
 	GetInput() (Input, error)
 }
 
-// Validate validates input
-type Validate interface {
+// RequiresValidation is a file that requires validation
+type RequiresValidation interface {
+	File
 	// Validate returns true if the template has valid values
 	Validate() error
 }

--- a/pkg/scaffold/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller/controller_suitetest.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/util"
-	"sigs.k8s.io/kubebuilder/pkg/scaffold/v2"
+	scaffoldv2 "sigs.k8s.io/kubebuilder/pkg/scaffold/v2"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/v2/internal"
 )
 
@@ -140,8 +140,8 @@ Expect(err).NotTo(HaveOccurred())
 
 	err := internal.InsertStringsInFile(a.Path,
 		map[string][]string{
-			v2.ApiPkgImportScaffoldMarker: []string{ctrlImportCodeFragment, apiImportCodeFragment},
-			v2.ApiSchemeScaffoldMarker:    []string{addschemeCodeFragment},
+			scaffoldv2.ApiPkgImportScaffoldMarker: []string{ctrlImportCodeFragment, apiImportCodeFragment},
+			scaffoldv2.ApiSchemeScaffoldMarker:    []string{addschemeCodeFragment},
 		})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

The method `setFieldsAndValidate` was doing two things, as the name suggests. The logic has been split into two separate methods: `setFields` and `validate`. The `Validate` interface has been modified so that it is only implemented by files, as other structs as resources or some scaffolders also use the `Validate() error` signature.

### Motivation

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.

/kind cleanup
