### PR TITLE
internal/config/config.go: use `DefaultVersion` instead of `config.Version2`

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ type Config struct {
 func New(path string) *Config {
 	return &Config{
 		Config: config.Config{
-			Version: config.Version2,
+			Version: DefaultVersion,
 		},
 		path:         path,
 		mustNotExist: true,


### PR DESCRIPTION
So `Config.Version` does not also need to be updated when `DefaultVersion` is changed in the future.