### PR TITLE
pkg/plugin/v2: use config project name if project version is v3+

### DIFF
--- a/pkg/plugin/v2/init.go
+++ b/pkg/plugin/v2/init.go
@@ -91,6 +91,9 @@ func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.config.Repo, "repo", "", "name to use for go module (e.g., github.com/user/repo), "+
 		"defaults to the go package of the current working directory.")
 	fs.StringVar(&p.config.Domain, "domain", "my.domain", "domain for groups")
+	if p.config.IsV3() {
+		fs.StringVar(&p.config.ProjectName, "project-name", "", "name of this project")
+	}
 }
 
 func (p *initPlugin) InjectConfig(c *config.Config) {
@@ -113,13 +116,20 @@ func (p *initPlugin) Validate() error {
 		}
 	}
 
-	// Check if the project name is a valid namespace according to k8s
+	// Check if the project name is a valid k8s namespace (DNS 1123 label).
 	dir, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("error to get the current path: %v", err)
+		return fmt.Errorf("error getting current directory: %v", err)
 	}
-	projectName := filepath.Base(dir)
-	if err := validation.IsDNS1123Label(strings.ToLower(projectName)); err != nil {
+	projectName := strings.ToLower(filepath.Base(dir))
+	if p.config.IsV3() {
+		if p.config.ProjectName == "" {
+			p.config.ProjectName = projectName
+		} else {
+			projectName = p.config.ProjectName
+		}
+	}
+	if err := validation.IsDNS1123Label(projectName); err != nil {
 		return fmt.Errorf("project name (%s) is invalid: %v", projectName, err)
 	}
 

--- a/pkg/plugin/v2/scaffolds/internal/templates/kustomize.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/kustomize.go
@@ -29,9 +29,7 @@ var _ file.Template = &Kustomize{}
 // Kustomize scaffolds the Kustomization file for the default overlay
 type Kustomize struct {
 	file.TemplateMixin
-
-	// Prefix to use for name prefix customization
-	Prefix string
+	file.ProjectNameMixin
 }
 
 // SetTemplateDefaults implements input.Template
@@ -44,27 +42,27 @@ func (f *Kustomize) SetTemplateDefaults() error {
 
 	f.IfExistsAction = file.Error
 
-	if f.Prefix == "" {
-		// use directory name as prefix
+	if f.ProjectName == "" {
+		// Use directory name as project name, which will be empty if the project version is < v3.
 		dir, err := os.Getwd()
 		if err != nil {
 			return err
 		}
-		f.Prefix = strings.ToLower(filepath.Base(dir))
+		f.ProjectName = strings.ToLower(filepath.Base(dir))
 	}
 
 	return nil
 }
 
 const kustomizeTemplate = `# Adds namespace to all resources.
-namespace: {{ .Prefix }}-system
+namespace: {{ .ProjectName }}-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: {{ .Prefix }}-
+namePrefix: {{ .ProjectName }}-
 
 # Labels to add to all resources and selectors.
 #commonLabels:
@@ -74,12 +72,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -88,7 +86,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 

--- a/pkg/plugin/v3/init.go
+++ b/pkg/plugin/v3/init.go
@@ -19,7 +19,7 @@ package v3
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -117,7 +117,7 @@ func (p *initPlugin) Validate() error {
 		if err != nil {
 			return fmt.Errorf("error getting current directory: %v", err)
 		}
-		p.config.ProjectName = strings.ToLower(path.Base(dir))
+		p.config.ProjectName = strings.ToLower(filepath.Base(dir))
 	}
 	if err := validation.IsDNS1123Label(p.config.ProjectName); err != nil {
 		return fmt.Errorf("project name (%s) is invalid: %v", p.config.ProjectName, err)

--- a/testdata/project-v2-addon/config/default/kustomization.yaml
+++ b/testdata/project-v2-addon/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 

--- a/testdata/project-v2-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v2-multigroup/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 

--- a/testdata/project-v2/config/default/kustomization.yaml
+++ b/testdata/project-v2/config/default/kustomization.yaml
@@ -16,12 +16,12 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
 patchesStrategicMerge:
@@ -30,7 +30,7 @@ patchesStrategicMerge:
   # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml
 


### PR DESCRIPTION
Follow up from #1609 for plugin v2. This is not a change to the plugin itself, just to how it handles project version 3-alpha's `projectName` field.

/cc @pwittrock @camilamacedo86 @joelanford 