### PR TITLE
Fix path to generated main.go 

### DIFF
--- a/pkg/plugin/v2/init.go
+++ b/pkg/plugin/v2/init.go
@@ -63,7 +63,7 @@ Writes the following files:
 - a Kustomization.yaml for customizating manifests
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics
-- a cmd/manager/main.go to run
+- a main.go to run
 
 project will prompt the user to run 'dep ensure' after writing the project files.
 `

--- a/pkg/plugin/v3/init.go
+++ b/pkg/plugin/v3/init.go
@@ -63,7 +63,7 @@ Writes the following files:
 - a Kustomization.yaml for customizating manifests
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics
-- a cmd/manager/main.go to run
+- a main.go to run
 
 project will prompt the user to run 'dep ensure' after writing the project files.
 `


### PR DESCRIPTION
Fixed path to the generated `main.go` file in `init` command description. I'm not sure about `v3`, because as I can see it will be possible to define the project's layout, so I can revert it.
