### PR TITLE
(travis improvements): Run checks scripts just once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,16 +50,19 @@ install:
   -
 
 script:
-- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
-- ./scripts/verify.sh
-# The golden_test.sh check if the the testdata is updated according to the current changes
-# To update the testdata use the Makefile targets `make generate-setup` then `make generate-testdata`
-- ./golden_test.sh
 - ./test.sh
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then PATH=$PATH:$(pwd) ./test_e2e.sh; fi
 
 jobs:
   include:
+    - stage: Validations
+      before_script:
+        - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+      script:
+        - ./scripts/verify.sh
+        # The golden_test.sh check if the the testdata is updated according to the current changes
+        # To update the testdata use the Makefile targets `make generate-setup` then `make generate-testdata`
+        - ./golden_test.sh
     - stage: Go Coverage
       before_script:
         # The following module is used to integrate the projct with coveralls.io. It allow us to easily sent the data.


### PR DESCRIPTION
**Description**
- We do not need to run the golint checks in all servers as the golden scripts. Just check them once would be enough. 