### PR TITLE
doc: replace links to godoc.org with links to pkg.go.dev

### DIFF
--- a/designs/README.md
+++ b/designs/README.md
@@ -18,7 +18,7 @@ proof-of-concept process can help iron out wrinkles and can help with the
 ## Out-of-Date Designs
 
 **KubeBuilder documentation (the [book](https://book.kubebuilder.io) and
-the [GoDoc](https://godoc.org/sigs.k8s.io/controller-runtime)) should be
+the [GoDoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime?tab=doc)) should be
 considered the canonical, update-to-date reference and architectural
 documentation** for KubeBuilder.
 

--- a/designs/simplified-scaffolding.md
+++ b/designs/simplified-scaffolding.md
@@ -140,7 +140,7 @@ scattered deep in a folder structure.
 
 We introduced the builder pattern for controller construction in
 controller-runtime
-([GoDoc](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/builder#ControllerManagedBy))
+([GoDoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder?tab=doc#ControllerManagedBy))
 as a way to simplify construction of controllers and reduce boilerplate
 for the common cases of controller construction.  Informal feedback from
 this has been positive, and it enables fairly rapid, clear, and concise

--- a/docs/book/getting_started/hello_world.md
+++ b/docs/book/getting_started/hello_world.md
@@ -2,10 +2,10 @@
 
 A new project may be scaffolded for a user by running `kubebuilder init` and then scaffolding a
 new API with `kubebuilder create api`. More on this topic in
-[Project Creation and Structure](../basics/project_creation_and_structure.md) 
+[Project Creation and Structure](../basics/project_creation_and_structure.md)
 
 This chapter shows a simple Controller implementation using the
-[controller-runtime builder](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/builder)
+[controller-runtime builder](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder?tab=doc)
 libraries to do most of the Controller configuration.
 
 While Kubernetes APIs have typically have 3 components, (Resource, Controller, Manager), this
@@ -92,7 +92,7 @@ func (a *ReplicaSetController) Reconcile(
 
   // List the Pods matching the PodTemplate Labels
   pods := &corev1.PodList{}
-  err = a.List(context.TODO(), 
+  err = a.List(context.TODO(),
     client.InNamespace(req.Namespace).
         MatchingLabels(rs.Spec.Template.Labels),
     pods)
@@ -101,7 +101,7 @@ func (a *ReplicaSetController) Reconcile(
   }
 
   // Update the ReplicaSet
-  rs.Labels["selector-pod-count"] = 
+  rs.Labels["selector-pod-count"] =
     fmt.Sprintf("%v", len(pods.Items))
   err = a.Update(context.TODO(), rs)
   if err != nil {

--- a/docs/book/src/cronjob-tutorial/controller-overview.md
+++ b/docs/book/src/cronjob-tutorial/controller-overview.md
@@ -1,6 +1,6 @@
 # What's in a controller?
 
-Controllers are the core of Kubernetes, and of any operator.  
+Controllers are the core of Kubernetes, and of any operator.
 
 It's a controller's job to ensure that, for any given object, the actual
 state of the world (both the cluster state, and potentially external state
@@ -11,7 +11,7 @@ matches the desired state in the object.  Each controller focuses on one
 We call this process *reconciling*.
 
 In controller-runtime, the logic that implements the reconciling for
-a specific kind is called a [*Reconciler*](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/reconcile).  A reconciler
+a specific kind is called a [*Reconciler*](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile?tab=doc).  A reconciler
 takes the name of an object, and returns whether or not we need to try
 again (e.g. in case of errors or periodic controllers, like the
 HorizontalPodAutoscaler).

--- a/docs/book/src/cronjob-tutorial/gvks.md
+++ b/docs/book/src/cronjob-tutorial/gvks.md
@@ -50,7 +50,7 @@ API!
 
 The `Scheme` we saw before is simply a way to keep track of what Go type
 corresponds to a given GVK (don't be overwhelmed by its
-[godocs](https://godoc.org/k8s.io/apimachinery/pkg/runtime#Scheme)).
+[godocs](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime?tab=doc#Scheme)).
 
 For instance, suppose we mark that the
 `"tutorial.kubebuilder.io/api/v1".CronJob{}` type as being in the

--- a/docs/book/src/cronjob-tutorial/testdata/emptyapi.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptyapi.go
@@ -64,7 +64,7 @@ more of them in a bit, but know that they act as extra metadata, telling
 [controller-tools](https://github.com/kubernetes-sigs/controller-tools) (our code and YAML generator) extra information.
 This particular one tells the `object` generator that this type represents
 a Kind.  Then, the `object` generator generates an implementation of the
-[runtime.Object](https://godoc.org/k8s.io/apimachinery/pkg/runtime#Object) interface for us, which is the standard
+[runtime.Object](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime?tab=doc#Object) interface for us, which is the standard
 interface that all types representing Kinds must implement.
 */
 
@@ -90,7 +90,7 @@ type CronJobList struct {
 
 /*
 Finally, we add the Go types to the API group.  This allows us to add the
-types in this API group to any [Scheme](https://godoc.org/k8s.io/apimachinery/pkg/runtime#Scheme).
+types in this API group to any [Scheme](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime?tab=doc#Scheme).
 */
 func init() {
 	SchemeBuilder.Register(&CronJob{}, &CronJobList{})

--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -57,7 +57,7 @@ needed to run.  As we add more functionality, we'll need to revisit these.
 
 /*
 `Reconcile` actually performs the reconciling for a single named object.
-Our [Request](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/reconcile#Request) just has a name, but we can use the client to fetch
+Our [Request](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile?tab=doc#Request) just has a name, but we can use the client to fetch
 that object from the cache.
 
 We return an empty result and no error, which indicates to controller-runtime that

--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 Our package starts out with some basic imports.  Particularly:
 
-- The core [controller-runtime](https://godoc.org/sigs.k8s.io/controller-runtime) library
+- The core [controller-runtime](https://pkg.go.dev/sigs.k8s.io/controller-runtime?tab=doc) library
 - The default controller-runtime logging, Zap (more on that a bit later)
 
 */
@@ -61,7 +61,7 @@ At this point, our main function is fairly simple:
 - We set up some basic flags for metrics.
 
 - We instantiate a
-[*manager*](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/manager#Manager),
+[*manager*](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager?tab=doc#Manager),
 which keeps track of running all of our controllers, as well as setting up
 shared caches and clients to the API server (notice we tell the manager about
 our Scheme).
@@ -118,7 +118,7 @@ func main() {
 	})
 
 	/*
-		For further information see [MultiNamespacedCacheBuilder](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder)
+		For further information see [MultiNamespacedCacheBuilder](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache?tab=doc#MultiNamespacedCacheBuilder)
 	*/
 
 	// +kubebuilder:scaffold:builder

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -95,7 +95,7 @@ func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		We'll fetch the CronJob using our client.  All client methods take a
 		context (to allow for cancellation) as their first argument, and the object
 		in question as their last.  Get is a bit special, in that it takes a
-		[`NamespacedName`](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client#ObjectKey)
+		[`NamespacedName`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client?tab=doc#ObjectKey)
 		as the middle argument (most don't have a middle argument, as we'll see
 		below).
 
@@ -125,18 +125,18 @@ func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	/*
 
-		<aside class="note"> 
+		<aside class="note">
 
 		<h1>What is this index about?</h1>
 
-		<p>The reconciler fetches all jobs owned by the cronjob for the status. As our number of cronjobs increases, 
-		looking these up can become quite slow as we have to filter through all of them. For a more efficient lookup, 
-		these jobs will be indexed locally on the controller's name. A jobOwnerKey field is added to the 
-		cached job objects. This key references the owning controller and functions as the index. Later in this 
+		<p>The reconciler fetches all jobs owned by the cronjob for the status. As our number of cronjobs increases,
+		looking these up can become quite slow as we have to filter through all of them. For a more efficient lookup,
+		these jobs will be indexed locally on the controller's name. A jobOwnerKey field is added to the
+		cached job objects. This key references the owning controller and functions as the index. Later in this
 		document we will configure the manager to actually index this field.</p>
-			
+
 		</aside>
-		
+
 		Once we have all the jobs we own, we'll split them into active, successful,
 		and failed jobs, keeping track of the most recent run so that we can record it
 		in status.  Remember, status should be able to be reconstituted from the state

--- a/docs/book/src/cronjob-tutorial/writing-tests.md
+++ b/docs/book/src/cronjob-tutorial/writing-tests.md
@@ -7,7 +7,7 @@ To walk you through integration testing patterns for Kubebuilder-generated contr
 
 The basic approach is that, in your generated `suite_test.go` file, you will use envtest to create a local Kubernetes API server, instantiate and run your controllers, and then write additional `*_test.go` files to test it using [Ginko](http://onsi.github.io/ginkgo).
 
-If you want to tinker with how your envtest cluster is configured, see section [Writing and Running Integration Tests](/reference/testing/envtest.md) as well as the [`envtest docs`](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/envtest).
+If you want to tinker with how your envtest cluster is configured, see section [Writing and Running Integration Tests](/reference/testing/envtest.md) as well as the [`envtest docs`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc).
 
 ## Test Environment Setup
 

--- a/docs/book/src/migration/v1vsv2.md
+++ b/docs/book/src/migration/v1vsv2.md
@@ -61,5 +61,5 @@ image size and attack surface.
 
 - v2 requires kustomize v3.1.0+.
 
-[LeaderElectionRunable]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/manager#LeaderElectionRunnable
-[pkg-runtime-godoc]: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/runtime
+[LeaderElectionRunable]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager?tab=doc#LeaderElectionRunnable
+[pkg-runtime-godoc]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/runtime?tab=doc

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_conversion.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_conversion.go
@@ -19,7 +19,7 @@ package v1
 /*
 Implementing the hub method is pretty easy -- we just have to add an empty
 method called `Hub()` to serve as a
-[marker](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/conversion#Hub).
+[marker](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/conversion?tab=doc#Hub).
 We could also just put this inline in our `cronjob_types.go` file.
 */
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -35,8 +35,8 @@ var cronjoblog = logf.Log.WithName("cronjob-resource")
 /*
 This setup is doubles as setup for our conversion webhooks: as long as our
 types implement the
-[Hub](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/conversion#Hub) and
-[Convertible](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/conversion#Convertible)
+[Hub](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/conversion?tab=doc#Hub) and
+[Convertible](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/conversion?tab=doc#Convertible)
 interfaces, a conversion webhook will be registered.
 */
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_conversion.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_conversion.go
@@ -27,7 +27,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
-	v1 "tutorial.kubebuilder.io/project/api/v1"
+	"tutorial.kubebuilder.io/project/api/v1"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_conversion.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_conversion.go
@@ -17,7 +17,7 @@ package v2
 
 /*
 For imports, we'll need the controller-runtime
-[`conversion`](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/conversion)
+[`conversion`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/conversion?tab=doc)
 package, plus the API version for our hub type (v1), and finally some of the
 standard packages.
 */
@@ -27,14 +27,14 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
-	"tutorial.kubebuilder.io/project/api/v1"
+	v1 "tutorial.kubebuilder.io/project/api/v1"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
 
 /*
 Our "spoke" versions need to implement the
-[`Convertible`](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/conversion#Convertible)
+[`Convertible`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/conversion?tab=doc#Convertible)
 interface.  Namely, they'll need `ConvertTo` and `ConvertFrom` methods to convert to/from
 the hub version.
 */

--- a/docs/book/src/multiversion-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -95,7 +95,7 @@ func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		We'll fetch the CronJob using our client.  All client methods take a
 		context (to allow for cancellation) as their first argument, and the object
 		in question as their last.  Get is a bit special, in that it takes a
-		[`NamespacedName`](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client#ObjectKey)
+		[`NamespacedName`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client?tab=doc#ObjectKey)
 		as the middle argument (most don't have a middle argument, as we'll see
 		below).
 

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -1,5 +1,5 @@
 ## Using envtest in integration tests
-[`controller-runtime`](http://sigs.k8s.io/controller-runtime) offers `envtest` ([godoc](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/envtest)), a package that helps write integration tests for your controllers by setting up and starting an instance of etcd and the Kubernetes API server, without kubelet, controller-manager or other components.
+[`controller-runtime`](http://sigs.k8s.io/controller-runtime) offers `envtest` ([godoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc)), a package that helps write integration tests for your controllers by setting up and starting an instance of etcd and the Kubernetes API server, without kubelet, controller-manager or other components.
 
 Using `envtest` in integration tests follows the general flow of:
 

--- a/docs/book/src/reference/markers.md
+++ b/docs/book/src/reference/markers.md
@@ -36,9 +36,9 @@ See [Generating CRDs](./generating-crd.md) for a comprehensive overview.
 ## Marker Syntax
 
 Exact syntax is described in the [godocs for
-controller-tools](https://godoc.org/sigs.k8s.io/controller-tools/pkg/markers).
+controller-tools](https://pkg.go.dev/sigs.k8s.io/controller-tools/pkg/markers?tab=doc).
 
-In general, markers may either be: 
+In general, markers may either be:
 
 - **Empty** (`+kubebuilder:validation:Optional`): empty markers are like boolean flags on the command line
   -- just specifying them enables some behavior.

--- a/docs/book/src/reference/webhook-for-core-types.md
+++ b/docs/book/src/reference/webhook-for-core-types.md
@@ -12,7 +12,7 @@ follow the steps below to add admission webhooks for core types.
 ## Implement Your Handler
 
 You need to have your handler implements the
-[admission.Handler](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/webhook/admission#Handler)
+[admission.Handler](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/webhook/admission?tab=doc#Handler)
 interface.
 
 ```go

--- a/docs/book/src/reference/webhook-overview.md
+++ b/docs/book/src/reference/webhook-overview.md
@@ -9,7 +9,7 @@ In the kubernetes world, there are 3 kinds of webhooks:
 [authorization webhook](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) and
 [CRD conversion webhook](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definition-versioning/#webhook-conversion).
 
-In [controller-runtime](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/webhook)
+In [controller-runtime](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/webhook?tab=doc)
 libraries, we support admission webhooks and CRD conversion webhooks.
 
 Kubernetes supports these dynamic admission webhooks as of version 1.9 (when the


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

1. fix outdated links, like `https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/cache#MultiNamespacedCacheBuilder`, by changing them to something like `https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache?tab=doc#MultiNamespacedCacheBuilder`
2. replace links to godoc.org with links to pkg.go.dev
3. remove trailing spaces