### PR TITLE
doc: Fix Kind name for CronJob book and correct wording

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/main.go
@@ -85,10 +85,10 @@ func main() {
 
 	if err = (&controllers.CronJobReconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Captain"),
+		Log:    ctrl.Log.WithName("controllers").WithName("CronJob"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Captain")
+		setupLog.Error(err, "unable to create controller", "controller", "CronJob")
 		os.Exit(1)
 	}
 
@@ -102,7 +102,7 @@ func main() {
 	*/
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&batchv1.CronJob{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
+			setupLog.Error(err, "unable to create webhook", "webhook", "CronJob")
 			os.Exit(1)
 		}
 	}

--- a/docs/book/src/multiversion-tutorial/conversion-concepts.md
+++ b/docs/book/src/multiversion-tutorial/conversion-concepts.md
@@ -46,13 +46,13 @@ define, and is modeled off of what Kubernetes does internally.
 
 When API clients, like kubectl or your controller, request a particular
 version of your resource, the Kubernetes API server needs to return
-a result that's of that version.  However, that version might not match
+a result of that version.  However, that version might not match
 the version stored by the API server.
 
 In that case, the API server needs to know how to convert between the
 desired version and the stored version.  Since the conversions aren't
 built in for CRDs, the Kubernetes API server calls out to a webhook to do
-the conversion instead.  For KubeBuilder, this webhook is implemented by
+the conversion instead.  With KubeBuilder, this webhook is implemented by
 controller-runtime, and performs the hub-and-spoke conversions that we
 discussed above.
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/main.go
@@ -79,10 +79,10 @@ func main() {
 
 	if err = (&controllers.CronJobReconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Captain"),
+		Log:    ctrl.Log.WithName("controllers").WithName("CronJob"),
 		Scheme: mgr.GetScheme(), // we've added this ourselves
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Captain")
+		setupLog.Error(err, "unable to create controller", "controller", "CronJob")
 		os.Exit(1)
 	}
 	// +kubebuilder:docs-gen:collapse=existing setup
@@ -91,7 +91,7 @@ func main() {
 		Our existing call to SetupWebhookWithManager registers our conversion webhooks with the manager, too.
 	*/
 	if err = (&batchv1.CronJob{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
+		setupLog.Error(err, "unable to create webhook", "webhook", "CronJob")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder


### PR DESCRIPTION
### Change Description
 
1. `main.go` referenced in book

- Where: Kind name
- What: Book was using `Captain` as the Kind name whereas it was suggesting to run `kubebuilder create api` with `CronJob`

2. `conversion-concept.md`

- Where: Doc
- What: Some minor wording cleanup

Also, this file has an incomplete sentence at [the top of the file](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/multiversion-tutorial/conversion-concepts.md), where the sentence ends with "Namely:" as per below:
> Before we do that, though, we'll need to understand how controller-runtime thinks about versions. Namely:

I suppose it's about to mention something along the line of "conversion", but kept it as is as I wasn't sure of the actual intention.

### Change Motivation
Doc consistency

---

As this is a minor change, there is no associated issue.