### PR TITLE
🌱 local e2e script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ Following the targets that can be used to test your changes locally.
 | make lint |  Check the code implementation | yes   |
 | make test-coverage |  Run coveralls to check the % of code covered by tests | yes   |
 | make check-testdata |  Checks if the testdata dir is updated with the latest changes | yes   |
+| make test-e2e-local |  Runs the CI e2e tests locally | no   |
 
 **NOTE** To use the `make lint` is required to install `golangci-lint` locally. More info: https://github.com/golangci/golangci-lint#install
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ test-coverage:  ## Run coveralls
 	# run the go tests and gen the file coverage-all used to do the integration with coverrals.io
 	go test -failfast -tags=integration -coverprofile=coverage-all.out -covermode=count ./pkg/... ./cmd/...
 
+.PHONY: test-e2e-local
+test-e2e-local: ## It will run the script to install kind and run e2e tests
+	## To keep the same kind cluster between test runs, use `SKIP_KIND_CLEANUP=1 make test-e2e-local`
+	./test_e2e_local.sh
+
 .PHONY: check-testdata
 check-testdata: ## Run the script to ensure that the testdata is updated
 	./check_testdata.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,13 +15,17 @@
 # limitations under the License.
 
 K8S_VERSION=$1
+KIND_NAME="kind"
+if [ $# -gt 1 ]; then
+    KIND_NAME=$2
+fi
 
 export GO111MODULE=on
 
 # setup go module to create the cluster
 
 # You can use --image flag to specify the cluster version you want, e.g --image=kindest/node:v1.13.6, the supported version are listed at https://hub.docker.com/r/kindest/node/tags
-kind create cluster -v 4 --retain --wait=1m --config test/kind-config.yaml --image=kindest/node:$K8S_VERSION
+kind create cluster -v 4 --name $KIND_NAME --retain --wait=1m --config test/kind-config.yaml --image=kindest/node:$K8S_VERSION
 
 # setup the go modules required
 go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -194,7 +194,11 @@ func (t *TestContext) Destroy() {
 
 // LoadImageToKindCluster loads a local docker image to the kind cluster
 func (t *TestContext) LoadImageToKindCluster() error {
-	kindOptions := []string{"load", "docker-image", t.ImageName}
+	cluster := "kind"
+	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
+		cluster = v
+	}
+	kindOptions := []string{"load", "docker-image", t.ImageName, "--name", cluster}
 	cmd := exec.Command("kind", kindOptions...)
 	_, err := t.Run(cmd)
 	return err

--- a/test_e2e_local.sh
+++ b/test_e2e_local.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source common.sh
+
+export TRACE=1
+export GO111MODULE=on
+export KIND_K8S_VERSION=${KIND_K8S_VERSION:-v1.17.0}
+
+fetch_tools
+install_kind
+build_kb
+
+setup_envs
+
+export KIND_CLUSTER=local-kubebuilder-e2e
+if ! kind get clusters | grep -q $KIND_CLUSTER ; then
+    source "$(pwd)/scripts/setup.sh" ${KIND_K8S_VERSION} $KIND_CLUSTER
+    docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+    kind load --name $KIND_CLUSTER docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+fi
+
+kind export kubeconfig --kubeconfig $tmp_root/kubeconfig --name $KIND_CLUSTER
+export KUBECONFIG=$tmp_root/kubeconfig
+
+# remove running containers on exit
+function cleanup() {
+    kind delete cluster --name $KIND_CLUSTER
+}
+
+if [ -z "${SKIP_KIND_CLEANUP:-}" ]; then
+    trap cleanup EXIT
+fi
+
+# when changing these commands, make sure to keep in sync with ./test_e2e.sh
+go test ./test/e2e/v2 -v -ginkgo.v
+go test ./test/e2e/v3 -v -ginkgo.v


### PR DESCRIPTION
This change introduces a `test_e2e_local.sh` script for running e2e
tests locally. Addresses #1435.

Split out from #1546 