### PR TITLE
bump kube-rbac-proxy to v0.5.0

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/migration/testdata/gopath/project-v1/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/migration/testdata/gopath/project-v1/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/scaffold/internal/templates/v1/metricsauth/kustomize_auth_proxy_patch.go
+++ b/pkg/scaffold/internal/templates/v1/metricsauth/kustomize_auth_proxy_patch.go
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/scaffold/internal/templates/v2/metricsauth/auth_proxy_patch.go
+++ b/pkg/scaffold/internal/templates/v2/metricsauth/auth_proxy_patch.go
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -31,8 +31,8 @@ build_kb
 setup_envs
 
 source "$(pwd)/scripts/setup.sh" ${KIND_K8S_VERSION}
-docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
-kind load docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+kind load docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
 
 # remove running containers on exit
 function cleanup() {

--- a/testdata/gopath/src/project/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/gopath/src/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v2-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
The current kube-rbac-proxy image used by kubebuilder contains a version of `musl` that is vulnerable to [CVE-2019-14697](https://nvd.nist.gov/vuln/detail/CVE-2019-14697)

Based on #1041, I believe kubebuilder follows upstream for kube-rbac-proxy. Upstream has released v0.5.0 which includes the patched version of `musl`. 

This PR updates the image used in this project. However, I believe similar to #1021, it will first require an owner to hand-tag and release v0.5.0, please. 