### PR TITLE
fix: use kube-system instead of system

### DIFF
--- a/pkg/plugin/v2/scaffolds/internal/templates/mgrrolebinding.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/mgrrolebinding.go
@@ -51,5 +51,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system
 `

--- a/pkg/plugin/v3/scaffolds/internal/templates/mgrrolebinding.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/mgrrolebinding.go
@@ -51,5 +51,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system
 `

--- a/testdata/project-v2-addon/config/rbac/role_binding.yaml
+++ b/testdata/project-v2-addon/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system

--- a/testdata/project-v2-multigroup/config/rbac/role_binding.yaml
+++ b/testdata/project-v2-multigroup/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system

--- a/testdata/project-v2/config/rbac/role_binding.yaml
+++ b/testdata/project-v2/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system

--- a/testdata/project-v3-addon/config/rbac/role_binding.yaml
+++ b/testdata/project-v3-addon/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system

--- a/testdata/project-v3-multigroup/config/rbac/role_binding.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system

--- a/testdata/project-v3/config/rbac/role_binding.yaml
+++ b/testdata/project-v3/config/rbac/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: system
+  namespace: kube-system


### PR DESCRIPTION
I think it's better to use kube-system instead of system, otherwise, we should provide a way to choose namespace and define custom ServiceAccount name.