### PR TITLE
plugin: improve error and help messages

### DIFF
--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -70,15 +70,15 @@ func (c cli) bindCreateAPI(ctx plugin.Context, cmd *cobra.Command) {
 			getter = tmpGetter
 		}
 	}
-	if !hasGetter {
-		err := fmt.Errorf("project version %q does not support an API creation plugin",
-			c.projectVersion)
+
+	cfg, err := config.LoadInitialized()
+	if err != nil {
 		cmdErr(cmd, err)
 		return
 	}
 
-	cfg, err := config.LoadInitialized()
-	if err != nil {
+	if !hasGetter {
+		err := fmt.Errorf("layout plugin %q does not support an API creation plugin", cfg.Layout)
 		cmdErr(cmd, err)
 		return
 	}

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -109,8 +109,11 @@ func (c cli) bindInit(ctx plugin.Context, cmd *cobra.Command) {
 		}
 	}
 	if !hasGetter {
-		log.Fatalf("project version %q does not support an initialization plugin",
-			c.projectVersion)
+		if len(c.cliPluginKeys) == 0 {
+			log.Fatalf("project version %q does not support an initialization plugin", c.projectVersion)
+		} else {
+			log.Fatalf("plugin %q does not support an initialization plugin", c.cliPluginKeys)
+		}
 	}
 
 	cfg := config.New(config.DefaultPath)

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -70,15 +70,15 @@ func (c cli) bindCreateWebhook(ctx plugin.Context, cmd *cobra.Command) {
 			getter = tmpGetter
 		}
 	}
-	if !hasGetter {
-		err := fmt.Errorf("project version %q does not support a webhook creation plugin",
-			c.projectVersion)
+
+	cfg, err := config.LoadInitialized()
+	if err != nil {
 		cmdErr(cmd, err)
 		return
 	}
 
-	cfg, err := config.LoadInitialized()
-	if err != nil {
+	if !hasGetter {
+		err := fmt.Errorf("layout plugin %q does not support a webhook creation plugin", cfg.Layout)
 		cmdErr(cmd, err)
 		return
 	}

--- a/pkg/plugin/v1/init.go
+++ b/pkg/plugin/v1/init.go
@@ -37,6 +37,8 @@ import (
 
 type initPlugin struct {
 	config *config.Config
+	// For help text.
+	commandName string
 
 	// boilerplate options
 	license string
@@ -57,7 +59,7 @@ var (
 	_ cmdutil.RunOptions = &initPlugin{}
 )
 
-func (p initPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *initPlugin) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
 
 Writes the following files:
@@ -76,6 +78,8 @@ project will prompt the user to run 'dep ensure' after writing the project files
   %s init --project-version=1 --domain example.org --license apache2 --owner "The Kubernetes authors"
 `,
 		ctx.CommandName)
+
+	p.commandName = ctx.CommandName
 }
 
 func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
@@ -177,6 +181,6 @@ func (p *initPlugin) PostScaffold() error {
 		return err
 	}
 
-	fmt.Println("Next: define a resource with:\n$ kubebuilder create api")
+	fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
 	return nil
 }

--- a/pkg/plugin/v2/init.go
+++ b/pkg/plugin/v2/init.go
@@ -35,6 +35,8 @@ import (
 
 type initPlugin struct {
 	config *config.Config
+	// For help text.
+	commandName string
 
 	// boilerplate options
 	license string
@@ -55,7 +57,7 @@ var (
 	_ cmdutil.RunOptions = &initPlugin{}
 )
 
-func (p initPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *initPlugin) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
 
 Writes the following files:
@@ -74,6 +76,8 @@ project will prompt the user to run 'dep ensure' after writing the project files
   %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"
 `,
 		ctx.CommandName)
+
+	p.commandName = ctx.CommandName
 }
 
 func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
@@ -174,6 +178,6 @@ func (p *initPlugin) PostScaffold() error {
 		return err
 	}
 
-	fmt.Println("Next: define a resource with:\n$ kubebuilder create api")
+	fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
 	return nil
 }

--- a/pkg/plugin/v2/webhook.go
+++ b/pkg/plugin/v2/webhook.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v2
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -33,6 +32,8 @@ import (
 
 type createWebhookPlugin struct {
 	config *config.Config
+	// For help text.
+	commandName string
 
 	resource   *resource.Options
 	defaulting bool
@@ -45,7 +46,7 @@ var (
 	_ cmdutil.RunOptions   = &createAPIPlugin{}
 )
 
-func (p createWebhookPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *createWebhookPlugin) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
 `
@@ -57,6 +58,8 @@ validating and (or) conversion webhooks.
   %s create webhook --group crew --version v1 --kind FirstMate --conversion
 `,
 		ctx.CommandName, ctx.CommandName)
+
+	p.commandName = ctx.CommandName
 }
 
 func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
@@ -88,8 +91,8 @@ func (p *createWebhookPlugin) Validate() error {
 	}
 
 	if !p.defaulting && !p.validation && !p.conversion {
-		return errors.New("kubebuilder webhook requires at least one of" +
-			" --defaulting, --programmatic-validation and --conversion to be true")
+		return fmt.Errorf("%s create webhook requires at least one of --defaulting,"+
+			" --programmatic-validation and --conversion to be true", p.commandName)
 	}
 
 	return nil


### PR DESCRIPTION
* pkg/plugin: inject command name from Context so help messages contain the correct command name

* pkg/cli: use layout or cliPluginKeys in error messages if no plugin for a command is found

/cc @camilamacedo86 @DirectXMan12 @Adirio 