### PR TITLE
Template mixins

### DIFF
--- a/pkg/model/file/template.go
+++ b/pkg/model/file/template.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package file
 
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/resource"
+)
+
 // Input is the input for scaffolding a file
 type Input struct {
 	// Path is the file to write
@@ -88,6 +92,24 @@ type MultiGroup interface {
 // SetVersion sets the MultiGroup value
 func (i *Input) SetMultiGroup(v bool) {
 	i.MultiGroup = v
+}
+
+// HasResource allows a resource to be used on a template
+type HasResource interface {
+	// InjectResource sets the template resource
+	InjectResource(*resource.Resource)
+}
+
+// ResourceMixin provides templates with a injectable resource field
+type ResourceMixin struct {
+	Resource *resource.Resource
+}
+
+// InjectResource implements HasResource
+func (m *ResourceMixin) InjectResource(res *resource.Resource) {
+	if m.Resource == nil {
+		m.Resource = res
+	}
 }
 
 // Template is a scaffoldable file template

--- a/pkg/model/file/template.go
+++ b/pkg/model/file/template.go
@@ -36,9 +36,6 @@ type Input struct {
 
 	// Repo is the go project package
 	Repo string
-
-	// MultiGroup is the multi-group boolean from the PROJECT file
-	MultiGroup bool
 }
 
 // Domain allows a domain to be set on an object
@@ -67,20 +64,26 @@ func (i *Input) SetRepo(r string) {
 	}
 }
 
-// MultiGroup allows the project version to be set on an object
-type MultiGroup interface {
-	// SetVersion sets the project version
-	SetMultiGroup(value bool)
+// HasMultiGroup allows the multi-group flag to be used on a template
+type HasMultiGroup interface {
+	// InjectMultiGroup sets the template multi-group flag
+	InjectMultiGroup(bool)
 }
 
-// SetVersion sets the MultiGroup value
-func (i *Input) SetMultiGroup(v bool) {
-	i.MultiGroup = v
+// MultiGroupMixin provides templates with a injectable multi-group flag field
+type MultiGroupMixin struct {
+	// MultiGroup is the multi-group flag
+	MultiGroup bool
+}
+
+// InjectMultiGroup implements HasMultiGroup
+func (m *MultiGroupMixin) InjectMultiGroup(flag bool) {
+	m.MultiGroup = flag
 }
 
 // HasBoilerplate allows a boilerplate to be used on a template
 type HasBoilerplate interface {
-	// InjectBoilerplate sets the template resource
+	// InjectBoilerplate sets the template boilerplate
 	InjectBoilerplate(string)
 }
 

--- a/pkg/model/file/template.go
+++ b/pkg/model/file/template.go
@@ -30,21 +30,24 @@ type Input struct {
 
 	// TemplateBody is the template body to execute
 	TemplateBody string
+}
 
+// HasDomain allows the domain to be used on a template
+type HasDomain interface {
+	// InjectDomain sets the template domain
+	InjectDomain(string)
+}
+
+// DomainMixin provides templates with a injectable domain field
+type DomainMixin struct {
 	// Domain is the domain for the APIs
 	Domain string
 }
 
-// Domain allows a domain to be set on an object
-type Domain interface {
-	// SetDomain sets the domain
-	SetDomain(string)
-}
-
-// SetDomain sets the domain
-func (i *Input) SetDomain(d string) {
-	if i.Domain == "" {
-		i.Domain = d
+// InjectDomain implements HasDomain
+func (m *DomainMixin) InjectDomain(domain string) {
+	if m.Domain == "" {
+		m.Domain = domain
 	}
 }
 

--- a/pkg/model/file/template.go
+++ b/pkg/model/file/template.go
@@ -33,9 +33,6 @@ type Input struct {
 
 	// Domain is the domain for the APIs
 	Domain string
-
-	// Repo is the go project package
-	Repo string
 }
 
 // Domain allows a domain to be set on an object
@@ -51,16 +48,22 @@ func (i *Input) SetDomain(d string) {
 	}
 }
 
-// Repo allows a repo to be set on an object
-type Repo interface {
-	// SetRepo sets the repo
-	SetRepo(string)
+// HasRepository allows the repository to be used on a template
+type HasRepository interface {
+	// InjectRepository sets the template repository
+	InjectRepository(string)
 }
 
-// SetRepo sets the repo
-func (i *Input) SetRepo(r string) {
-	if i.Repo == "" {
-		i.Repo = r
+// RepositoryMixin provides templates with a injectable repository field
+type RepositoryMixin struct {
+	// Repo is the go project package path
+	Repo string
+}
+
+// InjectRepository implements HasRepository
+func (m *RepositoryMixin) InjectRepository(repository string) {
+	if m.Repo == "" {
+		m.Repo = repository
 	}
 }
 

--- a/pkg/model/file/template.go
+++ b/pkg/model/file/template.go
@@ -31,9 +31,6 @@ type Input struct {
 	// TemplateBody is the template body to execute
 	TemplateBody string
 
-	// Boilerplate is the contents of a Boilerplate go header file
-	Boilerplate string
-
 	// Domain is the domain for the APIs
 	Domain string
 
@@ -70,19 +67,6 @@ func (i *Input) SetRepo(r string) {
 	}
 }
 
-// Boilerplate allows boilerplate text to be set on an object
-type Boilerplate interface {
-	// SetBoilerplate sets the boilerplate text
-	SetBoilerplate(string)
-}
-
-// SetBoilerplate sets the boilerplate text
-func (i *Input) SetBoilerplate(b string) {
-	if i.Boilerplate == "" {
-		i.Boilerplate = b
-	}
-}
-
 // MultiGroup allows the project version to be set on an object
 type MultiGroup interface {
 	// SetVersion sets the project version
@@ -92,6 +76,25 @@ type MultiGroup interface {
 // SetVersion sets the MultiGroup value
 func (i *Input) SetMultiGroup(v bool) {
 	i.MultiGroup = v
+}
+
+// HasBoilerplate allows a boilerplate to be used on a template
+type HasBoilerplate interface {
+	// InjectBoilerplate sets the template resource
+	InjectBoilerplate(string)
+}
+
+// BoilerplateMixin provides templates with a injectable boilerplate field
+type BoilerplateMixin struct {
+	// Boilerplate is the contents of a Boilerplate go header file
+	Boilerplate string
+}
+
+// InjectBoilerplate implements HasBoilerplate
+func (m *BoilerplateMixin) InjectBoilerplate(boilerplate string) {
+	if m.Boilerplate == "" {
+		m.Boilerplate = boilerplate
+	}
 }
 
 // HasResource allows a resource to be used on a template

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -81,8 +81,8 @@ func WithResource(resource *resource.Resource) UniverseOption {
 func (u Universe) InjectInto(t file.Template) {
 	// Inject project configuration
 	if u.Config != nil {
-		if templateWithDomain, ok := t.(file.Domain); ok {
-			templateWithDomain.SetDomain(u.Config.Domain)
+		if templateWithDomain, hasDomain := t.(file.HasDomain); hasDomain {
+			templateWithDomain.InjectDomain(u.Config.Domain)
 		}
 		if templateWithRepository, hasRepository := t.(file.HasRepository); hasRepository {
 			templateWithRepository.InjectRepository(u.Config.Repo)

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -92,8 +92,8 @@ func (u Universe) InjectInto(t file.Template) {
 		}
 	}
 	// Inject boilerplate
-	if templateWithBoilerplate, ok := t.(file.Boilerplate); ok {
-		templateWithBoilerplate.SetBoilerplate(u.Boilerplate)
+	if templateWithBoilerplate, hasBoilerplate := t.(file.HasBoilerplate); hasBoilerplate {
+		templateWithBoilerplate.InjectBoilerplate(u.Boilerplate)
 	}
 	// Inject resource
 	if u.Resource != nil {

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -84,8 +84,8 @@ func (u Universe) InjectInto(t file.Template) {
 		if templateWithDomain, ok := t.(file.Domain); ok {
 			templateWithDomain.SetDomain(u.Config.Domain)
 		}
-		if templateWithRepository, ok := t.(file.Repo); ok {
-			templateWithRepository.SetRepo(u.Config.Repo)
+		if templateWithRepository, hasRepository := t.(file.HasRepository); hasRepository {
+			templateWithRepository.InjectRepository(u.Config.Repo)
 		}
 		if templateWithMultiGroup, hasMultiGroup := t.(file.HasMultiGroup); hasMultiGroup {
 			templateWithMultiGroup.InjectMultiGroup(u.Config.MultiGroup)

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -87,8 +87,8 @@ func (u Universe) InjectInto(t file.Template) {
 		if templateWithRepository, ok := t.(file.Repo); ok {
 			templateWithRepository.SetRepo(u.Config.Repo)
 		}
-		if templateWithMultiGroup, ok := t.(file.MultiGroup); ok {
-			templateWithMultiGroup.SetMultiGroup(u.Config.MultiGroup)
+		if templateWithMultiGroup, hasMultiGroup := t.(file.HasMultiGroup); hasMultiGroup {
+			templateWithMultiGroup.InjectMultiGroup(u.Config.MultiGroup)
 		}
 	}
 	// Inject boilerplate

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -95,4 +95,10 @@ func (u Universe) InjectInto(t file.Template) {
 	if templateWithBoilerplate, ok := t.(file.Boilerplate); ok {
 		templateWithBoilerplate.SetBoilerplate(u.Boilerplate)
 	}
+	// Inject resource
+	if u.Resource != nil {
+		if templateWithResource, hasResource := t.(file.HasResource); hasResource {
+			templateWithResource.InjectResource(u.Resource)
+		}
+	}
 }

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -93,14 +93,14 @@ func (s *apiScaffolder) scaffoldV1() error {
 
 		if err := machinery.NewScaffold().Execute(
 			s.newUniverse(),
-			&crdv1.Register{Resource: s.resource},
-			&crdv1.Types{Resource: s.resource},
-			&crdv1.VersionSuiteTest{Resource: s.resource},
-			&crdv1.TypesTest{Resource: s.resource},
-			&crdv1.Doc{Resource: s.resource},
-			&crdv1.Group{Resource: s.resource},
-			&crdv1.AddToScheme{Resource: s.resource},
-			&crdv1.CRDSample{Resource: s.resource},
+			&crdv1.Register{},
+			&crdv1.Types{},
+			&crdv1.VersionSuiteTest{},
+			&crdv1.TypesTest{},
+			&crdv1.Doc{},
+			&crdv1.Group{},
+			&crdv1.AddToScheme{},
+			&crdv1.CRDSample{},
 		); err != nil {
 			return fmt.Errorf("error scaffolding APIs: %v", err)
 		}
@@ -120,10 +120,10 @@ func (s *apiScaffolder) scaffoldV1() error {
 
 		if err := machinery.NewScaffold().Execute(
 			s.newUniverse(),
-			&controllerv1.Controller{Resource: s.resource},
-			&controllerv1.AddController{Resource: s.resource},
-			&controllerv1.Test{Resource: s.resource},
-			&controllerv1.SuiteTest{Resource: s.resource},
+			&controllerv1.Controller{},
+			&controllerv1.AddController{},
+			&controllerv1.Test{},
+			&controllerv1.SuiteTest{},
 		); err != nil {
 			return fmt.Errorf("error scaffolding controller: %v", err)
 		}
@@ -151,18 +151,18 @@ func (s *apiScaffolder) scaffoldV2() error {
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),
-			&templatesv2.Types{Resource: s.resource},
-			&templatesv2.Group{Resource: s.resource},
-			&templatesv2.CRDSample{Resource: s.resource},
-			&templatesv2.CRDEditorRole{Resource: s.resource},
-			&templatesv2.CRDViewerRole{Resource: s.resource},
-			&crdv2.EnableWebhookPatch{Resource: s.resource},
-			&crdv2.EnableCAInjectionPatch{Resource: s.resource},
+			&templatesv2.Types{},
+			&templatesv2.Group{},
+			&templatesv2.CRDSample{},
+			&templatesv2.CRDEditorRole{},
+			&templatesv2.CRDViewerRole{},
+			&crdv2.EnableWebhookPatch{},
+			&crdv2.EnableCAInjectionPatch{},
 		); err != nil {
 			return fmt.Errorf("error scaffolding APIs: %v", err)
 		}
 
-		kustomizationFile := &crdv2.Kustomization{Resource: s.resource}
+		kustomizationFile := &crdv2.Kustomization{}
 		if err := machinery.NewScaffold().Execute(
 			s.newUniverse(),
 			kustomizationFile,
@@ -192,11 +192,11 @@ func (s *apiScaffolder) scaffoldV2() error {
 				fmt.Sprintf("%s_controller.go", strings.ToLower(s.resource.Kind))))
 		}
 
-		suiteTestFile := &controllerv2.SuiteTest{Resource: s.resource}
+		suiteTestFile := &controllerv2.SuiteTest{}
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),
 			suiteTestFile,
-			&controllerv2.Controller{Resource: s.resource},
+			&controllerv2.Controller{},
 		); err != nil {
 			return fmt.Errorf("error scaffolding controller: %v", err)
 		}

--- a/pkg/scaffold/internal/templates/v1/boilerplate.go
+++ b/pkg/scaffold/internal/templates/v1/boilerplate.go
@@ -29,6 +29,7 @@ var _ file.Template = &Boilerplate{}
 // Boilerplate scaffolds a boilerplate header file.
 type Boilerplate struct {
 	file.Input
+	file.BoilerplateMixin
 
 	// License is the License type to write
 	License string

--- a/pkg/scaffold/internal/templates/v1/controller/add.go
+++ b/pkg/scaffold/internal/templates/v1/controller/add.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &AddController{}
@@ -30,9 +29,7 @@ var _ file.Template = &AddController{}
 // AddController scaffolds adds a new Controller.
 type AddController struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/controller/add.go
+++ b/pkg/scaffold/internal/templates/v1/controller/add.go
@@ -29,6 +29,7 @@ var _ file.Template = &AddController{}
 // AddController scaffolds adds a new Controller.
 type AddController struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/controller/add.go
+++ b/pkg/scaffold/internal/templates/v1/controller/add.go
@@ -29,6 +29,7 @@ var _ file.Template = &AddController{}
 // AddController scaffolds adds a new Controller.
 type AddController struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v1/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controller.go
@@ -28,6 +28,7 @@ var _ file.Template = &Controller{}
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controller.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Controller{}
@@ -29,9 +28,7 @@ var _ file.Template = &Controller{}
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	file.Input
-
-	// Resource is the Resource to make the Controller for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
@@ -28,6 +28,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds a SuiteTest
 type SuiteTest struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &SuiteTest{}
@@ -29,9 +28,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds a SuiteTest
 type SuiteTest struct {
 	file.Input
-
-	// Resource is the Resource to make the Controller for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllersuitetest.go
@@ -28,6 +28,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds a SuiteTest
 type SuiteTest struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/controller/controllertest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllertest.go
@@ -28,6 +28,7 @@ var _ file.Template = &Test{}
 // Test scaffolds a Controller Test
 type Test struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/controller/controllertest.go
+++ b/pkg/scaffold/internal/templates/v1/controller/controllertest.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Test{}
@@ -29,9 +28,7 @@ var _ file.Template = &Test{}
 // Test scaffolds a Controller Test
 type Test struct {
 	file.Input
-
-	// Resource is the Resource to make the Controller for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
+++ b/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
@@ -28,6 +28,7 @@ var _ file.Template = &AddToScheme{}
 // AddToScheme scaffolds the code to add the resource to a SchemeBuilder.
 type AddToScheme struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
+++ b/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &AddToScheme{}
@@ -29,9 +28,7 @@ var _ file.Template = &AddToScheme{}
 // AddToScheme scaffolds the code to add the resource to a SchemeBuilder.
 type AddToScheme struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/crd_sample.go
+++ b/pkg/scaffold/internal/templates/v1/crd/crd_sample.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &CRDSample{}
@@ -31,9 +30,7 @@ var _ file.Template = &CRDSample{}
 // nolint:golint
 type CRDSample struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/doc.go
+++ b/pkg/scaffold/internal/templates/v1/crd/doc.go
@@ -27,6 +27,7 @@ var _ file.Template = &Doc{}
 // Doc scaffolds the pkg/apis/group/version/doc.go directory
 type Doc struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v1/crd/doc.go
+++ b/pkg/scaffold/internal/templates/v1/crd/doc.go
@@ -27,6 +27,7 @@ var _ file.Template = &Doc{}
 // Doc scaffolds the pkg/apis/group/version/doc.go directory
 type Doc struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/crd/doc.go
+++ b/pkg/scaffold/internal/templates/v1/crd/doc.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Doc{}
@@ -28,9 +27,7 @@ var _ file.Template = &Doc{}
 // Doc scaffolds the pkg/apis/group/version/doc.go directory
 type Doc struct {
 	file.Input
-
-	// Resource is a resource for the API version
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/group.go
+++ b/pkg/scaffold/internal/templates/v1/crd/group.go
@@ -27,6 +27,7 @@ var _ file.Template = &Group{}
 // Group scaffolds the pkg/apis/group/group.go
 type Group struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/crd/group.go
+++ b/pkg/scaffold/internal/templates/v1/crd/group.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Group{}
@@ -28,9 +27,7 @@ var _ file.Template = &Group{}
 // Group scaffolds the pkg/apis/group/group.go
 type Group struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/register.go
+++ b/pkg/scaffold/internal/templates/v1/crd/register.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Register{}
@@ -28,9 +27,7 @@ var _ file.Template = &Register{}
 // Register scaffolds the pkg/apis/group/version/register.go file
 type Register struct {
 	file.Input
-
-	// Resource is the resource to scaffold the types_test.go file for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/register.go
+++ b/pkg/scaffold/internal/templates/v1/crd/register.go
@@ -27,6 +27,7 @@ var _ file.Template = &Register{}
 // Register scaffolds the pkg/apis/group/version/register.go file
 type Register struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v1/crd/register.go
+++ b/pkg/scaffold/internal/templates/v1/crd/register.go
@@ -27,6 +27,7 @@ var _ file.Template = &Register{}
 // Register scaffolds the pkg/apis/group/version/register.go file
 type Register struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/crd/types.go
+++ b/pkg/scaffold/internal/templates/v1/crd/types.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Types{}
@@ -30,9 +29,7 @@ var _ file.Template = &Types{}
 // Types scaffolds the pkg/apis/group/version/kind_types.go file to define the schema for an API
 type Types struct {
 	file.Input
-
-	// Resource is the resource to scaffold the types_test.go file for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/types.go
+++ b/pkg/scaffold/internal/templates/v1/crd/types.go
@@ -29,6 +29,7 @@ var _ file.Template = &Types{}
 // Types scaffolds the pkg/apis/group/version/kind_types.go file to define the schema for an API
 type Types struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/crd/typestest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/typestest.go
@@ -29,6 +29,7 @@ var _ file.Template = &TypesTest{}
 // TypesTest scaffolds the pkg/apis/group/version/kind_types_test.go file to test the API schema
 type TypesTest struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/crd/typestest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/typestest.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &TypesTest{}
@@ -30,9 +29,7 @@ var _ file.Template = &TypesTest{}
 // TypesTest scaffolds the pkg/apis/group/version/kind_types_test.go file to test the API schema
 type TypesTest struct {
 	file.Input
-
-	// Resource is the resource to scaffold the types_test.go file for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &TypesTest{}
@@ -29,9 +28,7 @@ var _ file.Template = &TypesTest{}
 // VersionSuiteTest scaffolds the version_suite_test.go file to setup the versions test
 type VersionSuiteTest struct {
 	file.Input
-
-	// Resource is the resource to scaffold the types_test.go file for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
@@ -28,6 +28,7 @@ var _ file.Template = &TypesTest{}
 // VersionSuiteTest scaffolds the version_suite_test.go file to setup the versions test
 type VersionSuiteTest struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/makefile.go
+++ b/pkg/scaffold/internal/templates/v1/makefile.go
@@ -25,6 +25,8 @@ var _ file.Template = &Makefile{}
 // Makefile scaffolds the Makefile
 type Makefile struct {
 	file.Input
+	file.RepositoryMixin
+
 	// Image is controller manager image name
 	Image string
 

--- a/pkg/scaffold/internal/templates/v1/manager/apis.go
+++ b/pkg/scaffold/internal/templates/v1/manager/apis.go
@@ -29,6 +29,7 @@ var _ file.Template = &APIs{}
 // APIs scaffolds a apis.go to register types with a Scheme
 type APIs struct {
 	file.Input
+	file.BoilerplateMixin
 	// BoilerplatePath is the path to the boilerplate file
 	BoilerplatePath string
 	// Comments is a list of comments to add to the apis.go

--- a/pkg/scaffold/internal/templates/v1/manager/cmd.go
+++ b/pkg/scaffold/internal/templates/v1/manager/cmd.go
@@ -27,6 +27,7 @@ var _ file.Template = &Cmd{}
 // Cmd scaffolds a manager.go to run Controllers
 type Cmd struct {
 	file.Input
+	file.BoilerplateMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/manager/cmd.go
+++ b/pkg/scaffold/internal/templates/v1/manager/cmd.go
@@ -27,6 +27,7 @@ var _ file.Template = &Cmd{}
 // Cmd scaffolds a manager.go to run Controllers
 type Cmd struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 }
 

--- a/pkg/scaffold/internal/templates/v1/manager/controller.go
+++ b/pkg/scaffold/internal/templates/v1/manager/controller.go
@@ -27,6 +27,7 @@ var _ file.Template = &Controller{}
 // Controller scaffolds a controller.go to add Controllers to a manager.Cmd
 type Controller struct {
 	file.Input
+	file.BoilerplateMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/manager/dockerfile.go
+++ b/pkg/scaffold/internal/templates/v1/manager/dockerfile.go
@@ -25,6 +25,7 @@ var _ file.Template = &Dockerfile{}
 // Dockerfile scaffolds a Dockerfile for building a main
 type Dockerfile struct {
 	file.Input
+	file.RepositoryMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/manager/webhook.go
+++ b/pkg/scaffold/internal/templates/v1/manager/webhook.go
@@ -27,6 +27,7 @@ var _ file.Template = &Webhook{}
 // Webhook scaffolds a webhook.go to add webhook server(s) to a manager.Cmd
 type Webhook struct {
 	file.Input
+	file.BoilerplateMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
@@ -30,9 +29,7 @@ var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
 // AddAdmissionWebhookBuilderHandler scaffolds adds a new admission webhook builder.
 type AddAdmissionWebhookBuilderHandler struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 
 	Config
 }

--- a/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
@@ -29,6 +29,7 @@ var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
 // AddAdmissionWebhookBuilderHandler scaffolds adds a new admission webhook builder.
 type AddAdmissionWebhookBuilderHandler struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 

--- a/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_admissionbuilder_handler.go
@@ -29,6 +29,7 @@ var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
 // AddAdmissionWebhookBuilderHandler scaffolds adds a new admission webhook builder.
 type AddAdmissionWebhookBuilderHandler struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 
 	Config

--- a/pkg/scaffold/internal/templates/v1/webhook/add_server.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_server.go
@@ -28,6 +28,7 @@ var _ file.Template = &AddServer{}
 // AddServer scaffolds adds a new webhook server.
 type AddServer struct {
 	file.Input
+	file.BoilerplateMixin
 
 	Config
 }

--- a/pkg/scaffold/internal/templates/v1/webhook/add_server.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/add_server.go
@@ -28,6 +28,7 @@ var _ file.Template = &AddServer{}
 // AddServer scaffolds adds a new webhook server.
 type AddServer struct {
 	file.Input
+	file.RepositoryMixin
 	file.BoilerplateMixin
 
 	Config

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
@@ -29,6 +29,7 @@ var _ file.Template = &AdmissionWebhookBuilder{}
 // AdmissionWebhookBuilder scaffolds adds a new webhook server.
 type AdmissionWebhookBuilder struct {
 	file.Input
+	file.DomainMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &AdmissionWebhookBuilder{}
@@ -30,9 +29,7 @@ var _ file.Template = &AdmissionWebhookBuilder{}
 // AdmissionWebhookBuilder scaffolds adds a new webhook server.
 type AdmissionWebhookBuilder struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 
 	Config
 

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionbuilder.go
@@ -29,6 +29,7 @@ var _ file.Template = &AdmissionWebhookBuilder{}
 // AdmissionWebhookBuilder scaffolds adds a new webhook server.
 type AdmissionWebhookBuilder struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 
 	Config

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionhandler.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
@@ -30,9 +29,7 @@ var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
 // AdmissionHandler scaffolds an admission handler
 type AdmissionHandler struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 
 	Config
 

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionhandler.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionhandler.go
@@ -29,6 +29,7 @@ var _ file.Template = &AddAdmissionWebhookBuilderHandler{}
 // AdmissionHandler scaffolds an admission handler
 type AdmissionHandler struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 
 	Config

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionwebhooks.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionwebhooks.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &AdmissionWebhooks{}
@@ -30,9 +29,7 @@ var _ file.Template = &AdmissionWebhooks{}
 // AdmissionWebhooks scaffolds how to construct a webhook server and register webhooks.
 type AdmissionWebhooks struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 
 	Config
 }

--- a/pkg/scaffold/internal/templates/v1/webhook/admissionwebhooks.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/admissionwebhooks.go
@@ -29,6 +29,7 @@ var _ file.Template = &AdmissionWebhooks{}
 // AdmissionWebhooks scaffolds how to construct a webhook server and register webhooks.
 type AdmissionWebhooks struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 
 	Config

--- a/pkg/scaffold/internal/templates/v1/webhook/server.go
+++ b/pkg/scaffold/internal/templates/v1/webhook/server.go
@@ -28,6 +28,7 @@ var _ file.Template = &Server{}
 // Server scaffolds how to construct a webhook server and register webhooks.
 type Server struct {
 	file.Input
+	file.BoilerplateMixin
 
 	Config
 }

--- a/pkg/scaffold/internal/templates/v2/boilerplate.go
+++ b/pkg/scaffold/internal/templates/v2/boilerplate.go
@@ -29,6 +29,7 @@ var _ file.Template = &Boilerplate{}
 // Boilerplate scaffolds a boilerplate header file.
 type Boilerplate struct {
 	file.Input
+	file.BoilerplateMixin
 
 	// License is the License type to write
 	License string

--- a/pkg/scaffold/internal/templates/v2/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller.go
@@ -28,6 +28,7 @@ var _ file.Template = &Controller{}
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	file.Input
+	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v2/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller.go
@@ -28,6 +28,7 @@ var _ file.Template = &Controller{}
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v2/controller/controller.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Controller{}
@@ -29,9 +28,7 @@ var _ file.Template = &Controller{}
 // Controller scaffolds a Controller for a Resource
 type Controller struct {
 	file.Input
-
-	// Resource is the Resource to make the Controller for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
@@ -30,6 +30,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds the suite_test.go file to setup the controller test
 type SuiteTest struct {
 	file.Input
+	file.RepositoryMixin
 	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin

--- a/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
@@ -30,6 +30,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds the suite_test.go file to setup the controller test
 type SuiteTest struct {
 	file.Input
+	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/internal/machinery"
 	templatesv2 "sigs.k8s.io/kubebuilder/pkg/scaffold/internal/templates/v2"
 )
@@ -31,9 +30,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds the suite_test.go file to setup the controller test
 type SuiteTest struct {
 	file.Input
-
-	// Resource is the Resource to make the Controller for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
@@ -30,6 +30,7 @@ var _ file.Template = &SuiteTest{}
 // SuiteTest scaffolds the suite_test.go file to setup the controller test
 type SuiteTest struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/internal/templates/v2/crd/enablecainjection_patch.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gobuffalo/flect"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &EnableCAInjectionPatch{}
@@ -32,9 +31,7 @@ var _ file.Template = &EnableCAInjectionPatch{}
 // EnableCAInjectionPatch scaffolds a EnableCAInjectionPatch for a Resource
 type EnableCAInjectionPatch struct {
 	file.Input
-
-	// Resource is the Resource to make the EnableCAInjectionPatch for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/internal/templates/v2/crd/enablewebhook_patch.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gobuffalo/flect"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &EnableWebhookPatch{}
@@ -32,9 +31,7 @@ var _ file.Template = &EnableWebhookPatch{}
 // EnableWebhookPatch scaffolds a EnableWebhookPatch for a Resource
 type EnableWebhookPatch struct {
 	file.Input
-
-	// Resource is the Resource to make the EnableWebhookPatch for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/crd/kustomization.go
+++ b/pkg/scaffold/internal/templates/v2/crd/kustomization.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/internal/machinery"
 )
 
@@ -36,9 +35,7 @@ var _ file.Template = &Kustomization{}
 // Kustomization scaffolds the kustomization file in manager folder.
 type Kustomization struct {
 	file.Input
-
-	// Resource is the Resource to make the EnableWebhookPatch for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/crd_editor_rbac.go
+++ b/pkg/scaffold/internal/templates/v2/crd_editor_rbac.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &CRDEditorRole{}
@@ -30,9 +29,7 @@ var _ file.Template = &CRDEditorRole{}
 // CRD Editor role scaffolds the config/rbca/<kind>_editor_role.yaml
 type CRDEditorRole struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/crd_sample.go
+++ b/pkg/scaffold/internal/templates/v2/crd_sample.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &CRDSample{}
@@ -30,9 +29,7 @@ var _ file.Template = &CRDSample{}
 // CRDSample scaffolds a manifest for CRD sample.
 type CRDSample struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/crd_viewer_rbac.go
+++ b/pkg/scaffold/internal/templates/v2/crd_viewer_rbac.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &CRDViewerRole{}
@@ -30,9 +29,7 @@ var _ file.Template = &CRDViewerRole{}
 // CRD Viewer role scaffolds the config/rbca/<kind>_viewer_role.yaml
 type CRDViewerRole struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/gomod.go
+++ b/pkg/scaffold/internal/templates/v2/gomod.go
@@ -25,6 +25,8 @@ var _ file.Template = &GoMod{}
 // GoMod writes a templatefile for go.mod
 type GoMod struct {
 	file.Input
+	file.RepositoryMixin
+
 	ControllerRuntimeVersion string
 }
 

--- a/pkg/scaffold/internal/templates/v2/group.go
+++ b/pkg/scaffold/internal/templates/v2/group.go
@@ -27,6 +27,7 @@ var _ file.Template = &Group{}
 // Group scaffolds the api/<version>/groupversion_info.go
 type Group struct {
 	file.Input
+	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v2/group.go
+++ b/pkg/scaffold/internal/templates/v2/group.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Group{}
@@ -28,9 +27,7 @@ var _ file.Template = &Group{}
 // Group scaffolds the api/<version>/groupversion_info.go
 type Group struct {
 	file.Input
-
-	// Resource is a resource in the API group
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/group.go
+++ b/pkg/scaffold/internal/templates/v2/group.go
@@ -27,6 +27,7 @@ var _ file.Template = &Group{}
 // Group scaffolds the api/<version>/groupversion_info.go
 type Group struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v2/main.go
+++ b/pkg/scaffold/internal/templates/v2/main.go
@@ -37,6 +37,7 @@ var _ file.Template = &Main{}
 // Main scaffolds a main.go to run Controllers
 type Main struct {
 	file.Input
+	file.BoilerplateMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/types.go
+++ b/pkg/scaffold/internal/templates/v2/types.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Types{}
@@ -30,9 +29,7 @@ var _ file.Template = &Types{}
 // Types scaffolds the api/<version>/<kind>_types.go file to define the schema for an API
 type Types struct {
 	file.Input
-
-	// Resource is the resource to scaffold the types_test.go file for
-	Resource *resource.Resource
+	file.ResourceMixin
 }
 
 // GetInput implements input.Template

--- a/pkg/scaffold/internal/templates/v2/types.go
+++ b/pkg/scaffold/internal/templates/v2/types.go
@@ -29,6 +29,7 @@ var _ file.Template = &Types{}
 // Types scaffolds the api/<version>/<kind>_types.go file to define the schema for an API
 type Types struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 }
 

--- a/pkg/scaffold/internal/templates/v2/types.go
+++ b/pkg/scaffold/internal/templates/v2/types.go
@@ -29,6 +29,7 @@ var _ file.Template = &Types{}
 // Types scaffolds the api/<version>/<kind>_types.go file to define the schema for an API
 type Types struct {
 	file.Input
+	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 }

--- a/pkg/scaffold/internal/templates/v2/webhook/webhook.go
+++ b/pkg/scaffold/internal/templates/v2/webhook/webhook.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
-	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
 var _ file.Template = &Webhook{}
@@ -30,9 +29,7 @@ var _ file.Template = &Webhook{}
 // Webhook scaffolds a Webhook for a Resource
 type Webhook struct {
 	file.Input
-
-	// Resource is the Resource to make the Webhook for
-	Resource *resource.Resource
+	file.ResourceMixin
 
 	// Is the Group domain for the Resource replacing '.' with '-'
 	GroupDomainWithDash string

--- a/pkg/scaffold/internal/templates/v2/webhook/webhook.go
+++ b/pkg/scaffold/internal/templates/v2/webhook/webhook.go
@@ -29,6 +29,7 @@ var _ file.Template = &Webhook{}
 // Webhook scaffolds a Webhook for a Resource
 type Webhook struct {
 	file.Input
+	file.BoilerplateMixin
 	file.ResourceMixin
 
 	// Is the Group domain for the Resource replacing '.' with '-'

--- a/pkg/scaffold/internal/templates/v2/webhook/webhook.go
+++ b/pkg/scaffold/internal/templates/v2/webhook/webhook.go
@@ -27,8 +27,9 @@ import (
 var _ file.Template = &Webhook{}
 
 // Webhook scaffolds a Webhook for a Resource
-type Webhook struct {
+type Webhook struct { // nolint:maligned
 	file.Input
+	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
 

--- a/pkg/scaffold/webhook.go
+++ b/pkg/scaffold/webhook.go
@@ -102,10 +102,10 @@ func (s *webhookScaffolder) scaffoldV1() error {
 			model.WithResource(s.resource),
 		),
 		&managerv1.Webhook{},
-		&webhookv1.AdmissionHandler{Resource: s.resource, Config: webhookConfig},
-		&webhookv1.AdmissionWebhookBuilder{Resource: s.resource, Config: webhookConfig},
-		&webhookv1.AdmissionWebhooks{Resource: s.resource, Config: webhookConfig},
-		&webhookv1.AddAdmissionWebhookBuilderHandler{Resource: s.resource, Config: webhookConfig},
+		&webhookv1.AdmissionHandler{Config: webhookConfig},
+		&webhookv1.AdmissionWebhookBuilder{Config: webhookConfig},
+		&webhookv1.AdmissionWebhooks{Config: webhookConfig},
+		&webhookv1.AddAdmissionWebhookBuilderHandler{Config: webhookConfig},
 		&webhookv1.Server{Config: webhookConfig},
 		&webhookv1.AddServer{Config: webhookConfig},
 	)
@@ -125,11 +125,7 @@ func (s *webhookScaffolder) scaffoldV2() error {
 You need to implement the conversion.Hub and conversion.Convertible interfaces for your CRD types.`)
 	}
 
-	webhookScaffolder := &webhookv2.Webhook{
-		Resource:   s.resource,
-		Defaulting: s.defaulting,
-		Validating: s.validation,
-	}
+	webhookScaffolder := &webhookv2.Webhook{Defaulting: s.defaulting, Validating: s.validation}
 	if err := machinery.NewScaffold().Execute(
 		model.NewUniverse(
 			model.WithConfig(s.config),


### PR DESCRIPTION
# Description

- 76 file templates did not require the domain but it was being injected.
- 66 file templates did not require the repository but it was being injected.
- 72 file templates did not require the multi-group flag but it was being injected.
- 16 file templates did not require the boilerplate but it was being injected.
- 27 file templates required the resource and they were being provided manually.

This PR creates mixins for domain, repository, multi-group, boilerplate and resource as proposed in #1358, that inject those fields from the universe only on those templates that need it.

# Motivation

This PR is scoped under #1218
Closes #1358