### PR TITLE
 :warning: Update kubebuilder cli and plugin v3+ to use go version 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - osx
 
 go:
-  - 1.13.x
+  - 1.15.x
 
 git:
   depth: 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please see https://git.k8s.io/community/CLA.md for more info.
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.13+.
+- [go](https://golang.org/dl/) version v1.15+.
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - [kustomize](https://sigs.k8s.io/kustomize/docs/INSTALL.md) v3.1.0+

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docs/book/src/cronjob-tutorial/testdata/project/go.mod
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.mod
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,7 +9,7 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.13+.
+- [go](https://golang.org/dl/) version v1.15+.
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - [kustomize](https://sigs.k8s.io/kustomize/docs/INSTALL.md) v3.1.0+

--- a/docs/book/utils/go.mod
+++ b/docs/book/utils/go.mod
@@ -1,3 +1,3 @@
 module sigs.k8s.io/kubebuilder/docs/book/utils
 
-go 1.13
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder
 
-go 1.13
+go 1.15
 
 require (
 	github.com/gobuffalo/flect v0.2.2

--- a/pkg/plugin/internal/util/go_version.go
+++ b/pkg/plugin/internal/util/go_version.go
@@ -51,6 +51,8 @@ func fetchAndCheckGoVersion() error {
 	return nil
 }
 
+// checkGoVersion should only ever check if the Go version >= 1.13, since the kubebuilder binary only cares
+// that the go binary supports go modules which were stabilized in that version (i.e. in go 1.13) by default
 func checkGoVersion(verStr string) error {
 	goVerRegex := `^go?([0-9]+)\.([0-9]+)([\.0-9A-Za-z\-]+)?$`
 	m := regexp.MustCompile(goVerRegex).FindStringSubmatch(verStr)

--- a/pkg/plugin/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/pkg/plugin/v3/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/gomod.go
@@ -46,7 +46,7 @@ func (f *GoMod) SetTemplateDefaults() error {
 const goModTemplate = `
 module {{ .Repo }}
 
-go 1.13
+go 1.15
 
 require (
 	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}

--- a/testdata/project-v3-addon/Dockerfile
+++ b/testdata/project-v3-addon/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-multigroup/go.mod
+++ b/testdata/project-v3-multigroup/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0

--- a/testdata/project-v3/Dockerfile
+++ b/testdata/project-v3/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3/go.mod
+++ b/testdata/project-v3/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3
 
-go 1.13
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0


### PR DESCRIPTION
**Description**

- Update go version from 1.13 to 1.15 

**Note**
Here's the link to update the infra to run the CI jobs as well: kubernetes/test-infra#19527
