### PR TITLE
Add missing kubebuilder annotation to the getting started document

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -131,6 +131,11 @@ type GuestbookStatus struct {
 	Standby []string `json:"standby"`
 }
 
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+
+// Guestbook is the Schema for the guestbooks API
 type Guestbook struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
I changed the documentation, so it will contain a working example

Previously, the example not generated the deep copy function required by the SchemeBuilder.Register

It fixes #1586 issue, that complains about the not out of box working example
