### PR TITLE
update the minimal support k8s api version according to the tested versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please see https://git.k8s.io/community/CLA.md for more info.
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - [kustomize](https://sigs.k8s.io/kustomize/docs/INSTALL.md) v3.1.0+
-- Access to a Kubernetes v1.11.3+ cluster.
+- Access to a Kubernetes v1.14.1+ cluster.
 
 ## Contributing steps
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -13,7 +13,7 @@ This Quick Start guide will cover:
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - [kustomize](https://sigs.k8s.io/kustomize/docs/INSTALL.md) v3.1.0+
-- Access to a Kubernetes v1.11.3+ cluster.
+- Access to a Kubernetes v1.14.1+ cluster.
 
 ## Installation
 


### PR DESCRIPTION
**Description**
Upgrade the minimal k8s cluster version for the minimal required version at least the version checked/tested by the CI. 

Note that version 1.14. are no longer supported as well. See:https://kubernetes.io/docs/home/supported-doc-versions/