### PR TITLE
config: add `project-name` config key and optional `init --project-name`

### DIFF
--- a/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
@@ -49,5 +49,10 @@ project:
 kubebuilder init --domain tutorial.kubebuilder.io
 ```
 
+<aside class="note">
+Your project's name defaults to that of your current working directory.
+You can pass `--project-name=<dns1123-label-string>` to set a different project name.
+</aside>
+
 Now that we've got a project in place, let's take a look at what
 Kubebuilder has scaffolded for us so far...

--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -41,6 +41,9 @@ type Config struct {
 	// Repo is the go package name of the project root
 	Repo string `json:"repo,omitempty"`
 
+	// ProjectName is the name of this controller project set on initialization.
+	ProjectName string `json:"project-name,omitempty"`
+
 	// Resources tracks scaffolded resources in the project
 	// This info is tracked only in project with version 2
 	Resources []GVK `json:"resources,omitempty"`

--- a/pkg/plugin/v3/scaffolds/init.go
+++ b/pkg/plugin/v3/scaffolds/init.go
@@ -113,7 +113,7 @@ func (s *initScaffolder) scaffold() error {
 		},
 		&templates.Dockerfile{},
 		&templates.DockerignoreFile{},
-		&templates.Kustomize{},
+		&templates.Kustomize{Prefix: s.config.ProjectName},
 		&templates.ManagerWebhookPatch{},
 		&templates.ManagerRoleBinding{},
 		&templates.LeaderElectionRole{},

--- a/pkg/plugin/v3/scaffolds/internal/templates/kustomize.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/kustomize.go
@@ -18,7 +18,6 @@ package templates
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -30,7 +29,6 @@ var _ file.Template = &Kustomize{}
 // Kustomize scaffolds the Kustomization file for the default overlay
 type Kustomize struct {
 	file.TemplateMixin
-	file.RepositoryMixin
 
 	// Prefix to use for name prefix customization
 	Prefix string
@@ -47,16 +45,12 @@ func (f *Kustomize) SetTemplateDefaults() error {
 	f.IfExistsAction = file.Error
 
 	if f.Prefix == "" {
-		if f.Repo != "" {
-			f.Prefix = strings.ToLower(path.Base(f.Repo))
-		} else {
-			// Use directory name as prefix if no repo is present.
-			dir, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			f.Prefix = strings.ToLower(filepath.Base(dir))
+		// Use directory name as prefix.
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
 		}
+		f.Prefix = strings.ToLower(filepath.Base(wd))
 	}
 
 	return nil

--- a/testdata/project-v3-addon/PROJECT
+++ b/testdata/project-v3-addon/PROJECT
@@ -1,5 +1,6 @@
 domain: testproject.org
 layout: go.kubebuilder.io/v3-alpha
+project-name: project-v3-addon
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 resources:
 - group: crew

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -1,6 +1,7 @@
 domain: testproject.org
 layout: go.kubebuilder.io/v3-alpha
 multigroup: true
+project-name: project-v3-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 resources:
 - group: crew

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -1,5 +1,6 @@
 domain: testproject.org
 layout: go.kubebuilder.io/v3-alpha
+project-name: project-v3
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:
 - group: crew


### PR DESCRIPTION
This PR adds a `project-name` config key and an optional `init --project-name` to the v3-alpha plugin. Plugin authors for non-Go plugins will find such a key useful, as `repo` doesn't make much sense for non-Go plugins. This reverts #1596 behavior.

Changes:
* pkg/model/config: add 'project-name' which configures a project's name
* pkg/plugin/v3/init.go: add --project-name which sets a config's 'project-name' key

/cc @pwittrock @camilamacedo86 
