### PR TITLE
upgrade controller-tools version from v0.2.5 to v0.3.0

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -16,6 +16,17 @@
 
 set -e
 
+# The following code is required to allow the preview works with an upper go version
+# More info : https://community.netlify.com/t/go-version-1-13/5680
+# Get the directory that this script file is in
+THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+cd "$THIS_DIR"
+
+[[ -n "$(command -v gimme)" ]] && eval "$(gimme stable)"
+echo go version
+GOBIN=$THIS_DIR/functions go install ./...
+
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
@@ -56,7 +67,7 @@ ${cmd} /tmp/mdbook.${ext}
 chmod +x /tmp/mdbook
 
 echo "grabbing the latest released controller-gen"
-go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
+go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
 
 # make sure we add the go bin directory to our path
 gobin=$(go env GOBIN)

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cronjobs.batch.tutorial.kubebuilder.io
 spec:

--- a/pkg/scaffold/init.go
+++ b/pkg/scaffold/init.go
@@ -36,7 +36,7 @@ const (
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
 	ControllerRuntimeVersion = "v0.5.0"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
-	ControllerToolsVersion = "v0.2.5"
+	ControllerToolsVersion = "v0.3.0"
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
 	KustomizeVersion = "v3.5.4"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,5 +24,5 @@ export GO111MODULE=on
 kind create cluster -v 4 --retain --wait=1m --config test/kind-config.yaml --image=kindest/node:$K8S_VERSION
 
 # setup the go modules required
-go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
+go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
 go get sigs.k8s.io/kustomize/kustomize/v3@v3.2.1

--- a/testdata/project-v2-addon/Makefile
+++ b/testdata/project-v2-addon/Makefile
@@ -71,7 +71,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v2-addon/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v2-addon/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:

--- a/testdata/project-v2-addon/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2-addon/config/crd/bases/crew.testproject.org_captains.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:

--- a/testdata/project-v2-addon/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v2-addon/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/Makefile
+++ b/testdata/project-v2-multigroup/Makefile
@@ -71,7 +71,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v2-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: healthcheckpolicies.foo.policy.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: krakens.sea-creatures.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: leviathans.sea-creatures.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cruisers.ship.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: destroyers.ship.testproject.org
 spec:

--- a/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: frigates.ship.testproject.org
 spec:

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -71,7 +71,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -71,7 +71,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:

--- a/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_captains.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:

--- a/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -71,7 +71,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v3-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: healthcheckpolicies.foo.policy.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: krakens.sea-creatures.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: leviathans.sea-creatures.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cruisers.ship.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: destroyers.ship.testproject.org
 spec:

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: frigates.ship.testproject.org
 spec:

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -71,7 +71,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_captains.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:


### PR DESCRIPTION
**Description**
upgrade controller-tools version from v0.2.5 to v0.3.0

**Motivation**
- avoid technical debts issues
- get bug fix and improvements to support CRD and Webhook api V1. 

PS.:  Has no breaking changes. See: https://github.com/kubernetes-sigs/controller-tools/releases