### PR TITLE
WIP: :seedling: upgrade the cert-manager version used to get bugfix and keep the latest version before the breaking changes

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo" //nolint:golint
 )
 
-const certmanagerVersion = "v0.11.0"
+const certmanagerVersion = "v0.16.1"
 const prometheusOperatorVersion = "0.33"
 const certmanagerURL = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 const prometheusOperatorURL = "https://raw.githubusercontent.com/coreos/prometheus-operator/release-%s/bundle.yaml"


### PR DESCRIPTION
**Description**
-upgrade the cert-manager version used in the tests from 0.11.0 to 0.16.1. See: https://github.com/jetstack/cert-manager/releases/tag/v0.16.1

**Motivation**
It has a bug fix for the Kind. See that until we use the api version v1betav1 for webhooks we also need to do the tests with the cert-manager < 1.0.0. So, it will keep the latest version before the breaking changes 


