### PR TITLE
add missing lints to keep enabled all default ones

### DIFF
--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -21,8 +21,7 @@ import (
 )
 
 func ProjectExist() bool {
-	_, err := os.Stat("PROJECT")
-	if err != nil {
+	if _, err := os.Stat("PROJECT"); err != nil {
 		return false
 	}
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,6 +37,9 @@ golangci-lint run --disable-all \
     --enable=goconst \
     --enable=maligned \
     --enable=gosec \
+    --enable=staticcheck \
+    --enable=unused \
+    --enable=gosimple
 
 ##todo(camilamacedo86): The following checks requires fixes in the code
 # --enable=golint


### PR DESCRIPTION
Ensure that all default ones will be enabled. See: https://github.com/golangci/golangci-lint#enabled-by-default-linters 