### PR TITLE
Enable linters for golangci-lint

### DIFF
--- a/pkg/scaffold/project/project_test.go
+++ b/pkg/scaffold/project/project_test.go
@@ -133,7 +133,7 @@ Copyright %s Example Owners.
 			})
 
 			It("should skip writing Gopkg.toml", func() {
-				e := strings.Replace(string(result.Golden), project.DefaultGopkgHeader, "", -1)
+				e := strings.Replace(result.Golden, project.DefaultGopkgHeader, "", -1)
 				_, err = f.Write([]byte(e))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(f.Close()).NotTo(HaveOccurred())
@@ -158,7 +158,7 @@ Copyright %s Example Owners.
 			})
 
 			It("should keep the user content", func() {
-				e := strings.Replace(string(result.Golden),
+				e := strings.Replace(result.Golden,
 					project.DefaultGopkgUserContent, "Hello World", -1)
 				_, err = f.Write([]byte(e))
 				Expect(err).NotTo(HaveOccurred())

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -37,8 +37,12 @@ golangci-lint run --disable-all --deadline 5m \
     --enable=maligned \
     --enable=misspell \
     --enable=nakedret \
+    --enable=prealloc \
+    --enable=scopelint \
     --enable=staticcheck \
     --enable=structcheck \
+    --enable=typecheck \
+    --enable=unconvert \
     --enable=unparam \
     --enable=unused \
     --enable=varcheck \


### PR DESCRIPTION
Enabled linters: prealloc, scopelint, typecheck, unconvert

On my local run only "unconvert" linter had an issue in `pkg/scaffold/project/project_test.go` which is fixed.

Part of #1309
