### PR TITLE
fix: fixed version of sigs.k8s.io/kubebuilder-declarative-pattern which should be used

### DIFF
--- a/pkg/plugin/v2/api.go
+++ b/pkg/plugin/v2/api.go
@@ -182,6 +182,21 @@ func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 }
 
 func (p *createAPIPlugin) PostScaffold() error {
+	// Load the requested plugins
+	switch strings.ToLower(p.pattern) {
+	case "":
+		// Default pattern
+	case "addon":
+		// Ensure that we are pinning sigs.k8s.io/kubebuilder-declarative-pattern version
+		err := internal.RunCmd("Get controller runtime", "go", "get",
+			"sigs.k8s.io/kubebuilder-declarative-pattern@"+scaffold.KbDeclarativePattern)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown pattern %q", p.pattern)
+	}
+
 	if p.runMake {
 		return internal.RunCmd("Running make", "make")
 	}

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -28,6 +28,10 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/scaffold/internal/templates/crd"
 )
 
+// (used only to gen api with --pattern=addon)
+// KbDeclarativePattern is the sigs.k8s.io/kubebuilder-declarative-pattern version
+const KbDeclarativePattern = "v0.0.0-20200522144838-848d48e5b073"
+
 var _ Scaffolder = &apiScaffolder{}
 
 // apiScaffolder contains configuration for generating scaffolding for Go type


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1525 
Closes: #1503 (no longer required after it as well)
