### PR TITLE
doc: update reference with name of page

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -161,7 +161,8 @@ func (r *CronJob) validateCronJob() error {
 /*
 Some fields are declaratively validated by OpenAPI schema.
 You can find kubebuilder validation markers (prefixed
-with `// +kubebuilder:validation`) in the [API](api-design.md)
+with `// +kubebuilder:validation`) in the
+[Designing an API](api-design.md) section.
 You can find all of the kubebuilder supported markers for
 declaring validation by running `controller-gen crd -w`,
 or [here](/reference/markers/crd-validation.md).


### PR DESCRIPTION
### Change Description
- Where: CronJob Tutorial,  webhook implementation
- What: adjusted page reference; added fullstop

### Change Motivation
Better readability

---

As this is a minor change, there is no associated issue (as far as I could see).