### PR TITLE
Improve controller-gen installer task

### DIFF
--- a/pkg/scaffold/v2/makefile.go
+++ b/pkg/scaffold/v2/makefile.go
@@ -120,8 +120,6 @@ ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@{{.ControllerToolsVersion}} ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
 endif
+CONTROLLER_GEN=$(shell which controller-gen)
 `


### PR DESCRIPTION
This fixes if for the first run for goenv
https://github.com/kubernetes-sigs/kubebuilder/issues/1319

Removing the variation of controler-gen discovery `CONTROLLER_GEN=$(GOBIN)/controller-gen` in favour of the common `CONTROLLER_GEN=$(shell which controller-gen)`
It also works post install, works first and follow up runs..