### PR TITLE
🐛 Remove unneeded caBundle value from webhook patches (V3 only)

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/manifests.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/manifests.yaml
@@ -7,7 +7,6 @@ metadata:
   name: mutating-webhook-configuration
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system
@@ -33,7 +32,6 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - clientConfig:
-    caBundle: Cg==
     service:
       name: webhook-service
       namespace: system

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/crd/enablewebhook_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/crd/enablewebhook_patch.go
@@ -52,9 +52,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-addon/config/crd/patches/webhook_in_admirals.yaml
+++ b/testdata/project-v3-addon/config/crd/patches/webhook_in_admirals.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-addon/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3-addon/config/crd/patches/webhook_in_captains.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-addon/config/crd/patches/webhook_in_firstmates.yaml
+++ b/testdata/project-v3-addon/config/crd/patches/webhook_in_firstmates.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_captains.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_cruisers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_cruisers.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_destroyers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_destroyers.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_frigates.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_frigates.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_healthcheckpolicies.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_healthcheckpolicies.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_krakens.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_krakens.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_lakers.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_leviathans.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_leviathans.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3/config/crd/patches/webhook_in_admirals.yaml
+++ b/testdata/project-v3/config/crd/patches/webhook_in_admirals.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3/config/crd/patches/webhook_in_captains.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service

--- a/testdata/project-v3/config/crd/patches/webhook_in_firstmates.yaml
+++ b/testdata/project-v3/config/crd/patches/webhook_in_firstmates.yaml
@@ -8,9 +8,6 @@ spec:
   conversion:
     strategy: Webhook
     webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
       service:
         namespace: system
         name: webhook-service


### PR DESCRIPTION
Instead of having a dummy value in `caBundle`, (`caBundle: Cg==`), instead just omit that field entirely as it is not required.
Doing this means that repeated `kubectl apply` operators on a CRD work better, in accordance with [the documented behavior of apply and how it considers last-applied-configuration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#merging-changes-to-map-fields), since they do not change the `resourceVersion` of the CRD.

This fixes #1684.
