### PR TITLE
Offer a flag to change the image name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module sigs.k8s.io/kubebuilder
 go 1.13
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/gobuffalo/flect v0.1.5
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gobuffalo/flect v0.1.5 h1:xpKq9ap8MbYfhuPCF0dBH854Gp9CxZjr/IocxELFflo=
@@ -34,6 +36,8 @@ github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/scaffold/project.go
+++ b/pkg/scaffold/project.go
@@ -54,6 +54,7 @@ type ProjectScaffolder interface {
 type V1Project struct {
 	Project     project.Project
 	Boilerplate project.Boilerplate
+	ImageName   string
 
 	DepArgs          []string
 	DefinitelyEnsure *bool
@@ -118,9 +119,6 @@ func (p *V1Project) Scaffold() error {
 		return err
 	}
 
-	// default controller manager image name
-	imgName := "controller:latest"
-
 	s = &Scaffold{}
 	return s.Execute(
 		p.buildUniverse(),
@@ -133,8 +131,8 @@ func (p *V1Project) Scaffold() error {
 		&scaffoldv1.AuthProxyService{},
 		&project.AuthProxyRole{},
 		&project.AuthProxyRoleBinding{},
-		&manager.Config{Image: imgName},
-		&project.Makefile{Image: imgName},
+		&manager.Config{Image: p.ImageName},
+		&project.Makefile{Image: p.ImageName},
 		&project.GopkgToml{},
 		&manager.Dockerfile{},
 		&project.Kustomize{},
@@ -148,6 +146,7 @@ func (p *V1Project) Scaffold() error {
 type V2Project struct {
 	Project     project.Project
 	Boilerplate project.Boilerplate
+	ImageName   string
 }
 
 func (p *V2Project) Validate() error {
@@ -209,9 +208,6 @@ func (p *V2Project) Scaffold() error {
 		return err
 	}
 
-	// default controller manager image name
-	imgName := "controller:latest"
-
 	s = &Scaffold{}
 	return s.Execute(
 		p.buildUniverse(),
@@ -222,10 +218,10 @@ func (p *V2Project) Scaffold() error {
 		&metricsauthv2.ClientClusterRole{},
 		&project.AuthProxyRole{},
 		&project.AuthProxyRoleBinding{},
-		&managerv2.Config{Image: imgName},
+		&managerv2.Config{Image: p.ImageName},
 		&scaffoldv2.Main{},
 		&scaffoldv2.GoMod{ControllerRuntimeVersion: controllerRuntimeVersion},
-		&scaffoldv2.Makefile{Image: imgName, ControllerToolsVersion: controllerToolsVersion},
+		&scaffoldv2.Makefile{Image: p.ImageName, ControllerToolsVersion: controllerToolsVersion},
 		&scaffoldv2.Dockerfile{},
 		&scaffoldv2.Kustomize{},
 		&scaffoldv2.ManagerWebhookPatch{},


### PR DESCRIPTION
### Description

Add `--image` flag to `kubebuilder init ...` command that allows to specify a image name instead of having it hardcoded.

### Motivation

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.

/kind feature
