### PR TITLE
Makefile: Support multiple GOPATH directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,17 @@
 export GOPROXY?=https://proxy.golang.org/
 CONTROLLER_GEN_BIN_PATH := $(shell which controller-gen)
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif
@@ -46,7 +54,7 @@ build: ## Build the project locally
 .PHONY: install
 install: ## Build and install the binary with the current source code. Use it to test your changes locally.
 	make build
-	cp ./bin/kubebuilder $(shell go env GOPATH)/bin/kubebuilder
+	cp ./bin/kubebuilder $(GOBIN)/kubebuilder
 
 ##@ Development
 

--- a/common.sh
+++ b/common.sh
@@ -29,6 +29,13 @@ if [[ -n "${MODULES_OPT}" && -n "${MODULES_ENABLED}" ]]; then
     MOD_OPT="-mod=${MODULES_OPT}"
 fi
 
+# Default to the first GOPATH if there are multiple ones
+CHECK_GOPATH=$(go env GOPATH)
+if [[ $CHECK_GOPATH == *":"* ]]; then
+    GOPATH=$(echo $CHECK_GOPATH | cut -d: -f1)
+    GOBIN=$GOPATH/bin
+fi
+
 
 # Enable tracing in this script off by setting the TRACE variable in your
 # environment to any value:

--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -59,8 +59,14 @@ echo "grabbing the latest released controller-gen"
 go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
 
 # make sure we add the go bin directory to our path
-gobin=$(go env GOBIN)
-gobin=${GOBIN:-$(go env GOPATH)/bin}  # GOBIN won't always be set :-/
+CHECK_GOPATH=$(go env GOPATH)
+if [[ $CHECK_GOPATH == *":"* ]]; then
+    GOPATH=$(echo $CHECK_GOPATH | cut -d: -f1)
+    gobin=$GOPATH/bin
+else
+    gobin=$(go env GOBIN)
+    gobin=${GOBIN:-$(go env GOPATH)/bin}  # GOBIN won't always be set :-/
+fi
 
 export PATH=${gobin}:$PATH
 verb=${1:-build}

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -3,7 +3,13 @@
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
-
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
 all: manager
 
 # Run tests
@@ -58,7 +64,7 @@ docker-push:
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.0-beta.3
-CONTROLLER_GEN=$(shell go env GOPATH)/bin/controller-gen
+CONTROLLER_GEN=$(GOPATH)/bin/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif

--- a/generate_testdata.sh
+++ b/generate_testdata.sh
@@ -36,13 +36,20 @@ scaffold_test_project() {
     pushd .
     cd testdata/$project
     kb=$testdata_dir/../bin/kubebuilder
+
+    # Default to the first GOPATH if there are multiple ones
+    CHECK_GOPATH=$(go env GOPATH)
+    if [[ $CHECK_GOPATH == *":"* ]]; then
+        GOPATH=$(echo $CHECK_GOPATH | cut -d: -f1)
+    fi
     oldgopath=$GOPATH
+
     if [ $version == "2" ] || [ $version == "3-alpha" ]; then
         header_text "Starting to generate projects with version $version"
         header_text "Generating $project"
 
         export GO111MODULE=on
-        export PATH=$PATH:$(go env GOPATH)/bin
+        export PATH=$PATH:$GOPATH/bin
         go mod init sigs.k8s.io/kubebuilder/testdata/$project  # our repo autodetection will traverse up to the kb module if we don't do this
 
         header_text "initializing $project ..."

--- a/pkg/scaffold/internal/templates/makefile.go
+++ b/pkg/scaffold/internal/templates/makefile.go
@@ -60,9 +60,17 @@ IMG ?= {{ .Image }}
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif

--- a/testdata/project-v2-addon/Makefile
+++ b/testdata/project-v2-addon/Makefile
@@ -4,9 +4,17 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif

--- a/testdata/project-v2-multigroup/Makefile
+++ b/testdata/project-v2-multigroup/Makefile
@@ -4,9 +4,17 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -4,9 +4,17 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -4,9 +4,17 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -4,9 +4,17 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -4,9 +4,17 @@ IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
+# Default to the first directory in the list, if GOPATH has multiple paths
+CHECK_GOPATH=$(shell go env GOPATH)
+ifneq (,$(findstring :,$(CHECK_GOPATH)))
+GOPATH=$(firstword $(subst :, ,$(CHECK_GOPATH)))
+else
+GOPATH=$(shell go env GOPATH)
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
+GOBIN=$(GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif


### PR DESCRIPTION
If $GOPATH is consisted of multiple directories separated by ':'
then pick the first one. This is what 'go get' does as well.

Fixes #1402 
