### PR TITLE
:bug: kubebuilder edit ignore the errors if the project layout is already on same type

### DIFF
--- a/pkg/plugin/v2/scaffolds/edit.go
+++ b/pkg/plugin/v2/scaffolds/edit.go
@@ -42,7 +42,6 @@ func NewEditScaffolder(config *config.Config, multigroup bool) scaffold.Scaffold
 
 // Scaffold implements Scaffolder
 func (s *editScaffolder) Scaffold() error {
-	s.config.MultiGroup = s.multigroup
 	filename := "Dockerfile"
 	bs, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -56,21 +55,29 @@ func (s *editScaffolder) Scaffold() error {
 			str,
 			"COPY api/ api/",
 			`COPY apis/ apis/`)
-		if err != nil {
-			return err
-		}
 	} else {
 		str, err = ensureExistAndReplace(
 			str,
 			"COPY apis/ apis/",
 			`COPY api/ api/`)
-		if err != nil {
-			return err
-		}
 	}
-	// false positive
-	// nolint:gosec
-	return ioutil.WriteFile(filename, []byte(str), 0644)
+
+	// Ignore the error encountered, if the file is already in desired format.
+	if err != nil && s.multigroup != s.config.MultiGroup {
+		return err
+	}
+
+	s.config.MultiGroup = s.multigroup
+
+	// Check if the str is not empty, because when the file is already in desired format it will return empty string
+	// because there is nothing to replace.
+	if str != "" {
+		// false positive
+		// nolint:gosec
+		return ioutil.WriteFile(filename, []byte(str), 0644)
+	}
+
+	return nil
 }
 
 func ensureExistAndReplace(input, match, replace string) (string, error) {

--- a/pkg/plugin/v3/scaffolds/edit.go
+++ b/pkg/plugin/v3/scaffolds/edit.go
@@ -42,7 +42,6 @@ func NewEditScaffolder(config *config.Config, multigroup bool) scaffold.Scaffold
 
 // Scaffold implements Scaffolder
 func (s *editScaffolder) Scaffold() error {
-	s.config.MultiGroup = s.multigroup
 	filename := "Dockerfile"
 	bs, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -56,21 +55,30 @@ func (s *editScaffolder) Scaffold() error {
 			str,
 			"COPY api/ api/",
 			`COPY apis/ apis/`)
-		if err != nil {
-			return err
-		}
+
 	} else {
 		str, err = ensureExistAndReplace(
 			str,
 			"COPY apis/ apis/",
 			`COPY api/ api/`)
-		if err != nil {
-			return err
-		}
 	}
-	// false positive
-	// nolint:gosec
-	return ioutil.WriteFile(filename, []byte(str), 0644)
+
+	// Ignore the error encountered, if the file is already in desired format.
+	if err != nil && s.multigroup != s.config.MultiGroup {
+		return err
+	}
+
+	s.config.MultiGroup = s.multigroup
+
+	// Check if the str is not empty, because when the file is already in desired format it will return empty string
+	// because there is nothing to replace.
+	if str != "" {
+		// false positive
+		// nolint:gosec
+		return ioutil.WriteFile(filename, []byte(str), 0644)
+	}
+
+	return nil
 }
 
 func ensureExistAndReplace(input, match, replace string) (string, error) {


### PR DESCRIPTION
**Description of the change**

Add validation of kb edit command if the scaffolding is already on same side either `multigroup: true` or `multigroup: false`. kb edit command fails when it tries to change the Dockerfile that it doesn't find the apis or api directory respectively.

**Motivation of the change**
Fixes: #1747 