### PR TITLE
Check if has Scaffold before exec

### DIFF
--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -44,10 +44,11 @@ func Run(options RunOptions) error {
 		return err
 	}
 	// Step 3: scaffold
-	if err := scaffolder.Scaffold(); err != nil {
-		return err
+	if scaffolder != nil {
+		if err := scaffolder.Scaffold(); err != nil {
+			return err
+		}
 	}
-
 	// Step 4: finish
 	if err := options.PostScaffold(); err != nil {
 		return err


### PR DESCRIPTION
The interface should jump for the next step if a Scaffold was not returned. otherwise, it will fail. 
