### PR TITLE
:book: Set default-theme to light explicitly if theme is set to empty string

### DIFF
--- a/docs/book/theme/index.hbs
+++ b/docs/book/theme/index.hbs
@@ -53,6 +53,10 @@
         <script type="text/javascript">
             var path_to_root = "{{ path_to_root }}";
             var default_theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "{{ preferred_dark_theme }}" : "{{ default_theme }}";
+            
+            if (default_theme === "") {
+                default_theme = "light";
+            }
         </script>
 
         <!-- Work around some values being stored in localStorage wrapped in quotes -->


### PR DESCRIPTION
As per [mdbook documentation](https://github.com/rust-lang/mdBook/blob/master/book-example/src/format/config.md#configuring-renderers), the `default-theme` should be inferred to be `light`, and that should fix the problem.
As I could see `default-theme` was rendered empty in browser, this attempts to update the configuration to explicitly provide the `default-theme`.

Also, `theme` holding empty string can cause the same result, and thus we need to ensure it is corrected for early before `set_theme()` function from `book.js` being triggered.

This fixes #1674