### PR TITLE
feature/plugins: config `layout`, `--plugins` flag, and plugin name validation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,10 @@ func main() {
 			&pluginv1.Plugin{},
 			&pluginv2.Plugin{},
 		),
+		cli.WithDefaultPlugins(
+			&pluginv1.Plugin{},
+			&pluginv2.Plugin{},
+		),
 		cli.WithExtraCommands(
 			newEditCmd(),
 			newUpdateCmd(),

--- a/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
+++ b/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
@@ -62,7 +62,7 @@ project versions (via `SupportedProjectVersions()`).
 Example `PROJECT` file:
 
 ```yaml
-version: "3-alpha"
+version: "2"
 layout: go/v1.0.0
 domain: testproject.org
 repo: github.com/test-inc/testproject

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -55,14 +55,9 @@ func (c cli) newAPIContext() plugin.Context {
 }
 
 func (c cli) bindCreateAPI(ctx plugin.Context, cmd *cobra.Command) {
-	versionedPlugins, err := c.getVersionedPlugins()
-	if err != nil {
-		cmdErr(cmd, err)
-		return
-	}
 	var getter plugin.CreateAPIPluginGetter
 	var hasGetter bool
-	for _, p := range versionedPlugins {
+	for _, p := range c.resolvedPlugins {
 		tmpGetter, isGetter := p.(plugin.CreateAPIPluginGetter)
 		if isGetter {
 			if hasGetter {

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -55,14 +55,9 @@ func (c cli) newWebhookContext() plugin.Context {
 }
 
 func (c cli) bindCreateWebhook(ctx plugin.Context, cmd *cobra.Command) {
-	versionedPlugins, err := c.getVersionedPlugins()
-	if err != nil {
-		cmdErr(cmd, err)
-		return
-	}
 	var getter plugin.CreateWebhookPluginGetter
 	var hasGetter bool
-	for _, p := range versionedPlugins {
+	for _, p := range c.resolvedPlugins {
 		tmpGetter, isGetter := p.(plugin.CreateWebhookPluginGetter)
 		if isGetter {
 			if hasGetter {

--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -43,6 +43,9 @@ type Config struct {
 
 	// Multigroup tracks if the project has more than one group
 	MultiGroup bool `json:"multigroup,omitempty"`
+
+	// Layout contains a key specifying which plugin created a project.
+	Layout string `json:"layout,omitempty"`
 }
 
 // IsV1 returns true if it is a v1 project

--- a/pkg/plugin/v1/init.go
+++ b/pkg/plugin/v1/init.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 )
 
-type initPlugin struct { // nolint:maligned
+type initPlugin struct {
 	config *config.Config
 
 	// boilerplate options

--- a/pkg/plugin/v1/plugin.go
+++ b/pkg/plugin/v1/plugin.go
@@ -20,6 +20,16 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 )
 
+const (
+	pluginName    = "go" + plugin.DefaultNameQualifier
+	pluginVersion = "v1.0.0"
+
+	deprecationWarning = `The v1 projects are deprecated and will not be supported beyond Feb 1, 2020.
+See how to upgrade your project to v2: https://book.kubebuilder.io/migration/guide.html`
+)
+
+var supportedProjectVersions = []string{"1"}
+
 var (
 	_ plugin.Base                      = Plugin{}
 	_ plugin.InitPluginGetter          = Plugin{}
@@ -34,31 +44,10 @@ type Plugin struct {
 	createWebhookPlugin
 }
 
-func (Plugin) Name() string {
-	return "go"
-}
-
-func (Plugin) Version() string {
-	return "v1.0.0"
-}
-
-func (Plugin) SupportedProjectVersions() []string {
-	return []string{"1"}
-}
-
-func (p Plugin) GetInitPlugin() plugin.Init {
-	return &p.initPlugin
-}
-
-func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI {
-	return &p.createAPIPlugin
-}
-
-func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook {
-	return &p.createWebhookPlugin
-}
-
-func (Plugin) DeprecationWarning() string {
-	return `The v1 projects are deprecated and will not be supported beyond Feb 1, 2020.
-See how to upgrade your project to v2: https://book.kubebuilder.io/migration/guide.html`
-}
+func (Plugin) Name() string                                   { return pluginName }
+func (Plugin) Version() string                                { return pluginVersion }
+func (Plugin) SupportedProjectVersions() []string             { return supportedProjectVersions }
+func (p Plugin) GetInitPlugin() plugin.Init                   { return &p.initPlugin }
+func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI         { return &p.createAPIPlugin }
+func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook { return &p.createWebhookPlugin }
+func (Plugin) DeprecationWarning() string                     { return deprecationWarning }

--- a/pkg/plugin/v2/init.go
+++ b/pkg/plugin/v2/init.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 )
 
-type initPlugin struct { // nolint:maligned
+type initPlugin struct {
 	config *config.Config
 
 	// boilerplate options
@@ -107,6 +107,8 @@ func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
 }
 
 func (p *initPlugin) InjectConfig(c *config.Config) {
+	// v2 project configs get a 'layout' value.
+	c.Layout = plugin.KeyFor(Plugin{})
 	p.config = c
 }
 

--- a/pkg/plugin/v2/plugin.go
+++ b/pkg/plugin/v2/plugin.go
@@ -20,6 +20,13 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 )
 
+const (
+	pluginName    = "go" + plugin.DefaultNameQualifier
+	pluginVersion = "v2.0.0"
+)
+
+var supportedProjectVersions = []string{"2"}
+
 var (
 	_ plugin.Base                      = Plugin{}
 	_ plugin.InitPluginGetter          = Plugin{}
@@ -33,26 +40,9 @@ type Plugin struct {
 	createWebhookPlugin
 }
 
-func (Plugin) Name() string {
-	return "go"
-}
-
-func (Plugin) Version() string {
-	return "v2.0.0"
-}
-
-func (Plugin) SupportedProjectVersions() []string {
-	return []string{"2"}
-}
-
-func (p Plugin) GetInitPlugin() plugin.Init {
-	return &p.initPlugin
-}
-
-func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI {
-	return &p.createAPIPlugin
-}
-
-func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook {
-	return &p.createWebhookPlugin
-}
+func (Plugin) Name() string                                   { return pluginName }
+func (Plugin) Version() string                                { return pluginVersion }
+func (Plugin) SupportedProjectVersions() []string             { return supportedProjectVersions }
+func (p Plugin) GetInitPlugin() plugin.Init                   { return &p.initPlugin }
+func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI         { return &p.createAPIPlugin }
+func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook { return &p.createWebhookPlugin }

--- a/pkg/plugin/validation.go
+++ b/pkg/plugin/validation.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+
+	"sigs.k8s.io/kubebuilder/pkg/internal/validation"
 )
 
 // ValidateVersion ensures version adheres to the plugin version format,
@@ -33,6 +35,14 @@ func ValidateVersion(version string) error {
 	// ex. "3" or "v3.0".
 	if _, err := semver.ParseTolerant(version); err != nil {
 		return fmt.Errorf("failed to validate plugin version %q: %v", version, err)
+	}
+	return nil
+}
+
+// ValidateName ensures name is a valid DNS 1123 subdomain.
+func ValidateName(name string) error {
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) != 0 {
+		return fmt.Errorf("plugin name %q is invalid: %v", name, errs)
 	}
 	return nil
 }

--- a/testdata/project-v2-addon/PROJECT
+++ b/testdata/project-v2-addon/PROJECT
@@ -1,4 +1,5 @@
 domain: testproject.org
+layout: go.kubebuilder.io/v2.0.0
 repo: sigs.k8s.io/kubebuilder/testdata/project-v2-addon
 resources:
 - group: crew

--- a/testdata/project-v2-multigroup/PROJECT
+++ b/testdata/project-v2-multigroup/PROJECT
@@ -1,4 +1,5 @@
 domain: testproject.org
+layout: go.kubebuilder.io/v2.0.0
 multigroup: true
 repo: sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup
 resources:

--- a/testdata/project-v2/PROJECT
+++ b/testdata/project-v2/PROJECT
@@ -1,4 +1,5 @@
 domain: testproject.org
+layout: go.kubebuilder.io/v2.0.0
 repo: sigs.k8s.io/kubebuilder/testdata/project-v2
 resources:
 - group: crew


### PR DESCRIPTION
**Description of Change:**
* pkg/cli: `--plugins` allows a binary invoker to select which plugins known to a `CLI` to run; this flag can be set with a shortened (non-fully-qualified) name. Either a plugin name passed to `--plugins` or the name set in an initialized project's config layout, in order of precedence, is resolved to a known plugin.
* pkg/model/config: add project file `layout` key, containing the `Init` plugin key that scaffolded a project
* pkg/{cli,plugin}: add plugin name validation
* pkg/plugin/v2: set `layout` key in config

**Motivation for Change:** finishes up phase 1 of plugin implementation. The `layout` key determines which plugin (name and version) initialized a project, useful for a plugin implementation to deduce which post-init plugins should be called. `--plugins`/`layout`, in combination with a default plugin, are necessary to select which plugin to use if there are multiple viable plugins per project version.

TODO:
- [x] instead of getting first `*Getter` type, infer by config layout or default (in the case of `Init`)
- [ ] unit tests in `pkg/cli`

/cc @Adirio @hasbro17 @camilamacedo86 
/kind feature
