### PR TITLE
FIX: fix for controller-runtime 0.6.0 GetFieldIndexer().IndexField ctx param

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -544,7 +544,7 @@ func (r *CronJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.Clock = realClock{}
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(&kbatch.Job{}, jobOwnerKey, func(rawObj runtime.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &kbatch.Job{}, jobOwnerKey, func(rawObj runtime.Object) []string {
 		// grab the job object, extract the owner...
 		job := rawObj.(*kbatch.Job)
 		owner := metav1.GetControllerOf(job)

--- a/docs/book/src/multiversion-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -527,7 +527,7 @@ func (r *CronJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.Clock = realClock{}
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(&kbatch.Job{}, jobOwnerKey, func(rawObj runtime.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &kbatch.Job{}, jobOwnerKey, func(rawObj runtime.Object) []string {
 		// grab the job object, extract the owner...
 		job := rawObj.(*kbatch.Job)
 		owner := metav1.GetControllerOf(job)


### PR DESCRIPTION
in controller-runtime@v0.6.0 the FieldIndexer interface is
```
type FieldIndexer interface {
	// IndexFields adds an index with the given field name on the given object type
	// by using the given function to extract the value for that field.  If you want
	// compatibility with the Kubernetes API server, only return one key, and only use
	// fields that the API server supports.  Otherwise, you can return multiple keys,
	// and "equality" in the field selector means that at least one key matches the value.
	// The FieldIndexer will automatically take care of indexing over namespace
	// and supporting efficient all-namespace queries.
	IndexField(ctx context.Context, obj runtime.Object, field string, extractValue IndexerFunc) error
}
```
fix to add a context to IndexField method
just a small fix
