### PR TITLE
Cherry-pick c6fea14

### DIFF
--- a/docs/book/src/cronjob-tutorial/cert-manager.md
+++ b/docs/book/src/cronjob-tutorial/cert-manager.md
@@ -12,7 +12,7 @@ Cert manager also has a component called CA injector, which is responsible for
 injecting the CA bundle into the Mutating|ValidatingWebhookConfiguration.
 
 To accomplish that, you need to use an annotation with key
-`certmanager.k8s.io/inject-ca-from`
+`cert-manager.io/inject-ca-from`
 in the Mutating|ValidatingWebhookConfiguration objects.
 The value of the annotation should point to an existing certificate CR instance
 in the format of `<certificate-namespace>/<certificate-name>`.

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/certmanager/certificate.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/certmanager/kustomizeconfig.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/certmanager/kustomizeconfig.yaml
@@ -1,16 +1,16 @@
 # This configuration is for teaching kustomize how to update name ref and var substitution 
 nameReference:
 - kind: Issuer
-  group: certmanager.k8s.io
+  group: cert-manager.io
   fieldSpecs:
   - kind: Certificate
-    group: certmanager.k8s.io
+    group: cert-manager.io
     path: spec/issuerRef/name
 
 varReference:
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/commonName
 - kind: Certificate
-  group: certmanager.k8s.io
+  group: cert-manager.io
   path: spec/dnsNames

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/cainjection_in_cronjobs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/cainjection_in_cronjobs.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: cronjobs.batch.tutorial.kubebuilder.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: cronjobs.batch.tutorial.kubebuilder.io
 spec:
   conversion:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/webhookcainjection_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/cainjection_in_cronjobs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/cainjection_in_cronjobs.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: cronjobs.batch.tutorial.kubebuilder.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
   name: cronjobs.batch.tutorial.kubebuilder.io
 spec:
   conversion:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/webhookcainjection_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
Update doc certmanager 0.11 group and version change from certmanager.k8s.io/v1alpha1 to cert-manager.io/v1alpha2.

Cherry-pick by request https://github.com/kubernetes-sigs/kubebuilder/pull/1444#pullrequestreview-383924228.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>