### PR TITLE
fix create api command for it be idempotent

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -161,29 +161,27 @@ func (o *apiOptions) validate(c *config.Config) error {
 		o.doController = internal.YesNo(reader)
 	}
 
+	resourceExists := c.HasResource(o.resource.GVK())
+
+	if !c.IsV1() {
+		if !resourceExists && !o.doResource {
+			return errors.New("API resource do not exists. " +
+				"A Controller cannot be create for a resource that do not exist.")
+		}
+	}
+
 	// In case we want to scaffold a resource API we need to do some checks
 	if o.doResource {
 		// Skip the following check for v1 as resources aren't tracked
 		if !c.IsV1() {
 			// Check that resource doesn't exist or flag force was set
 			if !o.force {
-				resourceExists := false
-				for _, r := range c.Resources {
-					if r.Group == o.resource.Group &&
-						r.Version == o.resource.Version &&
-						r.Kind == o.resource.Kind {
-						resourceExists = true
-						break
-					}
-				}
 				if resourceExists {
-					return errors.New("API resource already exists")
+					fmt.Printf("API resource already exists. Creating just the Controller ...")
+					o.doResource = false
 				}
 			}
-		}
 
-		// The following check is v2 specific as multi-group isn't enabled by default
-		if c.IsV2() {
 			// Check the group is the same for single-group projects
 			if !c.MultiGroup {
 				validGroup := true


### PR DESCRIPTION
**Description**

- Check if has the resource if not it always will scaffold it
- Users are allowed to chosen between [y/n] to scaffold the controllers only.

**Motivation**
If we run `kubebuilder create api --group webapp --version v1 --kind Guestbook`

> resource=false
> controller=true

NOTE: It will break the project since the controller requires the resource in the scaffold. (it is a bug in the master which should not allow this option)

Closes: #1263

**Solution**
<img width="1247" alt="Screenshot 2020-02-26 at 09 32 46" src="https://user-images.githubusercontent.com/7708031/75332021-98713880-587b-11ea-85f4-11ad65088c9c.png">


