### PR TITLE
:seedling: add plugins directory to be checked in the tests and coveralls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ endif
 ##@ Tests
 
 .PHONY: go-test
-go-test: ## Run the go tests ($ go test -v ./cmd/... ./pkg/...)
-	go test -race -v ./cmd/... ./pkg/...
+go-test: ## Run the unit test
+	go test -race -v ./cmd/... ./pkg/... ./plugins/...
 
 .PHONY: test
 test: ## Run the unit tests (used in the CI)
@@ -95,7 +95,7 @@ test-coverage:  ## Run coveralls
 	# remove all coverage files if exists
 	- rm -rf *.out
 	# run the go tests and gen the file coverage-all used to do the integration with coverrals.io
-	go test -race -failfast -tags=integration -coverprofile=coverage-all.out ./pkg/... ./cmd/...
+	go test -race -failfast -tags=integration -coverprofile=coverage-all.out ./cmd/... ./pkg/... ./plugins/...
 
 .PHONY: test-e2e-local
 test-e2e-local: ## It will run the script to install kind and run e2e tests

--- a/test.sh
+++ b/test.sh
@@ -140,7 +140,7 @@ header_text "running kubebuilder unit tests"
 cd ${go_workspace}/src/sigs.k8s.io/kubebuilder
 
 export GO111MODULE=on
-go test  -race ./cmd/... ./pkg/...
+go test -race -v ./cmd/... ./pkg/... ./plugins/...
 
 # test project v2
 GO111MODULE=on test_project project-v2 2


### PR DESCRIPTION
**Description**

With the introduction of the plugin design, the directory plugins were added to the project. However, the target and scripts which runs the go unit tests and the coveralls were not updated to cover the new directories. 

