### PR TITLE
 Add bash/zsh completion command

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newCompletionCmd() *cobra.Command {
+	completionCmd := &cobra.Command{
+		Use: "completion",
+		Long: `Output shell completion code for the specified shell (bash or zsh). 
+The shell code must be evaluated to provide interactive completion of kubebuilder commands.
+This can be done by sourcing ~/.bash_profile or ~/.bashrc.
+Detailed instructions on how to do this are available at docs/book/src/reference/completion.md
+`,
+		Example: `To load all completions run:
+$ . <(kubebuilder completion)
+To configure your shell to load completions for each session add to your .bashrc:
+$ echo -e "\n. <(kubebuilder completion)" >> ~/.bashrc
+`,
+	}
+	completionCmd.AddCommand(newZshCmd())
+	completionCmd.AddCommand(newBashCmd())
+	return completionCmd
+}
+
+func newBashCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bash",
+		Short: "Generate bash completions",
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		},
+		Example: `To load completion run:
+$ . <(kubebuilder completion bash)
+To configure your bash shell to load completions for each session add to your bashrc:
+$ echo -e "\n. <(kubebuilder completion bash)" >> ~/.bashrc
+`,
+	}
+}
+
+func newZshCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "zsh",
+		Short: "Generate zsh completions",
+		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		},
+		Example: `To load completion run:
+$ . <(kubebuilder completion zsh)
+To configure your zsh shell to load completions for each session add to your bashrc:
+$ echo -e "\n. <(kubebuilder completion zsh)" >> ~/.bashrc
+`,
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,6 +123,9 @@ func buildCmdTree() *cobra.Command {
 	// kubebuilder version
 	rootCmd.AddCommand(version.NewVersionCmd())
 
+	// kubebuilder completion
+	rootCmd.AddCommand(newCompletionCmd())
+
 	return rootCmd
 }
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -69,6 +69,7 @@
       - [RBAC](./reference/markers/rbac.md)
 
   - [controller-gen CLI](./reference/controller-gen.md)
+  - [completion](./reference/completion.md)
   - [Artifacts](./reference/artifacts.md)
   - [Writing controller tests](./reference/writing-tests.md)
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -37,6 +37,14 @@ export PATH=$PATH:/usr/local/kubebuilder/bin
 
 Also, you can install a master snapshot from `https://go.kubebuilder.io/dl/latest/${os}/${arch}`.
 
+
+</aside>
+
+<aside class="note">
+<h1>Enabling shell autocompletion</h1>
+
+Kubebuilder provides autocompletion support for Bash and Zsh via the command `kubebuilder completion <bash|zsh>`, which can save you a lot of typing. For further information see the [completion](./reference/completion.md) document.
+
 </aside>
 
 ## Create a Project

--- a/docs/book/src/reference/completion.md
+++ b/docs/book/src/reference/completion.md
@@ -1,0 +1,35 @@
+# Enabling shell autocompletion
+The Kubebuilder completion script for Bash can be generated with the command `kubebuilder completion bash` as the Kubebuilder completion script for Zsh can be generated with the command `kubebuilder completion zsh`. 
+Note that sourcing the completion script in your shell enables Kubebuilder autocompletion. 
+
+<aside class="note">
+<h1>Prerequisites for Bash</h1>
+
+The completion Bash script depends on [bash-completion](https://github.com/scop/bash-completion), which means that you have to install this software first (you can test if you have bash-completion already installed). Also, ensure that your Bash version is 4.1+. 
+
+</aside>
+
+
+- Once installed, go ahead and add the path `/usr/local/bin/bash` in the  `/etc/shells`.
+
+    `echo “/usr/local/bin/bash” > /etc/shells`
+
+- Make sure to use installed shell by current user.
+
+    `chsh -s /usr/local/bin/bash`
+
+- Add following content in /.bash_profile or ~/.bashrc
+
+```
+# kubebuilder autocompletion
+if [ -f /usr/local/share/bash-completion/bash_completion ]; then
+. /usr/local/share/bash-completion/bash_completion
+fi
+. <(kubebuilder completion)
+```
+- Restart terminal for the changes to be reflected.
+
+<aside class="note">
+<h1>Zsh</h1>
+Follow a similar protocol for `zsh` completion.
+</aside>

--- a/docs/book/src/reference/reference.md
+++ b/docs/book/src/reference/reference.md
@@ -23,6 +23,7 @@
       - [RBAC](markers/rbac.md)
 
   - [controller-gen CLI](controller-gen.md)
+  - [completion](completion.md)
   - [Artifacts](artifacts.md)
   - [Writing controller tests](writing-tests.md)
   - [Metrics](metrics.md)


### PR DESCRIPTION
Description: 
Add completion command to enable Auto bash/zsh completion.
Motivation:
To have kubebuilder cli auto completion enabled.
Closes: #1346 
