### PR TITLE
:sparkles: store all config info (go/v3-alpha) 

### DIFF
--- a/generate_testdata.sh
+++ b/generate_testdata.sh
@@ -80,6 +80,7 @@ scaffold_test_project() {
     $kb create api --group sea-creatures --version v1beta2 --kind Leviathan --controller=true --resource=true --make=false
     $kb create api --group foo.policy --version v1 --kind HealthCheckPolicy --controller=true --resource=true --make=false
     $kb create api --group apps --version v1 --kind Pod --controller=true --resource=false --make=false
+    $kb create api --group authentication --version v1 --kind TokenReview --controller=true --resource=false --make=false
     if [ $project == "project-v3-multigroup" ]; then
       $kb create api --version v1 --kind Lakers --controller=true --resource=true --make=false
       $kb create webhook --version v1 --kind Lakers --defaulting --programmatic-validation

--- a/pkg/model/config/config_test.go
+++ b/pkg/model/config/config_test.go
@@ -30,6 +30,88 @@ var _ = Describe("PluginConfig", func() {
 		Data1 string `json:"data-1"`
 		Data2 string `json:"data-2"`
 	}
+	const defaultWebhookVersion = "v1"
+
+	resource := ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"}
+	resource.Webhooks = &Webhooks{false, false, true, defaultWebhookVersion}
+
+	It("should merge webhook when webhook is NOT equals", func() {
+		otherResource := ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"}
+		otherResource.Webhooks = &Webhooks{false, true, false, defaultWebhookVersion}
+		resource.merge(otherResource)
+		Expect(resource.Webhooks.Defaulting).To(BeFalse())
+		Expect(resource.Webhooks.Validation).To(BeTrue())
+		Expect(resource.Webhooks.Conversion).To(BeTrue())
+	})
+
+	It("should merge not update the conversion and validation to false when it is true already", func() {
+		otherResource := ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"}
+		otherResource.Webhooks = &Webhooks{false, false, false, defaultWebhookVersion}
+		resource.merge(otherResource)
+		Expect(resource.Webhooks.Defaulting).To(BeFalse())
+		Expect(resource.Webhooks.Validation).To(BeTrue())
+		Expect(resource.Webhooks.Conversion).To(BeTrue())
+	})
+
+	It("should merge API when API is NOT equals", func() {
+		otherResource := ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"}
+		otherResource.API = &API{Namespaced: true, CRDVersion: "v1"}
+		resource.merge(otherResource)
+		Expect(resource.API.Namespaced).To(BeTrue())
+		Expect(resource.API.CRDVersion).To(BeIdenticalTo("v1"))
+	})
+
+	It("should merge not update the API when its Namespaced is true and has CRDVersion already", func() {
+		otherResource := ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"}
+		otherResource.API = &API{Namespaced: false, CRDVersion: "betav1"}
+		resource.merge(otherResource)
+		Expect(resource.API.Namespaced).To(BeTrue())
+		Expect(resource.API.CRDVersion).To(BeIdenticalTo("v1"))
+	})
+
+	It("should return true when has the ResourceData is equals", func() {
+		Expect(resource.isGVKEqualTo(ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"})).To(BeTrue())
+	})
+
+	It("should return false when ResourceData is NOT equals", func() {
+		Expect(resource.isGVKEqualTo(ResourceData{Group: "Foo", Kind: "Baz", Version: "v2"})).To(BeFalse())
+	})
+
+	It("should return true when the API is empty", func() {
+		resource.API = &API{
+			Namespaced: false,
+			CRDVersion: "",
+		}
+		Expect(resource.API.IsEmpty()).To(BeTrue())
+	})
+
+	It("should return true when the API is NOT empty", func() {
+		resource.API = &API{
+			Namespaced: true,
+			CRDVersion: "",
+		}
+		Expect(resource.API.IsEmpty()).To(BeFalse())
+	})
+
+	It("should return true when the WebHooks is empty", func() {
+		resource.Webhooks = &Webhooks{WebhookVersion: ""}
+		Expect(resource.Webhooks.IsEmpty()).To(BeTrue())
+	})
+
+	It("should return true when the WebHooks is NOT empty", func() {
+		resource.Webhooks = &Webhooks{WebhookVersion: "v1"}
+		Expect(resource.Webhooks.IsEmpty()).To(BeFalse())
+	})
+
+	It("IsV2 should return true when the config is V2", func() {
+		cfg := Config{Version: Version2}
+		Expect(cfg.IsV2()).To(BeTrue())
+	})
+
+	It("IsV3 should return true when the config is V3", func() {
+		cfg := Config{Version: Version3Alpha}
+		Expect(cfg.IsV3()).To(BeTrue())
+	})
 
 	It("should encode correctly", func() {
 		var (
@@ -165,56 +247,61 @@ var _ = Describe("PluginConfig", func() {
 	})
 })
 
-var _ = Describe("Resource Version Compatibility", func() {
+var _ = Describe("ResourceData Version Compatibility", func() {
 
 	var (
-		c          *Config
-		gvk1, gvk2 GVK
+		c                    *Config
+		resource1, resource2 ResourceData
 
 		defaultVersion = "v1"
 	)
 
 	BeforeEach(func() {
 		c = &Config{}
-		gvk1 = GVK{Group: "example", Version: "v1", Kind: "TestKind"}
-		gvk2 = GVK{Group: "example", Version: "v1", Kind: "TestKind2"}
+		resource1 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind"}
+		resource2 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind2"}
 	})
 
 	Context("resourceAPIVersionCompatible", func() {
 		It("returns true for a list of empty resources", func() {
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns true for one resource with an empty version", func() {
-			c.Resources = []GVK{gvk1}
+			c.Resources = []ResourceData{resource1}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns true for one resource with matching version", func() {
-			gvk1.CRDVersion = defaultVersion
-			c.Resources = []GVK{gvk1}
+			resource1.API = &API{CRDVersion: defaultVersion}
+			resource1.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			c.Resources = []ResourceData{resource1}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns true for two resources with matching versions", func() {
-			gvk1.CRDVersion = defaultVersion
-			gvk2.CRDVersion = defaultVersion
-			c.Resources = []GVK{gvk1, gvk2}
+			resource1.API = &API{CRDVersion: defaultVersion}
+			resource1.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			resource2.API = &API{CRDVersion: defaultVersion}
+			resource2.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			c.Resources = []ResourceData{resource1, resource2}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns false for one resource with a non-matching version", func() {
-			gvk1.CRDVersion = v1beta1
-			c.Resources = []GVK{gvk1}
+			resource1.API = &API{CRDVersion: v1beta1}
+			resource1.Webhooks = &Webhooks{WebhookVersion: v1beta1}
+			c.Resources = []ResourceData{resource1}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeFalse())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeFalse())
 		})
 		It("returns false for two resources containing a non-matching version", func() {
-			gvk1.CRDVersion = v1beta1
-			gvk2.CRDVersion = defaultVersion
-			c.Resources = []GVK{gvk1, gvk2}
+			resource1.API = &API{CRDVersion: v1beta1}
+			resource1.Webhooks = &Webhooks{WebhookVersion: v1beta1}
+			resource2.API = &API{CRDVersion: defaultVersion}
+			resource2.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			c.Resources = []ResourceData{resource1, resource2}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeFalse())
-		})
-
-		It("returns false for two resources containing a non-matching version (webhooks)", func() {
-			gvk1.WebhookVersion = v1beta1
-			gvk2.WebhookVersion = defaultVersion
-			c.Resources = []GVK{gvk1, gvk2}
 			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeFalse())
 		})
 	})
@@ -223,35 +310,49 @@ var _ = Describe("Resource Version Compatibility", func() {
 var _ = Describe("Config", func() {
 	var (
 		c          *Config
-		gvk1, gvk2 GVK
+		gvk1, gvk2 ResourceData
 	)
 
 	BeforeEach(func() {
 		c = &Config{}
-		gvk1 = GVK{Group: "example", Version: "v1", Kind: "TestKind"}
-		gvk2 = GVK{Group: "example", Version: "v1", Kind: "TestKind2"}
+		gvk1 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind"}
+		gvk2 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind2"}
 	})
 
 	Context("UpdateResource", func() {
 		It("Adds a non-existing resource", func() {
 			c.UpdateResources(gvk1)
-			Expect(c.Resources).To(Equal([]GVK{gvk1}))
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
 			// Update again to ensure idempotency.
 			c.UpdateResources(gvk1)
-			Expect(c.Resources).To(Equal([]GVK{gvk1}))
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
 		})
 		It("Updates an existing resource", func() {
 			c.UpdateResources(gvk1)
-			gvk := GVK{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind, CRDVersion: "v1"}
-			c.UpdateResources(gvk)
-			Expect(c.Resources).To(Equal([]GVK{gvk}))
+			resource := ResourceData{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind}
+			c.UpdateResources(resource)
+			Expect(c.Resources).To(Equal([]ResourceData{resource}))
 		})
 		It("Updates an existing resource with more than one resource present", func() {
 			c.UpdateResources(gvk1)
 			c.UpdateResources(gvk2)
-			gvk := GVK{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind, CRDVersion: "v1"}
+			gvk := ResourceData{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind}
 			c.UpdateResources(gvk)
-			Expect(c.Resources).To(Equal([]GVK{gvk, gvk2}))
+			Expect(c.Resources).To(Equal([]ResourceData{gvk, gvk2}))
 		})
+	})
+
+	Context("HasGroup", func() {
+		It("should return true when config has a resource with the group", func() {
+			c.UpdateResources(gvk1)
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
+			Expect(c.HasGroup(gvk1.Group)).To(BeTrue())
+		})
+		It("should return false when config has a resource with not the same group", func() {
+			c.UpdateResources(gvk1)
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
+			Expect(c.HasGroup("hasNot")).To(BeFalse())
+		})
+
 	})
 })

--- a/pkg/model/file/interfaces.go
+++ b/pkg/model/file/interfaces.go
@@ -55,10 +55,10 @@ type Inserter interface {
 	GetCodeFragments() CodeFragmentsMap
 }
 
-// HasDomain allows the domain to be used on a template
-type HasDomain interface {
-	// InjectDomain sets the template domain
-	InjectDomain(string)
+// HasQualified allows the domain to be used on a template
+type HasQualified interface {
+	// InjectQualifiedGroup sets the template domain
+	InjectQualifiedGroup(string)
 }
 
 // HasRepository allows the repository to be used on a template

--- a/pkg/model/file/mixins.go
+++ b/pkg/model/file/mixins.go
@@ -67,16 +67,16 @@ func (t *InserterMixin) GetIfExistsAction() IfExistsAction {
 	return Overwrite
 }
 
-// DomainMixin provides templates with a injectable domain field
-type DomainMixin struct {
-	// Domain is the domain for the APIs
-	Domain string
+// QualifiedGroupMixin provides templates with a injectable domain field
+type QualifiedGroupMixin struct {
+	// QualifiedGroup is the domain for the APIs
+	QualifiedGroup string
 }
 
-// InjectDomain implements HasDomain
-func (m *DomainMixin) InjectDomain(domain string) {
-	if m.Domain == "" {
-		m.Domain = domain
+// InjectQualifiedGroup implements HasQualifiedGroup
+func (m *QualifiedGroupMixin) InjectQualifiedGroup(qualifiedGroup string) {
+	if m.QualifiedGroup == "" {
+		m.QualifiedGroup = qualifiedGroup
 	}
 }
 

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -24,6 +24,7 @@ import (
 )
 
 // Resource contains the information required to scaffold files for a resource.
+// nolint: maligned
 type Resource struct {
 	// Group is the API Group. Does not contain the domain.
 	Group string `json:"group,omitempty"`
@@ -43,29 +44,41 @@ type Resource struct {
 	// ImportAlias is a cleaned concatenation of Group and Version.
 	ImportAlias string `json:"-"`
 
-	// Package is the go package of the Resource.
-	Package string `json:"package,omitempty"`
+	// Endpoint is the API endpoint which is used import the go package of the Resource.
+	Endpoint string `json:"endpoint,omitempty"`
 
-	// Domain is the Group + "." + Domain of the Resource.
+	// QualifiedGroup is the Group + "." + QualifiedGroup of the Resource.
+	QualifiedGroup string `json:"qualified-group,omitempty"`
+
+	// Domain is the Group + "." + QualifiedGroup of the Resource.
 	Domain string `json:"domain,omitempty"`
 
+	// Controller holds true when the controller is scaffolded
+	Controller bool `json:"controller,omitempty"`
+
 	// Namespaced is true if the resource is namespaced.
+	// todo: remove when the v2 is no longer supported
 	Namespaced bool `json:"namespaced,omitempty"`
 
-	// CRDVersion holds the CustomResourceDefinition API version used for the Resource.
-	CRDVersion string `json:"crdVersion,omitempty"`
-	// WebhookVersion holds the {Validating,Mutating}WebhookConfiguration API version used for the Resource.
-	WebhookVersion string `json:"webhookVersion,omitempty"`
+	// API holds the the api data that is scaffolded
+	API config.API `json:"api,omitempty"`
+
+	// Webhooks holds webhooks data that is scaffolded
+	Webhooks config.Webhooks `json:"webhooks,omitempty"`
 }
 
-// GVK returns the group-version-kind information to check against tracked resources in the configuration file
-func (r *Resource) GVK() config.GVK {
-	return config.GVK{
-		Group:          r.Group,
-		Version:        r.Version,
-		Kind:           r.Kind,
-		CRDVersion:     r.CRDVersion,
-		WebhookVersion: r.WebhookVersion,
+// Data returns the ResourceData information to check against tracked resources in the configuration file
+func (r *Resource) Data() config.ResourceData {
+	return config.ResourceData{
+		Group:      r.Group,
+		Version:    r.Version,
+		Kind:       r.Kind,
+		Domain:     r.Domain,
+		Plural:     r.Plural,
+		Endpoint:   r.Endpoint,
+		Controller: r.Controller,
+		API:        &r.API,
+		Webhooks:   &r.Webhooks,
 	}
 }
 

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Resource", func() {
 					Domain:  "test.io",
 					Repo:    "test",
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Namespaced).To(Equal(options.Namespaced))
 			Expect(resource.Group).To(Equal(options.Group))
@@ -47,8 +47,8 @@ var _ = Describe("Resource", func() {
 			Expect(resource.Kind).To(Equal(options.Kind))
 			Expect(resource.Plural).To(Equal("firstmates"))
 			Expect(resource.ImportAlias).To(Equal("crewv1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "api", "v1")))
-			Expect(resource.Domain).To(Equal("crew.test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "api", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("crew.test.io"))
 
 			resource = options.NewResource(
 				&config.Config{
@@ -57,7 +57,7 @@ var _ = Describe("Resource", func() {
 					Repo:       "test",
 					MultiGroup: true,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Namespaced).To(Equal(options.Namespaced))
 			Expect(resource.Group).To(Equal(options.Group))
@@ -66,8 +66,8 @@ var _ = Describe("Resource", func() {
 			Expect(resource.Kind).To(Equal(options.Kind))
 			Expect(resource.Plural).To(Equal("firstmates"))
 			Expect(resource.ImportAlias).To(Equal("crewv1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "apis", "crew", "v1")))
-			Expect(resource.Domain).To(Equal("crew.test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "apis", "crew", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("crew.test.io"))
 		})
 
 		It("should default the Plural by pluralizing the Kind", func() {
@@ -82,28 +82,28 @@ var _ = Describe("Resource", func() {
 			options := &Options{Group: "crew", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource := options.NewResource(singleGroupConfig, true)
+			resource := options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("firstmates"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("firstmates"))
 
 			options = &Options{Group: "crew", Version: "v1", Kind: "Fish"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, true)
+			resource = options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("fish"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("fish"))
 
 			options = &Options{Group: "crew", Version: "v1", Kind: "Helmswoman"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, true)
+			resource = options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("helmswomen"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("helmswomen"))
 		})
 
@@ -115,7 +115,7 @@ var _ = Describe("Resource", func() {
 				&config.Config{
 					Version: config.Version2,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Plural).To(Equal("mates"))
 
@@ -124,7 +124,7 @@ var _ = Describe("Resource", func() {
 					Version:    config.Version2,
 					MultiGroup: true,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Plural).To(Equal("mates"))
 		})
@@ -145,37 +145,37 @@ var _ = Describe("Resource", func() {
 			options := &Options{Group: "my-project", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource := options.NewResource(singleGroupConfig, true)
+			resource := options.NewResource(singleGroupConfig, true, true)
 
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "api", "v1")))
-			Expect(resource.Domain).To(Equal("my-project.test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "api", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("my-project.test.io"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "apis", "my-project", "v1")))
-			Expect(resource.Domain).To(Equal("my-project.test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "apis", "my-project", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("my-project.test.io"))
 
 			options = &Options{Group: "my.project", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, true)
+			resource = options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "api", "v1")))
-			Expect(resource.Domain).To(Equal("my.project.test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "api", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("my.project.test.io"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "apis", "my.project", "v1")))
-			Expect(resource.Domain).To(Equal("my.project.test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "apis", "my.project", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("my.project.test.io"))
 		})
 
 		It("should not append '.' if provided an empty domain", func() {
@@ -186,18 +186,18 @@ var _ = Describe("Resource", func() {
 				&config.Config{
 					Version: config.Version2,
 				},
-				true,
+				true, true,
 			)
-			Expect(resource.Domain).To(Equal("crew"))
+			Expect(resource.QualifiedGroup).To(Equal("crew"))
 
 			resource = options.NewResource(
 				&config.Config{
 					Version:    config.Version2,
 					MultiGroup: true,
 				},
-				true,
+				true, true,
 			)
-			Expect(resource.Domain).To(Equal("crew"))
+			Expect(resource.QualifiedGroup).To(Equal("crew"))
 		})
 
 		It("should use core apis", func() {
@@ -216,24 +216,24 @@ var _ = Describe("Resource", func() {
 			options := &Options{Group: "apps", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource := options.NewResource(singleGroupConfig, false)
-			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
-			Expect(resource.Domain).To(Equal("apps"))
+			resource := options.NewResource(singleGroupConfig, false, true)
+			Expect(resource.Endpoint).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
+			Expect(resource.QualifiedGroup).To(Equal("apps"))
 
-			resource = options.NewResource(multiGroupConfig, false)
-			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
-			Expect(resource.Domain).To(Equal("apps"))
+			resource = options.NewResource(multiGroupConfig, false, true)
+			Expect(resource.Endpoint).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
+			Expect(resource.QualifiedGroup).To(Equal("apps"))
 
 			options = &Options{Group: "authentication", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, false)
-			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
-			Expect(resource.Domain).To(Equal("authentication.k8s.io"))
+			resource = options.NewResource(singleGroupConfig, false, true)
+			Expect(resource.Endpoint).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
+			Expect(resource.QualifiedGroup).To(Equal("authentication.k8s.io"))
 
-			resource = options.NewResource(multiGroupConfig, false)
-			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
-			Expect(resource.Domain).To(Equal("authentication.k8s.io"))
+			resource = options.NewResource(multiGroupConfig, false, true)
+			Expect(resource.Endpoint).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
+			Expect(resource.QualifiedGroup).To(Equal("authentication.k8s.io"))
 		})
 		It("should use domain if the group is empty for version v3", func() {
 			options := &Options{Version: "v1", Kind: "FirstMate"}
@@ -245,7 +245,7 @@ var _ = Describe("Resource", func() {
 					Domain:  "test.io",
 					Repo:    "test",
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Namespaced).To(Equal(options.Namespaced))
 			Expect(resource.Group).To(Equal(""))
@@ -254,8 +254,8 @@ var _ = Describe("Resource", func() {
 			Expect(resource.Kind).To(Equal(options.Kind))
 			Expect(resource.Plural).To(Equal("firstmates"))
 			Expect(resource.ImportAlias).To(Equal("testiov1"))
-			Expect(resource.Package).To(Equal(path.Join("test", "api", "v1")))
-			Expect(resource.Domain).To(Equal("test.io"))
+			Expect(resource.Endpoint).To(Equal(path.Join("test", "api", "v1")))
+			Expect(resource.QualifiedGroup).To(Equal("test.io"))
 		})
 	})
 })

--- a/pkg/model/universe.go
+++ b/pkg/model/universe.go
@@ -82,8 +82,8 @@ func WithResource(resource *resource.Resource) UniverseOption {
 func (u Universe) InjectInto(builder file.Builder) {
 	// Inject project configuration
 	if u.Config != nil {
-		if builderWithDomain, hasDomain := builder.(file.HasDomain); hasDomain {
-			builderWithDomain.InjectDomain(u.Config.Domain)
+		if builderWithDomain, hasQualifiedGroup := builder.(file.HasQualified); hasQualifiedGroup {
+			builderWithDomain.InjectQualifiedGroup(u.Config.Domain)
 		}
 		if builderWithRepository, hasRepository := builder.(file.HasRepository); hasRepository {
 			builderWithRepository.InjectRepository(u.Config.Repo)

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -143,7 +143,7 @@ func (p *createAPISubcommand) Validate() error {
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.doResource {
 		// Check that resource doesn't exist or flag force was set
-		if !p.force && p.config.HasResource(p.resource.GVK()) {
+		if !p.force && p.config.GetResource(p.resource.Data()) != nil {
 			return errors.New("API resource already exists")
 		}
 
@@ -176,7 +176,7 @@ func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewResource(p.config, p.doResource)
+	res := p.resource.NewResource(p.config, p.doResource, p.doController)
 	return scaffolds.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
 }
 

--- a/pkg/plugins/golang/v2/scaffolds/api.go
+++ b/pkg/plugins/golang/v2/scaffolds/api.go
@@ -93,7 +93,7 @@ func (s *apiScaffolder) newUniverse() *model.Universe {
 
 func (s *apiScaffolder) scaffold() error {
 	if s.doResource {
-		s.config.UpdateResources(s.resource.GVK())
+		s.config.UpdateResources(s.resource.Data())
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/api/group.go
@@ -53,7 +53,7 @@ const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
 // +kubebuilder:object:generate=true
-// +groupName={{ .Resource.Domain }}
+// +groupName={{ .Resource.QualifiedGroup }}
 package {{ .Resource.Version }}
 
 import (
@@ -63,7 +63,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.Domain }}", Version: "{{ .Resource.Version }}"}
+	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.QualifiedGroup }}", Version: "{{ .Resource.Version }}"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/api/webhook.go
@@ -65,7 +65,7 @@ func (f *Webhook) SetTemplateDefaults() error {
 
 	f.IfExistsAction = file.Error
 
-	f.GroupDomainWithDash = strings.Replace(f.Resource.Domain, ".", "-", -1)
+	f.GroupDomainWithDash = strings.Replace(f.Resource.QualifiedGroup, ".", "-", -1)
 
 	return nil
 }
@@ -100,7 +100,7 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 	//nolint:lll
 	defaultingWebhookTemplate = `
-// +kubebuilder:webhook:path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io
+// +kubebuilder:webhook:path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io
 
 var _ webhook.Defaulter = &{{ .Resource.Kind }}{}
 
@@ -114,7 +114,7 @@ func (r *{{ .Resource.Kind }}) Default() {
 	//nolint:lll
 	validatingWebhookTemplate = `
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
+// +kubebuilder:webhook:verbs=create;update,path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
 
 var _ webhook.Validator = &{{ .Resource.Kind }}{}
 

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -78,7 +78,7 @@ func (f *Kustomization) GetCodeFragments() file.CodeFragmentsMap {
 
 	// Generate resource code fragments
 	res := make([]string, 0)
-	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.Domain, f.Resource.Plural))
+	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.QualifiedGroup, f.Resource.Plural))
 
 	// Generate resource code fragments
 	webhookPatch := make([]string, 0)

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
@@ -49,5 +49,5 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: {{ .Resource.Plural }}.{{ .Resource.Domain }}
+  name: {{ .Resource.Plural }}.{{ .Resource.QualifiedGroup }}
 `

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
@@ -47,7 +47,7 @@ const enableWebhookPatchTemplate = `# The following patch enables conversion web
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: {{ .Resource.Plural }}.{{ .Resource.Domain }}
+  name: {{ .Resource.Plural }}.{{ .Resource.QualifiedGroup }}
 spec:
   conversion:
     strategy: Webhook

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
@@ -49,7 +49,7 @@ metadata:
   name: {{ lower .Resource.Kind }}-editor-role
 rules:
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}
   verbs:
@@ -61,7 +61,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}/status
   verbs:

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
@@ -49,7 +49,7 @@ metadata:
   name: {{ lower .Resource.Kind }}-viewer-role
 rules:
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}
   verbs:
@@ -57,7 +57,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}/status
   verbs:

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -44,7 +44,7 @@ func (f *CRDSample) SetTemplateDefaults() error {
 	return nil
 }
 
-const crdSampleTemplate = `apiVersion: {{ .Resource.Domain }}/{{ .Resource.Version }}
+const crdSampleTemplate = `apiVersion: {{ .Resource.QualifiedGroup }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:
   name: {{ lower .Resource.Kind }}-sample

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
@@ -68,7 +68,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	{{ if .WireResource -}}
-	{{ .Resource.ImportAlias }} "{{ .Resource.Package }}"
+	{{ .Resource.ImportAlias }} "{{ .Resource.Endpoint }}"
 	{{- end }}
 )
 
@@ -79,8 +79,8 @@ type {{ .Resource.Kind }}Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
 func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -96,7 +96,7 @@ func (f *SuiteTest) GetCodeFragments() file.CodeFragmentsMap {
 	// Generate import code fragments
 	imports := make([]string, 0)
 	if f.WireResource {
-		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Package))
+		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Endpoint))
 	}
 
 	// Generate add scheme code fragments

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/main.go
@@ -31,7 +31,7 @@ var _ file.Template = &Main{}
 type Main struct {
 	file.TemplateMixin
 	file.BoilerplateMixin
-	file.DomainMixin
+	file.QualifiedGroupMixin
 	file.RepositoryMixin
 }
 
@@ -139,7 +139,7 @@ func (f *MainUpdater) GetCodeFragments() file.CodeFragmentsMap {
 	// Generate import code fragments
 	imports := make([]string, 0)
 	if f.WireResource {
-		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Package))
+		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Endpoint))
 	}
 
 	if f.WireController {
@@ -230,7 +230,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "{{ hashFNV .Repo }}.{{ .Domain }}",
+		LeaderElectionID:   "{{ hashFNV .Repo }}.{{ .QualifiedGroup }}",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -96,7 +96,7 @@ func (p *createWebhookSubcommand) Validate() error {
 	}
 
 	// check if resource exist to create webhook
-	if !p.config.HasResource(p.resource.GVK()) {
+	if p.config.GetResource(p.resource.Data()) == nil {
 		return fmt.Errorf("%s create webhook requires an api with the group,"+
 			" kind and version provided", p.commandName)
 	}
@@ -112,7 +112,7 @@ func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewResource(p.config, false)
+	res := p.resource.NewResource(p.config, false, false)
 	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.defaulting, p.validation, p.conversion), nil
 }
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/group.go
@@ -57,7 +57,7 @@ const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
 // +kubebuilder:object:generate=true
-// +groupName={{ .Resource.Domain }}
+// +groupName={{ .Resource.QualifiedGroup }}
 package {{ .Resource.Version }}
 
 import (
@@ -67,7 +67,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.Domain }}", Version: "{{ .Resource.Version }}"}
+	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.QualifiedGroup }}", Version: "{{ .Resource.Version }}"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go
@@ -26,6 +26,7 @@ import (
 var _ file.Template = &Types{}
 
 // Types scaffolds the file that defines the schema for a CRD
+// nolint: maligned
 type Types struct {
 	file.TemplateMixin
 	file.MultiGroupMixin
@@ -84,7 +85,7 @@ type {{ .Resource.Kind }}Status struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-{{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
+{{ if not .Resource.API.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
 
 // {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
 type {{ .Resource.Kind }} struct {

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook.go
@@ -71,7 +71,7 @@ func (f *Webhook) SetTemplateDefaults() error {
 
 	f.IfExistsAction = file.Error
 
-	f.GroupDomainWithDash = strings.Replace(f.Resource.Domain, ".", "-", -1)
+	f.GroupDomainWithDash = strings.Replace(f.Resource.QualifiedGroup, ".", "-", -1)
 
 	if f.WebhookVersion == "" {
 		f.WebhookVersion = "v1"
@@ -111,7 +111,7 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	// TODO(estroz): update admissionReviewVersions to include v1 when controller-runtime supports that version.
 	//nolint:lll
 	defaultingWebhookTemplate = `
-// +kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1beta1}
+// +kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1beta1}
 
 var _ webhook.Defaulter = &{{ .Resource.Kind }}{}
 
@@ -127,7 +127,7 @@ func (r *{{ .Resource.Kind }}) Default() {
 	//nolint:lll
 	validatingWebhookTemplate = `
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1beta1}
+// +kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1beta1}
 
 var _ webhook.Validator = &{{ .Resource.Kind }}{}
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/crd/kustomization.go
@@ -78,7 +78,7 @@ func (f *Kustomization) GetCodeFragments() file.CodeFragmentsMap {
 
 	// Generate resource code fragments
 	res := make([]string, 0)
-	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.Domain, f.Resource.Plural))
+	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.QualifiedGroup, f.Resource.Plural))
 
 	// Generate resource code fragments
 	webhookPatch := make([]string, 0)

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
@@ -61,5 +61,5 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: {{ .Resource.Plural }}.{{ .Resource.Domain }}
+  name: {{ .Resource.Plural }}.{{ .Resource.QualifiedGroup }}
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
@@ -56,7 +56,7 @@ const enableWebhookPatchTemplate = `# The following patch enables a conversion w
 apiVersion: apiextensions.k8s.io/{{ .CRDVersion }}
 kind: CustomResourceDefinition
 metadata:
-  name: {{ .Resource.Plural }}.{{ .Resource.Domain }}
+  name: {{ .Resource.Plural }}.{{ .Resource.QualifiedGroup }}
 spec:
   conversion:
     strategy: Webhook

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/controller_manager_config.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/controller_manager_config.go
@@ -27,7 +27,7 @@ var _ file.Template = &ControllerManagerConfig{}
 // ControllerManagerConfig scaffolds the config file in config/manager folder.
 type ControllerManagerConfig struct {
 	file.TemplateMixin
-	file.DomainMixin
+	file.QualifiedGroupMixin
 	file.RepositoryMixin
 }
 
@@ -54,5 +54,5 @@ webhook:
   port: 9443
 leaderElection:
   leaderElect: true
-  resourceName: {{ hashFNV .Repo }}.{{ .Domain }}
+  resourceName: {{ hashFNV .Repo }}.{{ .QualifiedGroup }}
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/crd_editor_role.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/crd_editor_role.go
@@ -49,7 +49,7 @@ metadata:
   name: {{ lower .Resource.Kind }}-editor-role
 rules:
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}
   verbs:
@@ -61,7 +61,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}/status
   verbs:

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
@@ -49,7 +49,7 @@ metadata:
   name: {{ lower .Resource.Kind }}-viewer-role
 rules:
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}
   verbs:
@@ -57,7 +57,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - {{ .Resource.Domain }}
+  - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}/status
   verbs:

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -44,7 +44,7 @@ func (f *CRDSample) SetTemplateDefaults() error {
 	return nil
 }
 
-const crdSampleTemplate = `apiVersion: {{ .Resource.Domain }}/{{ .Resource.Version }}
+const crdSampleTemplate = `apiVersion: {{ .Resource.QualifiedGroup }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:
   name: {{ lower .Resource.Kind }}-sample

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
@@ -74,7 +74,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	{{ if .WireResource -}}
-	{{ .Resource.ImportAlias }} "{{ .Resource.Package }}"
+	{{ .Resource.ImportAlias }} "{{ .Resource.Endpoint }}"
 	{{- end }}
 )
 
@@ -85,9 +85,9 @@ type {{ .Resource.Kind }}Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/finalizers,verbs=update
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -96,7 +96,7 @@ func (f *SuiteTest) GetCodeFragments() file.CodeFragmentsMap {
 	// Generate import code fragments
 	imports := make([]string, 0)
 	if f.WireResource {
-		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Package))
+		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Endpoint))
 	}
 
 	// Generate add scheme code fragments

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
@@ -31,7 +31,7 @@ var _ file.Template = &Main{}
 type Main struct {
 	file.TemplateMixin
 	file.BoilerplateMixin
-	file.DomainMixin
+	file.QualifiedGroupMixin
 	file.RepositoryMixin
 	file.ComponentConfigMixin
 }
@@ -134,7 +134,7 @@ func (f *MainUpdater) GetCodeFragments() file.CodeFragmentsMap {
 	// Generate import code fragments
 	imports := make([]string, 0)
 	if f.WireResource {
-		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Package))
+		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias, f.Resource.Endpoint))
 	}
 
 	if f.WireController {
@@ -246,7 +246,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "{{ hashFNV .Repo }}.{{ .Domain }}",
+		LeaderElectionID:       "{{ hashFNV .Repo }}.{{ .QualifiedGroup }}",
 	})
 {{- else }}
 	var err error

--- a/plugins/addon/controller.go
+++ b/plugins/addon/controller.go
@@ -48,7 +48,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	api "{{ .Resource.Package }}"
+	api "{{ .Resource.Endpoint }}"
 )
 
 var _ reconcile.Reconciler = &{{ .Resource.Kind }}Reconciler{}
@@ -62,8 +62,8 @@ type {{ .Resource.Kind }}Reconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v2-multigroup/config/rbac/role.yaml
+++ b/testdata/project-v2-multigroup/config/rbac/role.yaml
@@ -27,6 +27,26 @@ rules:
   - patch
   - update
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - crew.testproject.org
   resources:
   - captains

--- a/testdata/project-v2-multigroup/controllers/authentication/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/authentication/suite_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/testdata/project-v2-multigroup/controllers/authentication/tokenreview_controller.go
+++ b/testdata/project-v2-multigroup/controllers/authentication/tokenreview_controller.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TokenReviewReconciler reconciles a TokenReview object
+type TokenReviewReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews/status,verbs=get;update;patch
+
+func (r *TokenReviewReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	_ = context.Background()
+	_ = r.Log.WithValues("tokenreview", req.NamespacedName)
+
+	// your logic here
+
+	return ctrl.Result{}, nil
+}
+
+func (r *TokenReviewReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
+		// For().
+		Complete(r)
+}

--- a/testdata/project-v2-multigroup/main.go
+++ b/testdata/project-v2-multigroup/main.go
@@ -35,6 +35,7 @@ import (
 	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/ship/v1beta1"
 	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/ship/v2alpha1"
 	appscontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/apps"
+	authenticationcontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/authentication"
 	crewcontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/crew"
 	foopolicycontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/foo.policy"
 	seacreaturescontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/sea-creatures"
@@ -161,6 +162,14 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
+		os.Exit(1)
+	}
+	if err = (&authenticationcontroller.TokenReviewReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("TokenReview"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "TokenReview")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/testdata/project-v3-addon/PROJECT
+++ b/testdata/project-v3-addon/PROJECT
@@ -3,15 +3,23 @@ layout: go.kubebuilder.io/v3-alpha
 projectName: project-v3-addon
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: Captain
   version: v1
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: FirstMate
   version: v1
-- crdVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
   group: crew
   kind: Admiral
   version: v1

--- a/testdata/project-v3-config/PROJECT
+++ b/testdata/project-v3-config/PROJECT
@@ -4,19 +4,38 @@ layout: go.kubebuilder.io/v3-alpha
 projectName: project-v3-config
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-config
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: Captain
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: FirstMate
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    conversion: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
   group: crew
   kind: Admiral
   version: v1
-  webhookVersion: v1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
+- controller: true
+  group: crew
+  kind: Laker
+  version: v1
 version: 3-alpha

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -4,40 +4,86 @@ multigroup: true
 projectName: project-v3-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: Captain
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: ship
   kind: Frigate
   version: v1beta1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    conversion: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
   group: ship
   kind: Destroyer
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
   group: ship
   kind: Cruiser
   version: v2alpha1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: sea-creatures
   kind: Kraken
   version: v1beta1
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: sea-creatures
   kind: Leviathan
   version: v1beta2
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: foo.policy
   kind: HealthCheckPolicy
   version: v1
-- crdVersion: v1
+- controller: true
+  endpoint: k8s.io/api/apps/v1
+  group: apps
+  kind: Pod
+  version: v1
+- controller: true
+  domain: k8s.io
+  endpoint: k8s.io/api/authentication/v1
+  group: authentication
+  kind: TokenReview
+  version: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: testproject.org
   kind: Lakers
   version: v1
-  webhookVersion: v1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 version: 3-alpha

--- a/testdata/project-v3-multigroup/config/rbac/role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/role.yaml
@@ -33,6 +33,32 @@ rules:
   - patch
   - update
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - crew.testproject.org
   resources:
   - captains

--- a/testdata/project-v3-multigroup/controllers/authentication/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/authentication/suite_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authentication
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/testdata/project-v3-multigroup/controllers/authentication/tokenreview_controller.go
+++ b/testdata/project-v3-multigroup/controllers/authentication/tokenreview_controller.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authentication
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TokenReviewReconciler reconciles a TokenReview object
+type TokenReviewReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the TokenReview object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0-alpha.8/pkg/reconcile
+func (r *TokenReviewReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = r.Log.WithValues("tokenreview", req.NamespacedName)
+
+	// your logic here
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TokenReviewReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
+		// For().
+		Complete(r)
+}

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -41,6 +41,7 @@ import (
 	testprojectorgv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers"
 	appscontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/apps"
+	authenticationcontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/authentication"
 	crewcontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/crew"
 	foopolicycontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/foo.policy"
 	seacreaturescontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/sea-creatures"
@@ -175,6 +176,14 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
+		os.Exit(1)
+	}
+	if err = (&authenticationcontrollers.TokenReviewReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("authentication").WithName("TokenReview"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "TokenReview")
 		os.Exit(1)
 	}
 	if err = (&controllers.LakersReconciler{

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -3,19 +3,38 @@ layout: go.kubebuilder.io/v3-alpha
 projectName: project-v3
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: Captain
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
   group: crew
   kind: FirstMate
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    conversion: true
+    webhookVersion: v1
+- api:
+    crdVersion: v1
+  controller: true
   group: crew
   kind: Admiral
   version: v1
-  webhookVersion: v1
+  webhooks:
+    defaulting: true
+    webhookVersion: v1
+- controller: true
+  group: crew
+  kind: Laker
+  version: v1
 version: 3-alpha


### PR DESCRIPTION
**Description**

Store in the PROJECT file:
- webhooks data
- if has or not an api scaffolded
- if has or not a controller scaffolded
- API domain  and endpoint when it is not the default form
- Plural form when it is not the default form

Refractories/Cleanups suggested: 
- Rename Domain in the internal code for QualifiedGroup
- Rename Package for Endpoint
- Rename GVK to ResourceData since it does not return only the GKV
- Replace `doResource` with `doAPI` only for v3  internal code. 

PS.: Note the plugin v2 internal code was changed/updated where only it would be mandatory in order to move forward with the changes. The idea is we ensure and not risk introduces breaking changes or bugs into it since we are closer to deprecated it.  

Regards the tests:
- Add new tests to cover the config
- Add new api scaffolded in the testdata for multigroup projects to cover better the k8s core types option.  

**Example**

Following an example with the edge cases and that cover nearly all scenarios. 

```yaml
domain: testproject.org
layout: go.kubebuilder.io/v3-alpha
multigroup: true
projectName: project-v3-multigroup
repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
resources:
- controller: true
  domain: k8s.io
  endpoint: k8s.io/api/authentication/v1
  group: authentication
  kind: TokenReview
  version: v1
- api:
    crdVersion: v1
    namespaced: true
  controller: true
  domain: testproject.org
  kind: Lakers
  version: v1
  webhooks:
    defaulting: true
    validation: true
    webhookVersion: v1
version: 3-alpha
```

**Motivation**
- Allow we have all project config into the config which can, for example, grant we re-create the project based on it. 
- keep the consistency across the project
- Allow we easily manage diff versions of apiVersions for webhooks and CRDs. See that the apiVersion fits very well as an attribute of its models. So, we could store the apiVersion which would allow how the tool should dealing with each case scenario. See: https://github.com/kubernetes-sigs/kubebuilder/pull/1644#discussion_r491227667

Close: https://github.com/kubernetes-sigs/kubebuilder/issues/1826

/hold

If we do not able o ve forward with https://github.com/kubernetes-sigs/kubebuilder/pull/1869 instead of this one. Then, here would be required to do a few changes : 
- Use the nomenclature Path instead of endpoint 
- Do not store the domain when it is a core value. 


