### PR TITLE
pkg/plugin/v3: add plugin `v3-alpha`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,12 +22,14 @@ import (
 	"sigs.k8s.io/kubebuilder/cmd/version"
 	"sigs.k8s.io/kubebuilder/pkg/cli"
 	pluginv2 "sigs.k8s.io/kubebuilder/pkg/plugin/v2"
+	pluginv3 "sigs.k8s.io/kubebuilder/pkg/plugin/v3"
 )
 
 func main() {
 	c, err := cli.New(
 		cli.WithPlugins(
 			&pluginv2.Plugin{},
+			&pluginv3.Plugin{},
 		),
 		cli.WithDefaultPlugins(
 			&pluginv2.Plugin{},

--- a/pkg/plugin/v3/api.go
+++ b/pkg/plugin/v3/api.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/kubebuilder/internal/cmdutil"
+	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/internal/util"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds"
+	"sigs.k8s.io/kubebuilder/plugins/addon"
+)
+
+// (used only to gen api with --pattern=addon)
+// KbDeclarativePatternVersion is the sigs.k8s.io/kubebuilder-declarative-pattern version
+// TODO: remove this when a better solution for using addons is implemented.
+const KbDeclarativePatternVersion = "v0.0.0-20200522144838-848d48e5b073"
+
+type createAPIPlugin struct {
+	config *config.Config
+
+	// pattern indicates that we should use a plugin to build according to a pattern
+	pattern string
+
+	resource *resource.Options
+
+	// Check if we have to scaffold resource and/or controller
+	resourceFlag   *pflag.Flag
+	controllerFlag *pflag.Flag
+	doResource     bool
+	doController   bool
+
+	// force indicates that the resource should be created even if it already exists
+	force bool
+
+	// runMake indicates whether to run make or not after scaffolding APIs
+	runMake bool
+}
+
+var (
+	_ plugin.CreateAPI   = &createAPIPlugin{}
+	_ cmdutil.RunOptions = &createAPIPlugin{}
+)
+
+func (p createAPIPlugin) UpdateContext(ctx *plugin.Context) {
+	ctx.Description = `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
+
+create resource will prompt the user for if it should scaffold the Resource and / or Controller.  To only
+scaffold a Controller for an existing Resource, select "n" for Resource.  To only define
+the schema for a Resource without writing a Controller, select "n" for Controller.
+
+After the scaffold is written, api will run make on the project.
+`
+	ctx.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
+  %s create api --group ship --version v1beta1 --kind Frigate
+
+  # Edit the API Scheme
+  nano api/v1beta1/frigate_types.go
+
+  # Edit the Controller
+  nano controllers/frigate/frigate_controller.go
+
+  # Edit the Controller Test
+  nano controllers/frigate/frigate_controller_test.go
+
+  # Install CRDs into the Kubernetes cluster using kubectl apply
+  make install
+
+  # Regenerate code and run against the Kubernetes cluster configured by ~/.kube/config
+  make run
+	`,
+		ctx.CommandName)
+}
+
+func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&p.runMake, "make", true, "if true, run make after generating files")
+
+	fs.BoolVar(&p.doResource, "resource", true,
+		"if set, generate the resource without prompting the user")
+	p.resourceFlag = fs.Lookup("resource")
+	fs.BoolVar(&p.doController, "controller", true,
+		"if set, generate the controller without prompting the user")
+	p.controllerFlag = fs.Lookup("controller")
+
+	// TODO: remove this when a better solution for using addons is implemented.
+	if os.Getenv("KUBEBUILDER_ENABLE_PLUGINS") != "" {
+		fs.StringVar(&p.pattern, "pattern", "",
+			"generates an API following an extension pattern (addon)")
+	}
+
+	fs.BoolVar(&p.force, "force", false,
+		"attempt to create resource even if it already exists")
+	p.resource = &resource.Options{}
+	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
+	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
+	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
+	fs.BoolVar(&p.resource.Namespaced, "namespaced", true, "resource is namespaced")
+}
+
+func (p *createAPIPlugin) InjectConfig(c *config.Config) {
+	p.config = c
+}
+
+func (p *createAPIPlugin) Run() error {
+	return cmdutil.Run(p)
+}
+
+func (p *createAPIPlugin) Validate() error {
+	if err := p.resource.Validate(); err != nil {
+		return err
+	}
+
+	// TODO: re-evaluate whether y/n input still makes sense. We should probably always
+	// scaffold the resource and controller.
+	reader := bufio.NewReader(os.Stdin)
+	if !p.resourceFlag.Changed {
+		fmt.Println("Create Resource [y/n]")
+		p.doResource = util.YesNo(reader)
+	}
+	if !p.controllerFlag.Changed {
+		fmt.Println("Create Controller [y/n]")
+		p.doController = util.YesNo(reader)
+	}
+
+	// In case we want to scaffold a resource API we need to do some checks
+	if p.doResource {
+		// Check that resource doesn't exist or flag force was set
+		if !p.force && p.config.HasResource(p.resource.GVK()) {
+			return errors.New("API resource already exists")
+		}
+
+		// Check that the provided group can be added to the project
+		if !p.config.MultiGroup && len(p.config.Resources) != 0 && !p.config.HasGroup(p.resource.Group) {
+			return fmt.Errorf("multiple groups are not allowed by default, " +
+				"to enable multi-group visit kubebuilder.io/migration/multi-group.html")
+		}
+	}
+
+	return nil
+}
+
+func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+	// Load the boilerplate
+	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
+	}
+
+	// Load the requested plugins
+	plugins := make([]model.Plugin, 0)
+	switch strings.ToLower(p.pattern) {
+	case "":
+		// Default pattern
+	case "addon":
+		plugins = append(plugins, &addon.Plugin{})
+	default:
+		return nil, fmt.Errorf("unknown pattern %q", p.pattern)
+	}
+
+	// Create the actual resource from the resource options
+	res := p.resource.NewResource(p.config, p.doResource)
+	return scaffolds.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
+}
+
+func (p *createAPIPlugin) PostScaffold() error {
+	// Load the requested plugins
+	switch strings.ToLower(p.pattern) {
+	case "":
+		// Default pattern
+	case "addon":
+		// Ensure that we are pinning sigs.k8s.io/kubebuilder-declarative-pattern version
+		// TODO: either find a better way to inject this version (ex. tools.go).
+		err := util.RunCmd("Get kubebuilder-declarative-pattern dependency", "go", "get",
+			"sigs.k8s.io/kubebuilder-declarative-pattern@"+KbDeclarativePatternVersion)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown pattern %q", p.pattern)
+	}
+
+	if p.runMake {
+		return util.RunCmd("Running make", "make")
+	}
+	return nil
+}

--- a/pkg/plugin/v3/init.go
+++ b/pkg/plugin/v3/init.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/kubebuilder/internal/cmdutil"
+	"sigs.k8s.io/kubebuilder/pkg/internal/validation"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/internal/util"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds"
+)
+
+type initPlugin struct {
+	config *config.Config
+	// For help text.
+	commandName string
+
+	// boilerplate options
+	license string
+	owner   string
+
+	// flags
+	fetchDeps          bool
+	skipGoVersionCheck bool
+}
+
+var (
+	_ plugin.Init        = &initPlugin{}
+	_ cmdutil.RunOptions = &initPlugin{}
+)
+
+func (p *initPlugin) UpdateContext(ctx *plugin.Context) {
+	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
+
+Writes the following files:
+- a boilerplate license file
+- a PROJECT file with the domain and repo
+- a Makefile to build the project
+- a go.mod with project dependencies
+- a Kustomization.yaml for customizating manifests
+- a Patch file for customizing image for manager manifests
+- a Patch file for enabling prometheus metrics
+- a cmd/manager/main.go to run
+
+project will prompt the user to run 'dep ensure' after writing the project files.
+`
+	ctx.Examples = fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
+  %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"
+`,
+		ctx.CommandName)
+
+	p.commandName = ctx.CommandName
+}
+
+func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&p.skipGoVersionCheck, "skip-go-version-check",
+		false, "if specified, skip checking the Go version")
+
+	// dependency args
+	fs.BoolVar(&p.fetchDeps, "fetch-deps", true, "ensure dependencies are downloaded")
+
+	// boilerplate args
+	fs.StringVar(&p.license, "license", "apache2",
+		"license to use to boilerplate, may be one of 'apache2', 'none'")
+	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
+
+	// project args
+	fs.StringVar(&p.config.Repo, "repo", "", "name to use for go module (e.g., github.com/user/repo), "+
+		"defaults to the go package of the current working directory.")
+	fs.StringVar(&p.config.Domain, "domain", "my.domain", "domain for groups")
+}
+
+func (p *initPlugin) InjectConfig(c *config.Config) {
+	c.Layout = plugin.KeyFor(Plugin{})
+	p.config = c
+}
+
+func (p *initPlugin) Run() error {
+	return cmdutil.Run(p)
+}
+
+func (p *initPlugin) Validate() error {
+	// Requires go1.11+
+	if !p.skipGoVersionCheck {
+		if err := util.ValidateGoVersion(); err != nil {
+			return err
+		}
+	}
+
+	// Check if the project name is a valid namespace according to k8s
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error to get the current path: %v", err)
+	}
+	projectName := filepath.Base(dir)
+	if err := validation.IsDNS1123Label(strings.ToLower(projectName)); err != nil {
+		return fmt.Errorf("project name (%s) is invalid: %v", projectName, err)
+	}
+
+	// Try to guess repository if flag is not set.
+	if p.config.Repo == "" {
+		repoPath, err := util.FindCurrentRepo()
+		if err != nil {
+			return fmt.Errorf("error finding current repository: %v", err)
+		}
+		p.config.Repo = repoPath
+	}
+
+	return nil
+}
+
+func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+	return scaffolds.NewInitScaffolder(p.config, p.license, p.owner), nil
+}
+
+func (p *initPlugin) PostScaffold() error {
+	if !p.fetchDeps {
+		fmt.Println("Skipping fetching dependencies.")
+		return nil
+	}
+
+	// Ensure that we are pinning controller-runtime version
+	// xref: https://github.com/kubernetes-sigs/kubebuilder/issues/997
+	err := util.RunCmd("Get controller runtime", "go", "get",
+		"sigs.k8s.io/controller-runtime@"+scaffolds.ControllerRuntimeVersion)
+	if err != nil {
+		return err
+	}
+
+	err = util.RunCmd("Update go.mod", "go", "mod", "tidy")
+	if err != nil {
+		return err
+	}
+
+	// TODO: make this conditional with a '--make' flag, like in 'create api'.
+	err = util.RunCmd("Running make", "make")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
+	return nil
+}

--- a/pkg/plugin/v3/plugin.go
+++ b/pkg/plugin/v3/plugin.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+)
+
+const pluginName = "go" + plugin.DefaultNameQualifier
+
+var (
+	supportedProjectVersions = []string{config.Version3Alpha}
+	pluginVersion            = plugin.Version{Number: 3, Stage: plugin.AlphaStage}
+)
+
+var (
+	_ plugin.Base                      = Plugin{}
+	_ plugin.InitPluginGetter          = Plugin{}
+	_ plugin.CreateAPIPluginGetter     = Plugin{}
+	_ plugin.CreateWebhookPluginGetter = Plugin{}
+)
+
+type Plugin struct {
+	initPlugin
+	createAPIPlugin
+	createWebhookPlugin
+}
+
+func (Plugin) Name() string                                   { return pluginName }
+func (Plugin) Version() plugin.Version                        { return pluginVersion }
+func (Plugin) SupportedProjectVersions() []string             { return supportedProjectVersions }
+func (p Plugin) GetInitPlugin() plugin.Init                   { return &p.initPlugin }
+func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI         { return &p.createAPIPlugin }
+func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook { return &p.createWebhookPlugin }

--- a/pkg/plugin/v3/scaffolds/api.go
+++ b/pkg/plugin/v3/scaffolds/api.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/internal/machinery"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/controller"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/crd"
+)
+
+var _ scaffold.Scaffolder = &apiScaffolder{}
+
+// apiScaffolder contains configuration for generating scaffolding for Go type
+// representing the API and controller that implements the behavior for the API.
+type apiScaffolder struct {
+	config      *config.Config
+	boilerplate string
+	resource    *resource.Resource
+	// plugins is the list of plugins we should allow to transform our generated scaffolding
+	plugins []model.Plugin
+	// doResource indicates whether to scaffold API Resource or not
+	doResource bool
+	// doController indicates whether to scaffold controller files or not
+	doController bool
+}
+
+// NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
+func NewAPIScaffolder(
+	config *config.Config,
+	boilerplate string,
+	res *resource.Resource,
+	doResource, doController bool,
+	plugins []model.Plugin,
+) scaffold.Scaffolder {
+	return &apiScaffolder{
+		config:       config,
+		boilerplate:  boilerplate,
+		resource:     res,
+		plugins:      plugins,
+		doResource:   doResource,
+		doController: doController,
+	}
+}
+
+// Scaffold implements Scaffolder
+func (s *apiScaffolder) Scaffold() error {
+	fmt.Println("Writing scaffold for you to edit...")
+	return s.scaffold()
+}
+
+func (s *apiScaffolder) newUniverse() *model.Universe {
+	return model.NewUniverse(
+		model.WithConfig(s.config),
+		model.WithBoilerplate(s.boilerplate),
+		model.WithResource(s.resource),
+	)
+}
+
+// TODO: re-use universe created by s.newUniverse() if possible.
+func (s *apiScaffolder) scaffold() error {
+	if s.doResource {
+		s.config.AddResource(s.resource.GVK())
+
+		if err := machinery.NewScaffold(s.plugins...).Execute(
+			s.newUniverse(),
+			&templates.Types{},
+			&templates.Group{},
+			&templates.CRDSample{},
+			&templates.CRDEditorRole{},
+			&templates.CRDViewerRole{},
+			&crd.EnableWebhookPatch{},
+			&crd.EnableCAInjectionPatch{},
+		); err != nil {
+			return fmt.Errorf("error scaffolding APIs: %v", err)
+		}
+
+		if err := machinery.NewScaffold().Execute(
+			s.newUniverse(),
+			&crd.Kustomization{},
+			&crd.KustomizeConfig{},
+		); err != nil {
+			return fmt.Errorf("error scaffolding kustomization: %v", err)
+		}
+
+	}
+
+	if s.doController {
+		if err := machinery.NewScaffold(s.plugins...).Execute(
+			s.newUniverse(),
+			&controller.SuiteTest{},
+			&controller.Controller{},
+		); err != nil {
+			return fmt.Errorf("error scaffolding controller: %v", err)
+		}
+	}
+
+	if err := machinery.NewScaffold(s.plugins...).Execute(
+		s.newUniverse(),
+		&templates.MainUpdater{WireResource: s.doResource, WireController: s.doController},
+	); err != nil {
+		return fmt.Errorf("error updating main.go: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/plugin/v3/scaffolds/doc.go
+++ b/pkg/plugin/v3/scaffolds/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package scaffold contains libraries for scaffolding code to use with controller-runtime
+package scaffolds

--- a/pkg/plugin/v3/scaffolds/edit.go
+++ b/pkg/plugin/v3/scaffolds/edit.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+)
+
+var _ scaffold.Scaffolder = &editScaffolder{}
+
+type editScaffolder struct {
+	config     *config.Config
+	multigroup bool
+}
+
+// NewEditScaffolder returns a new Scaffolder for configuration edit operations
+func NewEditScaffolder(config *config.Config, multigroup bool) scaffold.Scaffolder {
+	return &editScaffolder{
+		config:     config,
+		multigroup: multigroup,
+	}
+}
+
+// Scaffold implements Scaffolder
+func (s *editScaffolder) Scaffold() error {
+	s.config.MultiGroup = s.multigroup
+	filename := "Dockerfile"
+	bs, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	str := string(bs)
+
+	// update dockerfile
+	if s.multigroup {
+		str, err = ensureExistAndReplace(
+			str,
+			"COPY api/ api/",
+			`COPY apis/ apis/`)
+		if err != nil {
+			return err
+		}
+	} else {
+		str, err = ensureExistAndReplace(
+			str,
+			"COPY apis/ apis/",
+			`COPY api/ api/`)
+		if err != nil {
+			return err
+		}
+	}
+
+	return ioutil.WriteFile(filename, []byte(str), 0644)
+}
+
+func ensureExistAndReplace(input, match, replace string) (string, error) {
+	if !strings.Contains(input, match) {
+		return "", fmt.Errorf("can't find %q", match)
+	}
+	return strings.Replace(input, match, replace, -1), nil
+}

--- a/pkg/plugin/v3/scaffolds/init.go
+++ b/pkg/plugin/v3/scaffolds/init.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/internal/machinery"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/certmanager"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/manager"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/metricsauth"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/prometheus"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/webhook"
+)
+
+const (
+	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
+	ControllerRuntimeVersion = "v0.6.0"
+	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
+	ControllerToolsVersion = "v0.3.0"
+	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
+	KustomizeVersion = "v3.5.4"
+
+	imageName = "controller:latest"
+)
+
+var _ scaffold.Scaffolder = &initScaffolder{}
+
+type initScaffolder struct {
+	config          *config.Config
+	boilerplatePath string
+	license         string
+	owner           string
+}
+
+// NewInitScaffolder returns a new Scaffolder for project initialization operations
+func NewInitScaffolder(config *config.Config, license, owner string) scaffold.Scaffolder {
+	return &initScaffolder{
+		config:          config,
+		boilerplatePath: filepath.Join("hack", "boilerplate.go.txt"),
+		license:         license,
+		owner:           owner,
+	}
+}
+
+func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
+	return model.NewUniverse(
+		model.WithConfig(s.config),
+		model.WithBoilerplate(boilerplate),
+	)
+}
+
+// Scaffold implements Scaffolder
+func (s *initScaffolder) Scaffold() error {
+	fmt.Println("Writing scaffold for you to edit...")
+	return s.scaffold()
+}
+
+// TODO: re-use universe created by s.newUniverse() if possible.
+func (s *initScaffolder) scaffold() error {
+	bpFile := &templates.Boilerplate{}
+	bpFile.Path = s.boilerplatePath
+	bpFile.License = s.license
+	bpFile.Owner = s.owner
+	if err := machinery.NewScaffold().Execute(
+		s.newUniverse(""),
+		bpFile,
+	); err != nil {
+		return err
+	}
+
+	boilerplate, err := ioutil.ReadFile(s.boilerplatePath) //nolint:gosec
+	if err != nil {
+		return err
+	}
+
+	return machinery.NewScaffold().Execute(
+		s.newUniverse(string(boilerplate)),
+		&templates.GitIgnore{},
+		&templates.AuthProxyRole{},
+		&templates.AuthProxyRoleBinding{},
+		&metricsauth.AuthProxyPatch{},
+		&metricsauth.AuthProxyService{},
+		&metricsauth.ClientClusterRole{},
+		&manager.Config{Image: imageName},
+		&templates.Main{},
+		&templates.GoMod{ControllerRuntimeVersion: ControllerRuntimeVersion},
+		&templates.Makefile{
+			Image:                  imageName,
+			BoilerplatePath:        s.boilerplatePath,
+			ControllerToolsVersion: ControllerToolsVersion,
+			KustomizeVersion:       KustomizeVersion,
+		},
+		&templates.Dockerfile{},
+		&templates.Kustomize{},
+		&templates.ManagerWebhookPatch{},
+		&templates.ManagerRoleBinding{},
+		&templates.LeaderElectionRole{},
+		&templates.LeaderElectionRoleBinding{},
+		&templates.KustomizeRBAC{},
+		&manager.Kustomization{},
+		&webhook.Kustomization{},
+		&webhook.KustomizeConfigWebhook{},
+		&webhook.Service{},
+		&webhook.InjectCAPatch{},
+		&prometheus.Kustomization{},
+		&prometheus.ServiceMonitor{},
+		&certmanager.CertManager{},
+		&certmanager.Kustomization{},
+		&certmanager.KustomizeConfig{},
+	)
+}

--- a/pkg/plugin/v3/scaffolds/internal/templates/authproxyrole.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/authproxyrole.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &AuthProxyRole{}
+
+// AuthProxyRole scaffolds the config/rbac/auth_proxy_role.yaml file
+type AuthProxyRole struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *AuthProxyRole) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_role.yaml")
+	}
+
+	f.TemplateBody = proxyRoleTemplate
+
+	return nil
+}
+
+const proxyRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/authproxyrolebinding.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/authproxyrolebinding.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &AuthProxyRoleBinding{}
+
+// AuthProxyRoleBinding scaffolds the config/rbac/auth_proxy_role_binding_rbac.yaml file
+type AuthProxyRoleBinding struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *AuthProxyRoleBinding) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_role_binding.yaml")
+	}
+
+	f.TemplateBody = proxyRoleBindinggTemplate
+
+	return nil
+}
+
+const proxyRoleBindinggTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/boilerplate.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/boilerplate.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Boilerplate{}
+
+// Boilerplate scaffolds a boilerplate header file.
+type Boilerplate struct {
+	file.TemplateMixin
+	file.BoilerplateMixin
+
+	// License is the License type to write
+	License string
+
+	// Owner is the copyright owner - e.g. "The Kubernetes Authors"
+	Owner string
+
+	// Year is the copyright year
+	Year string
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Boilerplate) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("hack", "boilerplate.go.txt")
+	}
+
+	if f.Year == "" {
+		f.Year = fmt.Sprintf("%v", time.Now().Year())
+	}
+
+	// Boilerplate given
+	if len(f.Boilerplate) > 0 {
+		f.TemplateBody = f.Boilerplate
+		return nil
+	}
+
+	// Pick a template boilerplate option
+	switch f.License {
+	case "", "apache2":
+		f.TemplateBody = apache
+	case "none":
+		f.TemplateBody = none
+	}
+
+	return nil
+}
+
+const apache = `/*
+{{ if .Owner -}}
+Copyright {{ .Year }} {{ .Owner }}.
+{{- end }}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/`
+
+const none = `/*
+{{ if .Owner -}}
+Copyright {{ .Year }} {{ .Owner }}.
+{{- end }}
+*/`

--- a/pkg/plugin/v3/scaffolds/internal/templates/certmanager/certificate.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/certmanager/certificate.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &CertManager{}
+
+// CertManager scaffolds an issuer CR and a certificate CR
+type CertManager struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *CertManager) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "certmanager", "certificate.yaml")
+	}
+
+	f.TemplateBody = certManagerTemplate
+
+	return nil
+}
+
+const certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
+# breaking changes
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/certmanager/kustomize.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/certmanager/kustomize.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Kustomization{}
+
+// Kustomization scaffolds the kustomizaiton in the certmanager folder
+type Kustomization struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "certmanager", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	return nil
+}
+
+const kustomizationTemplate = `resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/certmanager/kustomizeconfig.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/certmanager/kustomizeconfig.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &KustomizeConfig{}
+
+// KustomizeConfig scaffolds the kustomizeconfig in the certmanager folder
+type KustomizeConfig struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *KustomizeConfig) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "certmanager", "kustomizeconfig.yaml")
+	}
+
+	f.TemplateBody = kustomizeConfigTemplate
+
+	return nil
+}
+
+//nolint:lll
+const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/commonName
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/controller/controller.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/controller/controller.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Controller{}
+
+// Controller scaffolds a Controller for a Resource
+type Controller struct {
+	file.TemplateMixin
+	file.MultiGroupMixin
+	file.BoilerplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Controller) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("controllers", "%[group]", "%[kind]_controller.go")
+		} else {
+			f.Path = filepath.Join("controllers", "%[kind]_controller.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
+
+	f.TemplateBody = controllerTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+//nolint:lll
+const controllerTemplate = `{{ .Boilerplate }}
+
+package controllers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	{{ .Resource.ImportAlias }} "{{ .Resource.Package }}"
+)
+
+// {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
+type {{ .Resource.Kind }}Reconciler struct {
+	client.Client
+	Log logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+
+func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	_ = context.Background()
+	_ = r.Log.WithValues("{{ .Resource.Kind | lower }}", req.NamespacedName)
+
+	// your logic here
+
+	return ctrl.Result{}, nil
+}
+
+func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}).
+		Complete(r)
+}
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/controller/controller_suitetest.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/controller/controller_suitetest.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &SuiteTest{}
+var _ file.Inserter = &SuiteTest{}
+
+// SuiteTest scaffolds the suite_test.go file to setup the controller test
+type SuiteTest struct {
+	file.TemplateMixin
+	file.RepositoryMixin
+	file.MultiGroupMixin
+	file.BoilerplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *SuiteTest) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("controllers", "%[group]", "suite_test.go")
+		} else {
+			f.Path = filepath.Join("controllers", "suite_test.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = fmt.Sprintf(controllerSuiteTestTemplate,
+		file.NewMarkerFor(f.Path, importMarker),
+		file.NewMarkerFor(f.Path, addSchemeMarker),
+	)
+
+	return nil
+}
+
+const (
+	importMarker    = "imports"
+	addSchemeMarker = "scheme"
+)
+
+// GetMarkers implements file.Inserter
+func (f *SuiteTest) GetMarkers() []file.Marker {
+	return []file.Marker{
+		file.NewMarkerFor(f.Path, importMarker),
+		file.NewMarkerFor(f.Path, addSchemeMarker),
+	}
+}
+
+const (
+	apiImportCodeFragment = `%s "%s"
+`
+	addschemeCodeFragment = `err = %s.AddToScheme(scheme.Scheme)
+Expect(err).NotTo(HaveOccurred())
+
+`
+)
+
+// GetCodeFragments implements file.Inserter
+func (f *SuiteTest) GetCodeFragments() file.CodeFragmentsMap {
+	fragments := make(file.CodeFragmentsMap, 2)
+
+	// Generate import code fragments
+	imports := make([]string, 0)
+	imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Package))
+
+	// Generate add scheme code fragments
+	addScheme := make([]string, 0)
+	addScheme = append(addScheme, fmt.Sprintf(addschemeCodeFragment, f.Resource.ImportAlias))
+
+	// Only store code fragments in the map if the slices are non-empty
+	if len(imports) != 0 {
+		fragments[file.NewMarkerFor(f.Path, importMarker)] = imports
+	}
+	if len(addScheme) != 0 {
+		fragments[file.NewMarkerFor(f.Path, addSchemeMarker)] = addScheme
+	}
+
+	return fragments
+}
+
+const controllerSuiteTestTemplate = `{{ .Boilerplate }}
+
+package controllers
+
+import (
+	"path/filepath"
+	"testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	%s
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+	"Controller Suite",
+	[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	%s
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd/enablecainjection_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd/enablecainjection_patch.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &EnableCAInjectionPatch{}
+
+// EnableCAInjectionPatch scaffolds a EnableCAInjectionPatch for a Resource
+type EnableCAInjectionPatch struct {
+	file.TemplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *EnableCAInjectionPatch) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "patches", "cainjection_in_%[plural].yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = enableCAInjectionPatchTemplate
+
+	return nil
+}
+
+const enableCAInjectionPatchTemplate = `# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: {{ .Resource.Plural }}.{{ .Resource.Domain }}
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd/enablewebhook_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd/enablewebhook_patch.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &EnableWebhookPatch{}
+
+// EnableWebhookPatch scaffolds a EnableWebhookPatch for a Resource
+type EnableWebhookPatch struct {
+	file.TemplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *EnableWebhookPatch) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "patches", "webhook_in_%[plural].yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = enableWebhookPatchTemplate
+
+	return nil
+}
+
+const enableWebhookPatchTemplate = `# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: {{ .Resource.Plural }}.{{ .Resource.Domain }}
+spec:
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+      caBundle: Cg==
+      service:
+        namespace: system
+        name: webhook-service
+        path: /convert
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd/kustomization.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd/kustomization.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Kustomization{}
+var _ file.Inserter = &Kustomization{}
+
+// Kustomization scaffolds the kustomization file in manager folder.
+type Kustomization struct {
+	file.TemplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = fmt.Sprintf(kustomizationTemplate,
+		file.NewMarkerFor(f.Path, resourceMarker),
+		file.NewMarkerFor(f.Path, webhookPatchMarker),
+		file.NewMarkerFor(f.Path, caInjectionPatchMarker),
+	)
+
+	return nil
+}
+
+const (
+	resourceMarker         = "crdkustomizeresource"
+	webhookPatchMarker     = "crdkustomizewebhookpatch"
+	caInjectionPatchMarker = "crdkustomizecainjectionpatch"
+)
+
+// GetMarkers implements file.Inserter
+func (f *Kustomization) GetMarkers() []file.Marker {
+	return []file.Marker{
+		file.NewMarkerFor(f.Path, resourceMarker),
+		file.NewMarkerFor(f.Path, webhookPatchMarker),
+		file.NewMarkerFor(f.Path, caInjectionPatchMarker),
+	}
+}
+
+const (
+	resourceCodeFragment = `- bases/%s_%s.yaml
+`
+	webhookPatchCodeFragment = `#- patches/webhook_in_%s.yaml
+`
+	caInjectionPatchCodeFragment = `#- patches/cainjection_in_%s.yaml
+`
+)
+
+// GetCodeFragments implements file.Inserter
+func (f *Kustomization) GetCodeFragments() file.CodeFragmentsMap {
+	fragments := make(file.CodeFragmentsMap, 3)
+
+	// Generate resource code fragments
+	res := make([]string, 0)
+	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.Domain, f.Resource.Plural))
+
+	// Generate resource code fragments
+	webhookPatch := make([]string, 0)
+	webhookPatch = append(webhookPatch, fmt.Sprintf(webhookPatchCodeFragment, f.Resource.Plural))
+
+	// Generate resource code fragments
+	caInjectionPatch := make([]string, 0)
+	caInjectionPatch = append(caInjectionPatch, fmt.Sprintf(caInjectionPatchCodeFragment, f.Resource.Plural))
+
+	// Only store code fragments in the map if the slices are non-empty
+	if len(res) != 0 {
+		fragments[file.NewMarkerFor(f.Path, resourceMarker)] = res
+	}
+	if len(webhookPatch) != 0 {
+		fragments[file.NewMarkerFor(f.Path, webhookPatchMarker)] = webhookPatch
+	}
+	if len(caInjectionPatch) != 0 {
+		fragments[file.NewMarkerFor(f.Path, caInjectionPatchMarker)] = caInjectionPatch
+	}
+
+	return fragments
+}
+
+var kustomizationTemplate = `# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+%s
+
+patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+%s
+
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+%s
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd/kustomizeconfig.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd/kustomizeconfig.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &KustomizeConfig{}
+
+// KustomizeConfig scaffolds the kustomizeconfig file in crd folder.
+type KustomizeConfig struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *KustomizeConfig) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "kustomizeconfig.yaml")
+	}
+
+	f.TemplateBody = kustomizeConfigTemplate
+
+	return nil
+}
+
+//nolint:lll
+const kustomizeConfigTemplate = `# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: CustomResourceDefinition
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhookClientConfig/service/name
+
+namespace:
+- kind: CustomResourceDefinition
+  group: apiextensions.k8s.io
+  path: spec/conversion/webhookClientConfig/service/namespace
+  create: false
+
+varReference:
+- path: metadata/annotations
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd_editor_rbac.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd_editor_rbac.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &CRDEditorRole{}
+
+// CRDEditorRole scaffolds the config/rbac/<kind>_editor_role.yaml
+type CRDEditorRole struct {
+	file.TemplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *CRDEditorRole) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "%[kind]_editor_role.yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = crdRoleEditorTemplate
+
+	return nil
+}
+
+const crdRoleEditorTemplate = `# permissions for end users to edit {{ .Resource.Plural }}.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ lower .Resource.Kind }}-editor-role
+rules:
+- apiGroups:
+  - {{ .Resource.Domain }}
+  resources:
+  - {{ .Resource.Plural }}
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - {{ .Resource.Domain }}
+  resources:
+  - {{ .Resource.Plural }}/status
+  verbs:
+  - get
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd_sample.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd_sample.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &CRDSample{}
+
+// CRDSample scaffolds a manifest for CRD sample.
+type CRDSample struct {
+	file.TemplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *CRDSample) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "samples", "%[group]_%[version]_%[kind].yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.IfExistsAction = file.Error
+
+	f.TemplateBody = crdSampleTemplate
+
+	return nil
+}
+
+const crdSampleTemplate = `apiVersion: {{ .Resource.Domain }}/{{ .Resource.Version }}
+kind: {{ .Resource.Kind }}
+metadata:
+  name: {{ lower .Resource.Kind }}-sample
+spec:
+  # Add fields here
+  foo: bar
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/crd_viewer_rbac.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/crd_viewer_rbac.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &CRDViewerRole{}
+
+// CRDViewerRole scaffolds the config/rbac/<kind>_viewer_role.yaml
+type CRDViewerRole struct {
+	file.TemplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *CRDViewerRole) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "%[kind]_viewer_role.yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = crdRoleViewerTemplate
+
+	return nil
+}
+
+const crdRoleViewerTemplate = `# permissions for end users to view {{ .Resource.Plural }}.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ lower .Resource.Kind }}-viewer-role
+rules:
+- apiGroups:
+  - {{ .Resource.Domain }}
+  resources:
+  - {{ .Resource.Plural }}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - {{ .Resource.Domain }}
+  resources:
+  - {{ .Resource.Plural }}/status
+  verbs:
+  - get
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/dockerfile.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Dockerfile{}
+
+// Dockerfile scaffolds a Dockerfile for building a main
+type Dockerfile struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Dockerfile) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = "Dockerfile"
+	}
+
+	f.TemplateBody = dockerfileTemplate
+
+	return nil
+}
+
+const dockerfileTemplate = `# Build the manager binary
+FROM golang:1.13 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/gitignore.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &GitIgnore{}
+
+// GitIgnore scaffolds the .gitignore file
+type GitIgnore struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *GitIgnore) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = ".gitignore"
+	}
+
+	f.TemplateBody = gitignoreTemplate
+
+	return nil
+}
+
+const gitignoreTemplate = `
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+
+# Test binary, build with ` + "`go test -c`" + `
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/gomod.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &GoMod{}
+
+// GoMod writes a templatefile for go.mod
+type GoMod struct {
+	file.TemplateMixin
+	file.RepositoryMixin
+
+	ControllerRuntimeVersion string
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *GoMod) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = "go.mod"
+	}
+
+	f.TemplateBody = goModTemplate
+
+	f.IfExistsAction = file.Overwrite
+
+	return nil
+}
+
+const goModTemplate = `
+module {{ .Repo }}
+
+go 1.13
+
+require (
+	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}
+)
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/group.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/group.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Group{}
+
+// Group scaffolds the api/<version>/groupversion_info.go
+type Group struct {
+	file.TemplateMixin
+	file.MultiGroupMixin
+	file.BoilerplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Group) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("apis", "%[group]", "%[version]", "groupversion_info.go")
+		} else {
+			f.Path = filepath.Join("api", "%[version]", "groupversion_info.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = groupTemplate
+
+	return nil
+}
+
+//nolint:lll
+const groupTemplate = `{{ .Boilerplate }}
+
+// Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
+// +kubebuilder:object:generate=true
+// +groupName={{ .Resource.Domain }}
+package {{ .Resource.Version }}
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.Domain }}", Version: "{{ .Resource.Version }}"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/kustomize.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/kustomize.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Kustomize{}
+
+// Kustomize scaffolds the Kustomization file for the default overlay
+type Kustomize struct {
+	file.TemplateMixin
+
+	// Prefix to use for name prefix customization
+	Prefix string
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Kustomize) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizeTemplate
+
+	f.IfExistsAction = file.Error
+
+	if f.Prefix == "" {
+		// use directory name as prefix
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		f.Prefix = strings.ToLower(filepath.Base(dir))
+	}
+
+	return nil
+}
+
+const kustomizeTemplate = `# Adds namespace to all resources.
+namespace: {{ .Prefix }}-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: {{ .Prefix }}-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+#- ../prometheus
+
+patchesStrategicMerge:
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+- manager_auth_proxy_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/leaderelectionrole.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/leaderelectionrole.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &LeaderElectionRole{}
+
+// LeaderElectionRole scaffolds the config/rbac/leader_election_role.yaml file
+type LeaderElectionRole struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *LeaderElectionRole) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "leader_election_role.yaml")
+	}
+
+	f.TemplateBody = leaderElectionRoleTemplate
+
+	return nil
+}
+
+const leaderElectionRoleTemplate = `# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/leaderelectionrolebinding.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/leaderelectionrolebinding.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &LeaderElectionRoleBinding{}
+
+// LeaderElectionRoleBinding scaffolds the config/rbac/leader_election_role_binding.yaml file
+type LeaderElectionRoleBinding struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *LeaderElectionRoleBinding) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "leader_election_role_binding.yaml")
+	}
+
+	f.TemplateBody = leaderElectionRoleBindingTemplate
+
+	return nil
+}
+
+const leaderElectionRoleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/main.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"hash/fnv"
+	"path/filepath"
+	"text/template"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+const defaultMainPath = "main.go"
+
+var _ file.Template = &Main{}
+var _ file.UseCustomFuncMap = &Main{}
+
+// Main scaffolds the controller manager entry point
+type Main struct {
+	file.TemplateMixin
+	file.BoilerplateMixin
+	file.DomainMixin
+	file.RepositoryMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Main) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join(defaultMainPath)
+	}
+
+	f.TemplateBody = fmt.Sprintf(mainTemplate,
+		file.NewMarkerFor(f.Path, importMarker),
+		file.NewMarkerFor(f.Path, addSchemeMarker),
+		file.NewMarkerFor(f.Path, setupMarker),
+	)
+
+	return nil
+}
+
+func hash(s string) (string, error) {
+	hasher := fnv.New32a()
+	hasher.Write([]byte(s)) // nolint:errcheck
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+// GetFuncMap implements file.UseCustomFuncMap
+func (f *Main) GetFuncMap() template.FuncMap {
+	fm := file.DefaultFuncMap()
+	fm["hash"] = hash
+	return fm
+}
+
+var _ file.Inserter = &MainUpdater{}
+
+// MainUpdater updates main.go to run Controllers
+type MainUpdater struct { //nolint:maligned
+	file.RepositoryMixin
+	file.MultiGroupMixin
+	file.ResourceMixin
+
+	// Flags to indicate which parts need to be included when updating the file
+	WireResource, WireController, WireWebhook bool
+}
+
+// GetPath implements Builder
+func (*MainUpdater) GetPath() string {
+	return defaultMainPath
+}
+
+// GetIfExistsAction implements Builder
+func (*MainUpdater) GetIfExistsAction() file.IfExistsAction {
+	return file.Overwrite
+}
+
+const (
+	importMarker    = "imports"
+	addSchemeMarker = "scheme"
+	setupMarker     = "builder"
+)
+
+// GetMarkers implements file.Inserter
+func (f *MainUpdater) GetMarkers() []file.Marker {
+	return []file.Marker{
+		file.NewMarkerFor(defaultMainPath, importMarker),
+		file.NewMarkerFor(defaultMainPath, addSchemeMarker),
+		file.NewMarkerFor(defaultMainPath, setupMarker),
+	}
+}
+
+const (
+	apiImportCodeFragment = `%s "%s"
+`
+	controllerImportCodeFragment = `"%s/controllers"
+`
+	// TODO(v3): `&%scontrollers` should be used instead of `&%scontroller` as there may be multiple
+	//  controller for different Kinds in the same group. However, this is a backwards incompatible
+	//  change, and thus should be done for next project version.
+	multiGroupControllerImportCodeFragment = `%scontroller "%s/controllers/%s"
+`
+	addschemeCodeFragment = `utilruntime.Must(%s.AddToScheme(scheme))
+`
+	reconcilerSetupCodeFragment = `if err = (&controllers.%sReconciler{
+		Client: mgr.GetClient(),
+		Log: ctrl.Log.WithName("controllers").WithName("%s"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "%s")
+		os.Exit(1)
+	}
+`
+	// TODO(v3): loggers for the same Kind controllers from different groups use the same logger.
+	//  `.WithName("controllers").WithName(GROUP).WithName(KIND)` should be used instead. However,
+	//  this is a backwards incompatible change, and thus should be done for next project version.
+	multiGroupReconcilerSetupCodeFragment = `if err = (&%scontroller.%sReconciler{
+		Client: mgr.GetClient(),
+		Log: ctrl.Log.WithName("controllers").WithName("%s"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "%s")
+		os.Exit(1)
+	}
+`
+	webhookSetupCodeFragment = `if err = (&%s.%s{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "%s")
+		os.Exit(1)
+	}
+`
+)
+
+// GetCodeFragments implements file.Inserter
+func (f *MainUpdater) GetCodeFragments() file.CodeFragmentsMap {
+	fragments := make(file.CodeFragmentsMap, 3)
+
+	// If resource is not being provided we are creating the file, not updating it
+	if f.Resource == nil {
+		return fragments
+	}
+
+	// Generate import code fragments
+	imports := make([]string, 0)
+	imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Package))
+	if f.WireController {
+		if !f.MultiGroup {
+			imports = append(imports, fmt.Sprintf(controllerImportCodeFragment, f.Repo))
+		} else {
+			imports = append(imports, fmt.Sprintf(multiGroupControllerImportCodeFragment,
+				f.Resource.GroupPackageName, f.Repo, f.Resource.Group))
+		}
+	}
+
+	// Generate add scheme code fragments
+	addScheme := make([]string, 0)
+	addScheme = append(addScheme, fmt.Sprintf(addschemeCodeFragment, f.Resource.ImportAlias))
+
+	// Generate setup code fragments
+	setup := make([]string, 0)
+	if f.WireController {
+		if !f.MultiGroup {
+			setup = append(setup, fmt.Sprintf(reconcilerSetupCodeFragment,
+				f.Resource.Kind, f.Resource.Kind, f.Resource.Kind))
+		} else {
+			setup = append(setup, fmt.Sprintf(multiGroupReconcilerSetupCodeFragment,
+				f.Resource.GroupPackageName, f.Resource.Kind, f.Resource.Kind, f.Resource.Kind))
+		}
+	}
+	if f.WireWebhook {
+		setup = append(setup, fmt.Sprintf(webhookSetupCodeFragment,
+			f.Resource.ImportAlias, f.Resource.Kind, f.Resource.Kind))
+	}
+
+	// Only store code fragments in the map if the slices are non-empty
+	if len(imports) != 0 {
+		fragments[file.NewMarkerFor(defaultMainPath, importMarker)] = imports
+	}
+	if len(addScheme) != 0 {
+		fragments[file.NewMarkerFor(defaultMainPath, addSchemeMarker)] = addScheme
+	}
+	if len(setup) != 0 {
+		fragments[file.NewMarkerFor(defaultMainPath, setupMarker)] = setup
+	}
+
+	return fragments
+}
+
+var mainTemplate = `{{ .Boilerplate }}
+
+package main
+
+import (
+	"flag"
+	"os"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	%s
+)
+
+var (
+	scheme = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	%s
+}
+
+func main() {
+	var metricsAddr string
+	var enableLeaderElection bool
+	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+		"Enable leader election for controller manager. " +
+		"Enabling this will ensure there is only one active controller manager.")
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true))) 
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:             scheme,
+		MetricsBindAddress: metricsAddr,
+		Port:               9443, 
+		LeaderElection:     enableLeaderElection, 
+		LeaderElectionID:   "{{ hash .Repo }}.{{ .Domain }}",
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	%s
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/makefile.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Makefile{}
+
+// Makefile scaffolds the Makefile
+type Makefile struct {
+	file.TemplateMixin
+
+	// Image is controller manager image name
+	Image string
+	// BoilerplatePath is the path to the boilerplate file
+	BoilerplatePath string
+	// Controller tools version to use in the project
+	ControllerToolsVersion string
+	//Kustomize version to use in the project
+	KustomizeVersion string
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Makefile) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = "Makefile"
+	}
+
+	f.TemplateBody = makefileTemplate
+
+	f.IfExistsAction = file.Error
+
+	if f.Image == "" {
+		f.Image = "controller:latest"
+	}
+
+	return nil
+}
+
+//nolint:lll
+const makefileTemplate = `
+# Image URL to use all building/pushing image targets
+IMG ?= {{ .Image }}
+# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
+CRD_OPTIONS ?= "crd:trivialVersions=true"
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+all: manager
+
+# Run tests
+test: generate fmt vet manifests
+	go test ./... -coverprofile cover.out
+
+# Build manager binary
+manager: generate fmt vet
+	go build -o bin/manager main.go
+
+# Run against the configured Kubernetes cluster in ~/.kube/config
+run: generate fmt vet manifests
+	go run ./main.go
+
+# Install CRDs into a cluster
+install: manifests kustomize
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+
+# Uninstall CRDs from a cluster
+uninstall: manifests kustomize
+	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+
+# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+deploy: manifests kustomize
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+# Generate manifests e.g. CRD, RBAC etc.
+manifests: controller-gen
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+# Run go fmt against code
+fmt:
+	go fmt ./...
+
+# Run go vet against code
+vet:
+	go vet ./...
+
+# Generate code
+generate: controller-gen
+	$(CONTROLLER_GEN) object:headerFile={{printf "%q" .BoilerplatePath}} paths="./..."
+
+# Build the docker image
+docker-build: test
+	docker build . -t ${IMG}
+
+# Push the docker image
+docker-push:
+	docker push ${IMG}
+
+# find or download controller-gen
+# download controller-gen if necessary
+controller-gen:
+ifeq (, $(shell which controller-gen))
+	@{ \
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@{{ .ControllerToolsVersion }} ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	}
+CONTROLLER_GEN=$(GOBIN)/controller-gen
+else
+CONTROLLER_GEN=$(shell which controller-gen)
+endif
+
+kustomize:
+ifeq (, $(shell which kustomize))
+	@{ \
+	set -e ;\
+	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go get sigs.k8s.io/kustomize/kustomize/v3@{{ .KustomizeVersion }} ;\
+	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
+	}
+KUSTOMIZE=$(GOBIN)/kustomize
+else
+KUSTOMIZE=$(shell which kustomize)
+endif
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/manager/config.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/manager/config.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Config{}
+
+// Config scaffolds yaml config for the manager.
+type Config struct {
+	file.TemplateMixin
+
+	// Image is controller manager image name
+	Image string
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Config) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "manager.yaml")
+	}
+
+	f.TemplateBody = configTemplate
+
+	return nil
+}
+
+const configTemplate = `apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - command:
+        - /manager
+        args:
+        - --enable-leader-election
+        image: {{ .Image }}
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      terminationGracePeriodSeconds: 10
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/manager/kustomization.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/manager/kustomization.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Kustomization{}
+
+// Kustomization scaffolds the Kustomization file in manager folder.
+type Kustomization struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizeManagerTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const kustomizeManagerTemplate = `resources:
+- manager.yaml
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/metricsauth/auth_proxy_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/metricsauth/auth_proxy_patch.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsauth
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &AuthProxyPatch{}
+
+// AuthProxyPatch scaffolds the patch file for enabling
+// prometheus metrics for manager Pod.
+type AuthProxyPatch struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *AuthProxyPatch) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_auth_proxy_patch.yaml")
+	}
+
+	f.TemplateBody = kustomizeAuthProxyPatchTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the 
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/metricsauth/authproxyservice.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/metricsauth/authproxyservice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsauth
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &AuthProxyService{}
+
+// AuthProxyService scaffolds the config/rbac/auth_proxy_service.yaml file
+type AuthProxyService struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *AuthProxyService) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_service.yaml")
+	}
+
+	f.TemplateBody = authProxyServiceTemplate
+
+	return nil
+}
+
+const authProxyServiceTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/metricsauth/clientclusterrole.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/metricsauth/clientclusterrole.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsauth
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &ClientClusterRole{}
+
+// ClientClusterRole scaffolds the config/rbac/client_clusterrole.yaml file
+type ClientClusterRole struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *ClientClusterRole) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "auth_proxy_client_clusterrole.yaml")
+	}
+
+	f.TemplateBody = clientClusterRoleTemplate
+
+	return nil
+}
+
+const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/mgrrolebinding.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/mgrrolebinding.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &ManagerRoleBinding{}
+
+// ManagerRoleBinding scaffolds the config/rbac/role_binding.yaml file
+type ManagerRoleBinding struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *ManagerRoleBinding) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "role_binding.yaml")
+	}
+
+	f.TemplateBody = managerBindingTemplate
+
+	return nil
+}
+
+const managerBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/prometheus/kustomize.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/prometheus/kustomize.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Kustomization{}
+
+// Kustomization scaffolds the kustomizaiton in the prometheus folder
+type Kustomization struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	return nil
+}
+
+const kustomizationTemplate = `resources:
+- monitor.yaml
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/prometheus/monitor.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/prometheus/monitor.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &ServiceMonitor{}
+
+// ServiceMonitor scaffolds an issuer CR and a certificate CR
+type ServiceMonitor struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *ServiceMonitor) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus", "monitor.yaml")
+	}
+
+	f.TemplateBody = serviceMonitorTemplate
+
+	return nil
+}
+
+const serviceMonitorTemplate = `
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/rbac.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/rbac.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &KustomizeRBAC{}
+
+// KustomizeRBAC scaffolds the Kustomization file in rbac folder.
+type KustomizeRBAC struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *KustomizeRBAC) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizeRBACTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const kustomizeRBACTemplate = `resources:
+- role.yaml
+- role_binding.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml
+# Comment the following 4 lines if you want to disable
+# the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+# which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
+- auth_proxy_client_clusterrole.yaml
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/types.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/types.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Types{}
+
+// Types scaffolds the api/<version>/<kind>_types.go file to define the schema for an API
+type Types struct {
+	file.TemplateMixin
+	file.MultiGroupMixin
+	file.BoilerplateMixin
+	file.ResourceMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Types) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("apis", "%[group]", "%[version]", "%[kind]_types.go")
+		} else {
+			f.Path = filepath.Join("api", "%[version]", "%[kind]_types.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
+
+	f.TemplateBody = typesTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const typesTemplate = `{{ .Boilerplate }}
+
+package {{ .Resource.Version }}
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+// {{ .Resource.Kind }}Spec defines the desired state of {{ .Resource.Kind }}
+type {{ .Resource.Kind }}Spec struct {
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "make" to regenerate code after modifying this file
+
+	// Foo is an example field of {{ .Resource.Kind }}. Edit {{ .Resource.Kind }}_types.go to remove/update
+	Foo string ` + "`" + `json:"foo,omitempty"` + "`" + `
+}
+
+// {{ .Resource.Kind }}Status defines the observed state of {{ .Resource.Kind }}
+type {{ .Resource.Kind }}Status struct {
+	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+	// Important: Run "make" to regenerate code after modifying this file
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+{{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
+
+// {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
+type {{ .Resource.Kind }} struct {
+	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
+	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
+
+	Spec   {{ .Resource.Kind }}Spec   ` + "`" + `json:"spec,omitempty"` + "`" + `
+	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty"` + "`" + `
+}
+
+// +kubebuilder:object:root=true
+
+// {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
+type {{ .Resource.Kind }}List struct {
+	metav1.TypeMeta ` + "`" + `json:",inline"` + "`" + `
+	metav1.ListMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
+	Items           []{{ .Resource.Kind }} ` + "`" + `json:"items"` + "`" + `
+}
+
+func init() {
+	SchemeBuilder.Register(&{{ .Resource.Kind }}{}, &{{ .Resource.Kind }}List{})
+}
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/webhook/enablecainection_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/webhook/enablecainection_patch.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &InjectCAPatch{}
+
+// InjectCAPatch scaffolds the InjectCAPatch file in manager folder.
+type InjectCAPatch struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *InjectCAPatch) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "webhookcainjection_patch.yaml")
+	}
+
+	f.TemplateBody = injectCAPatchTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const injectCAPatchTemplate = `# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/webhook/kustomization.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/webhook/kustomization.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Kustomization{}
+
+// Kustomization scaffolds the Kustomization file in manager folder.
+type Kustomization struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "webhook", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizeWebhookTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const kustomizeWebhookTemplate = `resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/webhook/kustomizeconfig.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/webhook/kustomizeconfig.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &KustomizeConfigWebhook{}
+
+// KustomizeConfigWebhook scaffolds the Kustomization file in manager folder.
+type KustomizeConfigWebhook struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *KustomizeConfigWebhook) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "webhook", "kustomizeconfig.yaml")
+	}
+
+	f.TemplateBody = kustomizeConfigWebhookTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+//nolint:lll
+const kustomizeConfigWebhookTemplate = `# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/webhook/service.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/webhook/service.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Service{}
+
+// Service scaffolds the Service file in manager folder.
+type Service struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Service) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "webhook", "service.yaml")
+	}
+
+	f.TemplateBody = serviceTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+const serviceTemplate = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/webhook/webhook.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/webhook/webhook.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &Webhook{}
+
+// Webhook scaffolds a Webhook for a Resource
+type Webhook struct { // nolint:maligned
+	file.TemplateMixin
+	file.MultiGroupMixin
+	file.BoilerplateMixin
+	file.ResourceMixin
+
+	// Is the Group domain for the Resource replacing '.' with '-'
+	GroupDomainWithDash string
+
+	// If scaffold the defaulting webhook
+	Defaulting bool
+	// If scaffold the validating webhook
+	Validating bool
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Webhook) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup {
+			f.Path = filepath.Join("apis", "%[group]", "%[version]", "%[kind]_webhook.go")
+		} else {
+			f.Path = filepath.Join("api", "%[version]", "%[kind]_webhook.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	fmt.Println(f.Path)
+
+	webhookTemplate := webhookTemplate
+	if f.Defaulting {
+		webhookTemplate = webhookTemplate + defaultingWebhookTemplate
+	}
+	if f.Validating {
+		webhookTemplate = webhookTemplate + validatingWebhookTemplate
+	}
+	f.TemplateBody = webhookTemplate
+
+	f.IfExistsAction = file.Error
+
+	f.GroupDomainWithDash = strings.Replace(f.Resource.Domain, ".", "-", -1)
+
+	return nil
+}
+
+const (
+	webhookTemplate = `{{ .Boilerplate }}
+
+package {{ .Resource.Version }}
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	{{- if or .Validating .Defaulting }}
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	{{- end }}
+)
+
+// log is for logging in this package.
+var {{ lower .Resource.Kind }}log = logf.Log.WithName("{{ lower .Resource.Kind }}-resource")
+
+func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+`
+
+	//nolint:lll
+	defaultingWebhookTemplate = `
+// +kubebuilder:webhook:path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io
+
+var _ webhook.Defaulter = &{{ .Resource.Kind }}{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *{{ .Resource.Kind }}) Default() {
+	{{ lower .Resource.Kind }}log.Info("default", "name", r.Name)
+
+	// TODO(user): fill in your defaulting logic.
+}
+`
+	//nolint:lll
+	validatingWebhookTemplate = `
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
+
+var _ webhook.Validator = &{{ .Resource.Kind }}{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *{{ .Resource.Kind }}) ValidateCreate() error {
+	{{ lower .Resource.Kind }}log.Info("validate create", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object creation.
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *{{ .Resource.Kind }}) ValidateUpdate(old runtime.Object) error {
+	{{ lower .Resource.Kind }}log.Info("validate update", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *{{ .Resource.Kind }}) ValidateDelete() error {
+	{{ lower .Resource.Kind }}log.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}
+`
+)

--- a/pkg/plugin/v3/scaffolds/internal/templates/webhook_manager_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/webhook_manager_patch.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/pkg/model/file"
+)
+
+var _ file.Template = &ManagerWebhookPatch{}
+
+// ManagerWebhookPatch scaffolds a ManagerWebhookPatch for a Resource
+type ManagerWebhookPatch struct {
+	file.TemplateMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *ManagerWebhookPatch) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "manager_webhook_patch.yaml")
+	}
+
+	f.TemplateBody = managerWebhookPatchTemplate
+
+	return nil
+}
+
+const managerWebhookPatchTemplate = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+`

--- a/pkg/plugin/v3/scaffolds/webhook.go
+++ b/pkg/plugin/v3/scaffolds/webhook.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/pkg/model"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/internal/machinery"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds/internal/templates/webhook"
+)
+
+var _ scaffold.Scaffolder = &webhookScaffolder{}
+
+type webhookScaffolder struct {
+	config      *config.Config
+	boilerplate string
+	resource    *resource.Resource
+
+	// Webhook type options.
+	defaulting, validation, conversion bool
+}
+
+// NewWebhookScaffolder returns a new Scaffolder for v2 webhook creation operations
+func NewWebhookScaffolder(
+	config *config.Config,
+	boilerplate string,
+	resource *resource.Resource,
+	defaulting bool,
+	validation bool,
+	conversion bool,
+) scaffold.Scaffolder {
+	return &webhookScaffolder{
+		config:      config,
+		boilerplate: boilerplate,
+		resource:    resource,
+		defaulting:  defaulting,
+		validation:  validation,
+		conversion:  conversion,
+	}
+}
+
+// Scaffold implements Scaffolder
+func (s *webhookScaffolder) Scaffold() error {
+	fmt.Println("Writing scaffold for you to edit...")
+	return s.scaffold()
+}
+
+func (s *webhookScaffolder) newUniverse() *model.Universe {
+	return model.NewUniverse(
+		model.WithConfig(s.config),
+		model.WithBoilerplate(s.boilerplate),
+		model.WithResource(s.resource),
+	)
+}
+
+func (s *webhookScaffolder) scaffold() error {
+	if s.conversion {
+		fmt.Println(`Webhook server has been set up for you.
+You need to implement the conversion.Hub and conversion.Convertible interfaces for your CRD types.`)
+	}
+
+	if err := machinery.NewScaffold().Execute(
+		s.newUniverse(),
+		&webhook.Webhook{Defaulting: s.defaulting, Validating: s.validation},
+		&templates.MainUpdater{WireWebhook: true},
+	); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/plugin/v3/webhook.go
+++ b/pkg/plugin/v3/webhook.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/spf13/pflag"
+
+	"sigs.k8s.io/kubebuilder/internal/cmdutil"
+	"sigs.k8s.io/kubebuilder/pkg/model/config"
+	"sigs.k8s.io/kubebuilder/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/scaffold"
+	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds"
+)
+
+type createWebhookPlugin struct {
+	config *config.Config
+	// For help text.
+	commandName string
+
+	resource   *resource.Options
+	defaulting bool
+	validation bool
+	conversion bool
+}
+
+var (
+	_ plugin.CreateWebhook = &createWebhookPlugin{}
+	_ cmdutil.RunOptions   = &createAPIPlugin{}
+)
+
+func (p *createWebhookPlugin) UpdateContext(ctx *plugin.Context) {
+	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
+validating and (or) conversion webhooks.
+`
+	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group crew, version v1
+  # and kind FirstMate.
+  %s create webhook --group crew --version v1 --kind FirstMate --defaulting --programmatic-validation
+
+  # Create conversion webhook for CRD of group crew, version v1 and kind FirstMate.
+  %s create webhook --group crew --version v1 --kind FirstMate --conversion
+`,
+		ctx.CommandName, ctx.CommandName)
+
+	p.commandName = ctx.CommandName
+}
+
+func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
+	p.resource = &resource.Options{}
+	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
+	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
+	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
+	fs.StringVar(&p.resource.Plural, "resource", "", "resource Resource")
+
+	fs.BoolVar(&p.defaulting, "defaulting", false,
+		"if set, scaffold the defaulting webhook")
+	fs.BoolVar(&p.validation, "programmatic-validation", false,
+		"if set, scaffold the validating webhook")
+	fs.BoolVar(&p.conversion, "conversion", false,
+		"if set, scaffold the conversion webhook")
+}
+
+func (p *createWebhookPlugin) InjectConfig(c *config.Config) {
+	p.config = c
+}
+
+func (p *createWebhookPlugin) Run() error {
+	return cmdutil.Run(p)
+}
+
+func (p *createWebhookPlugin) Validate() error {
+	if err := p.resource.Validate(); err != nil {
+		return err
+	}
+
+	if !p.defaulting && !p.validation && !p.conversion {
+		return fmt.Errorf("%s create webhook requires at least one of --defaulting,"+
+			" --programmatic-validation and --conversion to be true", p.commandName)
+	}
+
+	return nil
+}
+
+func (p *createWebhookPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+	// Load the boilerplate
+	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
+	if err != nil {
+		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
+	}
+
+	// Create the actual resource from the resource options
+	res := p.resource.NewResource(p.config, false)
+	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.defaulting, p.validation, p.conversion), nil
+}
+
+func (p *createWebhookPlugin) PostScaffold() error {
+	return nil
+}

--- a/testdata/project-v3-addon/PROJECT
+++ b/testdata/project-v3-addon/PROJECT
@@ -1,5 +1,5 @@
 domain: testproject.org
-layout: go.kubebuilder.io/v2
+layout: go.kubebuilder.io/v3-alpha
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 resources:
 - group: crew

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -1,5 +1,5 @@
 domain: testproject.org
-layout: go.kubebuilder.io/v2
+layout: go.kubebuilder.io/v3-alpha
 multigroup: true
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 resources:

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -1,5 +1,5 @@
 domain: testproject.org
-layout: go.kubebuilder.io/v2
+layout: go.kubebuilder.io/v3-alpha
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:
 - group: crew


### PR DESCRIPTION
A new plugin version `v3-alpha` will contain all new plugin/scaffold changes/features. Since plugin version `v2` is tested with project version 2, we probably should just test the new plugin with project version `3-alpha`. This won't necessarily be the case going forward, ex. once `4-alpha` is created we should generate separate testdata.

/cc @DirectXMan12 @camilamacedo86 @joelanford @mengqiy 
