### PR TITLE
:seedling: Revert ":sparkles: Add the liveness and readiness probe in the manager deployment"

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/manager/config.go
@@ -78,18 +78,6 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /readyz
-            port: 9443
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 9443
-          initialDelaySeconds: 5
-          periodSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -33,18 +33,6 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /readyz
-            port: 9443
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 9443
-          initialDelaySeconds: 5
-          periodSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -33,18 +33,6 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /readyz
-            port: 9443
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 9443
-          initialDelaySeconds: 5
-          periodSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -33,18 +33,6 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
-        livenessProbe:
-          httpGet:
-            path: /readyz
-            port: 9443
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 9443
-          initialDelaySeconds: 5
-          periodSeconds: 10
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Reverts kubernetes-sigs/kubebuilder#1795, which breaks go/v3-alpha.

It appears that the `/healthz` and/or `/readyz` handlers are not set up as #1795 assumes they have been. For now #1795 should be reverted so #1756 can add tests, then these endpoints can be re-added. 