### PR TITLE
plugins: move `--plugins` from global to `init`-only

### DIFF
--- a/pkg/cli/cli_suite_test.go
+++ b/pkg/cli/cli_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCLI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CLI Suite")
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+)
+
+var _ = Describe("CLI", func() {
+	Describe("resolvePluginsByKey", func() {
+		plugins := makePluginsForKeys(
+			"foo.example.com/v1.0.0",
+			"bar.example.com/v1.0.0",
+			"baz.example.com/v1.0.0",
+			"foo.kubebuilder.io/v1.0.0",
+			"foo.kubebuilder.io/v2.0.0",
+			"bar.kubebuilder.io/v1.0.0",
+			"bar.kubebuilder.io/v2.0.0",
+		)
+
+		It("should check key correctly", func() {
+
+			resolvedPlugins, err := resolvePluginsByKey(plugins, "foo.example.com/v1.0.0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getPluginKeys(resolvedPlugins...)).To(Equal([]string{"foo.example.com/v1.0.0"}))
+
+			resolvedPlugins, err = resolvePluginsByKey(plugins, "foo.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getPluginKeys(resolvedPlugins...)).To(Equal([]string{"foo.example.com/v1.0.0"}))
+
+			resolvedPlugins, err = resolvePluginsByKey(plugins, "baz")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getPluginKeys(resolvedPlugins...)).To(Equal([]string{"baz.example.com/v1.0.0"}))
+
+			resolvedPlugins, err = resolvePluginsByKey(plugins, "foo/v2.0.0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getPluginKeys(resolvedPlugins...)).To(Equal([]string{"foo.kubebuilder.io/v2.0.0"}))
+
+			_, err = resolvePluginsByKey(plugins, "blah")
+			Expect(err).To(MatchError(`plugin key "blah" does not match a known plugin`))
+
+			_, err = resolvePluginsByKey(plugins, "foo.example.com/v2.0.0")
+			Expect(err).To(MatchError(`plugin key "foo.example.com/v2.0.0" does not match a known plugin`))
+
+			_, err = resolvePluginsByKey(plugins, "foo.kubebuilder.io")
+			Expect(err).To(MatchError(`plugin key "foo.kubebuilder.io" matches more than one known plugin`))
+
+			_, err = resolvePluginsByKey(plugins, "foo/v1.0.0")
+			Expect(err).To(MatchError(`plugin key "foo/v1.0.0" matches more than one known plugin`))
+
+			_, err = resolvePluginsByKey(plugins, "foo")
+			Expect(err).To(MatchError(`plugin key "foo" matches more than one known plugin`))
+		})
+	})
+})
+
+type mockPlugin struct {
+	name, version string
+}
+
+func (p mockPlugin) Name() string                     { return p.name }
+func (p mockPlugin) Version() string                  { return p.version }
+func (mockPlugin) SupportedProjectVersions() []string { return []string{"2"} }
+
+func makeBasePlugin(name, version string) plugin.Base {
+	return mockPlugin{name, version}
+}
+
+func makePluginsForKeys(keys ...string) (plugins []plugin.Base) {
+	for _, key := range keys {
+		plugins = append(plugins, makeBasePlugin(plugin.SplitKey(key)))
+	}
+	return
+}
+
+func getPluginKeys(plugins ...plugin.Base) (keys []string) {
+	for _, p := range plugins {
+		keys = append(keys, plugin.KeyFor(p))
+	}
+	return
+}

--- a/testdata/project-v2-addon/go.mod
+++ b/testdata/project-v2-addon/go.mod
@@ -9,5 +9,5 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200408160153-97d9e01751e0
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200414151614-92702a3972f3
 )

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -9,5 +9,5 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
 	sigs.k8s.io/controller-runtime v0.5.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200408160153-97d9e01751e0
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200414151614-92702a3972f3
 )


### PR DESCRIPTION
Per discussion in https://github.com/kubernetes-sigs/kubebuilder/pull/1403#discussion_r405014466:
>[H]aving a global --plugins flag is not in scope for phase 1 since the type of plugin used in init solely determines what plugin is used for subsequent commands (the layout config key). A global --plugins flag will be discussed in phase 2: #1378.

~There still may be a use case for phase 1 global `--plugins`: I scaffold a project with `--plugins=go-x` then want to create an API using plugin `go-y`, which "understands" a project initialized by `go-y`; without a global `--plugins` flag I would have to change my config's `layout` value.~

~Thoughts?~

/cc @DirectXMan12 @mengqiy @joelanford
