### PR TITLE
:sparkles: default a LeaderElectionID

### DIFF
--- a/pkg/model/file/funcmap.go
+++ b/pkg/model/file/funcmap.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"strings"
+	"text/template"
+)
+
+// DefaultFuncMap returns the default template.FuncMap for rendering the template.
+func DefaultFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"title": strings.Title,
+		"lower": strings.ToLower,
+	}
+}

--- a/pkg/model/file/interfaces.go
+++ b/pkg/model/file/interfaces.go
@@ -17,6 +17,8 @@ limitations under the License.
 package file
 
 import (
+	"text/template"
+
 	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 )
 
@@ -81,4 +83,10 @@ type HasBoilerplate interface {
 type HasResource interface {
 	// InjectResource sets the template resource
 	InjectResource(*resource.Resource)
+}
+
+// UseCustomFuncMap allows a template to use a custom template.FuncMap instead of the default FuncMap.
+type UseCustomFuncMap interface {
+	// GetFuncMap returns a custom FuncMap.
+	GetFuncMap() template.FuncMap
 }

--- a/pkg/scaffold/internal/machinery/scaffold.go
+++ b/pkg/scaffold/internal/machinery/scaffold.go
@@ -179,10 +179,12 @@ func doTemplate(t file.Template) ([]byte, error) {
 
 // newTemplate a new template with common functions
 func newTemplate(t file.Template) *template.Template {
-	return template.New(fmt.Sprintf("%T", t)).Funcs(template.FuncMap{
-		"title": strings.Title,
-		"lower": strings.ToLower,
-	})
+	fm := file.DefaultFuncMap()
+	useFM, ok := t.(file.UseCustomFuncMap)
+	if ok {
+		fm = useFM.GetFuncMap()
+	}
+	return template.New(fmt.Sprintf("%T", t)).Funcs(fm)
 }
 
 // updateFileModel updates a single file

--- a/pkg/scaffold/internal/templates/v2/main.go
+++ b/pkg/scaffold/internal/templates/v2/main.go
@@ -18,7 +18,9 @@ package v2
 
 import (
 	"fmt"
+	"hash/fnv"
 	"path/filepath"
+	"text/template"
 
 	"sigs.k8s.io/kubebuilder/pkg/model/file"
 )
@@ -26,11 +28,14 @@ import (
 const defaultMainPath = "main.go"
 
 var _ file.Template = &Main{}
+var _ file.UseCustomFuncMap = &Main{}
 
 // Main scaffolds the controller manager entry point
 type Main struct {
 	file.TemplateMixin
 	file.BoilerplateMixin
+	file.DomainMixin
+	file.RepositoryMixin
 }
 
 // SetTemplateDefaults implements file.Template
@@ -46,6 +51,19 @@ func (f *Main) SetTemplateDefaults() error {
 	)
 
 	return nil
+}
+
+func hash(s string) (string, error) {
+	hasher := fnv.New32a()
+	hasher.Write([]byte(s)) // nolint:errcheck
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+// GetFuncMap implements file.UseCustomFuncMap
+func (f *Main) GetFuncMap() template.FuncMap {
+	fm := file.DefaultFuncMap()
+	fm["hash"] = hash
+	return fm
 }
 
 var _ file.Inserter = &MainUpdater{}
@@ -220,8 +238,9 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
 		Port:               9443, 
+		LeaderElection:     enableLeaderElection, 
+		LeaderElectionID:   "{{ hash .Repo }}.{{ .Domain }}",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/testdata/project-v2-multigroup/main.go
+++ b/testdata/project-v2-multigroup/main.go
@@ -72,8 +72,9 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
 		Port:               9443,
+		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "e9b53b87.testproject.org",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -57,8 +57,9 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
 		Port:               9443,
+		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "dc1d9fac.testproject.org",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/pull/446 removed the defaulting for LeaderElectionID.
It makes sense for controller-runtime. But kubebuilder should still be able to scaffold a project that work out-of-box.
So we will give users some instructions to update it in code comment.
