### PR TITLE
:sparkles: replace deprecated function LoggerTo() from zap package (only v3+)

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
@@ -56,7 +56,7 @@ var k8sClient client.Client // You'll be using this client in your tests.
 var testEnv *envtest.Environment
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	/*
 		First, the envtest cluster is configured to read CRDs from the CRD directory Kubebuilder scaffolds for you.

--- a/docs/book/src/multiversion-tutorial/testdata/project/controllers/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/controllers/suite_test.go
@@ -50,7 +50,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
@@ -144,7 +144,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/testdata/project-v3-addon/controllers/suite_test.go
+++ b/testdata/project-v3-addon/controllers/suite_test.go
@@ -50,7 +50,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/testdata/project-v3-multigroup/controllers/crew/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/crew/suite_test.go
@@ -50,7 +50,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
@@ -50,7 +50,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
@@ -51,7 +51,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/testdata/project-v3-multigroup/controllers/ship/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/ship/suite_test.go
@@ -52,7 +52,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/testdata/project-v3/controllers/suite_test.go
+++ b/testdata/project-v3/controllers/suite_test.go
@@ -50,7 +50,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{


### PR DESCRIPTION
* **Deprecated**: `func LoggerTo(destWriter io.Writer, development bool) logr.Logger`
* Will use the new function instead: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/log/zap/zap.go#L42