### PR TITLE
fix: unable to build multigroup projects

### DIFF
--- a/testdata/project-v2-multigroup/Dockerfile
+++ b/testdata/project-v2-multigroup/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY api/ api/
+COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY api/ api/
+COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build


### PR DESCRIPTION
closes: #1500

PS.: I do not consider this bug fix as a braking change because:

After having project scaffold and with the project layout update to multigroup support then, users are still able to use the command to re-run the edit --multigroup=true which would apply the fix. 

ps.: shows that we have not too many users using the multigroup since the issue was not reported so far.