### PR TITLE
Hotfix for TRAVIS error introduced by #1016

### DIFF
--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -52,7 +52,7 @@ vet:
 
 # Generate code
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 # Build the docker image
 docker-build: test


### PR DESCRIPTION
Fixes the Travis error introduced by #1016

The result of `{{ printf "%q" .BoilerplatePath }}` is `"hack/boilerplate.txt"` while Travis is expecting `./hack/boilerplate.txt`. Either the `testdata` should be change to reflect #1016 or `./{{ .Boilerplate }}` can be used instead. Both work as expected.