### PR TITLE
update testdata to fix CI

### DIFF
--- a/testdata/project-v2-addon/go.mod
+++ b/testdata/project-v2-addon/go.mod
@@ -9,5 +9,5 @@ require (
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200508060342-d7f9f832e44b
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200512162422-ce639cbf6d4c
 )

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -9,5 +9,5 @@ require (
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200508060342-d7f9f832e44b
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200512162422-ce639cbf6d4c
 )


### PR DESCRIPTION
It is just to fix the the testdata. A new change in the module `sigs.k8s.io/kubebuilder-declarative-pattern` was merged and it is indirectly added when the projects with add-on are generated. 

PS.: It is not very common, however, the solution to avoid this scenario would be to add the testdada check to the prow which we already have an issue with this need tracked. 