### PR TITLE
Match the port 9443 to match in main.go

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 443
+      targetPort: 9443
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
For the cronjob tutorial, match targetPort to what specified in main.go
