### PR TITLE
✨Suggestions for create and alpha commands

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -24,9 +24,10 @@ import (
 
 func (c *cli) newAlphaCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "alpha",
-		Short: "Expose commands which are in experimental or early stages of development",
-		Long:  `Command group for commands which are either experimental or in early stages of development`,
+		Use:        "alpha",
+		SuggestFor: []string{"experimental"},
+		Short:      "Expose commands which are in experimental or early stages of development",
+		Long:       `Command group for commands which are either experimental or in early stages of development`,
 		Example: fmt.Sprintf(`
 # scaffolds webhook server
 %s alpha webhook <params>`,

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -22,8 +22,9 @@ import (
 
 func (c *cli) newCreateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "create",
-		Short: "Scaffold a Kubernetes API or webhook",
-		Long:  `Scaffold a Kubernetes API or webhook.`,
+		Use:        "create",
+		SuggestFor: []string{"new"},
+		Short:      "Scaffold a Kubernetes API or webhook",
+		Long:       `Scaffold a Kubernetes API or webhook.`,
 	}
 }


### PR DESCRIPTION
# Description
Added suggestions for some commands so that when the CLI user writes a similar term it gets useful help information telling him the correct subcommand name

- `create`: `new`
- `alpha`: `experimental`