### PR TITLE
:bug: (go/v3-alpha) add leases.coordination.k8s.io to leader-election-role

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/config/rbac/leader_election_role.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/rbac/leader_election_role.go
@@ -48,8 +48,10 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list

--- a/testdata/project-v3-addon/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-addon/config/rbac/leader_election_role.yaml
@@ -6,8 +6,10 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list

--- a/testdata/project-v3-multigroup/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/leader_election_role.yaml
@@ -6,8 +6,10 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list

--- a/testdata/project-v3/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3/config/rbac/leader_election_role.yaml
@@ -6,8 +6,10 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - coordination.k8s.io
   resources:
   - configmaps
+  - leases
   verbs:
   - get
   - list


### PR DESCRIPTION
This PR adds `leases.coordination.k8s.io` to the leader-election-role Role under the same rule as `configmaps`. These permissions are required by default by controller-runtime's leader election, which uses "configmapsleases" as the default election type.

- go/v3-alpha: add leases.coordination.k8s.io to leader election RBAC

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
