### PR TITLE
Update quickstart to 2.3.1

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -24,11 +24,11 @@ os=$(go env GOOS)
 arch=$(go env GOARCH)
 
 # download kubebuilder and extract it to tmp
-curl -L https://go.kubebuilder.io/dl/2.3.0/${os}/${arch} | tar -xz -C /tmp/
+curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
 
 # move to a long-term location and put it on your path
 # (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
-sudo mv /tmp/kubebuilder_2.3.0_${os}_${arch} /usr/local/kubebuilder
+sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
 export PATH=$PATH:/usr/local/kubebuilder/bin
 ```
 


### PR DESCRIPTION
Update quick-start.md to Kubebuilder version 2.3.1 as 2.3.0 has a bug related to api creation.
This could impact new users negatively.