### PR TITLE
🌱 Update triage/support label references to kind/support

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -2,7 +2,7 @@
 name: Question
 about: Any questions you might have.
 title: ''
-labels: triage/support
+labels: kind/support
 assignees: ''
 
 ---


### PR DESCRIPTION
The label triage/support has been reclassified as kind/support. The
kind/* family of labels makes more logical sense, as they describe the
"kind" of thing an issue or PR is.

For more information, see the announcement email:
https://groups.google.com/g/kubernetes-dev/c/YcaJpsjjLKw/m/i15cLLx5CAAJ

