### PR TITLE
pkg/plugin/plugin.go: correct version stage comparison

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -104,9 +104,8 @@ func (v Version) Compare(vp Version) int {
 		if s == sp {
 			return 0
 		}
-		// Since stages are not equal, if s is greater it must either be: beta when sp is alpha
-		// or "", or alpha when sp is "", otherwise it is lesser.
-		if s == BetaStage || (s == AlphaStage && sp == "") {
+		// Since stages are not equal, check: stable > beta > alpha.
+		if s == "" || (s == BetaStage && sp == AlphaStage) {
 			return 1
 		}
 	} else if v.Number > vp.Number {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -133,13 +133,13 @@ var _ = g.Describe("Compare", func() {
 		}
 
 		sortedVersions = []Version{
-			{Number: 1},
 			{Number: 1, Stage: AlphaStage},
+			{Number: 1},
 			{Number: 2, Stage: AlphaStage},
 			{Number: 2, Stage: BetaStage},
-			{Number: 4},
 			{Number: 4, Stage: AlphaStage},
 			{Number: 4, Stage: BetaStage},
+			{Number: 4},
 			{Number: 30},
 			{Number: 44, Stage: AlphaStage},
 			{Number: 44, Stage: AlphaStage},


### PR DESCRIPTION
Plugin version comparisons were incorrect: stage cmp order should be: `stable > beta > alpha`.

/cc @camilamacedo86 @DirectXMan12 @joelanford 

/kind bug
