### PR TITLE
:sparkles: Added the changes for include finalizer as a default controller markers

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller.go
@@ -75,6 +75,7 @@ type {{ .Resource.Kind }}Reconciler struct {
 
 // +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/finalizers,verbs=update
 
 func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/config/rbac/role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/role.yaml
@@ -21,6 +21,12 @@ rules:
 - apiGroups:
   - crew.testproject.org
   resources:
+  - captains/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - crew.testproject.org
+  resources:
   - captains/status
   verbs:
   - get
@@ -38,6 +44,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - foo.policy.testproject.org
+  resources:
+  - healthcheckpolicies/finalizers
+  verbs:
+  - update
 - apiGroups:
   - foo.policy.testproject.org
   resources:
@@ -61,6 +73,12 @@ rules:
 - apiGroups:
   - sea-creatures.testproject.org
   resources:
+  - krakens/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
   - krakens/status
   verbs:
   - get
@@ -78,6 +96,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - leviathans/finalizers
+  verbs:
+  - update
 - apiGroups:
   - sea-creatures.testproject.org
   resources:
@@ -101,6 +125,12 @@ rules:
 - apiGroups:
   - ship.testproject.org
   resources:
+  - cruisers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ship.testproject.org
+  resources:
   - cruisers/status
   verbs:
   - get
@@ -121,6 +151,12 @@ rules:
 - apiGroups:
   - ship.testproject.org
   resources:
+  - destroyers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ship.testproject.org
+  resources:
   - destroyers/status
   verbs:
   - get
@@ -138,6 +174,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - frigates/finalizers
+  verbs:
+  - update
 - apiGroups:
   - ship.testproject.org
   resources:

--- a/testdata/project-v3-multigroup/controllers/crew/captain_controller.go
+++ b/testdata/project-v3-multigroup/controllers/crew/captain_controller.go
@@ -36,6 +36,7 @@ type CaptainReconciler struct {
 
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
@@ -36,6 +36,7 @@ type HealthCheckPolicyReconciler struct {
 
 // +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
 
 func (r *HealthCheckPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/kraken_controller.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/kraken_controller.go
@@ -36,6 +36,7 @@ type KrakenReconciler struct {
 
 // +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
 
 func (r *KrakenReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/leviathan_controller.go
@@ -36,6 +36,7 @@ type LeviathanReconciler struct {
 
 // +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
 
 func (r *LeviathanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/controllers/ship/cruiser_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/cruiser_controller.go
@@ -36,6 +36,7 @@ type CruiserReconciler struct {
 
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
 
 func (r *CruiserReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/controllers/ship/destroyer_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/destroyer_controller.go
@@ -36,6 +36,7 @@ type DestroyerReconciler struct {
 
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
 
 func (r *DestroyerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3-multigroup/controllers/ship/frigate_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/frigate_controller.go
@@ -36,6 +36,7 @@ type FrigateReconciler struct {
 
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
 
 func (r *FrigateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3/config/rbac/role.yaml
+++ b/testdata/project-v3/config/rbac/role.yaml
@@ -21,6 +21,12 @@ rules:
 - apiGroups:
   - crew.testproject.org
   resources:
+  - admirals/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - crew.testproject.org
+  resources:
   - admirals/status
   verbs:
   - get
@@ -41,6 +47,12 @@ rules:
 - apiGroups:
   - crew.testproject.org
   resources:
+  - captains/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - crew.testproject.org
+  resources:
   - captains/status
   verbs:
   - get
@@ -58,6 +70,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - firstmates/finalizers
+  verbs:
+  - update
 - apiGroups:
   - crew.testproject.org
   resources:

--- a/testdata/project-v3/controllers/admiral_controller.go
+++ b/testdata/project-v3/controllers/admiral_controller.go
@@ -36,6 +36,7 @@ type AdmiralReconciler struct {
 
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/finalizers,verbs=update
 
 func (r *AdmiralReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3/controllers/captain_controller.go
+++ b/testdata/project-v3/controllers/captain_controller.go
@@ -36,6 +36,7 @@ type CaptainReconciler struct {
 
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v3/controllers/firstmate_controller.go
+++ b/testdata/project-v3/controllers/firstmate_controller.go
@@ -36,6 +36,7 @@ type FirstMateReconciler struct {
 
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
 
 func (r *FirstMateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()


### PR DESCRIPTION
**Description of the change**
Added a <resource>/finalizer kubebuilder marker as a default marker for the controller. This is to allow the update;patch;get operation on finalizer of the resource if the [ownerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) enabled on the cluster.

**Motivation of the change**
The kubebuilder operator doesn't work seamlessly on the vanilla kubernetes like openshift unless the finalizers permission marker is added on the Reconcile function. 

Fixes #1654 