### PR TITLE
fix: remove role for configmaps/status which do not exists from leader_election_role.yaml

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/leaderelectionrole.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/leaderelectionrole.go
@@ -61,14 +61,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/testdata/project-v3-addon/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-addon/config/rbac/leader_election_role.yaml
@@ -19,14 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/testdata/project-v3-multigroup/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/leader_election_role.yaml
@@ -19,14 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/testdata/project-v3/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3/config/rbac/leader_election_role.yaml
@@ -19,14 +19,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create


### PR DESCRIPTION
Closes: #1473

Theoretically, any deletion would be a breaking change. However, in this case, we are scaffolding something that does not exist and has no value at all. So, because of this was done for V2,V3. 

blocked;

TODO: Apply to V3 plugin 2.X only.
Waiting for #1498