### PR TITLE
:bug: fix: the CRD paths is only ../.. when is multigroup

### DIFF
--- a/pkg/plugin/v2/scaffolds/internal/templates/controller/controller_suitetest.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/controller/controller_suitetest.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,6 +33,9 @@ type SuiteTest struct {
 	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
+
+	// CRDDirectoryRelativePath define the Path for the CRD when it is multigroup
+	CRDDirectoryRelativePath string
 }
 
 // SetTemplateDefaults implements file.Template
@@ -50,6 +53,13 @@ func (f *SuiteTest) SetTemplateDefaults() error {
 		file.NewMarkerFor(f.Path, importMarker),
 		file.NewMarkerFor(f.Path, addSchemeMarker),
 	)
+
+	// If is multigroup the path needs to be ../../ since it has
+	// the group dir.
+	f.CRDDirectoryRelativePath = `".."`
+	if f.MultiGroup {
+		f.CRDDirectoryRelativePath = `"..", ".."`
+	}
 
 	return nil
 }
@@ -138,7 +148,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join({{ .CRDDirectoryRelativePath }}, "config", "crd", "bases")},
 	}
 
 	var err error

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
@@ -33,6 +33,9 @@ type SuiteTest struct {
 	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin
+
+	// CRDDirectoryRelativePath define the Path for the CRD when it is multigroup
+	CRDDirectoryRelativePath string
 }
 
 // SetTemplateDefaults implements file.Template
@@ -50,6 +53,13 @@ func (f *SuiteTest) SetTemplateDefaults() error {
 		file.NewMarkerFor(f.Path, importMarker),
 		file.NewMarkerFor(f.Path, addSchemeMarker),
 	)
+
+	// If is multigroup the path needs to be ../../ since it has
+	// the group dir.
+	f.CRDDirectoryRelativePath = `".."`
+	if f.MultiGroup {
+		f.CRDDirectoryRelativePath = `"..", ".."`
+	}
 
 	return nil
 }
@@ -138,7 +148,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join({{ .CRDDirectoryRelativePath }}, "config", "crd", "bases")},
 	}
 
 	var err error

--- a/testdata/project-v2-addon/controllers/suite_test.go
+++ b/testdata/project-v2-addon/controllers/suite_test.go
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
 	var err error

--- a/testdata/project-v2/controllers/suite_test.go
+++ b/testdata/project-v2/controllers/suite_test.go
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
 	var err error

--- a/testdata/project-v3-addon/controllers/suite_test.go
+++ b/testdata/project-v3-addon/controllers/suite_test.go
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
 	var err error

--- a/testdata/project-v3/controllers/suite_test.go
+++ b/testdata/project-v3/controllers/suite_test.go
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
 	}
 
 	var err error


### PR DESCRIPTION
Follow up of https://github.com/kubernetes-sigs/kubebuilder/pull/1673

If is multigroup the path needs more one ../ otherwise not. 


