### PR TITLE
Fix broken plugin addon template

### DIFF
--- a/plugins/addon/controller.go
+++ b/plugins/addon/controller.go
@@ -48,7 +48,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	api "{{ .Resource.GoPackage }}/{{ .Resource.Version }}"
+	api "{{ .Resource.Package }}"
 )
 
 var _ reconcile.Reconciler = &{{ .Resource.Kind }}Reconciler{}
@@ -62,8 +62,8 @@ type {{ .Resource.Kind }}Reconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups={{.Resource.GroupDomain}},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{.Resource.GroupDomain}},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/plugins/addon/type.go
+++ b/plugins/addon/type.go
@@ -77,7 +77,7 @@ type {{.Resource.Kind}}Status struct {
 // +kubebuilder:object:root=true
 {{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
 
-// {{.Resource.Kind}} is the Schema for the {{ .Resource.Resource }} API
+// {{.Resource.Kind}} is the Schema for the {{ .Resource.Plural }} API
 type {{.Resource.Kind}} struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
 	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `


### PR DESCRIPTION
The plugin addon template is out-of-date and breaks functionality when creating api using the `--pattern=addon` flag.
This PR fixes the plugin addon template. 