### PR TITLE
:sparkles: Upgrade the version of kubernetes to v1.18.0 for local e2e tests

### DIFF
--- a/test_e2e_local.sh
+++ b/test_e2e_local.sh
@@ -21,7 +21,7 @@ source common.sh
 
 export TRACE=1
 export GO111MODULE=on
-export KIND_K8S_VERSION=${KIND_K8S_VERSION:-v1.17.0}
+export KIND_K8S_VERSION=${KIND_K8S_VERSION:-v1.18.0}
 
 fetch_tools
 install_kind


### PR DESCRIPTION
Description:
Update the local tests e2e scripts to use the kubernetes version v1.18.0

Motivation:
We are adding the kubebuilder e2e tests pre submit jobs on the kubernetes v1.18.0 in [#19690](https://github.com/kubernetes/test-infra/pull/19690)