### PR TITLE
pkg/model/config: wrap plugin config in types

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,7 +71,7 @@ version: "2"
 				Version: config.Version2,
 				Repo:    "github.com/example/project",
 				Domain:  "example.com",
-				Plugins: map[string]interface{}{
+				Plugins: config.PluginConfigs{
 					"plugin-x": map[string]interface{}{
 						"data-1": "single plugin datum",
 					},
@@ -144,7 +144,7 @@ plugins:
 			Version: config.Version2,
 			Repo:    "github.com/example/project",
 			Domain:  "example.com",
-			Plugins: map[string]interface{}{
+			Plugins: config.PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "single plugin datum",
 				},

--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -51,10 +51,16 @@ type Config struct {
 	// Layout contains a key specifying which plugin created a project.
 	Layout string `json:"layout,omitempty"`
 
-	// Plugins is an arbitrary YAML blob that can be used by external
-	// plugins for plugin-specific configuration.
-	Plugins map[string]interface{} `json:"plugins,omitempty"`
+	// Plugins holds plugin-specific configs mapped by plugin key. These configs should be
+	// encoded/decoded using EncodePluginConfig/DecodePluginConfig, respectively.
+	Plugins PluginConfigs `json:"plugins,omitempty"`
 }
+
+// PluginConfigs holds a set of arbitrary plugin configuration objects mapped by plugin key.
+type PluginConfigs map[string]pluginConfig
+
+// pluginConfig is an arbitrary plugin configuration object.
+type pluginConfig interface{}
 
 // IsV1 returns true if it is a v1 project
 func (c Config) IsV1() bool {
@@ -186,7 +192,7 @@ func (c *Config) EncodePluginConfig(key string, configObj interface{}) error {
 		return fmt.Errorf("failed to unmarshal %T object bytes: %s", configObj, err)
 	}
 	if c.Plugins == nil {
-		c.Plugins = make(map[string]interface{})
+		c.Plugins = make(map[string]pluginConfig)
 	}
 	c.Plugins[key] = fields
 	return nil

--- a/pkg/model/config/config_test.go
+++ b/pkg/model/config/config_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Config", func() {
 		pluginConfig = PluginConfig{}
 		expectedConfig = Config{
 			Version: Version2,
-			Plugins: map[string]interface{}{
+			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "",
 					"data-2": "",
@@ -72,7 +72,7 @@ var _ = Describe("Config", func() {
 		}
 		expectedConfig = Config{
 			Version: Version2,
-			Plugins: map[string]interface{}{
+			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "plugin value 1",
 					"data-2": "plugin value 2",
@@ -106,7 +106,7 @@ var _ = Describe("Config", func() {
 		By("Using empty config version 2")
 		config = Config{
 			Version: Version2,
-			Plugins: map[string]interface{}{
+			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{},
 			},
 		}
@@ -125,7 +125,7 @@ var _ = Describe("Config", func() {
 		By("Using config version 2 with extra fields as struct")
 		config = Config{
 			Version: Version2,
-			Plugins: map[string]interface{}{
+			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "plugin value 1",
 					"data-2": "plugin value 2",


### PR DESCRIPTION
This PR adds two new types, `PluginConfigs` and `pluginConfig`. `PluginConfigs` is a wrapper for `map[string]pluginConfig` for (de)serialization purposes and `pluginConfig` wraps `interface{}` so users do not have to see internals of plugin config storage.

* pkg/model/config: the `Plugin` field of a `Config` is now of type `PluginConfigs`
* internal,pkg: update test cases

Initial discussion: [#1443](https://github.com/kubernetes-sigs/kubebuilder/pull/1443/files#r398818145).

/cc @DirectXMan12 @mengqiy @camilamacedo86
