### PR TITLE
WIP: :sparkles: Add the liveness and readiness probe in the manager deployment

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -65,6 +65,7 @@ spec:
           name: https
       - name: manager
         args:
+        - "--https-address=:8081"
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
 `

--- a/pkg/plugin/v3/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/config/manager/config.go
@@ -78,6 +78,18 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
@@ -21,5 +21,6 @@ spec:
           name: https
       - name: manager
         args:
+        - "--https-address=:8081"
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -33,6 +33,18 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3-addon/main.go
+++ b/testdata/project-v3-addon/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"net/http"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -50,7 +51,9 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "probe-addr", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -64,11 +67,12 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		Port:               9443,
-		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "52ea9610.testproject.org",
+		Scheme:                 scheme,
+		MetricsBindAddress:     metricsAddr,
+		Port:                   9443,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "52ea9610.testproject.org",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -100,6 +104,9 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	_ = mgr.AddHealthzCheck("check", func(_ *http.Request) error { return nil })
+	_ = mgr.AddReadyzCheck("check", func(_ *http.Request) error { return nil })
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -21,5 +21,6 @@ spec:
           name: https
       - name: manager
         args:
+        - "--https-address=:8081"
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -33,6 +33,18 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 100m

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"net/http"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -69,7 +70,9 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "probe-addr", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -83,11 +86,12 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		Port:               9443,
-		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "14be1926.testproject.org",
+		Scheme:                 scheme,
+		MetricsBindAddress:     metricsAddr,
+		Port:                   9443,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "14be1926.testproject.org",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -187,6 +191,9 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	_ = mgr.AddHealthzCheck("check", func(_ *http.Request) error { return nil })
+	_ = mgr.AddReadyzCheck("check", func(_ *http.Request) error { return nil })
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -21,5 +21,6 @@ spec:
           name: https
       - name: manager
         args:
+        - "--https-address=:8081"
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -33,6 +33,18 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
**description**

Cherry-pick of https://github.com/kubernetes-sigs/kubebuilder/pull/1795

**motivation**
Re-introduce the change to close the  #1761
Note that it was reverted because the CI was not doing tthe e2e tests with the v3-alpha plugin which is done now. 