### PR TITLE
Clean old users from the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - kubebuilder-owners
   - kubebuilder-admins
-  - kubebuilder-maintainers
+  - kubebuilder-approvers
 reviewers:
+  - kubebuilder-admins
   - kubebuilder-reviewers
+  - kubebuilder-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,16 +1,24 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 aliases:
-  kubebuilder-owners:
-    - droot
-    - pwittrock
+  # active folks who can be contacted to perform admin-related
+  # tasks on the repo, or otherwise approve any PRs.
   kubebuilder-admins:
-    - directxman12
-  kubebuilder-maintainers:
-    - Liujingfang1
+    - droot
     - mengqiy
-    - pmorie
+    - directxman12
+
+  # non-admin folks who can approve any PRs in the repo
+  kubebuilder-approvers: [] 
+
+  # folks who can review and LGTM any PRs in the repo (doesn't include
+  # approvers & admins -- those count too via the OWNERS file)
   kubebuilder-reviewers:
     - camilamacedo86
     - joelanford
     - estroz
+
+  # folks who may have context on ancient history,
+  # but are no longer directly involved
+  kubebuilder-emeritus-approvers: 
+  - pwittrock


### PR DESCRIPTION
This cleans up old users from the OWNERS and OWNERS_ALIASES files.
This should mean that folks who get assigned for reviews are now active.