### PR TITLE
:running: Enable the lint check goimports 

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -38,12 +38,13 @@ golangci-lint run --disable-all \
     --enable=nakedret \
     --enable=interfacer \
     --enable=misspell \
-    --enable=dupl
+    --enable=dupl \
+    --enable=goimports \
+
 
 ##todo(camilamacedo86): The following checks requires fixes in the code
 # --enable=golint
 # --enable=gocyclo
-# --enable=goimports
 # --enable=lll
 # --enable=goconst
 # --enable=gosec


### PR DESCRIPTION
**Description**
Enable the lint check goimports
Note that nothing needed to be fixed in this case. 