### PR TITLE
✨ Add --plural flag

### DIFF
--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -165,6 +165,7 @@ type ResourceData struct {
 	Group   string `json:"group,omitempty"`
 	Version string `json:"version,omitempty"`
 	Kind    string `json:"kind,omitempty"`
+	Plural  string `json:"plural,omitempty"`
 
 	// API holds the API data
 	API *API `json:"api,omitempty"`

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gobuffalo/flect"
+
 	"sigs.k8s.io/kubebuilder/v2/pkg/model/config"
 )
 
@@ -61,13 +63,20 @@ type Resource struct {
 
 // Data returns the ResourceData information to check against tracked resources in the configuration file
 func (r *Resource) Data() config.ResourceData {
-	return config.ResourceData{
+	data := config.ResourceData{
 		Group:    r.Group,
 		Version:  r.Version,
 		Kind:     r.Kind,
 		API:      &r.API,
 		Webhooks: &r.Webhooks,
 	}
+
+	// Only store plural if it is irregular
+	if r.Plural != flect.Pluralize(strings.ToLower(r.Kind)) {
+		data.Plural = r.Plural
+	}
+
+	return data
 }
 
 func wrapKey(key string) string {

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -111,9 +111,9 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.force, "force", false,
 		"attempt to create resource even if it already exists")
 	p.resource = &resource.Options{}
-	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
+	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
 	fs.BoolVar(&p.resource.Namespaced, "namespaced", true, "resource is namespaced")
 }
 

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -67,7 +67,7 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
 	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
-	fs.StringVar(&p.resource.Plural, "resource", "", "resource Resource")
+	fs.StringVar(&p.resource.Plural, "resource", "", "resource kind irregular plural form")
 
 	fs.BoolVar(&p.defaulting, "defaulting", false,
 		"if set, scaffold the defaulting webhook")

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -125,9 +125,10 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.force, "force", false,
 		"attempt to create resource even if it already exists")
 	p.resource = &resource.Options{}
-	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
+	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
+	fs.StringVar(&p.resource.Plural, "plural", "", "resource kind irregular plural form")
 	fs.BoolVar(&p.resource.Namespaced, "namespaced", true, "resource is namespaced")
 	fs.StringVar(&p.resource.API.CRDVersion, "crd-version", defaultCRDVersion,
 		"version of CustomResourceDefinition to scaffold. Options: [v1, v1beta1]")

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -78,7 +78,7 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
 	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
-	fs.StringVar(&p.resource.Plural, "resource", "", "resource Resource")
+	fs.StringVar(&p.resource.Plural, "plural", "", "resource kind irregular plural form")
 	fs.StringVar(&p.resource.Webhooks.WebhookVersion, "webhook-version", defaultWebhookVersion,
 		"version of {Mutating,Validating}WebhookConfigurations to scaffold. Options: [v1, v1beta1]")
 


### PR DESCRIPTION
# Description
Add `--plural` flag to `kubebuilder create api` to allow irregular plural forms. Also, replace the `--resource` flag for `--plural` in `kubebuilder create webhook` for `v3-alpha` projects. This change was not done to `v2` as it would be a breaking change.

# Motivation
https://kubernetes.slack.com/archives/CAR30FCJZ/p1604861145449700

/kind feature