### PR TITLE
🌱 Remove unused mixin from controller suite test template

### DIFF
--- a/pkg/plugin/v2/scaffolds/internal/templates/controller/controller_suitetest.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/controller/controller_suitetest.go
@@ -29,7 +29,6 @@ var _ file.Inserter = &SuiteTest{}
 // SuiteTest scaffolds the suite_test.go file to setup the controller test
 type SuiteTest struct {
 	file.TemplateMixin
-	file.RepositoryMixin
 	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/controller/controller_suitetest.go
@@ -29,7 +29,6 @@ var _ file.Inserter = &SuiteTest{}
 // SuiteTest scaffolds the suite_test.go file to setup the controller test
 type SuiteTest struct {
 	file.TemplateMixin
-	file.RepositoryMixin
 	file.MultiGroupMixin
 	file.BoilerplateMixin
 	file.ResourceMixin


### PR DESCRIPTION
# Description
Remove `RepositoryMixin` from controller suite tests.

# Motivation
Controller suite test do not use the repository field for anything, so there is no need to inject it into the template.

P.S.: I have checked for every template and these two are the only ones with an unnecessary mixin or field.
