### PR TITLE
🏃‍♂️ fix kind kubeconfig export and docs

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -216,7 +216,6 @@ function setup_envs {
   export TEST_ASSET_KUBE_APISERVER=$tmp_root/kubebuilder/bin/kube-apiserver
   export TEST_ASSET_ETCD=$tmp_root/kubebuilder/bin/etcd
   export TEST_DEP=$tmp_root/kubebuilder/init_project
-  export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
 }
 
 # download_vendor_archive downloads vendor tarball for v1 projects. It skips the

--- a/docs/book/src/reference/kind.md
+++ b/docs/book/src/reference/kind.md
@@ -44,7 +44,7 @@ kind load docker-image your-image-name:your-tag
 
 - Point `kubectl` to the kind cluster
 ```bash
-export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+kind export kubeconfig
 ```
 
 - Delete a kind cluster


### PR DESCRIPTION
kind deprecated get kubeconfig-path, we should just directly export the kubeconfig for e2e.

found while debugging some flakey tests
