### PR TITLE
👻 Enhance regex patterns

### DIFF
--- a/pkg/internal/validation/dns.go
+++ b/pkg/internal/validation/dns.go
@@ -26,9 +26,9 @@ import (
 // "k8s.io/apimachinery" is needed, re-consider whether to add the dependency.
 
 const (
-	dns1123LabelFmt     string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+	dns1123LabelFmt     string = "[a-z0-9](?:[-a-z0-9]*[a-z0-9])?"
 	dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
-	dns1035LabelFmt     string = "[a-z]([-a-z0-9]*[a-z0-9])?"
+	dns1035LabelFmt     string = "[a-z](?:[-a-z0-9]*[a-z0-9])?"
 )
 
 type dnsValidationConfig struct {

--- a/pkg/internal/validation/project.go
+++ b/pkg/internal/validation/project.go
@@ -22,7 +22,7 @@ import (
 )
 
 // projectVersionFmt defines the project version format from a project config.
-const projectVersionFmt string = "[1-9][0-9]*(-(alpha|beta))?"
+const projectVersionFmt string = "[1-9][0-9]*(?:-(?:alpha|beta))?"
 
 var projectVersionRe = regexp.MustCompile("^" + projectVersionFmt + "$")
 

--- a/pkg/model/resource/options.go
+++ b/pkg/model/resource/options.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	versionPattern  = "^v\\d+(alpha\\d+|beta\\d+)?$"
+	versionPattern  = "^v\\d+(?:alpha\\d+|beta\\d+)?$"
 	groupRequired   = "group cannot be empty"
 	versionRequired = "version cannot be empty"
 	kindRequired    = "kind cannot be empty"

--- a/pkg/model/resource/options_test.go
+++ b/pkg/model/resource/options_test.go
@@ -47,27 +47,27 @@ var _ = Describe("Resource Options", func() {
 			options := &Options{Group: "crew", Version: "1", Kind: "FirstMate"}
 			Expect(options.Validate()).NotTo(Succeed())
 			Expect(options.Validate().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was 1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was 1)`))
 
 			options = &Options{Group: "crew", Version: "1beta1", Kind: "FirstMate"}
 			Expect(options.Validate()).NotTo(Succeed())
 			Expect(options.Validate().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was 1beta1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was 1beta1)`))
 
 			options = &Options{Group: "crew", Version: "a1beta1", Kind: "FirstMate"}
 			Expect(options.Validate()).NotTo(Succeed())
 			Expect(options.Validate().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was a1beta1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was a1beta1)`))
 
 			options = &Options{Group: "crew", Version: "v1beta", Kind: "FirstMate"}
 			Expect(options.Validate()).NotTo(Succeed())
 			Expect(options.Validate().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was v1beta)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was v1beta)`))
 
 			options = &Options{Group: "crew", Version: "v1beta1alpha1", Kind: "FirstMate"}
 			Expect(options.Validate()).NotTo(Succeed())
 			Expect(options.Validate().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was v1beta1alpha1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was v1beta1alpha1)`))
 		})
 
 		It("should fail if the Kind is not specified", func() {
@@ -149,27 +149,27 @@ var _ = Describe("Resource Options", func() {
 			options := &Options{Group: "crew", Version: "1", Kind: "FirstMate"}
 			Expect(options.ValidateV2()).NotTo(Succeed())
 			Expect(options.ValidateV2().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was 1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was 1)`))
 
 			options = &Options{Group: "crew", Version: "1beta1", Kind: "FirstMate"}
 			Expect(options.ValidateV2()).NotTo(Succeed())
 			Expect(options.ValidateV2().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was 1beta1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was 1beta1)`))
 
 			options = &Options{Group: "crew", Version: "a1beta1", Kind: "FirstMate"}
 			Expect(options.ValidateV2()).NotTo(Succeed())
 			Expect(options.ValidateV2().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was a1beta1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was a1beta1)`))
 
 			options = &Options{Group: "crew", Version: "v1beta", Kind: "FirstMate"}
 			Expect(options.ValidateV2()).NotTo(Succeed())
 			Expect(options.ValidateV2().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was v1beta)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was v1beta)`))
 
 			options = &Options{Group: "crew", Version: "v1beta1alpha1", Kind: "FirstMate"}
 			Expect(options.ValidateV2()).NotTo(Succeed())
 			Expect(options.ValidateV2().Error()).To(ContainSubstring(
-				`version must match ^v\d+(alpha\d+|beta\d+)?$ (was v1beta1alpha1)`))
+				`version must match ^v\d+(?:alpha\d+|beta\d+)?$ (was v1beta1alpha1)`))
 		})
 
 		It("should fail if the Kind is not specified for V2", func() {

--- a/pkg/plugin/internal/util/go_version.go
+++ b/pkg/plugin/internal/util/go_version.go
@@ -54,7 +54,7 @@ func fetchAndCheckGoVersion() error {
 // checkGoVersion should only ever check if the Go version >= 1.13, since the kubebuilder binary only cares
 // that the go binary supports go modules which were stabilized in that version (i.e. in go 1.13) by default
 func checkGoVersion(verStr string) error {
-	goVerRegex := `^go?([0-9]+)\.([0-9]+)([\.0-9A-Za-z\-]+)?$`
+	goVerRegex := `^go?([0-9]+)\.([0-9]+)[\.0-9A-Za-z\-]*$`
 	m := regexp.MustCompile(goVerRegex).FindStringSubmatch(verStr)
 	if m == nil {
 		return fmt.Errorf("invalid version string")

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -39,7 +39,7 @@ const (
 )
 
 // verRe defines the string format of a version.
-var verRe = regexp.MustCompile("^(v)?([1-9][0-9]*)(-alpha|-beta)?$")
+var verRe = regexp.MustCompile("^v?([1-9][0-9]*)(?:-(alpha|beta))?$")
 
 // Version is a plugin version containing a non-zero integer and an optional stage value
 // that if present identifies a version as not stable to some degree.
@@ -75,15 +75,15 @@ func ParseVersion(version string) (v Version, err error) {
 		return v, errors.New("plugin version is empty")
 	}
 
-	// A valid version string will have 4 submatches, each of which may be empty: the full string, "v",
-	// the integer, and the stage suffix. Invalid version strings do not have 4 submatches.
+	// A valid version string will have 3 submatches, each of which may be empty: the full string,
+	// the integer, and the stage suffix. Invalid version strings do not have 3 submatches.
 	submatches := verRe.FindStringSubmatch(version)
-	if len(submatches) != 4 {
+	if len(submatches) != 3 {
 		return v, fmt.Errorf("version format must match %s", verRe.String())
 	}
 
 	// Parse version number.
-	versionNumStr := submatches[2]
+	versionNumStr := submatches[1]
 	if versionNumStr == "" {
 		return v, errors.New("version must contain an integer")
 	}
@@ -92,7 +92,7 @@ func ParseVersion(version string) (v Version, err error) {
 	}
 
 	// Parse stage suffix, if any.
-	v.Stage = strings.TrimPrefix(submatches[3], "-")
+	v.Stage = submatches[2]
 
 	return v, v.Validate()
 }


### PR DESCRIPTION
# Descrition
- Used non-capturing groups when the info is not relevant
- Simplified some expressions

# Motivation
While non-capturing groups should be a bit more performant that capturing groups, the improvement will be negligible. The motivations is mainly improving the clarity and readability of the regex expressions by simplifying some patters and not having unused capture groups.

/kind cleanup
