### PR TITLE
✨  feat(logging): make logging work by default (only v3+)

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/main.go
@@ -228,9 +228,14 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. " +
 		"Enabling this will ensure there is only one active controller manager.")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true))) 
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,

--- a/testdata/project-v3-addon/main.go
+++ b/testdata/project-v3-addon/main.go
@@ -51,9 +51,14 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -69,9 +69,14 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,

--- a/testdata/project-v3/main.go
+++ b/testdata/project-v3/main.go
@@ -51,9 +51,14 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
### Description
This PR makes the `kubebuilder init` initialize the default logging in a way that:
- by Default the log level is `debug`
- any flag passed to the operator will change that log level accordingly (see https://sdk.operatorframework.io/docs/building-operators/golang/references/logging/)

### Motivation
to reduce friction and allow an operator developer not have to meddle with the main.go if not required, this will be related to trying inside the Reconcile function to call `r.Log.V(2).Info("message")` and trying to enable it on demand

### Related issues
- #885 related to changing logging levels
