### PR TITLE
Remove outdated TODO

### DIFF
--- a/pkg/scaffold/internal/templates/v2/crd/kustomization.go
+++ b/pkg/scaffold/internal/templates/v2/crd/kustomization.go
@@ -55,9 +55,6 @@ func (f *Kustomization) Update() error {
 		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
 	}
 
-	// TODO(directxman12): not technically valid if something changes from the default
-	// (we'd need to parse the markers)
-
 	kustomizeResourceCodeFragment := fmt.Sprintf("- bases/%s_%s.yaml\n", f.Resource.Domain, f.Resource.Plural)
 	kustomizeWebhookPatchCodeFragment := fmt.Sprintf("#- patches/webhook_in_%s.yaml\n", f.Resource.Plural)
 	kustomizeCAInjectionPatchCodeFragment := fmt.Sprintf("#- patches/cainjection_in_%s.yaml\n", f.Resource.Plural)


### PR DESCRIPTION
The TODO was refering to computing the plural form in this file when a custom plural form was provided. Since #1255 was merged, the plural form is obtained from the resource itself so the issue is no longer valid.

/kind cleanup