### PR TITLE
:sparkles: add kubebuilder/tooling and controller setup to use binaries from the project bin (go/v3-alpha)

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -36,8 +36,10 @@ arch=$(go env GOARCH)
 # download kubebuilder and extract it to tmp
 curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
 ```
+<aside class="note">
+<h1>Adding EnvTest binaries to your PATH</h1>
 
-If you are using a Kubebuilder plugin version less than version `v3+`, you must configure the Kubernetes binaries required for the [envtest][envtest], run: 
+To add [envtest][envtest] binaries to your path: 
 
 ```bash
 # move to a long-term location and put it on your path
@@ -45,6 +47,10 @@ If you are using a Kubebuilder plugin version less than version `v3+`, you must 
 sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
 export PATH=$PATH:/usr/local/kubebuilder/bin
 ```
+
+It is **OPTIONAL** for projects built with CLI versions > 2.3.1. 
+
+</aside>
 
 <aside class="note">
 <h1>Using master branch</h1>

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -114,12 +115,16 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -154,6 +159,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwg
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -41,6 +41,8 @@ const (
 	ControllerToolsVersion = "v0.4.1"
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
 	KustomizeVersion = "v3.8.7"
+	// KubernetesVersion defines the version used to download the binaries
+	KubernetesVersion = "1.16.4"
 
 	imageName = "controller:latest"
 )
@@ -112,11 +114,10 @@ func (s *initScaffolder) scaffold() error {
 		&templates.GoMod{ControllerRuntimeVersion: ControllerRuntimeVersion},
 		&templates.GitIgnore{},
 		&templates.Makefile{
-			Image:                    imageName,
-			BoilerplatePath:          s.boilerplatePath,
-			ControllerToolsVersion:   ControllerToolsVersion,
-			KustomizeVersion:         KustomizeVersion,
-			ControllerRuntimeVersion: ControllerRuntimeVersion,
+			Image:                  imageName,
+			BoilerplatePath:        s.boilerplatePath,
+			ControllerToolsVersion: ControllerToolsVersion,
+			KustomizeVersion:       KustomizeVersion,
 		},
 		&templates.Dockerfile{},
 		&templates.DockerIgnore{},
@@ -128,5 +129,8 @@ func (s *initScaffolder) scaffold() error {
 		&certmanager.Certificate{},
 		&certmanager.Kustomization{},
 		&certmanager.KustomizeConfig{},
+		&hack.Tooling{
+			KubernetesVersion: KubernetesVersion,
+		},
 	)
 }

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -47,7 +47,7 @@ func (f *WebhookSuite) SetTemplateDefaults() error {
 	// If is multigroup the path needs to be ../../.. since it has the group dir.
 	f.BaseDirectoryRelativePath = `"..", ".."`
 	if f.MultiGroup && f.Resource.Group != "" {
-		f.BaseDirectoryRelativePath = `"..", "..",".."`
+		f.BaseDirectoryRelativePath = `"..", "..", ".."`
 	}
 
 	return nil
@@ -124,6 +124,7 @@ import (
 	"path/filepath"
 	"testing"
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -167,6 +168,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "webhook")},
 		},
+	}
+	
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == ""{
+		binaryAssetsPath, err := filepath.Abs(filepath.Join({{ .BaseDirectoryRelativePath }}, "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/gitignore.go
@@ -46,7 +46,6 @@ const gitignoreTemplate = `
 *.so
 *.dylib
 bin
-testbin/*
 
 # Test binary, build with ` + "`go test -c`" + `
 *.test

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/hack/tooling.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/hack/tooling.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hack
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v2/pkg/model/file"
+)
+
+var _ file.Template = &Tooling{}
+
+// Tooling scaffolds the tooling file in the root dir.
+type Tooling struct {
+	file.TemplateMixin
+	file.BoilerplateMixin
+
+	// KubernetesVersion defines the version used to download the binaries
+	KubernetesVersion string
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *Tooling) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("hack", "tooling.go")
+	}
+
+	f.TemplateBody = toolingTemplate
+
+	f.IfExistsAction = file.Error
+
+	return nil
+}
+
+// nolint: lll
+const toolingTemplate = `{{ .Boilerplate }}
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+const (
+	// defaultKubebuilderPath is the fixed value defined in the controller-runtime to looking for the
+	// binaries.
+	defaultKubebuilderPath = "/usr/local/kubebuilder/bin"
+
+	// kubernetesVersion defines the version used to download the binaries
+	kubernetesVersion = "{{ .KubernetesVersion }}"
+)
+
+func main() {
+	klog.Info("Checking EnvTest binaries")
+	assetsEnv := os.Getenv("KUBEBUILDER_ASSETS")
+	if strings.TrimSpace(assetsEnv) != "" {
+		klog.Infof("EnvTest binaries configured via KUBEBUILDER_ASSETS: %s", assetsEnv)
+		os.Exit(0)
+	}
+
+	binPath := filepath.Join("..", "bin")
+	if hasBinaries(binPath) {
+		klog.Info("EnvTest binaries found in bin/")
+		os.Exit(0)
+	}
+
+	klog.Infof("Downloading EnvTest tools")
+	envtest_tools_archive_name := getEnvToolsArchiveName()
+	envtest_tools_download_url := "https://storage.googleapis.com/kubebuilder-tools/" + envtest_tools_archive_name
+
+	err := downloadFile(envtest_tools_archive_name, envtest_tools_download_url)
+	if err != nil {
+		klog.Fatalf("unable to download the file (%v) from (%v): %v", envtest_tools_archive_name, envtest_tools_download_url, err)
+
+	}
+
+	if _, err := os.Stat(binPath); os.IsNotExist(err)  {
+		klog.Infof("Creating bin/ directory")
+		err = os.Mkdir(binPath, 0755)
+		if err != nil {
+			klog.Fatalf("error to create the bin/ directory : %s", err)
+		}
+	}
+
+	cmd := exec.Command("tar", "-C", binPath, "--strip-components=2", "-zvxf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatalf("error to untar bin %v: %v", filepath.Join(binPath, envtest_tools_archive_name ) ,err)
+	}
+
+	cmd = exec.Command("rm", "-rf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatal(err)
+	}
+	klog.Infof("EnvTest binaries are in the directory %v", binPath)
+}
+
+// getEnvToolsArchiveName will return the name of the env tools archive based or the arch and so
+func getEnvToolsArchiveName() string {
+	cmd := exec.Command("go", "env", "GOARCH")
+	goarch, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	cmd = exec.Command("go", "env", "GOOS")
+	goos, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return fmt.Sprintf("kubebuilder-tools-%s-%s-%s.tar.gz", kubernetesVersion, strings.TrimSpace(string(goos)), strings.TrimSpace(string(goarch)))
+}
+
+// hasBinaries will return true when the envtest binaries are found
+func hasBinaries(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err)  {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "etcd")); os.IsNotExist(err)  {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kube-apiserver")); os.IsNotExist(err)  {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kubectl")); os.IsNotExist(err)  {
+		return false
+	}
+	return true
+}
+
+// downloadFile will download a url to a local file.
+func downloadFile(filepath string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+`

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
@@ -35,8 +35,6 @@ type Makefile struct {
 	ControllerToolsVersion string
 	// Kustomize version to use in the project
 	KustomizeVersion string
-	// ControllerRuntimeVersion version to be used to download the envtest setup script
-	ControllerRuntimeVersion string
 }
 
 // SetTemplateDefaults implements file.Template
@@ -73,11 +71,12 @@ endif
 all: manager
 
 # Run tests
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/{{ .ControllerRuntimeVersion }}/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+test: generate fmt vet manifests tooling 
+	go test ./... -coverprofile cover.out
+
+# Get the env test binaries
+tooling:
+	cd hack/; go run tooling.go 
 
 # Build manager binary
 manager: generate fmt vet

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -14,11 +14,12 @@ endif
 all: manager
 
 # Run tests
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0-alpha.8/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+test: generate fmt vet manifests tooling 
+	go test ./... -coverprofile cover.out
+
+# Get the env test binaries
+tooling:
+	cd hack/; go run tooling.go 
 
 # Build manager binary
 manager: generate fmt vet

--- a/testdata/project-v3-addon/controllers/suite_test.go
+++ b/testdata/project-v3-addon/controllers/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -55,6 +57,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.10.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.7.0-alpha.8
 	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20201109180626-1cbf859290ca
 )

--- a/testdata/project-v3-addon/hack/tooling.go
+++ b/testdata/project-v3-addon/hack/tooling.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+const (
+	// defaultKubebuilderPath is the fixed value defined in the controller-runtime to looking for the
+	// binaries.
+	defaultKubebuilderPath = "/usr/local/kubebuilder/bin"
+
+	// kubernetesVersion defines the version used to download the binaries
+	kubernetesVersion = "1.16.4"
+)
+
+func main() {
+	klog.Info("Checking EnvTest binaries")
+	assetsEnv := os.Getenv("KUBEBUILDER_ASSETS")
+	if strings.TrimSpace(assetsEnv) != "" {
+		klog.Infof("EnvTest binaries configured via KUBEBUILDER_ASSETS: %s", assetsEnv)
+		os.Exit(0)
+	}
+
+	binPath := filepath.Join("..", "bin")
+	if hasBinaries(binPath) {
+		klog.Info("EnvTest binaries found in bin/")
+		os.Exit(0)
+	}
+
+	klog.Infof("Downloading EnvTest tools")
+	envtest_tools_archive_name := getEnvToolsArchiveName()
+	envtest_tools_download_url := "https://storage.googleapis.com/kubebuilder-tools/" + envtest_tools_archive_name
+
+	err := downloadFile(envtest_tools_archive_name, envtest_tools_download_url)
+	if err != nil {
+		klog.Fatalf("unable to download the file (%v) from (%v): %v", envtest_tools_archive_name, envtest_tools_download_url, err)
+
+	}
+
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		klog.Infof("Creating bin/ directory")
+		err = os.Mkdir(binPath, 0755)
+		if err != nil {
+			klog.Fatalf("error to create the bin/ directory : %s", err)
+		}
+	}
+
+	cmd := exec.Command("tar", "-C", binPath, "--strip-components=2", "-zvxf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatalf("error to untar bin %v: %v", filepath.Join(binPath, envtest_tools_archive_name), err)
+	}
+
+	cmd = exec.Command("rm", "-rf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatal(err)
+	}
+	klog.Infof("EnvTest binaries are in the directory %v", binPath)
+}
+
+// getEnvToolsArchiveName will return the name of the env tools archive based or the arch and so
+func getEnvToolsArchiveName() string {
+	cmd := exec.Command("go", "env", "GOARCH")
+	goarch, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	cmd = exec.Command("go", "env", "GOOS")
+	goos, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return fmt.Sprintf("kubebuilder-tools-%s-%s-%s.tar.gz", kubernetesVersion, strings.TrimSpace(string(goos)), strings.TrimSpace(string(goarch)))
+}
+
+// hasBinaries will return true when the envtest binaries are found
+func hasBinaries(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "etcd")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kube-apiserver")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kubectl")); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// downloadFile will download a url to a local file.
+func downloadFile(filepath string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}

--- a/testdata/project-v3-config/.gitignore
+++ b/testdata/project-v3-config/.gitignore
@@ -6,7 +6,6 @@
 *.so
 *.dylib
 bin
-testbin/*
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -14,11 +14,12 @@ endif
 all: manager
 
 # Run tests
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0-alpha.8/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+test: generate fmt vet manifests tooling 
+	go test ./... -coverprofile cover.out
+
+# Get the env test binaries
+tooling:
+	cd hack/; go run tooling.go 
 
 # Build manager binary
 manager: generate fmt vet

--- a/testdata/project-v3-config/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3-config/api/v1/webhook_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -68,6 +69,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-config/controllers/suite_test.go
+++ b/testdata/project-v3-config/controllers/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -55,6 +57,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-config/go.mod
+++ b/testdata/project-v3-config/go.mod
@@ -9,5 +9,6 @@ require (
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.7.0-alpha.8
 )

--- a/testdata/project-v3-config/hack/tooling.go
+++ b/testdata/project-v3-config/hack/tooling.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+const (
+	// defaultKubebuilderPath is the fixed value defined in the controller-runtime to looking for the
+	// binaries.
+	defaultKubebuilderPath = "/usr/local/kubebuilder/bin"
+
+	// kubernetesVersion defines the version used to download the binaries
+	kubernetesVersion = "1.16.4"
+)
+
+func main() {
+	klog.Info("Checking EnvTest binaries")
+	assetsEnv := os.Getenv("KUBEBUILDER_ASSETS")
+	if strings.TrimSpace(assetsEnv) != "" {
+		klog.Infof("EnvTest binaries configured via KUBEBUILDER_ASSETS: %s", assetsEnv)
+		os.Exit(0)
+	}
+
+	binPath := filepath.Join("..", "bin")
+	if hasBinaries(binPath) {
+		klog.Info("EnvTest binaries found in bin/")
+		os.Exit(0)
+	}
+
+	klog.Infof("Downloading EnvTest tools")
+	envtest_tools_archive_name := getEnvToolsArchiveName()
+	envtest_tools_download_url := "https://storage.googleapis.com/kubebuilder-tools/" + envtest_tools_archive_name
+
+	err := downloadFile(envtest_tools_archive_name, envtest_tools_download_url)
+	if err != nil {
+		klog.Fatalf("unable to download the file (%v) from (%v): %v", envtest_tools_archive_name, envtest_tools_download_url, err)
+
+	}
+
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		klog.Infof("Creating bin/ directory")
+		err = os.Mkdir(binPath, 0755)
+		if err != nil {
+			klog.Fatalf("error to create the bin/ directory : %s", err)
+		}
+	}
+
+	cmd := exec.Command("tar", "-C", binPath, "--strip-components=2", "-zvxf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatalf("error to untar bin %v: %v", filepath.Join(binPath, envtest_tools_archive_name), err)
+	}
+
+	cmd = exec.Command("rm", "-rf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatal(err)
+	}
+	klog.Infof("EnvTest binaries are in the directory %v", binPath)
+}
+
+// getEnvToolsArchiveName will return the name of the env tools archive based or the arch and so
+func getEnvToolsArchiveName() string {
+	cmd := exec.Command("go", "env", "GOARCH")
+	goarch, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	cmd = exec.Command("go", "env", "GOOS")
+	goos, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return fmt.Sprintf("kubebuilder-tools-%s-%s-%s.tar.gz", kubernetesVersion, strings.TrimSpace(string(goos)), strings.TrimSpace(string(goarch)))
+}
+
+// hasBinaries will return true when the envtest binaries are found
+func hasBinaries(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "etcd")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kube-apiserver")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kubectl")); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// downloadFile will download a url to a local file.
+func downloadFile(filepath string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -14,11 +14,12 @@ endif
 all: manager
 
 # Run tests
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0-alpha.8/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+test: generate fmt vet manifests tooling 
+	go test ./... -coverprofile cover.out
+
+# Get the env test binaries
+tooling:
+	cd hack/; go run tooling.go 
 
 # Build manager binary
 manager: generate fmt vet

--- a/testdata/project-v3-multigroup/apis/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/webhook_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -68,6 +69,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/apis/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/webhook_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -68,6 +69,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/webhook_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -68,6 +69,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/apis/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/v1/webhook_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -68,6 +69,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/controllers/apps/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/apps/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package apps
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -53,6 +55,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/controllers/crew/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/crew/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package crew
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -55,6 +57,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package foopolicy
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -55,6 +57,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package seacreatures
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -56,6 +58,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/controllers/ship/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/ship/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ship
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -57,6 +59,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/controllers/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -55,6 +57,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3-multigroup/go.mod
+++ b/testdata/project-v3-multigroup/go.mod
@@ -9,5 +9,6 @@ require (
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.7.0-alpha.8
 )

--- a/testdata/project-v3-multigroup/hack/tooling.go
+++ b/testdata/project-v3-multigroup/hack/tooling.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+const (
+	// defaultKubebuilderPath is the fixed value defined in the controller-runtime to looking for the
+	// binaries.
+	defaultKubebuilderPath = "/usr/local/kubebuilder/bin"
+
+	// kubernetesVersion defines the version used to download the binaries
+	kubernetesVersion = "1.16.4"
+)
+
+func main() {
+	klog.Info("Checking EnvTest binaries")
+	assetsEnv := os.Getenv("KUBEBUILDER_ASSETS")
+	if strings.TrimSpace(assetsEnv) != "" {
+		klog.Infof("EnvTest binaries configured via KUBEBUILDER_ASSETS: %s", assetsEnv)
+		os.Exit(0)
+	}
+
+	binPath := filepath.Join("..", "bin")
+	if hasBinaries(binPath) {
+		klog.Info("EnvTest binaries found in bin/")
+		os.Exit(0)
+	}
+
+	klog.Infof("Downloading EnvTest tools")
+	envtest_tools_archive_name := getEnvToolsArchiveName()
+	envtest_tools_download_url := "https://storage.googleapis.com/kubebuilder-tools/" + envtest_tools_archive_name
+
+	err := downloadFile(envtest_tools_archive_name, envtest_tools_download_url)
+	if err != nil {
+		klog.Fatalf("unable to download the file (%v) from (%v): %v", envtest_tools_archive_name, envtest_tools_download_url, err)
+
+	}
+
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		klog.Infof("Creating bin/ directory")
+		err = os.Mkdir(binPath, 0755)
+		if err != nil {
+			klog.Fatalf("error to create the bin/ directory : %s", err)
+		}
+	}
+
+	cmd := exec.Command("tar", "-C", binPath, "--strip-components=2", "-zvxf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatalf("error to untar bin %v: %v", filepath.Join(binPath, envtest_tools_archive_name), err)
+	}
+
+	cmd = exec.Command("rm", "-rf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatal(err)
+	}
+	klog.Infof("EnvTest binaries are in the directory %v", binPath)
+}
+
+// getEnvToolsArchiveName will return the name of the env tools archive based or the arch and so
+func getEnvToolsArchiveName() string {
+	cmd := exec.Command("go", "env", "GOARCH")
+	goarch, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	cmd = exec.Command("go", "env", "GOOS")
+	goos, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return fmt.Sprintf("kubebuilder-tools-%s-%s-%s.tar.gz", kubernetesVersion, strings.TrimSpace(string(goos)), strings.TrimSpace(string(goarch)))
+}
+
+// hasBinaries will return true when the envtest binaries are found
+func hasBinaries(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "etcd")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kube-apiserver")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kubectl")); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// downloadFile will download a url to a local file.
+func downloadFile(filepath string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -14,11 +14,12 @@ endif
 all: manager
 
 # Run tests
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate fmt vet manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.0-alpha.8/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+test: generate fmt vet manifests tooling 
+	go test ./... -coverprofile cover.out
+
+# Get the env test binaries
+tooling:
+	cd hack/; go run tooling.go 
 
 # Build manager binary
 manager: generate fmt vet

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -68,6 +69,13 @@ var _ = BeforeSuite(func() {
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3/controllers/suite_test.go
+++ b/testdata/project-v3/controllers/suite_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
+
 	"path/filepath"
 	"testing"
 
@@ -55,6 +57,13 @@ var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	By("setting binaries")
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		binaryAssetsPath, err := filepath.Abs(filepath.Join("..", "bin"))
+		Expect(err).NotTo(HaveOccurred())
+		testEnv.BinaryAssetsDirectory = binaryAssetsPath
 	}
 
 	cfg, err := testEnv.Start()

--- a/testdata/project-v3/go.mod
+++ b/testdata/project-v3/go.mod
@@ -9,5 +9,6 @@ require (
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.7.0-alpha.8
 )

--- a/testdata/project-v3/hack/tooling.go
+++ b/testdata/project-v3/hack/tooling.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+const (
+	// defaultKubebuilderPath is the fixed value defined in the controller-runtime to looking for the
+	// binaries.
+	defaultKubebuilderPath = "/usr/local/kubebuilder/bin"
+
+	// kubernetesVersion defines the version used to download the binaries
+	kubernetesVersion = "1.16.4"
+)
+
+func main() {
+	klog.Info("Checking EnvTest binaries")
+	assetsEnv := os.Getenv("KUBEBUILDER_ASSETS")
+	if strings.TrimSpace(assetsEnv) != "" {
+		klog.Infof("EnvTest binaries configured via KUBEBUILDER_ASSETS: %s", assetsEnv)
+		os.Exit(0)
+	}
+
+	binPath := filepath.Join("..", "bin")
+	if hasBinaries(binPath) {
+		klog.Info("EnvTest binaries found in bin/")
+		os.Exit(0)
+	}
+
+	klog.Infof("Downloading EnvTest tools")
+	envtest_tools_archive_name := getEnvToolsArchiveName()
+	envtest_tools_download_url := "https://storage.googleapis.com/kubebuilder-tools/" + envtest_tools_archive_name
+
+	err := downloadFile(envtest_tools_archive_name, envtest_tools_download_url)
+	if err != nil {
+		klog.Fatalf("unable to download the file (%v) from (%v): %v", envtest_tools_archive_name, envtest_tools_download_url, err)
+
+	}
+
+	if _, err := os.Stat(binPath); os.IsNotExist(err) {
+		klog.Infof("Creating bin/ directory")
+		err = os.Mkdir(binPath, 0755)
+		if err != nil {
+			klog.Fatalf("error to create the bin/ directory : %s", err)
+		}
+	}
+
+	cmd := exec.Command("tar", "-C", binPath, "--strip-components=2", "-zvxf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatalf("error to untar bin %v: %v", filepath.Join(binPath, envtest_tools_archive_name), err)
+	}
+
+	cmd = exec.Command("rm", "-rf", envtest_tools_archive_name)
+	if err := cmd.Run(); err != nil {
+		klog.Fatal(err)
+	}
+	klog.Infof("EnvTest binaries are in the directory %v", binPath)
+}
+
+// getEnvToolsArchiveName will return the name of the env tools archive based or the arch and so
+func getEnvToolsArchiveName() string {
+	cmd := exec.Command("go", "env", "GOARCH")
+	goarch, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	cmd = exec.Command("go", "env", "GOOS")
+	goos, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return fmt.Sprintf("kubebuilder-tools-%s-%s-%s.tar.gz", kubernetesVersion, strings.TrimSpace(string(goos)), strings.TrimSpace(string(goarch)))
+}
+
+// hasBinaries will return true when the envtest binaries are found
+func hasBinaries(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "etcd")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kube-apiserver")); os.IsNotExist(err) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(path, "kubectl")); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// downloadFile will download a url to a local file.
+func downloadFile(filepath string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	return err
+}


### PR DESCRIPTION
**Description**
- add hack/tooling to setup the binaries in the bin project when the KUBEBUILDER_ASSETS is not setup
- update the quick start to make clear that the current steps to get the binaries still required until the CLI version   `v2.3.1`

**Motivation**
-  provide a solution that allows users run and debug/troubleshooting the tests, that not requires sudo permissions to setup an env to develop the projects, and provide a code easier to maintain and to read. 
- Closes : https://github.com/kubernetes-sigs/kubebuilder/issues/1732
- Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1892