### PR TITLE
cli: delegate management of a config to a `CLI`

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -48,6 +48,10 @@ func newEditCmd() *cobra.Command {
 	# Disable the multigroup layout
 	kubebuilder edit --multigroup=false`,
 		Run: func(_ *cobra.Command, _ []string) {
+			var err error
+			if options.config, err = config.LoadInitialized(); err != nil {
+				log.Fatal(err)
+			}
 			if err := cmdutil.Run(options); err != nil {
 				log.Fatal(editError{err})
 			}
@@ -62,6 +66,8 @@ func newEditCmd() *cobra.Command {
 var _ cmdutil.RunOptions = &editOptions{}
 
 type editOptions struct {
+	config *config.Config
+
 	multigroup bool
 }
 
@@ -69,24 +75,20 @@ func (o *editOptions) bindFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.multigroup, "multigroup", false, "enable or disable multigroup layout")
 }
 
-func (o *editOptions) LoadConfig() (*config.Config, error) {
-	return config.LoadInitialized()
-}
-
-func (o *editOptions) Validate(c *config.Config) error {
-	if !c.IsV2() {
-		if c.MultiGroup {
-			return fmt.Errorf("multiple group support can't be enabled for version %s", c.Version)
+func (o *editOptions) Validate() error {
+	if !o.config.IsV2() {
+		if o.config.MultiGroup {
+			return fmt.Errorf("multiple group support can't be enabled for version %s", o.config.Version)
 		}
 	}
 
 	return nil
 }
 
-func (o *editOptions) GetScaffolder(c *config.Config) (scaffold.Scaffolder, error) { //nolint:unparam
-	return scaffold.NewEditScaffolder(c, o.multigroup), nil
+func (o *editOptions) GetScaffolder() (scaffold.Scaffolder, error) {
+	return scaffold.NewEditScaffolder(&o.config.Config, o.multigroup), nil
 }
 
-func (o *editOptions) PostScaffold(_ *config.Config) error {
-	return nil
+func (o *editOptions) PostScaffold() error {
+	return o.config.Save()
 }

--- a/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
+++ b/designs/extensible-cli-and-scaffolding-plugins-phase-1.md
@@ -102,9 +102,13 @@ type GenericSubcommand interface {
     UpdateContext(*PluginContext)
     // BindFlags binds the plugin's flags to the CLI. This allows each plugin to define its own
     // command line flags for the kubebuilder subcommand.
-    BindFlags(fs *pflag.FlagSet)
+    BindFlags(*pflag.FlagSet)
     // Run runs the subcommand.
     Run() error
+    // InjectConfig passes a config to a plugin. The plugin may modify the
+    // config. Initializing, loading, and saving the config is managed by the
+    // cli package.
+    InjectConfig(*config.Config)
 }
 
 type PluginContext struct {

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -17,50 +17,39 @@ limitations under the License.
 package cmdutil
 
 import (
-	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
 )
 
 // RunOptions represent the types used to implement the different commands
 type RunOptions interface {
-	// The following steps define a generic logic to follow when developing new commands. Some steps may be no-ops.
-	// - Step 1: load the config failing if expected but not found or if not expected but found
-	LoadConfig() (*config.Config, error)
-	// - Step 2: verify that the command can be run (e.g., go version, project version, arguments, ...)
-	Validate(*config.Config) error
-	// - Step 3: create the Scaffolder instance
-	GetScaffolder(*config.Config) (scaffold.Scaffolder, error)
-	// - Step 4: call the Scaffold method of the Scaffolder instance
-	// Doesn't need any method
-	// - Step 5: finish the command execution
-	PostScaffold(*config.Config) error
+	// - Step 1: verify that the command can be run (e.g., go version, project version, arguments, ...)
+	Validate() error
+	// - Step 2: create the Scaffolder instance
+	GetScaffolder() (scaffold.Scaffolder, error)
+	// - Step 3: call the Scaffold method of the Scaffolder instance. Doesn't need any method
+	// - Step 4: finish the command execution
+	PostScaffold() error
 }
 
 // Run executes a command
 func Run(options RunOptions) error {
-	// Step 1: load config
-	projectConfig, err := options.LoadConfig()
-	if err != nil {
+	// Step 1: validate
+	if err := options.Validate(); err != nil {
 		return err
 	}
 
-	// Step 2: validate
-	if err := options.Validate(projectConfig); err != nil {
-		return err
-	}
-
-	// Step 3: create scaffolder
-	scaffolder, err := options.GetScaffolder(projectConfig)
+	// Step 2: get scaffolder
+	scaffolder, err := options.GetScaffolder()
 	if err != nil {
 		return err
 	}
-	// Step 4: scaffold
+	// Step 3: scaffold
 	if err := scaffolder.Scaffold(); err != nil {
 		return err
 	}
 
-	// Step 5: finish
-	if err := options.PostScaffold(projectConfig); err != nil {
+	// Step 4: finish
+	if err := options.PostScaffold(); err != nil {
 		return err
 	}
 

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 )
 
@@ -81,10 +82,18 @@ func (c cli) bindCreateAPI(ctx plugin.Context, cmd *cobra.Command) {
 		return
 	}
 
+	cfg, err := config.LoadInitialized()
+	if err != nil {
+		cmdErr(cmd, err)
+		return
+	}
+
 	createAPI := getter.GetCreateAPIPlugin()
+	createAPI.InjectConfig(&cfg.Config)
 	createAPI.BindFlags(cmd.Flags())
 	createAPI.UpdateContext(&ctx)
 	cmd.Long = ctx.Description
 	cmd.Example = ctx.Examples
-	cmd.RunE = runECmdFunc(createAPI, fmt.Sprintf("failed to create api for project with version %q", c.projectVersion))
+	cmd.RunE = runECmdFunc(cfg, createAPI,
+		fmt.Sprintf("failed to create API with version %q", c.projectVersion))
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -316,27 +316,3 @@ After the scaffold is written, api will run make on the project.
 		},
 	}
 }
-
-// cmdErr updates a cobra command to output error information when executed
-// or used with the help flag.
-func cmdErr(cmd *cobra.Command, err error) {
-	cmd.Long = fmt.Sprintf("%s\nNote: %v", cmd.Long, err)
-	cmd.RunE = errCmdFunc(err)
-}
-
-// errCmdFunc returns a cobra RunE function that returns the provided error
-func errCmdFunc(err error) func(*cobra.Command, []string) error {
-	return func(*cobra.Command, []string) error {
-		return err
-	}
-}
-
-// runECmdFunc returns a cobra RunE function that runs gsub and returns its value.
-func runECmdFunc(gsub plugin.GenericSubcommand, msg string) func(*cobra.Command, []string) error { // nolint:interfacer
-	return func(*cobra.Command, []string) error {
-		if err := gsub.Run(); err != nil {
-			return fmt.Errorf("%s: %v", msg, err)
-		}
-		return nil
-	}
-}

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kubebuilder/internal/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+)
+
+// cmdErr updates a cobra command to output error information when executed
+// or used with the help flag.
+func cmdErr(cmd *cobra.Command, err error) {
+	cmd.Long = fmt.Sprintf("%s\nNote: %v", cmd.Long, err)
+	cmd.RunE = errCmdFunc(err)
+}
+
+// errCmdFunc returns a cobra RunE function that returns the provided error
+func errCmdFunc(err error) func(*cobra.Command, []string) error {
+	return func(*cobra.Command, []string) error {
+		return err
+	}
+}
+
+// runECmdFunc returns a cobra RunE function that runs gsub and saves the
+// config, which may have been modified by gsub.
+func runECmdFunc(
+	c *config.Config,
+	gsub plugin.GenericSubcommand, // nolint:interfacer
+	msg string) func(*cobra.Command, []string) error {
+	return func(*cobra.Command, []string) error {
+		if err := gsub.Run(); err != nil {
+			return fmt.Errorf("%s: %v", msg, err)
+		}
+		return c.Save()
+	}
+}

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 )
 
@@ -81,11 +82,18 @@ func (c cli) bindCreateWebhook(ctx plugin.Context, cmd *cobra.Command) {
 		return
 	}
 
+	cfg, err := config.LoadInitialized()
+	if err != nil {
+		cmdErr(cmd, err)
+		return
+	}
+
 	createWebhook := getter.GetCreateWebhookPlugin()
+	createWebhook.InjectConfig(&cfg.Config)
 	createWebhook.BindFlags(cmd.Flags())
 	createWebhook.UpdateContext(&ctx)
 	cmd.Long = ctx.Description
 	cmd.Example = ctx.Examples
-	cmd.RunE = runECmdFunc(createWebhook,
-		fmt.Sprintf("failed to create webhook for project with version %q", c.projectVersion))
+	cmd.RunE = runECmdFunc(cfg, createWebhook,
+		fmt.Sprintf("failed to create webhook with version %q", c.projectVersion))
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 )
 
 type Base interface {
@@ -57,6 +59,10 @@ type GenericSubcommand interface {
 	BindFlags(*pflag.FlagSet)
 	// Run runs the subcommand.
 	Run() error
+	// InjectConfig passes a config to a plugin. The plugin may modify the
+	// config. Initializing, loading, and saving the config is managed by the
+	// cli package.
+	InjectConfig(*config.Config)
 }
 
 type Context struct {
@@ -77,9 +83,6 @@ type InitPluginGetter interface {
 
 type Init interface {
 	GenericSubcommand
-	// SetVersion injects the version a project is initialized with into the
-	// plugin.
-	SetVersion(string)
 }
 
 type CreateAPIPluginGetter interface {

--- a/pkg/plugin/v1/api.go
+++ b/pkg/plugin/v1/api.go
@@ -27,8 +27,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/internal/cmdutil"
-	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/pkg/plugin/internal"
@@ -37,6 +37,8 @@ import (
 )
 
 type createAPIPlugin struct {
+	config *config.Config
+
 	// pattern indicates that we should use a plugin to build according to a pattern
 	pattern string
 
@@ -111,15 +113,15 @@ func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
 		"if true an example reconcile body should be written while scaffolding a resource.")
 }
 
+func (p *createAPIPlugin) InjectConfig(c *config.Config) {
+	p.config = c
+}
+
 func (p *createAPIPlugin) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *createAPIPlugin) LoadConfig() (*config.Config, error) {
-	return config.LoadInitialized()
-}
-
-func (p *createAPIPlugin) Validate(_ *config.Config) error {
+func (p *createAPIPlugin) Validate() error {
 	if err := p.resource.Validate(); err != nil {
 		return err
 	}
@@ -137,15 +139,12 @@ func (p *createAPIPlugin) Validate(_ *config.Config) error {
 	return nil
 }
 
-func (p *createAPIPlugin) GetScaffolder(c *config.Config) (scaffold.Scaffolder, error) {
+func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 	// Load the boilerplate
 	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
 	}
-
-	// Create the actual resource from the resource options
-	res := p.resource.NewV1Resource(&c.Config, p.doResource)
 
 	// Load the requested plugins
 	plugins := make([]model.Plugin, 0)
@@ -158,10 +157,12 @@ func (p *createAPIPlugin) GetScaffolder(c *config.Config) (scaffold.Scaffolder, 
 		return nil, fmt.Errorf("unknown pattern %q", p.pattern)
 	}
 
-	return scaffold.NewAPIScaffolder(c, string(bp), res, p.doResource, p.doController, plugins), nil
+	// Create the actual resource from the resource options
+	res := p.resource.NewV1Resource(p.config, p.doResource)
+	return scaffold.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
 }
 
-func (p *createAPIPlugin) PostScaffold(_ *config.Config) error {
+func (p *createAPIPlugin) PostScaffold() error {
 	if p.runMake {
 		return internal.RunCmd("Running make", "make")
 	}

--- a/pkg/plugin/v1/init.go
+++ b/pkg/plugin/v1/init.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -29,8 +28,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/internal/cmdutil"
-	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/internal/validation"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/pkg/plugin/internal"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold"
@@ -104,31 +103,20 @@ func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
 
 	// project args
-	if p.config == nil {
-		p.config = config.New(config.DefaultPath)
-	}
 	fs.StringVar(&p.config.Repo, "repo", "", "name to use for go module (e.g., github.com/user/repo), "+
 		"defaults to the go package of the current working directory.")
 	fs.StringVar(&p.config.Domain, "domain", "my.domain", "domain for groups")
+}
+
+func (p *initPlugin) InjectConfig(c *config.Config) {
+	p.config = c
 }
 
 func (p *initPlugin) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *initPlugin) SetVersion(v string) {
-	p.config.Version = v
-}
-
-func (p *initPlugin) LoadConfig() (*config.Config, error) {
-	_, err := config.Read()
-	if err == nil || os.IsExist(err) {
-		return nil, errors.New("config already initialized")
-	}
-	return p.config, nil
-}
-
-func (p *initPlugin) Validate(c *config.Config) error {
+func (p *initPlugin) Validate() error {
 	// Requires go1.11+
 	if !p.skipGoVersionCheck {
 		if err := internal.ValidateGoVersion(); err != nil {
@@ -147,12 +135,12 @@ func (p *initPlugin) Validate(c *config.Config) error {
 	}
 
 	// Try to guess repository if flag is not set
-	if c.Repo == "" {
+	if p.config.Repo == "" {
 		repoPath, err := internal.FindCurrentRepo()
 		if err != nil {
 			return fmt.Errorf("error finding current repository: %v", err)
 		}
-		c.Repo = repoPath
+		p.config.Repo = repoPath
 	}
 
 	// Verify dep is installed
@@ -164,11 +152,11 @@ func (p *initPlugin) Validate(c *config.Config) error {
 	return nil
 }
 
-func (p *initPlugin) GetScaffolder(c *config.Config) (scaffold.Scaffolder, error) { // nolint:unparam
-	return scaffold.NewInitScaffolder(c, p.license, p.owner), nil
+func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+	return scaffold.NewInitScaffolder(p.config, p.license, p.owner), nil
 }
 
-func (p *initPlugin) PostScaffold(_ *config.Config) error {
+func (p *initPlugin) PostScaffold() error {
 	if !p.depFlag.Changed {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Println("Run `dep ensure` to fetch dependencies (Recommended) [y/n]?")

--- a/pkg/plugin/v1/webhook.go
+++ b/pkg/plugin/v1/webhook.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/internal/cmdutil"
-	"sigs.k8s.io/kubebuilder/internal/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/pkg/plugin/internal"
@@ -32,6 +32,8 @@ import (
 )
 
 type createWebhookPlugin struct {
+	config *config.Config
+
 	resource    *resource.Options
 	server      string
 	webhookType string
@@ -71,22 +73,22 @@ func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.resource.Plural, "resource", "", "resource Resource")
 }
 
+func (p *createWebhookPlugin) InjectConfig(c *config.Config) {
+	p.config = c
+}
+
 func (p *createWebhookPlugin) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *createWebhookPlugin) LoadConfig() (*config.Config, error) {
-	return config.LoadInitialized()
-}
-
-func (p *createWebhookPlugin) Validate(_ *config.Config) error {
+func (p *createWebhookPlugin) Validate() error {
 	if err := p.resource.Validate(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (p *createWebhookPlugin) GetScaffolder(c *config.Config) (scaffold.Scaffolder, error) { // nolint:unparam
+func (p *createWebhookPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 	// Load the boilerplate
 	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
 	if err != nil {
@@ -94,12 +96,11 @@ func (p *createWebhookPlugin) GetScaffolder(c *config.Config) (scaffold.Scaffold
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewV1Resource(&c.Config, false)
-
-	return scaffold.NewV1WebhookScaffolder(&c.Config, string(bp), res, p.server, p.webhookType, p.operations), nil
+	res := p.resource.NewV1Resource(p.config, false)
+	return scaffold.NewV1WebhookScaffolder(p.config, string(bp), res, p.server, p.webhookType, p.operations), nil
 }
 
-func (p *createWebhookPlugin) PostScaffold(_ *config.Config) error {
+func (p *createWebhookPlugin) PostScaffold() error {
 	if p.doMake {
 		err := internal.RunCmd("Running make", "make")
 		if err != nil {

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -19,8 +19,8 @@ package scaffold
 import (
 	"fmt"
 
-	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/internal/machinery"
 	controllerv1 "sigs.k8s.io/kubebuilder/pkg/scaffold/internal/templates/v1/controller"
@@ -80,7 +80,7 @@ func (s *apiScaffolder) Scaffold() error {
 
 func (s *apiScaffolder) newUniverse() *model.Universe {
 	return model.NewUniverse(
-		model.WithConfig(&s.config.Config),
+		model.WithConfig(s.config),
 		model.WithBoilerplate(s.boilerplate),
 		model.WithResource(s.resource),
 	)
@@ -126,12 +126,7 @@ func (s *apiScaffolder) scaffoldV1() error {
 
 func (s *apiScaffolder) scaffoldV2() error {
 	if s.doResource {
-		// Only save the resource in the config file if it didn't exist
-		if s.config.AddResource(s.resource.GVK()) {
-			if err := s.config.Save(); err != nil {
-				return fmt.Errorf("error updating project file with resource information : %v", err)
-			}
-		}
+		s.config.AddResource(s.resource.GVK())
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),

--- a/pkg/scaffold/edit.go
+++ b/pkg/scaffold/edit.go
@@ -17,7 +17,7 @@ limitations under the License.
 package scaffold
 
 import (
-	"sigs.k8s.io/kubebuilder/internal/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 )
 
 var _ Scaffolder = &editScaffolder{}
@@ -38,6 +38,5 @@ func NewEditScaffolder(config *config.Config, multigroup bool) Scaffolder {
 // Scaffold implements Scaffolder
 func (s *editScaffolder) Scaffold() error {
 	s.config.MultiGroup = s.multigroup
-
-	return s.config.Save()
+	return nil
 }

--- a/pkg/scaffold/init.go
+++ b/pkg/scaffold/init.go
@@ -21,8 +21,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"sigs.k8s.io/kubebuilder/internal/config"
 	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/internal/machinery"
 	templatesv1 "sigs.k8s.io/kubebuilder/pkg/scaffold/internal/templates/v1"
 	managerv1 "sigs.k8s.io/kubebuilder/pkg/scaffold/internal/templates/v1/manager"
@@ -65,7 +65,7 @@ func NewInitScaffolder(config *config.Config, license, owner string) Scaffolder 
 
 func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
 	return model.NewUniverse(
-		model.WithConfig(&s.config.Config),
+		model.WithConfig(s.config),
 		model.WithBoilerplate(boilerplate),
 	)
 }
@@ -73,10 +73,6 @@ func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
 // Scaffold implements Scaffolder
 func (s *initScaffolder) Scaffold() error {
 	fmt.Println("Writing scaffold for you to edit...")
-
-	if err := s.config.Save(); err != nil {
-		return err
-	}
 
 	switch {
 	case s.config.IsV1():


### PR DESCRIPTION
A config object is initialized/loaded/saved by the CLI. Scaffolds or plugins shouldn't have to load/save a config object, nor should anything exported have internal parameters that cannot be populated if called outside of kubebuilder.

/cc @DirectXMan12 @mengqiy @Adirio @camilamacedo86 