### PR TITLE
docs: added a full stop for better readbility

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -103,7 +103,7 @@ func main() {
 	/*
 		The above example will change the scope of your project to a single Namespace. In this scenario,
 		it is also suggested to restrict the provided authorization to this namespace by replacing the default
-		ClusterRole and ClusterRoleBinding to Role and RoleBinding respectively
+		ClusterRole and ClusterRoleBinding to Role and RoleBinding respectively.
 		For further information see the kubernetes documentation about Using [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
 		Also, it is possible to use the MultiNamespacedCacheBuilder to watch a specific set of namespaces:


### PR DESCRIPTION
* Added a "full stop" after "RoleBinding respectively" and before "For further information" to separate both paragraphs since even though they are perfectly written inside "emptymain.go" file but not appearing as desired in the Kubebuilder book (i.e. documentation) 
* For better readability and understanding
* Change done inside kubebuilder/docs/book/src/cronjob-tutorial/testdata/emptymain.go


