### PR TITLE
:sparkles: specify nonroot uid for manager (v3+ only)

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/manager/config.go
@@ -67,6 +67,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsUser: 65532
       containers:
       - command:
         - /manager
@@ -74,6 +76,8 @@ spec:
         - --enable-leader-election
         image: {{ .Image }}
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             cpu: 100m

--- a/pkg/plugin/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/dockerfile.go
@@ -62,7 +62,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]
 `

--- a/testdata/project-v3-addon/Dockerfile
+++ b/testdata/project-v3-addon/Dockerfile
@@ -22,6 +22,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsUser: 65532
       containers:
       - command:
         - /manager
@@ -29,6 +31,8 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -22,6 +22,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsUser: 65532
       containers:
       - command:
         - /manager
@@ -29,6 +31,8 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3/Dockerfile
+++ b/testdata/project-v3/Dockerfile
@@ -22,6 +22,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsUser: 65532
       containers:
       - command:
         - /manager
@@ -29,6 +31,8 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
PR #983 changes the manager's user to nonroot but it doesn't work out of the box. 

This change modifies the default behaviour of manager pod to use non-root uid for both kube-rbac-proxy container and the manager.

There are two issues when deploying the manager in non-root cluster if we try to use the config/default as-is  

1. kube-rbac-proxy uses root by default instead of a nonroot image - https://github.com/brancz/kube-rbac-proxy/blob/master/Dockerfile#L1 which causes pod to request for root and fail. 

2. Kubernetes cannot verify the `nonroot` user in manager because it is a string (https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/v2/scaffolds/internal/templates/dockerfile.go#L65) resulting in `container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root` 