### PR TITLE
Include PROJECT file information into model.Universe

### DIFF
--- a/cmd/vendor_update.go
+++ b/cmd/vendor_update.go
@@ -39,13 +39,21 @@ kubebuilder update vendor
 		Run: func(cmd *cobra.Command, args []string) {
 			internal.DieIfNotConfigured()
 
-			err := (&scaffold.Scaffold{}).Execute(
-				&model.Universe{},
+			universe, err := model.NewUniverse(
+				model.WithConfigFrom("PROJECT"),
+				model.WithoutBoilerplate,
+			)
+			if err != nil {
+				log.Fatalf("error updating vendor dependencies: %v", err)
+			}
+
+			err = (&scaffold.Scaffold{}).Execute(
+				universe,
 				input.Options{},
 				&project.GopkgToml{},
 			)
 			if err != nil {
-				log.Fatalf("error updating vendor dependecies %v", err)
+				log.Fatalf("error updating vendor dependencies: %v", err)
 			}
 		},
 	}

--- a/cmd/webhook_v1.go
+++ b/cmd/webhook_v1.go
@@ -66,9 +66,20 @@ This command is only available for v1 scaffolding project.
 			}
 
 			fmt.Println("Writing scaffold for you to edit...")
+
+			universe, err := model.NewUniverse(
+				model.WithConfig(projectConfig),
+				// TODO: missing model.WithBoilerplate[From], needs boilerplate or path
+				model.WithResource(o.res, projectConfig),
+			)
+			if err != nil {
+				log.Fatalf("error scaffolding webhook: %v", err)
+			}
+
 			webhookConfig := webhook.Config{Server: o.server, Type: o.webhookType, Operations: o.operations}
+
 			err = (&scaffold.Scaffold{}).Execute(
-				&model.Universe{},
+				universe,
 				input.Options{},
 				&manager.Webhook{},
 				&webhook.AdmissionHandler{Resource: o.res, Config: webhookConfig},
@@ -79,7 +90,7 @@ This command is only available for v1 scaffolding project.
 				&webhook.AddServer{Config: webhookConfig},
 			)
 			if err != nil {
-				log.Fatal(err)
+				log.Fatalf("error scaffolding webhook: %v", err)
 			}
 
 			if o.doMake {

--- a/pkg/model/file.go
+++ b/pkg/model/file.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
+)
+
+// File describes a file that will be written
+type File struct {
+	// Path is the file to write
+	Path string `json:"path,omitempty"`
+
+	// Contents is the generated output
+	Contents string `json:"contents,omitempty"`
+
+	// TODO: Move input.IfExistsAction into model
+	// IfExistsAction determines what to do if the file exists
+	IfExistsAction input.IfExistsAction `json:"ifExistsAction,omitempty"`
+}

--- a/pkg/model/resource.go
+++ b/pkg/model/resource.go
@@ -16,24 +16,8 @@ limitations under the License.
 
 package model
 
-import (
-	"sigs.k8s.io/kubebuilder/pkg/scaffold/input"
-)
-
-// Universe describes the entire state of file generation
-type Universe struct {
-	Boilerplate string `json:"boilerplate,omitempty"`
-
-	Resource *Resource `json:"resource,omitempty"`
-
-	Files []*File `json:"files,omitempty"`
-
-	// Multigroup tracks if the project has more than one group
-	MultiGroup bool `json:"multigroup,omitempty"`
-}
-
 // Resource describes the resource currently being generated
-// TODO: Just use the resource type?
+// TODO: unify with pkg/scaffold/resource.Resource
 type Resource struct {
 	// Namespaced is true if the resource is namespaced
 	Namespaced bool `json:"namespaces,omitempty"`
@@ -58,17 +42,4 @@ type Resource struct {
 
 	// GroupDomain is the Group + "." + Domain for the Resource
 	GroupDomain string `json:"groupDomain,omitempty"`
-}
-
-// File describes a file that will be written
-type File struct {
-	// Path is the file to write
-	Path string `json:"path,omitempty"`
-
-	// Contents is the generated output
-	Contents string `json:"contents,omitempty"`
-
-	// TODO: Move input.IfExistsAction into model
-	// IfExistsAction determines what to do if the file exists
-	IfExistsAction input.IfExistsAction `json:"ifExistsAction,omitempty"`
 }

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/gobuffalo/flect"
+
+	internalconfig "sigs.k8s.io/kubebuilder/internal/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/scaffold/resource"
+	"sigs.k8s.io/kubebuilder/pkg/scaffold/util"
+)
+
+// Universe describes the entire state of file generation
+type Universe struct {
+	// Config stores the project configuration
+	Config *config.Config `json:"config,omitempty"`
+
+	// Boilerplate is the copyright comment added at the top of scaffolded files
+	Boilerplate string `json:"boilerplate,omitempty"`
+
+	// Resource contains the information of the API that is being scaffolded
+	Resource *Resource `json:"resource,omitempty"`
+
+	// Files contains the model of the files that are being scaffolded
+	Files []*File `json:"files,omitempty"`
+}
+
+// NewUniverse creates a new Universe
+func NewUniverse(options ...UniverseOption) (*Universe, error) {
+	universe := &Universe{}
+
+	// Apply options
+	for _, option := range options {
+		if err := option(universe); err != nil {
+			return nil, err
+		}
+	}
+
+	return universe, nil
+}
+
+// UniverseOption configure Universe
+type UniverseOption func(*Universe) error
+
+// WithConfigFrom loads the project configuration from the provided path
+func WithConfigFrom(path string) UniverseOption {
+	return func(universe *Universe) error {
+		projectConfig, err := internalconfig.ReadFrom(path)
+		if err != nil {
+			return err
+		}
+
+		universe.Config = projectConfig
+		return nil
+	}
+}
+
+// WithConfig stores the already loaded project configuration
+func WithConfig(projectConfig *config.Config) UniverseOption {
+	return func(universe *Universe) error {
+		universe.Config = projectConfig
+		return nil
+	}
+}
+
+// WithBoilerplateFrom loads the boilerplate from the provided path
+func WithBoilerplateFrom(path string) UniverseOption {
+	return func(universe *Universe) error {
+		boilerplate, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		universe.Boilerplate = string(boilerplate)
+		return nil
+	}
+}
+
+// WithBoilerplate stores the already loaded project configuration
+func WithBoilerplate(boilerplate string) UniverseOption {
+	return func(universe *Universe) error {
+		universe.Boilerplate = string(boilerplate)
+		return nil
+	}
+}
+
+// WithoutBoilerplate is used for files that do not require a boilerplate
+func WithoutBoilerplate(universe *Universe) error {
+	universe.Boilerplate = "-"
+	return nil
+}
+
+// WithResource stores the provided resource
+func WithResource(resource *resource.Resource, project *config.Config) UniverseOption {
+	return func(universe *Universe) error {
+		resourceModel := &Resource{
+			Namespaced: resource.Namespaced,
+			Group:      resource.Group,
+			Version:    resource.Version,
+			Kind:       resource.Kind,
+			Resource:   resource.Resource,
+			Plural:     flect.Pluralize(strings.ToLower(resource.Kind)),
+		}
+
+		resourceModel.GoPackage, resourceModel.GroupDomain = util.GetResourceInfo(
+			resource,
+			project.Repo,
+			project.Domain,
+			project.MultiGroup,
+		)
+
+		universe.Resource = resourceModel
+		return nil
+	}
+}

--- a/pkg/scaffold/project.go
+++ b/pkg/scaffold/project.go
@@ -87,14 +87,18 @@ func (p *V1Project) EnsureDependencies() (bool, error) {
 	return true, c.Run()
 }
 
-func (p *V1Project) buildUniverse() *model.Universe {
-	return &model.Universe{}
-}
-
 func (p *V1Project) Scaffold() error {
 	s := &Scaffold{
 		BoilerplateOptional: true,
 		ConfigOptional:      true,
+	}
+
+	universe, err := model.NewUniverse(
+		model.WithConfig(&p.Project.Config),
+		model.WithoutBoilerplate,
+	)
+	if err != nil {
+		return fmt.Errorf("error initializing project: %v", err)
 	}
 
 	projectInput, err := p.Project.GetInput()
@@ -108,7 +112,7 @@ func (p *V1Project) Scaffold() error {
 	}
 
 	err = s.Execute(
-		p.buildUniverse(),
+		universe,
 		input.Options{ProjectPath: projectInput.Path, BoilerplatePath: bpInput.Path},
 		&p.Project,
 		&p.Boilerplate,
@@ -121,8 +125,17 @@ func (p *V1Project) Scaffold() error {
 	imgName := "controller:latest"
 
 	s = &Scaffold{}
+
+	universe, err = model.NewUniverse(
+		model.WithConfig(&p.Project.Config),
+		model.WithBoilerplateFrom(p.Boilerplate.Path),
+	)
+	if err != nil {
+		return fmt.Errorf("error initializing project: %v", err)
+	}
+
 	return s.Execute(
-		p.buildUniverse(),
+		universe,
 		input.Options{ProjectPath: projectInput.Path, BoilerplatePath: bpInput.Path},
 		&project.GitIgnore{},
 		&project.KustomizeRBAC{},
@@ -176,14 +189,18 @@ func (p *V2Project) EnsureDependencies() (bool, error) {
 	return true, err
 }
 
-func (p *V2Project) buildUniverse() *model.Universe {
-	return &model.Universe{}
-}
-
 func (p *V2Project) Scaffold() error {
 	s := &Scaffold{
 		BoilerplateOptional: true,
 		ConfigOptional:      true,
+	}
+
+	universe, err := model.NewUniverse(
+		model.WithConfig(&p.Project.Config),
+		model.WithoutBoilerplate,
+	)
+	if err != nil {
+		return fmt.Errorf("error initializing project: %v", err)
 	}
 
 	projectInput, err := p.Project.GetInput()
@@ -197,7 +214,7 @@ func (p *V2Project) Scaffold() error {
 	}
 
 	err = s.Execute(
-		p.buildUniverse(),
+		universe,
 		input.Options{ProjectPath: projectInput.Path, BoilerplatePath: bpInput.Path},
 		&p.Project,
 		&p.Boilerplate,
@@ -210,8 +227,17 @@ func (p *V2Project) Scaffold() error {
 	imgName := "controller:latest"
 
 	s = &Scaffold{}
+
+	universe, err = model.NewUniverse(
+		model.WithConfig(&p.Project.Config),
+		model.WithBoilerplateFrom(p.Boilerplate.Path),
+	)
+	if err != nil {
+		return fmt.Errorf("error initializing project: %v", err)
+	}
+
 	return s.Execute(
-		p.buildUniverse(),
+		universe,
 		input.Options{ProjectPath: projectInput.Path, BoilerplatePath: bpInput.Path},
 		&project.GitIgnore{},
 		&metricsauthv2.AuthProxyPatch{},
@@ -239,5 +265,6 @@ func (p *V2Project) Scaffold() error {
 		&prometheus.ServiceMonitor{},
 		&certmanager.CertManager{},
 		&certmanager.Kustomization{},
-		&certmanager.KustomizeConfig{})
+		&certmanager.KustomizeConfig{},
+	)
 }

--- a/plugins/addon/type.go
+++ b/plugins/addon/type.go
@@ -19,7 +19,7 @@ func ReplaceTypes(u *model.Universe) error {
 	}
 
 	var path string
-	if u.MultiGroup {
+	if u.Config.MultiGroup {
 		path = filepath.Join("apis", u.Resource.Version, strings.ToLower(u.Resource.Kind)+"_types.go")
 	} else {
 		path = filepath.Join("api", u.Resource.Version, strings.ToLower(u.Resource.Kind)+"_types.go")


### PR DESCRIPTION
### Description

Include the PROJECT file into `model.Universe`.

It also provides a constructor for `model.Universe` called `model.NewUniverse` that uses the functional options paradigm to provide optional configuration.

### Motivation

The main motivation is providing plugins access to the configuration file. Additionally, `scaffold.Execute` needs some information aside from the files it scaffolds. Right now this informnation is provided in three different ways. As fields to the `Scaffold` instance, the first parameter to `Scaffold.Execute` (`model.Universe`), and the second parameter to `Scaffold.Execute` (`input.Options`). This change is a first step into providing a single way to provide that information.

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.

/kind feature
