### PR TITLE
pkg/plugin/v3: use repo instead of directory basename as project name

### DIFF
--- a/pkg/plugin/v3/init.go
+++ b/pkg/plugin/v3/init.go
@@ -18,8 +18,7 @@ package v3
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -109,17 +108,6 @@ func (p *initPlugin) Validate() error {
 			return err
 		}
 	}
-
-	// Check if the project name is a valid namespace according to k8s
-	dir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("error to get the current path: %v", err)
-	}
-	projectName := filepath.Base(dir)
-	if err := validation.IsDNS1123Label(strings.ToLower(projectName)); err != nil {
-		return fmt.Errorf("project name (%s) is invalid: %v", projectName, err)
-	}
-
 	// Try to guess repository if flag is not set.
 	if p.config.Repo == "" {
 		repoPath, err := util.FindCurrentRepo()
@@ -127,6 +115,13 @@ func (p *initPlugin) Validate() error {
 			return fmt.Errorf("error finding current repository: %v", err)
 		}
 		p.config.Repo = repoPath
+	}
+
+	// Use base repository path as project name, since a project should be able to exist in an
+	// arbitrarily-named directory.
+	projectName := path.Base(p.config.Repo)
+	if err := validation.IsDNS1123Label(strings.ToLower(projectName)); err != nil {
+		return fmt.Errorf("project name (%s) is invalid: %v", projectName, err)
 	}
 
 	return nil

--- a/pkg/plugin/v3/scaffolds/internal/templates/kustomize.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/kustomize.go
@@ -18,6 +18,7 @@ package templates
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -29,6 +30,7 @@ var _ file.Template = &Kustomize{}
 // Kustomize scaffolds the Kustomization file for the default overlay
 type Kustomize struct {
 	file.TemplateMixin
+	file.RepositoryMixin
 
 	// Prefix to use for name prefix customization
 	Prefix string
@@ -45,12 +47,16 @@ func (f *Kustomize) SetTemplateDefaults() error {
 	f.IfExistsAction = file.Error
 
 	if f.Prefix == "" {
-		// use directory name as prefix
-		dir, err := os.Getwd()
-		if err != nil {
-			return err
+		if f.Repo != "" {
+			f.Prefix = strings.ToLower(path.Base(f.Repo))
+		} else {
+			// Use directory name as prefix if no repo is present.
+			dir, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			f.Prefix = strings.ToLower(filepath.Base(dir))
 		}
-		f.Prefix = strings.ToLower(filepath.Base(dir))
 	}
 
 	return nil
@@ -74,12 +80,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -88,7 +94,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 

--- a/testdata/project-v3-addon/config/default/kustomization.yaml
+++ b/testdata/project-v3-addon/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 

--- a/testdata/project-v3-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 

--- a/testdata/project-v3/config/default/kustomization.yaml
+++ b/testdata/project-v3/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 


### PR DESCRIPTION
When I create a project, I want to be able to specify my project name. Furthermore I would like to create/work on my project in an arbitrary directory. Instead of adding a flag to support setting project name, use the basename of `--repo` which is more likely to be the desired project name than the directory name.

/cc @DirectXMan12 @hasbro17 @camilamacedo86 