### PR TITLE
Update OWNERS and OWNERS_ALIASES files to new format

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,8 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
-owners:
-  - droot
-  - pwittrock
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 approvers:
+  - kubebuilder-owners
   - kubebuilder-admins
   - kubebuilder-maintainers
 reviewers:
-  - kubebuilder-admins
-  - kubebuilder-maintainers
   - kubebuilder-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,10 +1,11 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 aliases:
-  kubebuilder-admins:
-    - directxman12
+  kubebuilder-owners:
     - droot
     - pwittrock
+  kubebuilder-admins:
+    - directxman12
   kubebuilder-maintainers:
     - Liujingfang1
     - mengqiy


### PR DESCRIPTION
The `OWNERS` and `OWNERS_ALIASES` files format were outdated, I followed the guide in https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md to update to the current format.

NOTE: no new reviewer nor approver was added with this change.
