### PR TITLE
pkg/cli: use cmd error idiom for 'init' and plugin keys in cmd errors

### DIFF
--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -60,8 +60,8 @@ func (c cli) bindCreateAPI(ctx plugin.Context, cmd *cobra.Command) {
 		tmpGetter, isGetter := p.(plugin.CreateAPIPluginGetter)
 		if isGetter {
 			if getter != nil {
-				err := fmt.Errorf("duplicate API creation plugins for project version %q: %s, %s",
-					c.projectVersion, getter.Name(), p.Name())
+				err := fmt.Errorf("duplicate API creation plugins for project version %q (%s, %s), "+
+					"use a more specific plugin key", c.projectVersion, plugin.KeyFor(getter), plugin.KeyFor(p))
 				cmdErr(cmd, err)
 				return
 			}

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -32,6 +32,12 @@ func cmdErr(cmd *cobra.Command, err error) {
 	cmd.RunE = errCmdFunc(err)
 }
 
+// cmdErrNoHelp calls cmdErr(cmd, err) then turns cmd's usage off.
+func cmdErrNoHelp(cmd *cobra.Command, err error) {
+	cmdErr(cmd, err)
+	cmd.SilenceUsage = true
+}
+
 // errCmdFunc returns a cobra RunE function that returns the provided error
 func errCmdFunc(err error) func(*cobra.Command, []string) error {
 	return func(*cobra.Command, []string) error {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -121,18 +121,23 @@ func (c cli) bindInit(ctx plugin.Context, cmd *cobra.Command) {
 		tmpGetter, isGetter := p.(plugin.InitPluginGetter)
 		if isGetter {
 			if getter != nil {
-				log.Fatalf("duplicate initialization plugins for project version %q: %s, %s",
-					c.projectVersion, getter.Name(), p.Name())
+				err := fmt.Errorf("duplicate initialization plugins for project version %q (%s, %s), "+
+					"use a more specific plugin key", c.projectVersion, plugin.KeyFor(getter), plugin.KeyFor(p))
+				cmdErrNoHelp(cmd, err)
+				return
 			}
 			getter = tmpGetter
 		}
 	}
 	if getter == nil {
+		var err error
 		if c.cliPluginKey == "" {
-			log.Fatalf("project version %q does not support an initialization plugin", c.projectVersion)
+			err = fmt.Errorf("project version %q does not support an initialization plugin", c.projectVersion)
 		} else {
-			log.Fatalf("plugin %q does not support an initialization plugin", c.cliPluginKey)
+			err = fmt.Errorf("plugin %q does not support an initialization plugin", c.cliPluginKey)
 		}
+		cmdErrNoHelp(cmd, err)
+		return
 	}
 
 	cfg := internalconfig.New(internalconfig.DefaultPath)

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -60,8 +60,8 @@ func (c cli) bindCreateWebhook(ctx plugin.Context, cmd *cobra.Command) {
 		tmpGetter, isGetter := p.(plugin.CreateWebhookPluginGetter)
 		if isGetter {
 			if getter != nil {
-				err := fmt.Errorf("duplicate webhook creation plugins for project version %q: %s, %s",
-					c.projectVersion, getter.Name(), p.Name())
+				err := fmt.Errorf("duplicate webhook creation plugins for project version %q (%s, %s), "+
+					"use a more specific plugin key", c.projectVersion, plugin.KeyFor(getter), plugin.KeyFor(p))
 				cmdErr(cmd, err)
 				return
 			}


### PR DESCRIPTION
Instead of only using plugin names in command errors, keys should be used for more informative error messages. An action should be suggested in the error message as well.

Additionally, the `init` command setup should use the `cmdErr` idiom used by other command setups for uniform error reporting.

/cc @camilamacedo86 @joelanford @mengqiy 