### PR TITLE
docs: example of age print column

### DIFF
--- a/docs/book/src/reference/generating-crd.md
+++ b/docs/book/src/reference/generating-crd.md
@@ -76,6 +76,7 @@ example:
 // +kubebuilder:printcolumn:name="Alias",type=string,JSONPath=`.spec.alias`
 // +kubebuilder:printcolumn:name="Rank",type=integer,JSONPath=`.spec.rank`
 // +kubebuilder:printcolumn:name="Bravely Run Away",type=boolean,JSONPath=`.spec.knights[?(@ == "Sir Robin")]`,description="when danger rears its ugly head, he bravely turned his tail and fled",priority=10
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Added an "Age" print column as an example as well.

Its a pretty common use case, and it was not obvious to me how to make it work. In my head, I would have to do something like `now - .metadata.creationTimestamp` somehow.... found that I just need to set the `type` to `date` by digging the prometheus-operator codebase.

Hope this makes it easier for the next people :)