### PR TITLE
pkg/model/config: only project versions >= v3 can use plugins config options

### DIFF
--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -153,8 +153,8 @@ func (c Config) Marshal() ([]byte, error) {
 		content = []byte{}
 	}
 	// Append extra fields to put them at the config's bottom, unless the
-	// project is v1 which does not support extra fields.
-	if !cfg.IsV1() && len(c.Plugins) != 0 {
+	// project version is < v3 which do not support a plugins field.
+	if cfg.IsV3() && len(c.Plugins) != 0 {
 		pluginConfigBytes, err := yaml.Marshal(Config{Plugins: c.Plugins})
 		if err != nil {
 			return nil, fmt.Errorf("error marshalling project configuration extra fields: %v", err)
@@ -169,8 +169,8 @@ func (c *Config) Unmarshal(b []byte) error {
 	if err := yaml.UnmarshalStrict(b, c); err != nil {
 		return fmt.Errorf("error unmarshalling project configuration: %v", err)
 	}
-	// v1 projects do not support extra fields.
-	if c.IsV1() {
+	// Project versions < v3 do not support a plugins field.
+	if !c.IsV3() {
 		c.Plugins = nil
 	}
 	return nil
@@ -178,11 +178,12 @@ func (c *Config) Unmarshal(b []byte) error {
 
 // EncodePluginConfig encodes a config object into c by overwriting the existing
 // object stored under key. This method is intended to be used for custom
-// configuration objects.
+// configuration objects, which were introduced in project version 3-alpha.
+// EncodePluginConfig will return an error if used on any project version < v3.
 func (c *Config) EncodePluginConfig(key string, configObj interface{}) error {
-	// Short-circuit v1
-	if c.IsV1() {
-		return fmt.Errorf("v1 project configs do not have extra fields")
+	// Short-circuit project versions < v3.
+	if !c.IsV3() {
+		return fmt.Errorf("project versions < v3 do not support extra fields")
 	}
 
 	// Get object's bytes and set them under key in extra fields.
@@ -201,13 +202,13 @@ func (c *Config) EncodePluginConfig(key string, configObj interface{}) error {
 	return nil
 }
 
-// DecodePluginConfig decodes a plugin config stored in c into configObj. This
-// method is intended to be used for custom configuration objects.
-// configObj must be a pointer.
+// DecodePluginConfig decodes a plugin config stored in c into configObj, which must be a pointer
+// This method is intended to be used for custom configuration objects, which were introduced
+// in project version 3-alpha. EncodePluginConfig will return an error if used on any project version < v3.
 func (c Config) DecodePluginConfig(key string, configObj interface{}) error {
-	// Short-circuit v1
-	if c.IsV1() {
-		return fmt.Errorf("v1 project configs do not have extra fields")
+	// Short-circuit project versions < v3.
+	if !c.IsV3() {
+		return fmt.Errorf("project versions < v3 do not support extra fields")
 	}
 	if len(c.Plugins) == 0 {
 		return nil

--- a/pkg/model/config/config_test.go
+++ b/pkg/model/config/config_test.go
@@ -40,20 +40,25 @@ var _ = Describe("Config", func() {
 		By("Using config version 1")
 		config = Config{Version: Version1}
 		pluginConfig = PluginConfig{}
-		Expect(config.EncodePluginConfig(key, pluginConfig)).To(HaveOccurred())
-
-		By("Using config version 1 with extra fields")
-		config = Config{Version: Version1}
-		pluginConfig = PluginConfig{
-			Data1: "single plugin datum",
-		}
-		Expect(config.EncodePluginConfig(key, pluginConfig)).To(HaveOccurred())
+		Expect(config.EncodePluginConfig(key, pluginConfig)).NotTo(Succeed())
 
 		By("Using config version 2")
 		config = Config{Version: Version2}
 		pluginConfig = PluginConfig{}
+		Expect(config.EncodePluginConfig(key, pluginConfig)).NotTo(Succeed())
+
+		By("Using config version 2 with extra fields")
+		config = Config{Version: Version2}
+		pluginConfig = PluginConfig{
+			Data1: "single plugin datum",
+		}
+		Expect(config.EncodePluginConfig(key, pluginConfig)).NotTo(Succeed())
+
+		By("Using config version 3-alpha")
+		config = Config{Version: Version3Alpha}
+		pluginConfig = PluginConfig{}
 		expectedConfig = Config{
-			Version: Version2,
+			Version: Version3Alpha,
 			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "",
@@ -61,17 +66,17 @@ var _ = Describe("Config", func() {
 				},
 			},
 		}
-		Expect(config.EncodePluginConfig(key, pluginConfig)).NotTo(HaveOccurred())
+		Expect(config.EncodePluginConfig(key, pluginConfig)).To(Succeed())
 		Expect(config).To(Equal(expectedConfig))
 
-		By("Using config version 2 with extra fields as struct")
-		config = Config{Version: Version2}
+		By("Using config version 3-alpha with extra fields as struct")
+		config = Config{Version: Version3Alpha}
 		pluginConfig = PluginConfig{
 			"plugin value 1",
 			"plugin value 2",
 		}
 		expectedConfig = Config{
-			Version: Version2,
+			Version: Version3Alpha,
 			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "plugin value 1",
@@ -79,7 +84,7 @@ var _ = Describe("Config", func() {
 				},
 			},
 		}
-		Expect(config.EncodePluginConfig(key, pluginConfig)).NotTo(HaveOccurred())
+		Expect(config.EncodePluginConfig(key, pluginConfig)).To(Succeed())
 		Expect(config).To(Equal(expectedConfig))
 	})
 
@@ -94,37 +99,42 @@ var _ = Describe("Config", func() {
 		By("Using config version 1")
 		config = Config{Version: Version1}
 		pluginConfig = PluginConfig{}
-		Expect(config.DecodePluginConfig(key, &pluginConfig)).To(HaveOccurred())
+		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(Succeed())
 
-		By("Using config version 1 with extra fields")
-		config = Config{Version: Version1}
+		By("Using config version 2")
+		config = Config{Version: Version2}
+		pluginConfig = PluginConfig{}
+		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(Succeed())
+
+		By("Using config version 2 with extra fields")
+		config = Config{Version: Version2}
 		pluginConfig = PluginConfig{
 			Data1: "single plugin datum",
 		}
-		Expect(config.DecodePluginConfig(key, &pluginConfig)).To(HaveOccurred())
+		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(Succeed())
 
-		By("Using empty config version 2")
+		By("Using empty config version 3-alpha")
 		config = Config{
-			Version: Version2,
+			Version: Version3Alpha,
 			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{},
 			},
 		}
 		pluginConfig = PluginConfig{}
 		expectedPluginConfig = PluginConfig{}
-		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(HaveOccurred())
+		Expect(config.DecodePluginConfig(key, &pluginConfig)).To(Succeed())
 		Expect(pluginConfig).To(Equal(expectedPluginConfig))
 
-		By("Using config version 2")
-		config = Config{Version: Version2}
+		By("Using config version 3-alpha")
+		config = Config{Version: Version3Alpha}
 		pluginConfig = PluginConfig{}
 		expectedPluginConfig = PluginConfig{}
-		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(HaveOccurred())
+		Expect(config.DecodePluginConfig(key, &pluginConfig)).To(Succeed())
 		Expect(pluginConfig).To(Equal(expectedPluginConfig))
 
-		By("Using config version 2 with extra fields as struct")
+		By("Using config version 3-alpha with extra fields as struct")
 		config = Config{
-			Version: Version2,
+			Version: Version3Alpha,
 			Plugins: PluginConfigs{
 				"plugin-x": map[string]interface{}{
 					"data-1": "plugin value 1",
@@ -137,7 +147,7 @@ var _ = Describe("Config", func() {
 			"plugin value 1",
 			"plugin value 2",
 		}
-		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(HaveOccurred())
+		Expect(config.DecodePluginConfig(key, &pluginConfig)).To(Succeed())
 		Expect(pluginConfig).To(Equal(expectedPluginConfig))
 	})
 })


### PR DESCRIPTION
The `plugins` field was introduced in the `3-alpha` project config version, and should not be able to be used with any project version less than that.

/cc @joelanford @camilamacedo86 @DirectXMan12 

/kind bug