### PR TITLE
docs: add/update CLI plugin docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,13 @@ $ git clone git@github.com:<user>/kubebuilder.git $GOPATH/src/sigs.k8s.io/kubebu
 ```
 
 1. Ensure you activate module support before continue (`$ export GO111MODULE=on`)
-1. Run the command `make install` to create a bin with the source code 
+1. Run the command `make install` to create a bin with the source code
 
 **NOTE** In order to check the local environment run `make go-test`.
 
-## What to do before submitting a pull request 
+## What to do before submitting a pull request
 
-1. Run the script `make generate` to update/generate the mock data used in the e2e test in `$GOPATH/src/sigs.k8s.io/kubebuilder/testdata/` 
+1. Run the script `make generate` to update/generate the mock data used in the e2e test in `$GOPATH/src/sigs.k8s.io/kubebuilder/testdata/`
 
 **IMPORTANT:** The `make generate` is very helpful. By using it, you can check if good part of the commands still working successfully after the changes. Also, note that its usage is a pre-requirement to submit a PR.
 
@@ -60,8 +60,8 @@ Following the targets that can be used to test your changes locally.
 
 ## Where the CI Tests are configured
 
-1. See the [Travis](.travis.yml) file to check its tests and the scripts used on it. 
-1. Note that the prow tests used in the CI are configured in [kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml). 
+1. See the [Travis](.travis.yml) file to check its tests and the scripts used on it.
+1. Note that the prow tests used in the CI are configured in [kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml).
 1. Check that all scripts used by the CI are defined in the project.  
 
 ## How to contribute to docs
@@ -82,39 +82,49 @@ cherry-picked into `book-v2` branch.
 
 Check the CI job after to do the Pull Request and then, click on in the `Details` of `netlify/kubebuilder/deploy-preview`
 
-## Understanding the versions
+## Versioning
 
 |   Name	|   Example	|  Description |
 |---	|---	|---	|
-|  PROJECT version |  `v1`,`v2`,`v3` | As of the introduction of [Extensible CLI and Scaffolding Plugins](https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-1.md), PROJECT version represents the layout of PROJECT file itself.  For `v1` and `v2` projects, there's extra meaning -- see below.  |
-|  Release version | `v2.2.0`, `v2.3.0`, `v2.3.1` | Tagged versions of the KubeBuilder project, representing changes to the source code in this repository. See the [releases](https://github.com/kubernetes-sigs/kubebuilder/releases) page. |
-|  Plugin Versions | `go.kubebuilder.io/v2.0.0` | Represents the version of an individual plugin, as well as the corresponding scaffolding that it generates. |
+|  KubeBuilder version | `v2.2.0`, `v2.3.0`, `v2.3.1` | Tagged versions of the KubeBuilder project, representing changes to the source code in this repository. See the [releases][kb-releases] page for binary releases. |
+|  Project version |  `"1"`, `"2"`, `"3-alpha"` | Project version defines the scheme of a `PROJECT` configuration file. This version is defined in a `PROJECT` file's `version`. |
+|  Plugin version | `v2`, `v3-alpha` | Represents the version of an individual plugin, as well as the corresponding scaffolding that it generates. This version is defined in a plugin key, ex. `go.kubebuilder.io/v2`. See the [design doc][cli-plugins-versioning] for more details. |
 
-Note that PROJECT version should only be bumped if a breaking change is introduced in the PROJECT file format itself.  Changes to the Go scaffolding or the KubeBuilder CLI *do not* affect the PROJECT version.
+### Incrementing versions
 
-Similarly, the introduction of a new major version (`(x+1).0.0`) of the Go plugin might only lead to a new minor (`x.(y+1).0`) release of KubeBuilder, since no breaking change is being made to the CLI itself.  It'd only be a breaking change to KubeBuilder if we remove support for an older version of the plugin.
+For more information on how KubeBuilder release versions work, see the [semver](https://semver.org/) documentation.
 
-For more information on how the release and plugin versions work, see the the [semver](https://semver.org/) documentation.
+Project versions should only be increased if a breaking change is introduced in the PROJECT file scheme itself. Changes to the Go scaffolding or the KubeBuilder CLI *do not* affect project version.
 
-**NOTE:** In the case of the `v1` and `v2` PROJECT version, a corresponding Plugin version is implied and constant -- `v1` implies the `go.kubebuilder.io/v1` Plugin, and similarly for `v2`.  This is for legacy purposes -- no such implication is made with the `v3` PROJECT version.
+Similarly, the introduction of a new plugin version might only lead to a new minor version release of KubeBuilder, since no breaking change is being made to the CLI itself. It'd only be a breaking change to KubeBuilder if we remove support for an older plugin version. See the plugins design doc [versioning section][cli-plugins-versioning]
+for more details on plugin versioning.
 
-## Introducing changes in the scaffold files
+**NOTE:** the scheme for project version `"2"` was defined before the concept of plugins was introduced, so plugin `go.kubebuilder.io/v2` is implicitly used for those project types. Schema for project versions `"3-alpha"` and beyond define a `layout` key that informs the plugin system of which plugin to use.
 
-Changes in the scaffolded files require a new Plugin version. If we delete or update a file that is scaffolded by default, it's a breaking change and requires a `MAJOR` Plugin version.  If we add a new file, it may not be a breaking change.
+## Introducing changes to plugins
 
-**More simply:** any change that will break the expected behaviour of a project built with the previous `MINOR` Plugin versions is a breaking change to that plugin. 
+Changes made to plugins only require a plugin version increase if and only if a change is made to a plugin
+that breaks projects scaffolded with the previous plugin version. Once a plugin version `vX` is stabilized (it doesn't
+have an "alpha" or "beta" suffix), a new plugin package should be created containing a new plugin with version
+`v(X+1)-alpha`. Typically this is done by (semantically) `cp -r pkg/plugin/vX pkg/plugin/v(X+1)` then updating
+version numbers and paths. All further breaking changes to the plugin should be made in this package; the `vX`
+plugin would then be frozen to breaking changes.
 
-**EXAMPLE:**
+### Example
 
-KubeBuilder Release version (`5.3.1`) scaffolds projects with the plugin version `3.2.1` by default.
+KubeBuilder scaffolds projects with plugin `go.kubebuilder.io/v2` by default. A `v3-alpha` version
+was created after `v2` stabilized.
 
-The changes introduced in our PR will not work well with the projects which were built with the plugin versions `3.0.0...3.5.1` without users taking manual steps to update their projects. Thus, our changes introduce a breaking change to the Go plugin, and require a `MAJOR` Plugin version bump.
+You create a feature that adds a new marker to the file `main.go` scaffolded by `init`
+that `create api` will use to update that file. The changes introduced in your feature
+would cause errors if used with projects built with plugins `go.kubebuilder.io/v2`
+without users manually updating their projects. Thus, your changes introduce a breaking change
+to plugin `go.kubebuilder.io`, and can only be merged into plugin version `v3-alpha`.
+This plugin's package should exist already, so a PR must be made against the
 
-In the PR, we should add a migration guide to the [Migrations](https://book.kubebuilder.io/migrations.html) section of the KubeBuilder book. It should detail the required steps that users should take to upgrade their projects from `go.kubebuilder.io/3.X.X` to the new `MAJOR` Plugin version `go.kubebuilder.io/4.0.0`.
-
-This also means we should introduce a new KubeBuilder minor version `5.4.0` when the project is released: since we've only added a new plugin version without removing the old one, this is considered a new feature to KubeBuilder, and not a breaking change.
-
-**IMPORTANT** Breaking changes cannot be made to PROJECT versions v1 and v2, and consequently plugin versions `go.kubebuilder.io/1` and `go.kubebuilder.io/2`.
+You must also add a migration guide to the [migrations](https://book.kubebuilder.io/migrations.html)
+section of the KubeBuilder book in your PR. It should detail the steps required
+for users to upgrade their projects from `v2` to `v3-alpha`.
 
 ## Community, discussion and support
 
@@ -127,10 +137,12 @@ You can reach the maintainers of this project at:
 ## Becoming a reviewer or approver
 
 Contributors may eventually become official reviewers or approvers in
-KubeBuilder and the related repositories.  See
+KubeBuilder and the related repositories. See
 [CONTRIBUTING-ROLES.md](docs/CONTRIBUTING-ROLES.md) for more information.
 
 ## Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
 
+[kb-releases]:https://github.com/kubernetes-sigs/kubebuilder/releases
+[cli-plugins-versioning]:docs/book/src/reference/cli-plugins.md

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -78,6 +78,7 @@
   - [Using envtest in integration tests](./reference/envtest.md)
 
   - [Metrics](./reference/metrics.md)
+  - [CLI Plugins](./reference/cli-plugins.md)
 
 ---
 

--- a/docs/book/src/reference/cli-plugins.md
+++ b/docs/book/src/reference/cli-plugins.md
@@ -1,0 +1,250 @@
+# CLI Plugins
+
+Kubebuilder CLI plugins wrap scaffolding and CLI features in conveniently packaged Go types that are executed by the
+`kubebuilder` binary, or any binary that imports them. More specifically, a plugin configures the execution of one
+of the following CLI commands:
+* `init`: project initialization.
+* `create api`: scaffold Kubernetes API definitions.
+* `create webhook`: scaffold Kubernetes webhooks.
+
+Plugins are identified by a key of the form `<name>/<version>`. There are two ways to specify a plugin to run:
+* Setting `kubebuilder init --plugins=<plugin key>`, which will initialize a project configured for plugin with key
+ `<plugin key>`.
+* A `layout: <plugin key>` in the scaffolded `PROJECT` configuration file. Commands (except for `init`, which scaffolds
+  this file) will look at this value before running to choose which plugin to run.
+
+By default, `<plugin key>` will be `go.kubebuilder.io/vX`, where `X` is some integer.
+
+## Plugin interfaces
+
+Each plugin is required to implement the [`Base`][plugin-base] interface.
+
+```go
+type Base interface {
+  // Version returns the plugin's version, which contains a positive integer
+  // and an optional "stage" string. The string representation of this version
+  // has format:
+  // (v)?[1-9][0-9]*(-(alpha|beta))?
+  Version() Version
+  // Name returns a DNS1123 label string defining the plugin type.
+  // For example, Kubebuilder's main plugin would return "go".
+  //
+  // Plugin names can be fully-qualified, and non-fully-qualified names are
+  // prepended to ".kubebuilder.io" to prevent conflicts.
+  Name() string
+  // SupportedProjectVersions lists all project configuration versions this
+  // plugin supports, ex. []string{"2", "3"}. The returned slice cannot be empty.
+  SupportedProjectVersions() []string
+}
+```
+
+### Plugin types
+
+On top of being a `Base`, a plugin should also implement the [`GenericSubcommand`][plugin-subc] interface so it can be
+run with a CLI:
+
+```go
+type GenericSubcommand interface {
+  // UpdateContext updates a PluginContext with command-specific help text,
+  // like description and examples. Can be a no-op if default help text is desired.
+  UpdateContext(*PluginContext)
+  // BindFlags binds the plugin's flags to the CLI. This allows each plugin to
+  // define its own command line flags for the kubebuilder subcommand.
+  BindFlags(*pflag.FlagSet)
+  // InjectConfig passes a config to a plugin. The plugin may modify the
+  // config. Initializing, loading, and saving the config is managed by the
+  // cli package.
+  InjectConfig(*config.Config)
+  // Run runs the subcommand.
+  Run() error
+}
+```
+
+The [plugin context][plugin-context] is optionally updated by `UpdateContext(ctx)` to set custom help text for the target
+command; this method can be a no-op, which will preserve the default help text set by the [cobra][cobra] command constructors.
+
+A plugin also implements one of the following interface pairs to declare its support for specific subcommands:
+
+```go
+// To implement the 'init' subcommand.
+type InitPluginGetter interface {
+  Base
+  GetInitPlugin() Init
+}
+
+type Init interface {
+  GenericSubcommand
+}
+
+// To implement the 'create api' subcommand.
+type CreateAPIPluginGetter interface {
+  Base
+  GetCreateAPIPlugin() CreateAPI
+}
+
+type CreateAPI interface {
+  GenericSubcommand
+}
+
+// To implement the 'create webhook' subcommand.
+type CreateWebhookPluginGetter interface {
+  Base
+  GetCreateWebhookPlugin() CreateWebhook
+}
+
+type CreateWebhook interface {
+  GenericSubcommand
+}
+```
+
+The pair system allows a plugin implementation to have the same `Base` "parent" plugin with child typed plugins. For
+example, the following plugin `go.example.com/v1` implements each of the above pairs:
+
+```go
+import (
+  "github.com/spf13/pflag"
+  "sigs.k8s.io/kubebuilder/pkg/model/config"
+  "sigs.k8s.io/kubebuilder/pkg/plugin"
+)
+
+// Plugin embeds internal types that implement one plugin type each,
+// while implementing `Base` itself.
+type Plugin struct {
+  initPlugin
+  createAPIPlugin
+  createWebhookPlugin
+}
+
+// Base implementation.
+func (Plugin) Name() string                                   { return "go.example.com" }
+func (Plugin) Version() plugin.Version                        { return plugin.Version{Number: 1} }
+func (Plugin) SupportedProjectVersions() []string             { return []string{"3"} }
+// Getters.
+func (p Plugin) GetInitPlugin() plugin.Init                   { return &p.initPlugin }
+func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI         { return &p.createAPIPlugin }
+func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook { return &p.createWebhookPlugin }
+
+// Example of one of the internal implementations of GenericSubcommand.
+type createAPIPlugin struct { ... }
+func (p createAPIPlugin) UpdateContext(ctx *plugin.Context) { ... }
+func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet)      { ... }
+func (p *createAPIPlugin) InjectConfig(c *config.Config)    { ... }
+func (p *createAPIPlugin) Run() error                       { ... }
+```
+
+For a full implementation example, check out Kubebuilder's native [`go.kubebuilder.io`][kb-go-plugin] plugin.
+
+#### Deprecated Plugins
+
+Once a plugin is deprecated, have it implement a `Deprecated` interface so a deprecation warning will be printed when it is used:
+
+```go
+// Deprecated is an interface that, if implemented, informs the CLI
+// that the plugin is deprecated.  The CLI uses this to print deprecation
+// warnings when the plugin is in use.
+type Deprecated interface {
+  // DeprecationWarning returns a deprecation message that callers
+  // can use to warn users of deprecations
+  DeprecationWarning() string
+}
+```
+
+## CLI system
+
+Plugins are run using a [`CLI`][cli] object, which maps a plugin type to a subcommand and calls that plugin's methods.
+For example, writing a program that injects an `Init` plugin into a `CLI` then calling `CLI.Run()` will call the
+plugin's `UpdateContext`, `BindFlags`, `InjectConfig`, and `Run` methods with information a user has passed to the
+program in `kubebuilder init`. Hopefully the following code example will clarify this rather confusing description:
+
+```go
+// Several plugins for different languages with different versions.
+import (
+  ansiblev1 "github.com/example/my-plugins/pkg/plugins/ansible/v1"
+  golangv1 "github.com/example/my-plugins/pkg/plugins/golang/v1" // From the above example.
+  golangv2 "github.com/example/my-plugins/pkg/plugins/golang/v2"
+  helmv1 "github.com/example/my-plugins/pkg/plugins/helm/v1"
+)
+
+// Create a CLI with name 'controller-builder' that supports
+// project version "3" and Go, Helm, and Ansible plugins
+// of various versions. This CLI defaults to running the latest
+// Go plugin version unless '--plugins' or 'layout' specify
+// one of the other plugins.
+func main() {
+  c, err := cli.New(
+    cli.WithCommandName("controller-builder"),
+    cli.WithDefaultProjectVersion("3"),
+    cli.WithExtraCommands(newCustomCobraCmd()),
+    cli.WithPlugins(
+      &golangv1.Plugin{},  // "go.example.com/v1"
+      &golangv2.Plugin{},  // "go.example.com/v2-alpha"
+      &helmv1.Plugin{},    // "helm.example.com/v1"
+      &ansiblev1.Plugin{}, // "ansible.example.com/v1"
+    ),
+    cli.WithDefaultPlugins(
+      &golangv1.Plugin{},  // "go.example.com/v1", default
+    ),
+  )
+  if err != nil {
+    log.Fatal(err)
+  }
+  if err := c.Run(); err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+This program can then be built and run in the following ways:
+
+Default behavior:
+
+```sh
+# Initialize a project with the default Init plugin, "go.example.com/v1".
+# This key is automatically written to a PROJECT config file.
+$ controller-builder init
+# Create an API and webhook with "go.example.com/v1" CreateAPI and
+# CreateWebhook plugin methods. This key was read from the config file.
+$ controller-builder create api [flags]
+$ controller-builder create webhook [flags]
+```
+
+Selecting a plugin using `--plugins`:
+
+```sh
+# Initialize a project with the "ansible.example.com/v1" Init plugin.
+# Like above, this key is written to a config file.
+$ controller-builder init --plugins ansible
+# Create an API and webhook with "ansible.example.com/v1" CreateAPI
+# and CreateWebhook plugin methods. This key was read from the config file.
+$ controller-builder create api [flags]
+$ controller-builder create webhook [flags]
+```
+
+## Plugin naming
+
+Plugin names must be DNS1123 labels and should be fully qualified, i.e. they have a suffix like
+`.example.com`. For example, the base Go scaffold used with `kubebuilder` commands has name `go.kubebuilder.io`.
+Qualified names prevent conflicts between plugin names; both `go.kubebuilder.io` and `go.example.com` can both scaffold
+Go code and can be specified by a user.
+
+## Plugin versioning
+
+A plugin's `Version()` method returns a [`plugin.Version`][plugin-version-type] object containing an integer value
+and optionally a stage string of either "alpha" or "beta". The integer denotes the current version of a plugin.
+Two different integer values between versions of plugins indicate that the two plugins are incompatible. The stage
+string denotes plugin stability:
+* `alpha` should be used for plugins that are frequently changed and may break between uses.
+* `beta` should be used for plugins that are only changed in minor ways, ex. bug fixes.
+
+### Breaking changes
+
+Any change that will break a project scaffolded by the previous plugin version is a breaking change.
+
+
+[plugin-base]:https://pkg.go.dev/sigs.k8s.io/kubebuilder/pkg/plugin#Base
+[plugin-subc]:https://pkg.go.dev/sigs.k8s.io/kubebuilder/pkg/plugin#GenericSubcommand
+[plugin-context]:https://pkg.go.dev/sigs.k8s.io/kubebuilder/pkg/plugin#Context
+[cobra]:https://pkg.go.dev/github.com/spf13/cobra
+[kb-go-plugin]:https://pkg.go.dev/sigs.k8s.io/kubebuilder/pkg/plugin/v2#Plugin
+[cli]:https://pkg.go.dev/sigs.k8s.io/kubebuilder/pkg/cli#CLI
+[plugin-version-type]:https://pkg.go.dev/sigs.k8s.io/kubebuilder/pkg/plugin#Version

--- a/docs/book/src/reference/reference.md
+++ b/docs/book/src/reference/reference.md
@@ -27,3 +27,4 @@
   - [Artifacts](artifacts.md)
   - [Writing controller tests](writing-tests.md)
   - [Metrics](metrics.md)
+  - [CLI plugins](cli-plugins.md)


### PR DESCRIPTION
Plugin versions do not need to contain a patch version number, since patch-like changes should not require the user to change their config's layout value. This commit rewrites and adds some documentation on general plugin development and versioning.

See https://github.com/kubernetes-sigs/kubebuilder/issues/1519#issuecomment-632334210 for details.

Will follow up with patch version removal once #1536 is merged, which will allow both patched and non-patched version (`v2.0.0` vs `v2.0`) resolution without a breaking change.

/cc @camilamacedo86 @DirectXMan12 @joelanford 
