### PR TITLE
:warning: upgrade controller-tool dep from 0.3.0 to 0.4.0 (go/v3-alpha only)

### DIFF
--- a/pkg/plugin/v3/scaffolds/init.go
+++ b/pkg/plugin/v3/scaffolds/init.go
@@ -39,7 +39,7 @@ const (
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
 	ControllerRuntimeVersion = "v0.6.3"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
-	ControllerToolsVersion = "v0.3.0"
+	ControllerToolsVersion = "v0.4.0"
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
 	KustomizeVersion = "v3.5.4"
 

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -78,7 +78,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -78,7 +78,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -78,7 +78,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen


### PR DESCRIPTION
**Description**
- upgrade controller-tool dep from 0.3.0 to 0.4.0 (go/v3-alpha only)

NOTE: The controller-tool no generates  CRD version to v1 by default (#468) and add admissionregisteration/v1 support for webhook (#469) which means that are breaking changes for v2+. Then, because of this, the fix can only be addressed to v3+ plugin. 

**Motivation**
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1634