### PR TITLE
⚠️ [Rename] Disambiguate plugin by calling subcommand what the plugin getters returns instead of plugin

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -55,7 +55,7 @@ type Option func(*cli) error
 // cli defines the command line structure and interfaces that are used to
 // scaffold kubebuilder project files.
 type cli struct {
-	// Base command name. Can be injected downstream.
+	// Root command name. Can be injected downstream.
 	commandName string
 	// Default project version. Used in CLI flag setup.
 	defaultProjectVersion string
@@ -70,16 +70,16 @@ type cli struct {
 	completionCommand bool
 
 	// Plugins injected by options.
-	pluginsFromOptions map[string][]plugin.Base
+	pluginsFromOptions map[string][]plugin.Plugin
 	// Default plugins injected by options. Only one plugin per project version
 	// is allowed.
-	defaultPluginsFromOptions map[string]plugin.Base
+	defaultPluginsFromOptions map[string]plugin.Plugin
 	// A plugin key passed to --plugins on invoking 'init'.
 	cliPluginKey string
 	// A filtered set of plugins that should be used by command constructors.
-	resolvedPlugins []plugin.Base
+	resolvedPlugins []plugin.Plugin
 
-	// Base command.
+	// Root command.
 	cmd *cobra.Command
 	// Commands injected by options.
 	extraCommands []*cobra.Command
@@ -90,8 +90,8 @@ func New(opts ...Option) (CLI, error) {
 	c := &cli{
 		commandName:               "kubebuilder",
 		defaultProjectVersion:     internalconfig.DefaultVersion,
-		pluginsFromOptions:        make(map[string][]plugin.Base),
-		defaultPluginsFromOptions: make(map[string]plugin.Base),
+		pluginsFromOptions:        make(map[string][]plugin.Plugin),
+		defaultPluginsFromOptions: make(map[string]plugin.Plugin),
 	}
 	for _, opt := range opts {
 		if err := opt(c); err != nil {
@@ -131,7 +131,7 @@ func WithDefaultProjectVersion(version string) Option {
 }
 
 // WithPlugins is an Option that sets the cli's plugins.
-func WithPlugins(plugins ...plugin.Base) Option {
+func WithPlugins(plugins ...plugin.Plugin) Option {
 	return func(c *cli) error {
 		for _, p := range plugins {
 			for _, version := range p.SupportedProjectVersions() {
@@ -149,7 +149,7 @@ func WithPlugins(plugins ...plugin.Base) Option {
 
 // WithDefaultPlugins is an Option that sets the cli's default plugins. Only
 // one plugin per project version is allowed.
-func WithDefaultPlugins(plugins ...plugin.Base) Option {
+func WithDefaultPlugins(plugins ...plugin.Plugin) Option {
 	return func(c *cli) error {
 		for _, p := range plugins {
 			for _, version := range p.SupportedProjectVersions() {
@@ -230,7 +230,7 @@ func (c *cli) initialize() error {
 	// in situations like 'init --plugins "go"' when multiple go-type plugins
 	// are available but only one default is for a particular project version.
 	allPlugins := c.pluginsFromOptions[c.projectVersion]
-	defaultPlugin := []plugin.Base{c.defaultPluginsFromOptions[c.projectVersion]}
+	defaultPlugin := []plugin.Plugin{c.defaultPluginsFromOptions[c.projectVersion]}
 	switch {
 	case c.cliPluginKey != "":
 		// Filter plugin by keys passed in CLI.

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -45,14 +45,15 @@ func errCmdFunc(err error) func(*cobra.Command, []string) error {
 	}
 }
 
-// runECmdFunc returns a cobra RunE function that runs gsub and saves the
-// config, which may have been modified by gsub.
+// runECmdFunc returns a cobra RunE function that runs subcommand and saves the
+// config, which may have been modified by subcommand.
 func runECmdFunc(
 	c *config.Config,
-	gsub plugin.GenericSubcommand, // nolint:interfacer
-	msg string) func(*cobra.Command, []string) error {
+	subcommand plugin.Subcommand, // nolint:interfacer
+	msg string,
+) func(*cobra.Command, []string) error {
 	return func(*cobra.Command, []string) error {
-		if err := gsub.Run(); err != nil {
+		if err := subcommand.Run(); err != nil {
 			return fmt.Errorf("%s: %v", msg, err)
 		}
 		return c.Save()

--- a/pkg/cli/plugins.go
+++ b/pkg/cli/plugins.go
@@ -46,8 +46,8 @@ func (e errAmbiguousPlugin) Error() string {
 // or does not match any known plugin's key, an error is returned.
 //
 // This function does not guarantee that the resolved set contains a plugin
-// for each plugin type, i.e. an Init plugin might not be returned.
-func resolvePluginsByKey(versionedPlugins []plugin.Base, pluginKey string) (resolved []plugin.Base, err error) {
+// for each subcommand type, i.e. an InitSubcommand might not be returned.
+func resolvePluginsByKey(versionedPlugins []plugin.Plugin, pluginKey string) (resolved []plugin.Plugin, err error) {
 
 	name, version := plugin.SplitKey(pluginKey)
 
@@ -102,7 +102,7 @@ func resolvePluginsByKey(versionedPlugins []plugin.Base, pluginKey string) (reso
 
 // findPluginsMatchingName returns a set of plugins with Name() exactly
 // matching name.
-func findPluginsMatchingName(plugins []plugin.Base, name string) (equal []plugin.Base) {
+func findPluginsMatchingName(plugins []plugin.Plugin, name string) (equal []plugin.Plugin) {
 	for _, p := range plugins {
 		if p.Name() == name {
 			equal = append(equal, p)
@@ -113,7 +113,7 @@ func findPluginsMatchingName(plugins []plugin.Base, name string) (equal []plugin
 
 // findPluginsMatchingShortName returns a set of plugins with
 // GetShortName(Name()) exactly matching shortName.
-func findPluginsMatchingShortName(plugins []plugin.Base, shortName string) (equal []plugin.Base) {
+func findPluginsMatchingShortName(plugins []plugin.Plugin, shortName string) (equal []plugin.Plugin) {
 	for _, p := range plugins {
 		if plugin.GetShortName(p.Name()) == shortName {
 			equal = append(equal, p)
@@ -123,7 +123,7 @@ func findPluginsMatchingShortName(plugins []plugin.Base, shortName string) (equa
 }
 
 // makePluginKeySlice returns a slice of all keys for each plugin in plugins.
-func makePluginKeySlice(plugins ...plugin.Base) (keys []string) {
+func makePluginKeySlice(plugins ...plugin.Plugin) (keys []string) {
 	for _, p := range plugins {
 		keys = append(keys, plugin.KeyFor(p))
 	}
@@ -132,7 +132,7 @@ func makePluginKeySlice(plugins ...plugin.Base) (keys []string) {
 }
 
 // validatePlugins validates the name and versions of a list of plugins.
-func validatePlugins(plugins ...plugin.Base) error {
+func validatePlugins(plugins ...plugin.Plugin) error {
 	pluginKeySet := make(map[string]struct{}, len(plugins))
 	for _, p := range plugins {
 		if err := validatePlugin(p); err != nil {
@@ -149,7 +149,7 @@ func validatePlugins(plugins ...plugin.Base) error {
 }
 
 // validatePlugin validates the name and versions of a plugin.
-func validatePlugin(p plugin.Base) error {
+func validatePlugin(p plugin.Plugin) error {
 	pluginName := p.Name()
 	if err := plugin.ValidateName(pluginName); err != nil {
 		return fmt.Errorf("invalid plugin name %q: %v", pluginName, err)

--- a/pkg/cli/plugins_test.go
+++ b/pkg/cli/plugins_test.go
@@ -37,7 +37,7 @@ var _ = Describe("resolvePluginsByKey", func() {
 			"bar.kubebuilder.io/v1",
 			"bar.kubebuilder.io/v2",
 		)
-		resolvedPlugins []plugin.Base
+		resolvedPlugins []plugin.Plugin
 		err             error
 	)
 

--- a/pkg/plugin/helpers.go
+++ b/pkg/plugin/helpers.go
@@ -35,8 +35,8 @@ func Key(name, version string) string {
 	return path.Join(name, "v"+strings.TrimLeft(version, "v"))
 }
 
-// KeyFor returns a Base plugin's unique identifying string.
-func KeyFor(p Base) string {
+// KeyFor returns a Plugin's unique identifying string.
+func KeyFor(p Plugin) string {
 	return Key(p.Name(), p.Version().String())
 }
 

--- a/pkg/plugin/interfaces.go
+++ b/pkg/plugin/interfaces.go
@@ -22,18 +22,18 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 )
 
-// Base is an interface that defines the common base for all plugins
-type Base interface {
+// Plugin is an interface that defines the common base for all plugins
+type Plugin interface {
 	// Name returns a DNS1123 label string identifying the plugin uniquely. This name should be fully-qualified,
 	// i.e. have a short prefix describing the plugin type (like a language) followed by a domain.
 	// For example, Kubebuilder's main plugin would return "go.kubebuilder.io".
 	Name() string
 	// Version returns the plugin's version.
 	//
-	// Note: this version is different from config version.
+	// NOTE: this version is different from config version.
 	Version() Version
-	// SupportedProjectVersions lists all project configuration versions this
-	// plugin supports, ex. []string{"2", "3"}. The returned slice cannot be empty.
+	// SupportedProjectVersions lists all project configuration versions this plugin supports, ex. []string{"2", "3"}.
+	// The returned slice cannot be empty.
 	SupportedProjectVersions() []string
 }
 
@@ -43,77 +43,84 @@ type Deprecated interface {
 	DeprecationWarning() string
 }
 
-// GenericSubcommand is an interface that defines the plugins operations
-type GenericSubcommand interface {
-	// UpdateContext updates a Context with command-specific help text, like description and examples.
+// Subcommand is an interface that defines the common base for subcommands returned by plugins
+type Subcommand interface {
+	// UpdateContext updates a Context with subcommand-specific help text, like description and examples. It also serves
+	// to pass context from the CLI to the subcommand, such as the command name.
 	// Can be a no-op if default help text is desired.
 	UpdateContext(*Context)
-	// BindFlags binds the plugin's flags to the CLI. This allows each plugin to define its own
-	// command line flags for the kubebuilder subcommand.
+	// BindFlags binds the subcommand's flags to the CLI. This allows each subcommand to define its own
+	// command line flags.
 	BindFlags(*pflag.FlagSet)
 	// Run runs the subcommand.
 	Run() error
-	// InjectConfig passes a config to a plugin. The plugin may modify the
-	// config. Initializing, loading, and saving the config is managed by the
-	// cli package.
+	// InjectConfig passes a config to a plugin. The plugin may modify the config.
+	// Initializing, loading, and saving the config is managed by the cli package.
 	InjectConfig(*config.Config)
 }
 
-// Context is the runtime context for a plugin.
+// Context is the runtime context for a subcommand.
 type Context struct {
-	// CommandName sets the command name for a plugin.
+	// CommandName sets the command name for a subcommand.
 	CommandName string
 	// Description is a description of what this subcommand does. It is used to display help.
 	Description string
-	// Examples are one or more examples of the command-line usage
-	// of this plugin's project subcommand support. It is used to display help.
+	// Examples are one or more examples of the command-line usage of this subcommand. It is used to display help.
 	Examples string
 }
 
-// InitPluginGetter is an interface that defines gets an Init plugin
-type InitPluginGetter interface {
-	Base
-	// GetInitPlugin returns the underlying Init interface.
-	GetInitPlugin() Init
-}
-
-// Init is an interface that represents an `init` command
+// Init is an interface for plugins that provide an `init` subcommand
 type Init interface {
-	GenericSubcommand
+	Plugin
+	// GetInitSubcommand returns the underlying InitSubcommand interface.
+	GetInitSubcommand() InitSubcommand
 }
 
-// CreateAPIPluginGetter is an interface that defines gets an Create API plugin
-type CreateAPIPluginGetter interface {
-	Base
-	// GetCreateAPIPlugin returns the underlying CreateAPI interface.
-	GetCreateAPIPlugin() CreateAPI
+// InitSubcommand is an interface that represents an `init` subcommand
+type InitSubcommand interface {
+	Subcommand
 }
 
-// CreateAPI is an interface that represents an `create api` command
+// CreateAPI is an interface for plugins that provide a `create api` subcommand
 type CreateAPI interface {
-	GenericSubcommand
+	Plugin
+	// GetCreateAPISubcommand returns the underlying CreateAPISubcommand interface.
+	GetCreateAPISubcommand() CreateAPISubcommand
 }
 
-// CreateWebhookPluginGetter is an interface that defines gets an Create WebHook plugin
-type CreateWebhookPluginGetter interface {
-	Base
-	// GetCreateWebhookPlugin returns the underlying CreateWebhook interface.
-	GetCreateWebhookPlugin() CreateWebhook
+// CreateAPISubcommand is an interface that represents a `create api` subcommand
+type CreateAPISubcommand interface {
+	Subcommand
 }
 
-// CreateWebhook is an interface that represents an `create wekbhook` command
+// CreateWebhook is an interface for plugins that provide a `create webhook` subcommand
 type CreateWebhook interface {
-	GenericSubcommand
+	Plugin
+	// GetCreateWebhookSubcommand returns the underlying CreateWebhookSubcommand interface.
+	GetCreateWebhookSubcommand() CreateWebhookSubcommand
 }
 
-// EditPluginGetter is an interface that defines gets an Edit plugin
-type EditPluginGetter interface {
-	Base
-	// GetEditPlugin returns the underlying Edit interface.
-	GetEditPlugin() Edit
+// CreateWebhookSubcommand is an interface that represents a `create wekbhook` subcommand
+type CreateWebhookSubcommand interface {
+	Subcommand
 }
 
-// Edit is an interface that represents an `edit` command
+// Edit is an interface for plugins that provide a `edit` subcommand
 type Edit interface {
-	GenericSubcommand
+	Plugin
+	// GetEditSubcommand returns the underlying EditSubcommand interface.
+	GetEditSubcommand() EditSubcommand
+}
+
+// EditSubcommand is an interface that represents an `edit` subcommand
+type EditSubcommand interface {
+	Subcommand
+}
+
+// Full is an interface for plugins that provide `init`, `create api`, `create webhook` and `edit` subcommands
+type Full interface {
+	Init
+	CreateAPI
+	CreateWebhook
+	Edit
 }

--- a/pkg/plugin/v2/api.go
+++ b/pkg/plugin/v2/api.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/kubebuilder/plugins/addon"
 )
 
-type createAPIPlugin struct {
+type createAPISubcommand struct {
 	config *config.Config
 
 	// pattern indicates that we should use a plugin to build according to a pattern
@@ -60,11 +60,11 @@ type createAPIPlugin struct {
 }
 
 var (
-	_ plugin.CreateAPI   = &createAPIPlugin{}
-	_ cmdutil.RunOptions = &createAPIPlugin{}
+	_ plugin.CreateAPISubcommand = &createAPISubcommand{}
+	_ cmdutil.RunOptions         = &createAPISubcommand{}
 )
 
-func (p createAPIPlugin) UpdateContext(ctx *plugin.Context) {
+func (p createAPISubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
 
 create resource will prompt the user for if it should scaffold the Resource and / or Controller.  To only
@@ -94,7 +94,7 @@ After the scaffold is written, api will run make on the project.
 		ctx.CommandName)
 }
 
-func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.runMake, "make", true, "if true, run make after generating files")
 
 	fs.BoolVar(&p.doResource, "resource", true,
@@ -118,15 +118,15 @@ func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.resource.Namespaced, "namespaced", true, "resource is namespaced")
 }
 
-func (p *createAPIPlugin) InjectConfig(c *config.Config) {
+func (p *createAPISubcommand) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *createAPIPlugin) Run() error {
+func (p *createAPISubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *createAPIPlugin) Validate() error {
+func (p *createAPISubcommand) Validate() error {
 	if err := p.resource.ValidateV2(); err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (p *createAPIPlugin) Validate() error {
 	return nil
 }
 
-func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *createAPISubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	// Load the boilerplate
 	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
 	if err != nil {
@@ -181,7 +181,7 @@ func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
 }
 
-func (p *createAPIPlugin) PostScaffold() error {
+func (p *createAPISubcommand) PostScaffold() error {
 	// Load the requested plugins
 	switch strings.ToLower(p.pattern) {
 	case "":

--- a/pkg/plugin/v2/edit.go
+++ b/pkg/plugin/v2/edit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/internal/cmdutil"
 	"sigs.k8s.io/kubebuilder/pkg/model/config"
 	"sigs.k8s.io/kubebuilder/pkg/plugin"
@@ -27,18 +28,18 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin/v2/scaffolds"
 )
 
-type editPlugin struct {
+type editSubcommand struct {
 	config *config.Config
 
 	multigroup bool
 }
 
 var (
-	_ plugin.Edit        = &editPlugin{}
-	_ cmdutil.RunOptions = &editPlugin{}
+	_ plugin.EditSubcommand = &editSubcommand{}
+	_ cmdutil.RunOptions    = &editSubcommand{}
 )
 
-func (p *editPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *editSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `This command will edit the project configuration. You can have single or multi group project.`
 
 	ctx.Examples = fmt.Sprintf(`# Enable the multigroup layout
@@ -49,11 +50,11 @@ func (p *editPlugin) UpdateContext(ctx *plugin.Context) {
 	`, ctx.CommandName, ctx.CommandName)
 }
 
-func (p *editPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.multigroup, "multigroup", false, "enable or disable multigroup layout")
 }
 
-func (p *editPlugin) InjectConfig(c *config.Config) {
+func (p *editSubcommand) InjectConfig(c *config.Config) {
 	// v3 project configs get a 'layout' value.
 	if c.IsV3() {
 		c.Layout = plugin.KeyFor(Plugin{})
@@ -61,18 +62,18 @@ func (p *editPlugin) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *editPlugin) Run() error {
+func (p *editSubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *editPlugin) Validate() error {
+func (p *editSubcommand) Validate() error {
 	return nil
 }
 
-func (p *editPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *editSubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewEditScaffolder(p.config, p.multigroup), nil
 }
 
-func (p *editPlugin) PostScaffold() error {
+func (p *editSubcommand) PostScaffold() error {
 	return nil
 }

--- a/pkg/plugin/v2/init.go
+++ b/pkg/plugin/v2/init.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin/v2/scaffolds"
 )
 
-type initPlugin struct {
+type initSubcommand struct {
 	config *config.Config
 	// For help text.
 	commandName string
@@ -48,11 +48,11 @@ type initPlugin struct {
 }
 
 var (
-	_ plugin.Init        = &initPlugin{}
-	_ cmdutil.RunOptions = &initPlugin{}
+	_ plugin.InitSubcommand = &initSubcommand{}
+	_ cmdutil.RunOptions    = &initSubcommand{}
 )
 
-func (p *initPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *initSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
 
 Writes the following files:
@@ -75,7 +75,7 @@ project will prompt the user to run 'dep ensure' after writing the project files
 	p.commandName = ctx.CommandName
 }
 
-func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.skipGoVersionCheck, "skip-go-version-check",
 		false, "if specified, skip checking the Go version")
 
@@ -96,7 +96,7 @@ func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
 	}
 }
 
-func (p *initPlugin) InjectConfig(c *config.Config) {
+func (p *initSubcommand) InjectConfig(c *config.Config) {
 	// v3 project configs get a 'layout' value.
 	if c.IsV3() {
 		c.Layout = plugin.KeyFor(Plugin{})
@@ -104,11 +104,11 @@ func (p *initPlugin) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *initPlugin) Run() error {
+func (p *initSubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *initPlugin) Validate() error {
+func (p *initSubcommand) Validate() error {
 	// Requires go1.11+
 	if !p.skipGoVersionCheck {
 		if err := util.ValidateGoVersion(); err != nil {
@@ -145,11 +145,11 @@ func (p *initPlugin) Validate() error {
 	return nil
 }
 
-func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *initSubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewInitScaffolder(p.config, p.license, p.owner), nil
 }
 
-func (p *initPlugin) PostScaffold() error {
+func (p *initSubcommand) PostScaffold() error {
 	if !p.fetchDeps {
 		fmt.Println("Skipping fetching dependencies.")
 		return nil

--- a/pkg/plugin/v2/plugin.go
+++ b/pkg/plugin/v2/plugin.go
@@ -28,41 +28,35 @@ var (
 	pluginVersion            = plugin.Version{Number: 2}
 )
 
-var (
-	_ plugin.Base                      = Plugin{}
-	_ plugin.InitPluginGetter          = Plugin{}
-	_ plugin.CreateAPIPluginGetter     = Plugin{}
-	_ plugin.CreateWebhookPluginGetter = Plugin{}
-	_ plugin.EditPluginGetter          = Plugin{}
-)
+var _ plugin.Full = Plugin{}
 
-// Plugin defines the plugins operations for the v2 plugin version.
+// Plugin implements the plugin.Full interface
 type Plugin struct {
-	initPlugin
-	createAPIPlugin
-	createWebhookPlugin
-	editPlugin
+	initSubcommand
+	createAPISubcommand
+	createWebhookSubcommand
+	editSubcommand
 }
 
-// Name returns the name of the plugin for the v2 which is in this case `go.kubebuilder.io`
+// Name returns the name of the plugin
 func (Plugin) Name() string { return pluginName }
 
-// Version returns the version of the plugin which in this case is 2
+// Version returns the version of the plugin
 func (Plugin) Version() plugin.Version { return pluginVersion }
 
-// SupportedProjectVersions returns an array with all versions project versions are supported by the plugin
-// E.g a plugin can be used with projects that were built with the PROJECT version 3-alpha but not in the Project
-// version 2. See that the PROJECT version is defined in the attribute version of the PROJECT file.
+// SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []string { return supportedProjectVersions }
 
-// GetInitPlugin will return the plugin versions for v2 which is responsible for initialized and scaffold the project
-func (p Plugin) GetInitPlugin() plugin.Init { return &p.initPlugin }
+// GetInitSubcommand will return the subcommand which is responsible for initializing and common scaffolding
+func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
 
-// GetCreateAPIPlugin will return the plugin for v2 which is responsible for scaffold apis
-func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI { return &p.createAPIPlugin }
+// GetCreateAPISubcommand will return the subcommand which is responsible for scaffolding apis
+func (p Plugin) GetCreateAPISubcommand() plugin.CreateAPISubcommand { return &p.createAPISubcommand }
 
-// GetCreateWebhookPlugin will return the plugin for v2 which is responsible for scaffold webhooks for the project
-func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook { return &p.createWebhookPlugin }
+// GetCreateWebhookSubcommand will return the subcommand which is responsible for scaffolding webhooks
+func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
+	return &p.createWebhookSubcommand
+}
 
-// GetEditPlugin will return the plugin for v2 which is responsible for editing the scaffold of the project
-func (p Plugin) GetEditPlugin() plugin.Edit { return &p.editPlugin }
+// GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
+func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }

--- a/pkg/plugin/v2/webhook.go
+++ b/pkg/plugin/v2/webhook.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin/v2/scaffolds"
 )
 
-type createWebhookPlugin struct {
+type createWebhookSubcommand struct {
 	config *config.Config
 	// For help text.
 	commandName string
@@ -43,11 +43,11 @@ type createWebhookPlugin struct {
 }
 
 var (
-	_ plugin.CreateWebhook = &createWebhookPlugin{}
-	_ cmdutil.RunOptions   = &createAPIPlugin{}
+	_ plugin.CreateWebhookSubcommand = &createWebhookSubcommand{}
+	_ cmdutil.RunOptions             = &createWebhookSubcommand{}
 )
 
-func (p *createWebhookPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *createWebhookSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
 `
@@ -63,7 +63,7 @@ validating and (or) conversion webhooks.
 	p.commandName = ctx.CommandName
 }
 
-func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	p.resource = &resource.Options{}
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
@@ -78,15 +78,15 @@ func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
 		"if set, scaffold the conversion webhook")
 }
 
-func (p *createWebhookPlugin) InjectConfig(c *config.Config) {
+func (p *createWebhookSubcommand) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *createWebhookPlugin) Run() error {
+func (p *createWebhookSubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *createWebhookPlugin) Validate() error {
+func (p *createWebhookSubcommand) Validate() error {
 	if err := p.resource.ValidateV2(); err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (p *createWebhookPlugin) Validate() error {
 	return nil
 }
 
-func (p *createWebhookPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *createWebhookSubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	// Load the boilerplate
 	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
 	if err != nil {
@@ -117,6 +117,6 @@ func (p *createWebhookPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.defaulting, p.validation, p.conversion), nil
 }
 
-func (p *createWebhookPlugin) PostScaffold() error {
+func (p *createWebhookSubcommand) PostScaffold() error {
 	return nil
 }

--- a/pkg/plugin/v3/api.go
+++ b/pkg/plugin/v3/api.go
@@ -46,7 +46,7 @@ const KbDeclarativePatternVersion = "v0.0.0-20200522144838-848d48e5b073"
 // DefaultMainPath is default file path of main.go
 const DefaultMainPath = "main.go"
 
-type createAPIPlugin struct {
+type createAPISubcommand struct {
 	config *config.Config
 
 	// pattern indicates that we should use a plugin to build according to a pattern
@@ -68,11 +68,11 @@ type createAPIPlugin struct {
 }
 
 var (
-	_ plugin.CreateAPI   = &createAPIPlugin{}
-	_ cmdutil.RunOptions = &createAPIPlugin{}
+	_ plugin.CreateAPISubcommand = &createAPISubcommand{}
+	_ cmdutil.RunOptions         = &createAPISubcommand{}
 )
 
-func (p createAPIPlugin) UpdateContext(ctx *plugin.Context) {
+func (p createAPISubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
 
 create resource will prompt the user for if it should scaffold the Resource and / or Controller.  To only
@@ -102,7 +102,7 @@ After the scaffold is written, api will run make on the project.
 		ctx.CommandName)
 }
 
-func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.runMake, "make", true, "if true, run make after generating files")
 
 	fs.BoolVar(&p.doResource, "resource", true,
@@ -127,15 +127,15 @@ func (p *createAPIPlugin) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.resource.Namespaced, "namespaced", true, "resource is namespaced")
 }
 
-func (p *createAPIPlugin) InjectConfig(c *config.Config) {
+func (p *createAPISubcommand) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *createAPIPlugin) Run() error {
+func (p *createAPISubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *createAPIPlugin) Validate() error {
+func (p *createAPISubcommand) Validate() error {
 	if err := p.resource.Validate(); err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func (p *createAPIPlugin) Validate() error {
 	return nil
 }
 
-func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *createAPISubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	// Load the boilerplate
 	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
 	if err != nil {
@@ -201,7 +201,7 @@ func (p *createAPIPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
 }
 
-func (p *createAPIPlugin) PostScaffold() error {
+func (p *createAPISubcommand) PostScaffold() error {
 	// Load the requested plugins
 	switch strings.ToLower(p.pattern) {
 	case "":

--- a/pkg/plugin/v3/edit.go
+++ b/pkg/plugin/v3/edit.go
@@ -28,18 +28,18 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds"
 )
 
-type editPlugin struct {
+type editSubcommand struct {
 	config *config.Config
 
 	multigroup bool
 }
 
 var (
-	_ plugin.Edit        = &editPlugin{}
-	_ cmdutil.RunOptions = &editPlugin{}
+	_ plugin.EditSubcommand = &editSubcommand{}
+	_ cmdutil.RunOptions    = &editSubcommand{}
 )
 
-func (p *editPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *editSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `This command will edit the project configuration. You can have single or multi group project.`
 
 	ctx.Examples = fmt.Sprintf(`# Enable the multigroup layout
@@ -50,26 +50,26 @@ func (p *editPlugin) UpdateContext(ctx *plugin.Context) {
 	`, ctx.CommandName, ctx.CommandName)
 }
 
-func (p *editPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.multigroup, "multigroup", false, "enable or disable multigroup layout")
 }
 
-func (p *editPlugin) InjectConfig(c *config.Config) {
+func (p *editSubcommand) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *editPlugin) Run() error {
+func (p *editSubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *editPlugin) Validate() error {
+func (p *editSubcommand) Validate() error {
 	return nil
 }
 
-func (p *editPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *editSubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewEditScaffolder(p.config, p.multigroup), nil
 }
 
-func (p *editPlugin) PostScaffold() error {
+func (p *editSubcommand) PostScaffold() error {
 	return nil
 }

--- a/pkg/plugin/v3/init.go
+++ b/pkg/plugin/v3/init.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds"
 )
 
-type initPlugin struct {
+type initSubcommand struct {
 	config *config.Config
 	// For help text.
 	commandName string
@@ -49,11 +49,11 @@ type initPlugin struct {
 }
 
 var (
-	_ plugin.Init        = &initPlugin{}
-	_ cmdutil.RunOptions = &initPlugin{}
+	_ plugin.InitSubcommand = &initSubcommand{}
+	_ cmdutil.RunOptions    = &initSubcommand{}
 )
 
-func (p *initPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *initSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
 
 Writes the following files:
@@ -76,7 +76,7 @@ project will prompt the user to run 'dep ensure' after writing the project files
 	p.commandName = ctx.CommandName
 }
 
-func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.skipGoVersionCheck, "skip-go-version-check",
 		false, "if specified, skip checking the Go version")
 
@@ -95,16 +95,16 @@ func (p *initPlugin) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.config.ProjectName, "project-name", "", "name of this project")
 }
 
-func (p *initPlugin) InjectConfig(c *config.Config) {
+func (p *initSubcommand) InjectConfig(c *config.Config) {
 	c.Layout = plugin.KeyFor(Plugin{})
 	p.config = c
 }
 
-func (p *initPlugin) Run() error {
+func (p *initSubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *initPlugin) Validate() error {
+func (p *initSubcommand) Validate() error {
 	// Requires go1.11+
 	if !p.skipGoVersionCheck {
 		if err := util.ValidateGoVersion(); err != nil {
@@ -141,11 +141,11 @@ func (p *initPlugin) Validate() error {
 	return nil
 }
 
-func (p *initPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *initSubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewInitScaffolder(p.config, p.license, p.owner), nil
 }
 
-func (p *initPlugin) PostScaffold() error {
+func (p *initSubcommand) PostScaffold() error {
 	if !p.fetchDeps {
 		fmt.Println("Skipping fetching dependencies.")
 		return nil

--- a/pkg/plugin/v3/plugin.go
+++ b/pkg/plugin/v3/plugin.go
@@ -28,41 +28,35 @@ var (
 	pluginVersion            = plugin.Version{Number: 3, Stage: plugin.AlphaStage}
 )
 
-var (
-	_ plugin.Base                      = Plugin{}
-	_ plugin.InitPluginGetter          = Plugin{}
-	_ plugin.CreateAPIPluginGetter     = Plugin{}
-	_ plugin.CreateWebhookPluginGetter = Plugin{}
-	_ plugin.EditPluginGetter          = Plugin{}
-)
+var _ plugin.Full = Plugin{}
 
-// Plugin defines the plugins operations for the v3+ plugin versions.
+// Plugin implements the plugin.Full interface
 type Plugin struct {
-	initPlugin
-	createAPIPlugin
-	createWebhookPlugin
-	editPlugin
+	initSubcommand
+	createAPISubcommand
+	createWebhookSubcommand
+	editSubcommand
 }
 
-// Name returns the name of the plugin for the v3+ which is in this case `go.kubebuilder.io`
+// Name returns the name of the plugin
 func (Plugin) Name() string { return pluginName }
 
-// Version returns the version of the plugin.
+// Version returns the version of the plugin
 func (Plugin) Version() plugin.Version { return pluginVersion }
 
-// SupportedProjectVersions returns an array with all versions project versions are supported by the plugin
-// E.g a plugin can be used with projects that were built with the PROJECT version 3-alpha but not in the Project
-// version 2. See that the PROJECT version is defined in the attribute version of the PROJECT file.
+// SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []string { return supportedProjectVersions }
 
-// GetInitPlugin will return the plugin versions for v3+ which is responsible for initialized and scaffold the project
-func (p Plugin) GetInitPlugin() plugin.Init { return &p.initPlugin }
+// GetInitSubcommand will return the subcommand which is responsible for initializing and common scaffolding
+func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
 
-// GetCreateAPIPlugin will return the plugin for v3+ which is responsible for scaffold apis
-func (p Plugin) GetCreateAPIPlugin() plugin.CreateAPI { return &p.createAPIPlugin }
+// GetCreateAPISubcommand will return the subcommand which is responsible for scaffolding apis
+func (p Plugin) GetCreateAPISubcommand() plugin.CreateAPISubcommand { return &p.createAPISubcommand }
 
-// GetCreateWebhookPlugin will return the plugin for v3+ which is responsible for scaffold webhooks for the project
-func (p Plugin) GetCreateWebhookPlugin() plugin.CreateWebhook { return &p.createWebhookPlugin }
+// GetCreateWebhookSubcommand will return the subcommand which is responsible for scaffolding webhooks
+func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
+	return &p.createWebhookSubcommand
+}
 
-// GetEditPlugin will return the plugin for v3+ which is responsible for editing the scaffold of the project
-func (p Plugin) GetEditPlugin() plugin.Edit { return &p.editPlugin }
+// GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
+func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }

--- a/pkg/plugin/v3/webhook.go
+++ b/pkg/plugin/v3/webhook.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/kubebuilder/pkg/plugin/v3/scaffolds"
 )
 
-type createWebhookPlugin struct {
+type createWebhookSubcommand struct {
 	config *config.Config
 	// For help text.
 	commandName string
@@ -43,11 +43,11 @@ type createWebhookPlugin struct {
 }
 
 var (
-	_ plugin.CreateWebhook = &createWebhookPlugin{}
-	_ cmdutil.RunOptions   = &createAPIPlugin{}
+	_ plugin.CreateWebhookSubcommand = &createWebhookSubcommand{}
+	_ cmdutil.RunOptions             = &createWebhookSubcommand{}
 )
 
-func (p *createWebhookPlugin) UpdateContext(ctx *plugin.Context) {
+func (p *createWebhookSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
 `
@@ -63,7 +63,7 @@ validating and (or) conversion webhooks.
 	p.commandName = ctx.CommandName
 }
 
-func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
+func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	p.resource = &resource.Options{}
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
@@ -78,15 +78,15 @@ func (p *createWebhookPlugin) BindFlags(fs *pflag.FlagSet) {
 		"if set, scaffold the conversion webhook")
 }
 
-func (p *createWebhookPlugin) InjectConfig(c *config.Config) {
+func (p *createWebhookSubcommand) InjectConfig(c *config.Config) {
 	p.config = c
 }
 
-func (p *createWebhookPlugin) Run() error {
+func (p *createWebhookSubcommand) Run() error {
 	return cmdutil.Run(p)
 }
 
-func (p *createWebhookPlugin) Validate() error {
+func (p *createWebhookSubcommand) Validate() error {
 	if err := p.resource.Validate(); err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (p *createWebhookPlugin) Validate() error {
 	return nil
 }
 
-func (p *createWebhookPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
+func (p *createWebhookSubcommand) GetScaffolder() (scaffold.Scaffolder, error) {
 	// Load the boilerplate
 	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
 	if err != nil {
@@ -117,6 +117,6 @@ func (p *createWebhookPlugin) GetScaffolder() (scaffold.Scaffolder, error) {
 	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.defaulting, p.validation, p.conversion), nil
 }
 
-func (p *createWebhookPlugin) PostScaffold() error {
+func (p *createWebhookSubcommand) PostScaffold() error {
 	return nil
 }


### PR DESCRIPTION
# Description
Rename plugin getters return objects to `Subcommand`.

# Motivation
Currently, both the structs with the getters and those returned by them are called "plugin" (`Plugin -> Plugin`), leading to missunderstandings. In order to clarify which is which, one of them should be renamed. There are two possibilities:

1. Rename the struct with the getters to something like `PluginFactory`: `PluginFactory -> Plugin`
2. Rename the returned type to something like `Subcommand`: `Plugin -> Subcommand`

The word "plugin" is already extensively used in the code (comments, variable names, ...) to refer to the left term, so I figured that it would be easier to go for the second option.

When deciding which name to use, I saw how the base class for the right term structs was already `GenericSubcommand` and it basically represents that, with methods to bind flags and execute the command, so I opted for `Subcommand`.

