### PR TITLE
don't depend on shared controller-gen which could be too old, use expected version directly

### DIFF
--- a/docs/book/src/reference/generating-crd.md
+++ b/docs/book/src/reference/generating-crd.md
@@ -179,7 +179,7 @@ doing.
 Each controller-gen "generator" is controlled by an option to
 controller-gen, using the same syntax as markers.  For instance, to
 generate CRDs with "trivial versions" (no version conversion webhooks), we
-call `controller-gen crd:trivialVersions=true paths=./api/...`.
+call `go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:trivialVersions=true paths=./api/...`.
 
 controller-gen also supports different output "rules" to control how
 and where output goes.  Notice the `manifests` make rule (condensed
@@ -198,13 +198,13 @@ CRD-related config (non-code) artifacts should end up in
 To see all the options for `controller-gen`, run
 
 ```shell
-$ controller-gen -h
+$ go run sigs.k8s.io/controller-tools/cmd/controller-gen -h
 ```
 
 or, for more details:
 
 ```shell
-$ controller-gen -hhh
+$ go run sigs.k8s.io/controller-tools/cmd/controller-gen -hhh
 ```
 
 [marker-ref]: ./markers.md "Markers for Config/Code Generation"

--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -51,7 +51,7 @@ IMG ?= {{ .Image }}
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Define how controller-gen is executed
-CONTROLLER_GEN ?= "go run sigs.k8s.io/controller-tools/cmd/controller-gen"
+CONTROLLER_GEN ?= go run sigs.k8s.io/controller-tools/cmd/controller-gen
 
 all: manager
 

--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -50,12 +50,8 @@ IMG ?= {{ .Image }}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+# Define how controller-gen is executed
+CONTROLLER_GEN ?= "go run sigs.k8s.io/controller-tools/cmd/controller-gen"
 
 all: manager
 
@@ -111,17 +107,5 @@ docker-push:
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@{{.ControllerToolsVersion}} ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@{{.ControllerToolsVersion}}
 `

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -4,12 +4,8 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
-# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
+# Define how controller-gen is executed
+CONTROLLER_GEN ?= "go run sigs.k8s.io/controller-tools/cmd/controller-gen"
 
 all: manager
 
@@ -65,16 +61,4 @@ docker-push:
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.4 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.4

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -5,7 +5,7 @@ IMG ?= controller:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Define how controller-gen is executed
-CONTROLLER_GEN ?= "go run sigs.k8s.io/controller-tools/cmd/controller-gen"
+CONTROLLER_GEN ?= go run sigs.k8s.io/controller-tools/cmd/controller-gen
 
 all: manager
 

--- a/testdata/project-v2/go.mod
+++ b/testdata/project-v2/go.mod
@@ -10,4 +10,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 	sigs.k8s.io/controller-runtime v0.4.0
+	sigs.k8s.io/controller-tools v0.2.4 // indirect
 )


### PR DESCRIPTION
If, because of any reason, the `$GOPATH/bin/controller-gen` binary is not the expected version, it will generate faulty resources. The `which` check prevents any update to controller-gen.

Why not relying on go modules and reference controller-gen in there and using it with go run? (If controller-gen is `go get`ed, it will not download as long as the requested version is still in your go modules cache).

This enforces developers using kubebuilder to use go modules as dependency management for their project, but this is already enforced by providing `testdata/project-v2/go.mod`

**This PR is the minimal version to get the desired effect without workflow change**! But we can do better (additionally to this PR):

We could go a step ahead, instead of the target `controller-gen` in the Makefile, we could offer a `tools.go` file with the following content. [This is currently the best working way to define dev dependencies](https://github.com/golang/go/issues/25922)
```go
// +build tools

package main

import (
	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
)
```

```diff
--- a/testdata/project-v2/go.mod
+++ b/testdata/project-v2/go.mod
@@ -10,4 +10,5 @@ require (
        k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
        k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
        sigs.k8s.io/controller-runtime v0.4.0
-       sigs.k8s.io/controller-tools v0.2.4 // indirect
+       sigs.k8s.io/controller-tools v0.2.4
 )
```

This will ensure, during creation, the default version of controller-tools is installed (currently v0.2.4), but the developer is free to up that version using `go get sigs.k8s.io/controller-tools@vX.X.X` and the reference is kept in go.mod

This makes `go get`ing the controller-gen in the Makefile abundant, remove that
```diff
--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -39,8 +39,8 @@ deploy: manifests
        kustomize build config/default | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
-manifests: controller-gen
+manifests:
       go run sigs.k8s.io/controller-tools/cmd/controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Run go fmt against code
 fmt:
@@ -51,7 +51,7 @@ vet:
        go vet ./...
 
 # Generate code
-generate: controller-gen
+generate:
        go run sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=./hack/boilerplate.go.txt paths="./..."
 
 # Build the docker image
@@ -61,8 +61,3 @@ docker-build: test
 # Push the docker image
 docker-push:
        docker push ${IMG}
-
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
-       go get sigs.k8s.io/controller-tools@v0.2.4
```
