### PR TITLE
Using utilruntime.Must() for adding schemes

### DIFF
--- a/pkg/scaffold/internal/templates/v2/main.go
+++ b/pkg/scaffold/internal/templates/v2/main.go
@@ -113,7 +113,7 @@ const (
 	//  change, and thus should be done for next project version.
 	multiGroupControllerImportCodeFragment = `%scontroller "%s/controllers/%s"
 `
-	addschemeCodeFragment = `_ = %s.AddToScheme(scheme)
+	addschemeCodeFragment = `utilruntime.Must(%s.AddToScheme(scheme))
 `
 	reconcilerSetupCodeFragment = `if err = (&controllers.%sReconciler{
 		Client: mgr.GetClient(),
@@ -206,6 +206,7 @@ import (
 	"flag"
 	"os"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -219,7 +220,7 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	%s
 }

--- a/testdata/project-v2-addon/main.go
+++ b/testdata/project-v2-addon/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,9 +38,9 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	_ = crewv1.AddToScheme(scheme)
+	utilruntime.Must(crewv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/testdata/project-v2-multigroup/main.go
+++ b/testdata/project-v2-multigroup/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,15 +47,15 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	_ = crewv1.AddToScheme(scheme)
-	_ = shipv1beta1.AddToScheme(scheme)
-	_ = shipv1.AddToScheme(scheme)
-	_ = shipv2alpha1.AddToScheme(scheme)
-	_ = seacreaturesv1beta1.AddToScheme(scheme)
-	_ = seacreaturesv1beta2.AddToScheme(scheme)
-	_ = foopolicyv1.AddToScheme(scheme)
+	utilruntime.Must(crewv1.AddToScheme(scheme))
+	utilruntime.Must(shipv1beta1.AddToScheme(scheme))
+	utilruntime.Must(shipv1.AddToScheme(scheme))
+	utilruntime.Must(shipv2alpha1.AddToScheme(scheme))
+	utilruntime.Must(seacreaturesv1beta1.AddToScheme(scheme))
+	utilruntime.Must(seacreaturesv1beta2.AddToScheme(scheme))
+	utilruntime.Must(foopolicyv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,9 +38,9 @@ var (
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	_ = crewv1.AddToScheme(scheme)
+	utilruntime.Must(crewv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
Add the use of `utilruntime.Must()` from apimachinery to catch errors with scheme configurations. 

Signed-off-by: Chris Hein <me@chrishein.com>
