### PR TITLE
⚠ Generate controllers with API Group name as package names in multi-group projects (only Go plugin v3)

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller.go
@@ -55,7 +55,11 @@ func (f *Controller) SetTemplateDefaults() error {
 //nolint:lll
 const controllerTemplate = `{{ .Boilerplate }}
 
+{{if and .MultiGroup .Resource.Group }}
+package {{ .Resource.GroupPackageName }}
+{{else}}
 package controllers
+{{end}}
 
 import (
 	"context"

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
@@ -111,7 +111,11 @@ func (f *SuiteTest) GetCodeFragments() file.CodeFragmentsMap {
 
 const controllerSuiteTestTemplate = `{{ .Boilerplate }}
 
+{{if and .MultiGroup .Resource.Group }}
+package {{ .Resource.GroupPackageName }}
+{{else}}
 package controllers
+{{end}}
 
 import (
 	"path/filepath"

--- a/testdata/project-v3-multigroup/controllers/crew/captain_controller.go
+++ b/testdata/project-v3-multigroup/controllers/crew/captain_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package crew
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/crew/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/crew/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package crew
 
 import (
 	"path/filepath"

--- a/testdata/project-v3-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package foopolicy
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package foopolicy
 
 import (
 	"path/filepath"

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/kraken_controller.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/kraken_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package seacreatures
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/leviathan_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package seacreatures
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package seacreatures
 
 import (
 	"path/filepath"

--- a/testdata/project-v3-multigroup/controllers/ship/cruiser_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/cruiser_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package ship
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/ship/destroyer_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/destroyer_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package ship
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/ship/frigate_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/frigate_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package ship
 
 import (
 	"context"

--- a/testdata/project-v3-multigroup/controllers/ship/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/ship/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package ship
 
 import (
 	"path/filepath"


### PR DESCRIPTION
### Description

Use GroupPackageName (the API Group cleaned to be used as
the package name) as the package name when generating
controllers and controller suite test files with
non-empty API groups in MultiGroup projects.

When generating controller with an empty group name in a
MultiGroup project, or when generating a controller in a non
MultiGroup project keep the current behavior, which is
using the `controllers` package name for both the
controllers and controllers suite test files.

This applies only to Go v3 plugin as I understand this is a breaking change and breaking changes cannot be applied in v2. Can breaking changes be applied to v3 plugin code without the need of creating a new Go v4 plugin version? Is v3 still not considered "released"? By reading the versioning doc (https://github.com/kubernetes-sigs/kubebuilder/blob/master/VERSIONING.md#understanding-the-versions) it seems as if we'd need Go v4 plugin.

Let me know if there's something missing (doc? other stuff that I'm not aware of?)

### Motivation

With the behavior before this PR all controllers in a multigroup project defined their package name as "controllers" even when they were inside their own directories. In Go it's often common having the same directory name as the package name (when possible syntactically).

See issue https://github.com/kubernetes-sigs/kubebuilder/issues/1717 for more details.

### Related Issues

https://github.com/kubernetes-sigs/kubebuilder/issues/1717  Controllers in a multigroup project belong to the 'controllers' package