### PR TITLE
:seedling: cleanup: remove v1 comment

### DIFF
--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -89,7 +89,6 @@ func (c Config) HasResource(target GVK) bool {
 
 // AddResource appends the provided resource to the tracked ones
 // It returns if the configuration was modified
-// NOTE: in v1 resources are not tracked, so we return false
 func (c *Config) AddResource(gvk GVK) bool {
 	// No-op if the resource was already tracked, return false
 	if c.HasResource(gvk) {


### PR DESCRIPTION
**Description**
Remove the comment over v1, since no longer exists v1 code in the project

**Motivation**
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1781