### PR TITLE
Fix 1680: Usage of nonexistent namespace in cronjob example tests

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller_test.go
@@ -55,7 +55,7 @@ var _ = Describe("CronJob controller", func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
 		CronjobName      = "test-cronjob"
-		CronjobNamespace = "test-cronjob-namespace"
+		CronjobNamespace = "default"
 		JobName          = "test-job"
 
 		timeout  = time.Second * 10

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -146,7 +147,7 @@ func TestAPIs(t *testing.T) {
 
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"Controller Suite",
-		[]Reporter{envtest.NewlineReporter{}})
+		[]Reporter{printer.NewlineReporter{}})
 }
 
 /*


### PR DESCRIPTION
This PR closes #1680. The cause of the bug was usage of a namespace that did not exist yet; in the test, we now use the `default` namespace that is guaranteed to exist without extra boilerplate logic. We also use `printer.NewlineReporter{}` consistent with this change in other kubebuilder code.