### PR TITLE
Fix typo in deleteExternalResources comment

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -95,7 +95,7 @@ func (r *Reconciler) deleteExternalResources(cronJob *batch.CronJob) error {
 	// delete any external resources associated with the cronJob
 	//
 	// Ensure that delete implementation is idempotent and safe to invoke
-	// multiple types for same object.
+	// multiple times for same object.
 }
 
 // Helper functions to check and remove string from a slice of strings.


### PR DESCRIPTION
I believe the intention was to explain idempotence, so this is just a small typo correction