### PR TITLE
🌱 Remove unused commnadName field

### DIFF
--- a/pkg/plugin/v2/edit.go
+++ b/pkg/plugin/v2/edit.go
@@ -29,8 +29,6 @@ import (
 
 type editPlugin struct {
 	config *config.Config
-	// For help text
-	commandName string
 
 	multigroup bool
 }
@@ -49,8 +47,6 @@ func (p *editPlugin) UpdateContext(ctx *plugin.Context) {
         # Disable the multigroup layout
         %s edit --multigroup=false
 	`, ctx.CommandName, ctx.CommandName)
-
-	p.commandName = ctx.CommandName
 }
 
 func (p *editPlugin) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugin/v3/edit.go
+++ b/pkg/plugin/v3/edit.go
@@ -30,8 +30,6 @@ import (
 
 type editPlugin struct {
 	config *config.Config
-	// For help text
-	commandName string
 
 	multigroup bool
 }
@@ -50,8 +48,6 @@ func (p *editPlugin) UpdateContext(ctx *plugin.Context) {
         # Disable the multigroup layout
         %s edit --multigroup=false
 	`, ctx.CommandName, ctx.CommandName)
-
-	p.commandName = ctx.CommandName
 }
 
 func (p *editPlugin) BindFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION
# Description
Removes a field that was not being used inside the `edit` command.

# Motivation
Excess code removal. In the rest of the commands (`init`, `create`, ...) this field is used for error string formating but in `edit` it is not needed.

/kind cleanup