### PR TITLE
:bug: check if resource exist to allow to create webhooks

### DIFF
--- a/pkg/plugin/v2/webhook.go
+++ b/pkg/plugin/v2/webhook.go
@@ -96,6 +96,12 @@ func (p *createWebhookPlugin) Validate() error {
 			" --programmatic-validation and --conversion to be true", p.commandName)
 	}
 
+	// check if resource exist to create webhook
+	if !p.config.HasResource(p.resource.GVK()) {
+		return fmt.Errorf("%s create webhook requires an api with the group,"+
+			" kind and version provided", p.commandName)
+	}
+
 	return nil
 }
 

--- a/pkg/plugin/v3/webhook.go
+++ b/pkg/plugin/v3/webhook.go
@@ -96,6 +96,12 @@ func (p *createWebhookPlugin) Validate() error {
 			" --programmatic-validation and --conversion to be true", p.commandName)
 	}
 
+	// check if resource exist to create webhook
+	if !p.config.HasResource(p.resource.GVK()) {
+		return fmt.Errorf("%s create webhook requires an api with the group,"+
+			" kind and version provided", p.commandName)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description**
Add check to ensure that the resource exists to allow create webhooks and avoid issues such as : 

```
# sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/ship/v1
apis/ship/v1/captain_webhook.go:29:10: undefined: Captain
apis/ship/v1/captain_webhook.go:39:28: undefined: Captain
apis/ship/v1/captain_webhook.go:42:10: undefined: Captain
apis/ship/v1/captain_webhook.go:51:28: undefined: Captain
apis/ship/v1/captain_webhook.go:54:10: undefined: Captain
apis/ship/v1/captain_webhook.go:62:10: undefined: Captain
apis/ship/v1/captain_webhook.go:70:10: undefined: Captain
```

**Motivation**
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1701