### PR TITLE
⚠Provide version information as a CLI option

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -17,7 +17,7 @@
 builds:
 - main: ./cmd
   binary: kubebuilder
-  ldflags: -s -X sigs.k8s.io/kubebuilder/v2/cmd/version.kubeBuilderVersion={{.Version}} -X sigs.k8s.io/kubebuilder/v2/cmd/version.gitCommit={{.Commit}} -X sigs.k8s.io/kubebuilder/v2/cmd/version.buildDate={{.Date}} -X sigs.k8s.io/kubebuilder/v2/cmd/version.kubernetesVendorVersion={{.Env.KUBERNETES_VERSION}}
+  ldflags: -s -X sigs.k8s.io/kubebuilder/v2/cmd.kubeBuilderVersion={{.Version}} -X sigs.k8s.io/kubebuilder/v2/cmd.gitCommit={{.Commit}} -X sigs.k8s.io/kubebuilder/v2/cmd.buildDate={{.Date}} -X sigs.k8s.io/kubebuilder/v2/cmd.kubernetesVendorVersion={{.Env.KUBERNETES_VERSION}}
   goos:
    - darwin
    - linux

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,12 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package main
 
 import (
 	"fmt"
-
-	"github.com/spf13/cobra"
 )
 
 // var needs to be used instead of const as ldflags is used to fill this
@@ -34,8 +32,8 @@ var (
 	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
-// Version contains all the information related to the CLI version
-type Version struct {
+// version contains all the information related to the CLI version
+type version struct {
 	KubeBuilderVersion string `json:"kubeBuilderVersion"`
 	KubernetesVendor   string `json:"kubernetesVendor"`
 	GitCommit          string `json:"gitCommit"`
@@ -44,33 +42,14 @@ type Version struct {
 	GoArch             string `json:"goArch"`
 }
 
-func getVersion() Version {
-	return Version{
+// versionString returns the CLI version
+func versionString() string {
+	return fmt.Sprintf("Version: %#v", version{
 		kubeBuilderVersion,
 		kubernetesVendorVersion,
 		gitCommit,
 		buildDate,
 		goos,
 		goarch,
-	}
-}
-
-// Print prints the CLI version
-func (v Version) Print() {
-	fmt.Printf("Version: %#v\n", v)
-}
-
-// NewCmd creates a new command that prints the CLI version
-func NewCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "version",
-		Short:   "Print the kubebuilder version",
-		Long:    `Print the kubebuilder version`,
-		Example: `kubebuilder version`,
-		Run:     runVersion,
-	}
-}
-
-func runVersion(_ *cobra.Command, _ []string) {
-	getVersion().Print()
+	})
 }

--- a/common.sh
+++ b/common.sh
@@ -149,8 +149,8 @@ function build_kb {
   if [ "$INJECT_KB_VERSION" = "unknown" ]; then
     opts=""
   else
-    # TODO: what does this thing do.
-    opts=-ldflags "-X sigs.k8s.io/kubebuilder/v2/cmd/version.kubeBuilderVersion=$INJECT_KB_VERSION"
+    # Injects the version into the cmd/version.go file
+    opts=-ldflags "-X sigs.k8s.io/kubebuilder/v2/cmd.kubeBuilderVersion=$INJECT_KB_VERSION"
   fi
 
   GO111MODULE=on go build $opts -o $tmp_root/kubebuilder/bin/kubebuilder ./cmd

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -57,6 +57,9 @@ type Option func(*cli) error
 type cli struct {
 	// Root command name. Can be injected downstream.
 	commandName string
+	// CLI version string
+	version string
+
 	// Default project version. Used in CLI flag setup.
 	defaultProjectVersion string
 	// Project version to scaffold.
@@ -114,6 +117,14 @@ func (c cli) Run() error {
 func WithCommandName(name string) Option {
 	return func(c *cli) error {
 		c.commandName = name
+		return nil
+	}
+}
+
+// WithVersion is an Option that defines the version string of the cli.
+func WithVersion(version string) Option {
+	return func(c *cli) error {
+		c.version = version
 		return nil
 	}
 }
@@ -363,8 +374,15 @@ func (c cli) buildRootCmd() *cobra.Command {
 
 	// kubebuilder edit
 	rootCmd.AddCommand(c.newEditCmd())
+
 	// kubebuilder init
 	rootCmd.AddCommand(c.newInitCmd())
+
+	// kubebuilder version
+	// Only add version if a version string was provided
+	if c.version != "" {
+		rootCmd.AddCommand(c.newVersionCmd())
+	}
 
 	return rootCmd
 }
@@ -416,7 +434,6 @@ After the scaffold is written, api will run make on the project.
   make run
 `,
 			c.commandName, c.commandName),
-
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
 				log.Fatal(err)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -291,6 +291,16 @@ var _ = Describe("CLI", func() {
 			})
 		})
 
+		Context("WithVersion", func() {
+			It("should use the provided version string", func() {
+				version := "Version: 0.0.0"
+				c, err = New(WithVersion(version), WithDefaultPlugins(pluginAV1), WithPlugins(allPlugins...))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c).NotTo(BeNil())
+				Expect(c.(*cli).version).To(Equal(version))
+			})
+		})
+
 		Context("WithDefaultProjectVersion", func() {
 			var defaultProjectVersion string
 

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,33 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cli
 
 import (
-	"log"
+	"fmt"
 
-	"sigs.k8s.io/kubebuilder/v2/pkg/cli"
-	pluginv2 "sigs.k8s.io/kubebuilder/v2/pkg/plugin/v2"
-	pluginv3 "sigs.k8s.io/kubebuilder/v2/pkg/plugin/v3"
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	c, err := cli.New(
-		cli.WithCommandName("kubebuilder"),
-		cli.WithVersion(versionString()),
-		cli.WithPlugins(
-			&pluginv2.Plugin{},
-			&pluginv3.Plugin{},
-		),
-		cli.WithDefaultPlugins(
-			&pluginv2.Plugin{},
-		),
-		cli.WithCompletion,
-	)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if err := c.Run(); err != nil {
-		log.Fatal(err)
+func (c *cli) newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "version",
+		Short:   fmt.Sprintf("Print the %s version", c.commandName),
+		Long:    fmt.Sprintf("Print the %s version", c.commandName),
+		Example: fmt.Sprintf("%s version", c.commandName),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			fmt.Println(c.version)
+			return nil
+		},
 	}
 }


### PR DESCRIPTION
# Description
Provide a `WithVersion` CLI `Option` that allows to provide a version string instead of having to create a `version` command and provide it as an extra command. When a version is provided this way, the CLI will create a version command automatically that prints this version string.

# Changes
- ✨ New argument type for `cli.New`: `WithVersion`. Creating a command and providing it with `WithExtraCommands` should still work with the previous behavior, so this is not a breaking change, but frameworks using `kubebuilder` should migrate to the new approach.
- ⚠️ Removed `Version` and `NewCmd` from package `cmd/version`. This package is not part of the library itself, but as it is exported, it may be used by third parties.