### PR TITLE
:seedling: the v2 webooks should use the v2 resource validation (:ghost:)

### DIFF
--- a/pkg/plugin/v2/webhook.go
+++ b/pkg/plugin/v2/webhook.go
@@ -87,7 +87,7 @@ func (p *createWebhookPlugin) Run() error {
 }
 
 func (p *createWebhookPlugin) Validate() error {
-	if err := p.resource.Validate(); err != nil {
+	if err := p.resource.ValidateV2(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Description

Follow up/fix of the PR:  https://github.com/kubernetes-sigs/kubebuilder/pull/1679/files#diff-5dd6baa6201e0ce7342b1eafbbb472e0R87-R89
Webhooks scaffolded with v2+ should use the V2 resource validation