### PR TITLE
Check For Prerequisites For Scaffolded Makefile

### DIFF
--- a/pkg/scaffold/internal/templates/v2/makefile.go
+++ b/pkg/scaffold/internal/templates/v2/makefile.go
@@ -58,6 +58,21 @@ IMG ?= {{ .Image }}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# A list of dependencies taken from:
+# https://book.kubebuilder.io/quick-start.html#prerequisites
+DEPS = go docker kubectl kustomize
+
+# We define this with :=, as we want it to be ran immediately
+# before every other target.
+CHECK_DEPS := $(foreach dep,\
+	$(DEPS), \
+	$(if \
+		$(shell command -v $(dep) 2>/dev/null), \
+		, \
+		$(error "Unable to find $(dep) in your PATH") \
+	) \
+)
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
This commit checks that the prerequisites listed in the Kubebuilder book
are in `$PATH` before proceeding with any target.

We probably want the user to get better feedback up front instead of
`make` failing half-way through (possibly)

Fixes #1371

--- 

Not part of the commit message, but here's how it works.

```
devon@DESKTOP-KDNMKJN:~/git/kubebuilder/devon-test$ make
Makefile:13: *** "Unable to find kustomize in your PATH".  Stop.
devon@DESKTOP-KDNMKJN:~/git/kubebuilder/devon-test$ curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4
_linux_amd64.tar.gz | tar -xvzf- && mv kustomize ~/bin && chmod +x ~/bin/kustomize
kustomize
devon@DESKTOP-KDNMKJN:~/git/kubebuilder/devon-test$ make
/home/devon/git/go/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go build -o bin/manager main.go
[...snip for brevity...]
```

Purposefully removed `kustomize` from my `$PATH`, fails as intended, replace it, continues to work.
