### PR TITLE
fix: master branch CI with mock testdata update

### DIFF
--- a/testdata/project-v2-addon/go.mod
+++ b/testdata/project-v2-addon/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
-	k8s.io/apimachinery v0.17.2
-	k8s.io/client-go v0.17.2
-	sigs.k8s.io/controller-runtime v0.5.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200415210853-85eb326a6add
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect
+	k8s.io/apimachinery v0.18.2
+	k8s.io/client-go v0.18.2
+	sigs.k8s.io/controller-runtime v0.6.0
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200507203943-d901af431e3a
+	sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 // indirect
 )

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
-	k8s.io/apimachinery v0.17.2
-	k8s.io/client-go v0.17.2
-	sigs.k8s.io/controller-runtime v0.5.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200415210853-85eb326a6add
+	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect
+	k8s.io/apimachinery v0.18.2
+	k8s.io/client-go v0.18.2
+	sigs.k8s.io/controller-runtime v0.6.0
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200507203943-d901af431e3a
+	sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 // indirect
 )


### PR DESCRIPTION
Just `make generate` to update the master branch and fix the CI. 

Reason: The mod kubebuilder-declarative-pattern is added when the testdata add-on project is gen, if it changes after the PR be pushed and the CI finished then, the boot will merge the PR in the master because it will just re-run the prow tests. However, the make check-testdata for the master branch will be executed after the merge and will fail.

Solution: Add `make check-generate` in the prow to avoid this scenario in the future. The need was tracked in: https://github.com/kubernetes-sigs/kubebuilder/issues/1503