### PR TITLE
:sparkles: remove v1 version and only shows --plugins flag when the project version is != V2

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ func readFrom(fs afero.Fs, path string) (c config.Config, err error) {
 
 	// kubebuilder v1 omitted version, so default to v1
 	if c.Version == "" {
-		c.Version = config.Version1
+		return config.Config{}, fmt.Errorf("project version key `version` is empty or does not exist in %s", path)
 	}
 
 	return
@@ -178,4 +178,9 @@ type saveError struct {
 
 func (e saveError) Error() string {
 	return fmt.Sprintf("unable to save the configuration: %v", e.err)
+}
+
+// IsVersionSupported returns true if version is a supported project version.
+func IsVersionSupported(version string) bool {
+	return version == config.Version2 || version == config.Version3Alpha
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -193,8 +193,8 @@ func (c *cli) initialize() error {
 		c.configured = true
 		c.projectVersion = projectConfig.Version
 
-		if projectConfig.IsV1() {
-			return fmt.Errorf(noticeColor, "project version 1 is no longer supported.\n"+
+		if !internalconfig.IsVersionSupported(c.projectVersion) {
+			return fmt.Errorf(noticeColor, fmt.Sprintf("project version %q is no longer supported.\n", projectConfig.Version)+
 				"See how to upgrade your project: https://book.kubebuilder.io/migration/guide.html\n")
 		}
 	} else {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -46,7 +46,7 @@ func (c *cli) newInitCmd() *cobra.Command {
 	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion,
 		fmt.Sprintf("project version, possible values: (%s)", strings.Join(c.getAvailableProjectVersions(), ", ")))
 	// The --plugins flag can only be called to init projects v2+.
-	if c.projectVersion != config.Version1 {
+	if c.projectVersion != config.Version2 {
 		cmd.Flags().StringSlice(pluginsFlag, nil,
 			"Name and optionally version of the plugin to initialize the project with. "+
 				fmt.Sprintf("Available plugins: (%s)", strings.Join(c.getAvailablePlugins(), ", ")))

--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -25,7 +25,6 @@ import (
 
 // Scaffolding versions
 const (
-	Version1      = "1"
 	Version2      = "2"
 	Version3Alpha = "3-alpha"
 )
@@ -65,11 +64,6 @@ type PluginConfigs map[string]pluginConfig
 // pluginConfig is an arbitrary plugin configuration object.
 type pluginConfig interface{}
 
-// IsV1 returns true if it is a v1 project
-func (c Config) IsV1() bool {
-	return c.Version == Version1
-}
-
 // IsV2 returns true if it is a v2 project
 func (c Config) IsV2() bool {
 	return c.Version == Version2
@@ -97,11 +91,6 @@ func (c Config) HasResource(target GVK) bool {
 // It returns if the configuration was modified
 // NOTE: in v1 resources are not tracked, so we return false
 func (c *Config) AddResource(gvk GVK) bool {
-	// Short-circuit v1
-	if c.IsV1() {
-		return false
-	}
-
 	// No-op if the resource was already tracked, return false
 	if c.HasResource(gvk) {
 		return false

--- a/pkg/model/config/config_test.go
+++ b/pkg/model/config/config_test.go
@@ -37,8 +37,8 @@ var _ = Describe("Config", func() {
 			expectedConfig Config
 		)
 
-		By("Using config version 1")
-		config = Config{Version: Version1}
+		By("Using config version empty")
+		config = Config{}
 		pluginConfig = PluginConfig{}
 		Expect(config.EncodePluginConfig(key, pluginConfig)).NotTo(Succeed())
 
@@ -95,11 +95,6 @@ var _ = Describe("Config", func() {
 			pluginConfig         PluginConfig
 			expectedPluginConfig PluginConfig
 		)
-
-		By("Using config version 1")
-		config = Config{Version: Version1}
-		pluginConfig = PluginConfig{}
-		Expect(config.DecodePluginConfig(key, &pluginConfig)).NotTo(Succeed())
 
 		By("Using config version 2")
 		config = Config{Version: Version2}


### PR DESCRIPTION
**Description**
- remove v1 version 
- shows plugins --flag only if Project Version is != V2

**Motivation**

https://github.com/kubernetes-sigs/kubebuilder/pull/1636

Co-author @estroz 