### PR TITLE
:bug: fix copyright info when has not a owner set

### DIFF
--- a/pkg/plugin/v2/scaffolds/internal/templates/boilerplate.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/boilerplate.go
@@ -71,6 +71,8 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 const apache = `/*
 {{ if .Owner -}}
 Copyright {{ .Year }} {{ .Owner }}.
+{{- else -}}
+Copyright {{ .Year }}.
 {{- end }}
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,5 +91,7 @@ limitations under the License.
 const none = `/*
 {{ if .Owner -}}
 Copyright {{ .Year }} {{ .Owner }}.
+{{- else -}}
+Copyright {{ .Year }}.
 {{- end }}
 */`

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/hack/boilerplate.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/hack/boilerplate.go
@@ -71,6 +71,8 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 const apache = `/*
 {{ if .Owner -}}
 Copyright {{ .Year }} {{ .Owner }}.
+{{- else -}}
+Copyright {{ .Year }}.
 {{- end }}
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,5 +91,7 @@ limitations under the License.
 const none = `/*
 {{ if .Owner -}}
 Copyright {{ .Year }} {{ .Owner }}.
+{{- else -}}
+Copyright {{ .Year }}.
 {{- end }}
 */`


### PR DESCRIPTION
**Description**
Ensure that the copyright will be set when the owner is empty with the year only.

**Motivation**
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1620

**Local Test**

```
$ cat main.go 
/*
Copyright 2020.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

```