### PR TITLE
🐛 use rbac.authorization.k8s.io/v1 for the auth proxy client

### DIFF
--- a/pkg/plugin/v2/scaffolds/internal/templates/metricsauth/clientclusterrole.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/metricsauth/clientclusterrole.go
@@ -40,7 +40,7 @@ func (f *ClientClusterRole) SetTemplateDefaults() error {
 	return nil
 }
 
-const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1beta1
+const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/rbac/client_cluster_role.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/rbac/client_cluster_role.go
@@ -40,7 +40,7 @@ func (f *ClientClusterRole) SetTemplateDefaults() error {
 	return nil
 }
 
-const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1beta1
+const clientClusterRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/project-v2-addon/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v2-addon/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/project-v2-multigroup/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v2-multigroup/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/project-v2/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v2/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/project-v3-addon/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3-addon/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/project-v3-multigroup/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/testdata/project-v3/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
This PR updates the `metrics-reader` ClusterRole scaffolded by the v3 Go plugin to use apiVersion `rbac.authorization.k8s.io/v1` instead of the deprecated (since k8s 1.17) `rbac.authorization.k8s.io/v1beta1`.

All other template scaffolds are using `rbac.authorization.k8s.io/v1`. It seems that it was an oversight that caused this file to continue using `rbac.authorization.k8s.io/v1beta1`.