### PR TITLE
Introduce .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - prealloc
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+
+run:
+  deadline: 5m

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,31 +18,4 @@ source ./common.sh
 
 header_text "running golangci-lint"
 cd .. # To go to the root of the project
-# Keep the enabled linters in separate, ordered lines to avoid duplicates.
-golangci-lint run --disable-all --deadline 5m \
-    --enable=deadcode \
-    --enable=dupl \
-    --enable=errcheck \
-    --enable=goconst \
-    --enable=gocyclo \
-    --enable=gofmt \
-    --enable=goimports \
-    --enable=golint \
-    --enable=gosec \
-    --enable=gosimple \
-    --enable=govet \
-    --enable=ineffassign \
-    --enable=interfacer \
-    --enable=lll \
-    --enable=maligned \
-    --enable=misspell \
-    --enable=nakedret \
-    --enable=prealloc \
-    --enable=scopelint \
-    --enable=staticcheck \
-    --enable=structcheck \
-    --enable=typecheck \
-    --enable=unconvert \
-    --enable=unparam \
-    --enable=unused \
-    --enable=varcheck \
+golangci-lint run


### PR DESCRIPTION
This change adds `.golangci.yml` file for better control over linting with `golangci-lint`. The list of linters moved from `scripts/verify.sh` to this file. No linters were added or removed.

This was suggested in https://github.com/kubernetes-sigs/kubebuilder/issues/1267#issuecomment-571814215
Also kind of related to https://github.com/kubernetes-sigs/kubebuilder/issues/1309
