### PR TITLE
🌱 Unify bolierplate with a single template body

### DIFF
--- a/pkg/plugin/v2/scaffolds/internal/templates/boilerplate.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/boilerplate.go
@@ -34,6 +34,9 @@ type Boilerplate struct {
 	// License is the License type to write
 	License string
 
+	// Licenses maps License types to their actual string
+	Licenses map[string]string
+
 	// Owner is the copyright owner - e.g. "The Kubernetes Authors"
 	Owner string
 
@@ -41,10 +44,39 @@ type Boilerplate struct {
 	Year string
 }
 
+// Validate implements file.RequiresValidation
+func (f Boilerplate) Validate() error {
+	if f.License == "" {
+		// A default license will be set later
+	} else if _, found := knownLicenses[f.License]; found {
+		// One of the know licenses
+	} else if _, found := f.Licenses[f.License]; found {
+		// A map containing the requested license was also provided
+	} else {
+		return fmt.Errorf("unknown specified license %s", f.License)
+	}
+
+	return nil
+}
+
 // SetTemplateDefaults implements input.Template
 func (f *Boilerplate) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("hack", "boilerplate.go.txt")
+	}
+
+	if f.License == "" {
+		f.License = "apache2"
+	}
+
+	if f.Licenses == nil {
+		f.Licenses = make(map[string]string, len(knownLicenses))
+	}
+
+	for key, value := range knownLicenses {
+		if _, hasLicense := f.Licenses[key]; !hasLicense {
+			f.Licenses[key] = value
+		}
 	}
 
 	if f.Year == "" {
@@ -57,24 +89,25 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 		return nil
 	}
 
-	// Pick a template boilerplate option
-	switch f.License {
-	case "", "apache2":
-		f.TemplateBody = apache
-	case "none":
-		f.TemplateBody = none
-	}
+	f.TemplateBody = boilerplateTemplate
 
 	return nil
 }
 
-const apache = `/*
+const boilerplateTemplate = `/*
 {{ if .Owner -}}
 Copyright {{ .Year }} {{ .Owner }}.
 {{- else -}}
 Copyright {{ .Year }}.
 {{- end }}
+{{ index .Licenses .License }}*/`
 
+var knownLicenses = map[string]string{
+	"apache2": apache2,
+	"none":    "",
+}
+
+const apache2 = `
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -86,12 +119,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/`
-
-const none = `/*
-{{ if .Owner -}}
-Copyright {{ .Year }} {{ .Owner }}.
-{{- else -}}
-Copyright {{ .Year }}.
-{{- end }}
-*/`
+`

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/hack/boilerplate.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/hack/boilerplate.go
@@ -34,6 +34,9 @@ type Boilerplate struct {
 	// License is the License type to write
 	License string
 
+	// Licenses maps License types to their actual string
+	Licenses map[string]string
+
 	// Owner is the copyright owner - e.g. "The Kubernetes Authors"
 	Owner string
 
@@ -41,10 +44,39 @@ type Boilerplate struct {
 	Year string
 }
 
+// Validate implements file.RequiresValidation
+func (f Boilerplate) Validate() error {
+	if f.License == "" {
+		// A default license will be set later
+	} else if _, found := knownLicenses[f.License]; found {
+		// One of the know licenses
+	} else if _, found := f.Licenses[f.License]; found {
+		// A map containing the requested license was also provided
+	} else {
+		return fmt.Errorf("unknown specified license %s", f.License)
+	}
+
+	return nil
+}
+
 // SetTemplateDefaults implements input.Template
 func (f *Boilerplate) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("hack", "boilerplate.go.txt")
+	}
+
+	if f.License == "" {
+		f.License = "apache2"
+	}
+
+	if f.Licenses == nil {
+		f.Licenses = make(map[string]string, len(knownLicenses))
+	}
+
+	for key, value := range knownLicenses {
+		if _, hasLicense := f.Licenses[key]; !hasLicense {
+			f.Licenses[key] = value
+		}
 	}
 
 	if f.Year == "" {
@@ -57,24 +89,25 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 		return nil
 	}
 
-	// Pick a template boilerplate option
-	switch f.License {
-	case "", "apache2":
-		f.TemplateBody = apache
-	case "none":
-		f.TemplateBody = none
-	}
+	f.TemplateBody = boilerplateTemplate
 
 	return nil
 }
 
-const apache = `/*
+const boilerplateTemplate = `/*
 {{ if .Owner -}}
 Copyright {{ .Year }} {{ .Owner }}.
 {{- else -}}
 Copyright {{ .Year }}.
 {{- end }}
+{{ index .Licenses .License }}*/`
 
+var knownLicenses = map[string]string{
+	"apache2": apache2,
+	"none":    "",
+}
+
+const apache2 = `
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -86,12 +119,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/`
-
-const none = `/*
-{{ if .Owner -}}
-Copyright {{ .Year }} {{ .Owner }}.
-{{- else -}}
-Copyright {{ .Year }}.
-{{- end }}
-*/`
+`


### PR DESCRIPTION
# Description
Boilerplate code has one different template bodys for each accepted license. Modify it so that a single template body is used and the license is extracted from a map of licenses.

# Motivation
This PR has two main goals:
1. Reduce the duplicated code by not having multiple copyright sections of the boilerplate.
1. Stop templating parts of the file during the `SetTemplateDefault` call, as later modifications to the template struct will not be reflected in the scaffolded file. For example, lets supose we want to modify the license  to "none" after the defaults have been set. As the template body was already selected including the License already in it, our change to the license would not yield any error but would not be applied.