### PR TITLE
:bug: Add validation for the main.go file present in root directory

### DIFF
--- a/pkg/plugin/v3/api.go
+++ b/pkg/plugin/v3/api.go
@@ -43,6 +43,9 @@ import (
 // TODO: remove this when a better solution for using addons is implemented.
 const KbDeclarativePatternVersion = "v0.0.0-20200522144838-848d48e5b073"
 
+// DefaultMainPath is default file path of main.go
+const DefaultMainPath = "main.go"
+
 type createAPIPlugin struct {
 	config *config.Config
 
@@ -139,6 +142,11 @@ func (p *createAPIPlugin) Validate() error {
 
 	if p.resource.Group == "" && p.config.Domain == "" {
 		return fmt.Errorf("can not have group and domain both empty")
+	}
+
+	// check if main.go is present in the root directory
+	if _, err := os.Stat(DefaultMainPath); os.IsNotExist(err) {
+		return fmt.Errorf("%s file should present in the root directory", DefaultMainPath)
 	}
 
 	// TODO: re-evaluate whether y/n input still makes sense. We should probably always


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
Description of the Change:
Added validation to check if main.go is present in the root directory or not.
Added the change for v2 and v3 as this is a bug fix.

Motivation of the change:
If user moves the main.go file and then tries to create any resources like webhook, the operation is done half way, the webhook gets created but kb errors out when trying to write to main file. This should be early detected and the operation should not be allowed at all.

Fixes: #1719  