### PR TITLE
Remove no-op validations

### DIFF
--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -54,12 +54,6 @@ type Resource struct {
 	CreateExampleReconcileBody bool `json:"-"`
 }
 
-// Validate checks the Resource values to make sure they are valid.
-func (r *Resource) Validate() error {
-	// TODO: remove when all calls have been removed
-	return nil
-}
-
 func (r *Resource) GVK() config.GVK {
 	return config.GVK{
 		Group:   r.Group,

--- a/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
+++ b/pkg/scaffold/internal/templates/v1/crd/addtoscheme.go
@@ -44,11 +44,6 @@ func (f *AddToScheme) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *AddToScheme) Validate() error {
-	return f.Resource.Validate()
-}
-
 // NB(directxman12): we need that package alias on the API import otherwise imports.Process
 // gets wicked (or hella, if you're feeling west-coasty) confused.
 

--- a/pkg/scaffold/internal/templates/v1/crd/crd_sample.go
+++ b/pkg/scaffold/internal/templates/v1/crd/crd_sample.go
@@ -47,11 +47,6 @@ func (f *CRDSample) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *CRDSample) Validate() error {
-	return f.Resource.Validate()
-}
-
 const crdSampleTemplate = `apiVersion: {{ .Resource.Domain }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:

--- a/pkg/scaffold/internal/templates/v1/crd/doc.go
+++ b/pkg/scaffold/internal/templates/v1/crd/doc.go
@@ -43,11 +43,6 @@ func (f *Doc) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Doc) Validate() error {
-	return f.Resource.Validate()
-}
-
 // nolint:lll
 const docGoTemplate = `{{ .Boilerplate }}
 

--- a/pkg/scaffold/internal/templates/v1/crd/group.go
+++ b/pkg/scaffold/internal/templates/v1/crd/group.go
@@ -42,11 +42,6 @@ func (f *Group) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Group) Validate() error {
-	return f.Resource.Validate()
-}
-
 const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.GroupPackageName }} contains {{ .Resource.Group }} API versions

--- a/pkg/scaffold/internal/templates/v1/crd/register.go
+++ b/pkg/scaffold/internal/templates/v1/crd/register.go
@@ -43,11 +43,6 @@ func (f *Register) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Register) Validate() error {
-	return f.Resource.Validate()
-}
-
 // nolint:lll
 const registerTemplate = `{{ .Boilerplate }}
 

--- a/pkg/scaffold/internal/templates/v1/crd/types.go
+++ b/pkg/scaffold/internal/templates/v1/crd/types.go
@@ -47,11 +47,6 @@ func (f *Types) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Types) Validate() error {
-	return f.Resource.Validate()
-}
-
 const typesTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}

--- a/pkg/scaffold/internal/templates/v1/crd/typestest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/typestest.go
@@ -47,11 +47,6 @@ func (f *TypesTest) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *TypesTest) Validate() error {
-	return f.Resource.Validate()
-}
-
 const typesTestTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}

--- a/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
+++ b/pkg/scaffold/internal/templates/v1/crd/version_suitetest.go
@@ -44,11 +44,6 @@ func (f *VersionSuiteTest) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *VersionSuiteTest) Validate() error {
-	return f.Resource.Validate()
-}
-
 const versionSuiteTestTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}

--- a/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
+++ b/pkg/scaffold/internal/templates/v2/controller/controller_suitetest.go
@@ -53,11 +53,6 @@ func (f *SuiteTest) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *SuiteTest) Validate() error {
-	return f.Resource.Validate()
-}
-
 const (
 	importMarker    = "imports"
 	addSchemeMarker = "scheme"

--- a/pkg/scaffold/internal/templates/v2/crd/enablecainjection_patch.go
+++ b/pkg/scaffold/internal/templates/v2/crd/enablecainjection_patch.go
@@ -47,11 +47,6 @@ func (f *EnableCAInjectionPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *EnableCAInjectionPatch) Validate() error {
-	return f.Resource.Validate()
-}
-
 const EnableCAInjectionPatchTemplate = `# The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/pkg/scaffold/internal/templates/v2/crd/enablewebhook_patch.go
+++ b/pkg/scaffold/internal/templates/v2/crd/enablewebhook_patch.go
@@ -47,11 +47,6 @@ func (f *EnableWebhookPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *EnableWebhookPatch) Validate() error {
-	return f.Resource.Validate()
-}
-
 const enableWebhookPatchTemplate = `# The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/pkg/scaffold/internal/templates/v2/crd_editor_rbac.go
+++ b/pkg/scaffold/internal/templates/v2/crd_editor_rbac.go
@@ -43,11 +43,6 @@ func (f *CRDEditorRole) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *CRDEditorRole) Validate() error {
-	return f.Resource.Validate()
-}
-
 const crdRoleEditorTemplate = `# permissions for end users to edit {{ .Resource.Plural }}.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/pkg/scaffold/internal/templates/v2/crd_sample.go
+++ b/pkg/scaffold/internal/templates/v2/crd_sample.go
@@ -46,11 +46,6 @@ func (f *CRDSample) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *CRDSample) Validate() error {
-	return f.Resource.Validate()
-}
-
 const crdSampleTemplate = `apiVersion: {{ .Resource.Domain }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:

--- a/pkg/scaffold/internal/templates/v2/crd_viewer_rbac.go
+++ b/pkg/scaffold/internal/templates/v2/crd_viewer_rbac.go
@@ -43,11 +43,6 @@ func (f *CRDViewerRole) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *CRDViewerRole) Validate() error {
-	return f.Resource.Validate()
-}
-
 const crdRoleViewerTemplate = `# permissions for end users to view {{ .Resource.Plural }}.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/pkg/scaffold/internal/templates/v2/group.go
+++ b/pkg/scaffold/internal/templates/v2/group.go
@@ -47,11 +47,6 @@ func (f *Group) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Group) Validate() error {
-	return f.Resource.Validate()
-}
-
 // nolint:lll
 const groupTemplate = `{{ .Boilerplate }}
 

--- a/pkg/scaffold/internal/templates/v2/types.go
+++ b/pkg/scaffold/internal/templates/v2/types.go
@@ -53,11 +53,6 @@ func (f *Types) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Types) Validate() error {
-	return f.Resource.Validate()
-}
-
 const typesTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}

--- a/pkg/scaffold/internal/templates/v2/webhook/webhook.go
+++ b/pkg/scaffold/internal/templates/v2/webhook/webhook.go
@@ -70,11 +70,6 @@ func (f *Webhook) SetTemplateDefaults() error {
 	return nil
 }
 
-// Validate validates the values
-func (f *Webhook) Validate() error {
-	return f.Resource.Validate()
-}
-
 const (
 	WebhookTemplate = `{{ .Boilerplate }}
 


### PR DESCRIPTION
After resouce validation was moved to the `Options` struct (#1255), `Resource.Validate()` is a no-op.

This PR requests removes these `Validate` functions.


