### PR TITLE
start a cookbook section in the book per #1475

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -79,4 +79,6 @@
 
 ---
 
+- [Cookbook](./cookbook/cookbook.md)
+
 [Appendix: The TODO Landing Page](./TODO.md)

--- a/docs/book/src/cookbook/cookbook.md
+++ b/docs/book/src/cookbook/cookbook.md
@@ -1,0 +1,32 @@
+# Cookbook
+
+A curated collection of operator development patterns, use-cases and generic\
+recommendations.
+
+## Rationale
+
+While the tutorial part of this book provides onboarding into the operator
+realm, real world use cases often surpass the tutorial example(s). Hence we
+want to provide a place to share common implementation patterns in order
+to enable other users, may they be operator experts or novices, a palce to both
+share and validate common approaches they encounter while developing operators.
+
+## Recipies
+
+<aside class="note">
+
+<h1>Following Along</h1>
+
+Note that code examples of cookbook entries live as literate Go files in the
+book source directory:
+[docs/book/src/cookbook/testdata][cookbook-sources]. You may find both snippets
+and fully runnable projects among the examples.
+
+[cookbook-sources]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/cookbook/testdata
+
+</aside>
+
+*If you are reading this and you are wondering where the entries are: there are
+none yet. It is the perfect time for you to contribute something from your
+experience in developing operators right now.*
+

--- a/docs/book/src/cookbook/cookbook.md
+++ b/docs/book/src/cookbook/cookbook.md
@@ -8,7 +8,7 @@ recommendations.
 While the tutorial part of this book provides onboarding into the operator
 realm, real world use cases often surpass the tutorial example(s). Hence we
 want to provide a place to share common implementation patterns in order
-to enable other users, may they be operator experts or novices, a palce to both
+to enable other users, may they be operator experts or novices, a place to both
 share and validate common approaches they encounter while developing operators.
 
 ## Recipies

--- a/docs/book/src/cookbook/cookbook.md
+++ b/docs/book/src/cookbook/cookbook.md
@@ -1,6 +1,6 @@
 # Cookbook
 
-A curated collection of operator development patterns, use-cases and generic\
+A curated collection of operator development patterns, use-cases and generic
 recommendations.
 
 ## Rationale
@@ -11,7 +11,7 @@ want to provide a place to share common implementation patterns in order
 to enable other users, may they be operator experts or novices, a place to both
 share and validate common approaches they encounter while developing operators.
 
-## Recipies
+## Recipes
 
 <aside class="note">
 


### PR DESCRIPTION
**Description:**
The changeset adds a new top level section to the book below "Reference", called "Cookbook".

**Motivation:**
The existing book does a fantastic job introducing new users to the operator realm. I want to enable the community to create a place in the book to share and validate each others most common design patterns and problem solutions from daily operator development as it often goes well beyond the onboarding tutorials.

Issue: https://github.com/kubernetes-sigs/kubebuilder/issues/1475