### PR TITLE
Fix old link to envtest docs that should have been removed

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -73,9 +73,8 @@
   - [controller-gen CLI](./reference/controller-gen.md)
   - [completion](./reference/completion.md)
   - [Artifacts](./reference/artifacts.md)
-  - [Writing controller tests](./reference/writing-tests.md)
 
-  - [Using envtest in integration tests](./reference/envtest.md)
+  - [Configuring EnvTest](./reference/envtest.md)
 
   - [Metrics](./reference/metrics.md)
 

--- a/docs/book/src/cronjob-tutorial/writing-tests.md
+++ b/docs/book/src/cronjob-tutorial/writing-tests.md
@@ -7,7 +7,7 @@ To walk you through integration testing patterns for Kubebuilder-generated contr
 
 The basic approach is that, in your generated `suite_test.go` file, you will use envtest to create a local Kubernetes API server, instantiate and run your controllers, and then write additional `*_test.go` files to test it using [Ginko](http://onsi.github.io/ginkgo).
 
-If you want to tinker with how your envtest cluster is configured, see section [Writing and Running Integration Tests](/reference/testing/envtest.md) as well as the [`envtest docs`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc).
+If you want to tinker with how your envtest cluster is configured, see section [Configuring envtest for integration tests](../reference/envtest.md) as well as the [`envtest docs`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc).
 
 ## Test Environment Setup
 

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -1,4 +1,4 @@
-## Using envtest in integration tests
+# Configuring envtest for integration tests
 [`controller-runtime`](http://sigs.k8s.io/controller-runtime) offers `envtest` ([godoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc)), a package that helps write integration tests for your controllers by setting up and starting an instance of etcd and the Kubernetes API server, without kubelet, controller-manager or other components.
 
 Using `envtest` in integration tests follows the general flow of:
@@ -24,10 +24,10 @@ err = testEnv.Stop()
 
 Logs from the test runs are prefixed with `test-env`.
 
-### Configuring your test control plane
+## Configuring your test control plane
 You can use environment variables and/or flags to specify the `api-server` and `etcd` setup within your integration tests.
 
-#### Environment Variables
+### Environment Variables
 
 | Variable name | Type | When to use |
 | --- | :--- | :--- |
@@ -38,7 +38,7 @@ You can use environment variables and/or flags to specify the `api-server` and `
 | `KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT` | boolean | Set to `true` to attach the control plane's stdout and stderr to os.Stdout and os.Stderr. This can be useful when debugging test failures, as output will include output from the control plane. |
 
 
-#### Flags
+### Flags
 Here's an example of modifying the flags with which to start the API server in your integration tests, compared to the default values in `envtest.DefaultKubeAPIServerFlags`:
 
 ```go
@@ -56,7 +56,7 @@ testEnv = &envtest.Environment{
 }
 ```
 
-### Testing considerations
+## Testing considerations
 
 Unless you're using an existing cluster, keep in mind that no built-in controllers are running in the test context. In some ways, the test control plane will behave differently from "real" clusters, and that might have an impact on how you write tests. One common example is garbage collection; because there are no controllers monitoring built-in resources, objects do not get deleted, even if an `OwnerReference` is set up.
 


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
This PR fixes #1621, which was caused by an old sidebar link that should have been deleted as part of moving the integration test example under the CronJob example section.
