### PR TITLE
Fix unofficial way of handling already existing files

### DIFF
--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -221,7 +221,7 @@ func (api *API) scaffoldV2() error {
 			crdKustomization,
 			&crdv2.KustomizeConfig{},
 		)
-		if err != nil && !isAlreadyExistsError(err) {
+		if err != nil {
 			return fmt.Errorf("error scaffolding kustomization: %v", err)
 		}
 

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -219,19 +219,6 @@ func (s *Scaffold) Execute(u *model.Universe, options input.Options, files ...in
 	return nil
 }
 
-type errorAlreadyExists struct {
-	path string
-}
-
-func (e *errorAlreadyExists) Error() string {
-	return fmt.Sprintf("%s already exists", e.path)
-}
-
-func isAlreadyExistsError(e error) bool {
-	_, ok := e.(*errorAlreadyExists)
-	return ok
-}
-
 // doFile scaffolds a single file
 func (s *Scaffold) buildFileModel(e input.File) (*model.File, error) {
 	// Set common fields
@@ -269,7 +256,7 @@ func (s *Scaffold) writeFile(file *model.File) error {
 		case input.Skip:
 			return nil
 		case input.Error:
-			return &errorAlreadyExists{path: file.Path}
+			return fmt.Errorf("%s already exists", file.Path)
 		}
 	}
 

--- a/pkg/scaffold/v2/crd/kustomization.go
+++ b/pkg/scaffold/v2/crd/kustomization.go
@@ -50,7 +50,6 @@ func (f *Kustomization) GetInput() (input.Input, error) {
 		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
 	}
 	f.TemplateBody = kustomizationTemplate
-	f.Input.IfExistsAction = input.Error
 	return f.Input, nil
 }
 

--- a/pkg/scaffold/v2/crd/kustomizeconfig.go
+++ b/pkg/scaffold/v2/crd/kustomizeconfig.go
@@ -35,7 +35,6 @@ func (f *KustomizeConfig) GetInput() (input.Input, error) {
 		f.Path = filepath.Join("config", "crd", "kustomizeconfig.yaml")
 	}
 	f.TemplateBody = kustomizeConfigTemplate
-	f.Input.IfExistsAction = input.Error
 	return f.Input, nil
 }
 


### PR DESCRIPTION
### Description

Two files were being scaffolded with the `IfExistsAction` set to `Error` which will make the scaffolder return an error, and these kinds of errors were being skipped afterwards. `IfExistsAction` set to `Skip` (default value) is the official way of achieving this.

After doing so, the `isAlreadyExistsError` was unused, and therefore there was no reason to keep `alreadyExistsError` as a struct, `fmt.Errorf` was used instead to simplify the code.

### Motivation

This PR is part of a bigger change tracked in #1218 but can be applied rightaway.

/kind bug
