### PR TITLE
Delegate go vet and go fmt to golangci-lint

### DIFF
--- a/pkg/scaffold/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/v2/controller/controller_suitetest.go
@@ -137,8 +137,8 @@ Expect(err).NotTo(HaveOccurred())
 
 	err := internal.InsertStringsInFile(f.Path,
 		map[string][]string{
-			scaffoldv2.ApiPkgImportScaffoldMarker: []string{ctrlImportCodeFragment, apiImportCodeFragment},
-			scaffoldv2.ApiSchemeScaffoldMarker:    []string{addschemeCodeFragment},
+			scaffoldv2.ApiPkgImportScaffoldMarker: {ctrlImportCodeFragment, apiImportCodeFragment},
+			scaffoldv2.ApiSchemeScaffoldMarker:    {addschemeCodeFragment},
 		})
 	if err != nil {
 		return err

--- a/pkg/scaffold/v2/internal/string_utils_test.go
+++ b/pkg/scaffold/v2/internal/string_utils_test.go
@@ -36,8 +36,9 @@ v1beta1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
 			markerNValues: map[string][]string{
-				"// +kubebuilder:scaffold:apis-add-scheme": []string{
-					"v1.AddToScheme(scheme)\n", "somefunc()\n"},
+				"// +kubebuilder:scaffold:apis-add-scheme": {
+					"v1.AddToScheme(scheme)\n", "somefunc()\n",
+				},
 			},
 			expected: `
 v1beta1.AddToScheme(scheme)
@@ -52,8 +53,9 @@ v1beta1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
 			markerNValues: map[string][]string{
-				"// +kubebuilder:scaffold:apis-add-scheme": []string{
-					"v1beta1.AddToScheme(scheme)\n", "v1.AddToScheme(scheme)\n"},
+				"// +kubebuilder:scaffold:apis-add-scheme": {
+					"v1beta1.AddToScheme(scheme)\n", "v1.AddToScheme(scheme)\n",
+				},
 			},
 			expected: `
 v1beta1.AddToScheme(scheme)
@@ -68,8 +70,11 @@ v1beta1.AddToScheme(scheme)
 // +kubebuilder:scaffold:apis-add-scheme
 `,
 			markerNValues: map[string][]string{
-				"// +kubebuilder:scaffold:apis-add-scheme": []string{`v1.AddToScheme(scheme)
-`}},
+				"// +kubebuilder:scaffold:apis-add-scheme": {
+					`v1.AddToScheme(scheme)
+`,
+				},
+			},
 			expected: `
 v1beta1.AddToScheme(scheme)
 v1.AddToScheme(scheme)

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -14,20 +14,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-set -e
-
 source ./common.sh
-
-header_text "running go vet"
-go vet ${MOD_OPT} ../...
-
-header_text "running go fmt"
-go fmt ${MOD_OPT} ../...
 
 header_text "running golangci-lint"
 cd .. # To go to the root of the project
 golangci-lint run --disable-all \
     --deadline 5m \
+    --enable=govet \
+    --enable=gofmt \
     --enable=misspell \
     --enable=structcheck \
     --enable=deadcode \
@@ -37,7 +31,6 @@ golangci-lint run --disable-all \
     --enable=ineffassign \
     --enable=nakedret \
     --enable=interfacer \
-    --enable=misspell \
     --enable=dupl \
     --enable=goimports \
     --enable=gocyclo \
@@ -45,10 +38,7 @@ golangci-lint run --disable-all \
 
 ##todo(camilamacedo86): The following checks requires fixes in the code
 # --enable=golint
-# --enable=gocyclo
 # --enable=lll
 # --enable=goconst
 # --enable=gosec
 # --enable=maligned
-
-GO111MODULES=on go list -mod=readonly ./...


### PR DESCRIPTION
`go vet` and `go fmt` were being called before `golangci-lint`. The later is able to run those two checks and that will benefit from the speed enhancements golangci-lint does (concurrency, evaluating files only once, building shared caches, etc.)