### PR TITLE
🌱  refactoring hash function to global template funcs

### DIFF
--- a/pkg/model/file/funcmap.go
+++ b/pkg/model/file/funcmap.go
@@ -17,6 +17,8 @@ limitations under the License.
 package file
 
 import (
+	"fmt"
+	"hash/fnv"
 	"strings"
 	"text/template"
 )
@@ -24,7 +26,17 @@ import (
 // DefaultFuncMap returns the default template.FuncMap for rendering the template.
 func DefaultFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"title": strings.Title,
-		"lower": strings.ToLower,
+		"title":   strings.Title,
+		"lower":   strings.ToLower,
+		"hashFNV": hashFNV,
 	}
+}
+
+// hashFNV will generate a random string useful for generating a unique string
+func hashFNV(s string) (string, error) {
+	hasher := fnv.New32a()
+	if _, err := hasher.Write([]byte(s)); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }

--- a/pkg/plugin/v2/scaffolds/internal/templates/main.go
+++ b/pkg/plugin/v2/scaffolds/internal/templates/main.go
@@ -18,9 +18,7 @@ package templates
 
 import (
 	"fmt"
-	"hash/fnv"
 	"path/filepath"
-	"text/template"
 
 	"sigs.k8s.io/kubebuilder/v2/pkg/model/file"
 )
@@ -28,7 +26,6 @@ import (
 const defaultMainPath = "main.go"
 
 var _ file.Template = &Main{}
-var _ file.UseCustomFuncMap = &Main{}
 
 // Main scaffolds a file that defines the controller manager entry point
 type Main struct {
@@ -51,21 +48,6 @@ func (f *Main) SetTemplateDefaults() error {
 	)
 
 	return nil
-}
-
-func hash(s string) (string, error) {
-	hasher := fnv.New32a()
-	if _, err := hasher.Write([]byte(s)); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
-}
-
-// GetFuncMap implements file.UseCustomFuncMap
-func (f *Main) GetFuncMap() template.FuncMap {
-	fm := file.DefaultFuncMap()
-	fm["hash"] = hash
-	return fm
 }
 
 var _ file.Inserter = &MainUpdater{}
@@ -241,14 +223,14 @@ func main() {
 		"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true))) 
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		Port:               9443, 
-		LeaderElection:     enableLeaderElection, 
-		LeaderElectionID:   "{{ hash .Repo }}.{{ .Domain }}",
+		Port:               9443,
+		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "{{ hashFNV .Repo }}.{{ .Domain }}",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/plugin/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/main.go
@@ -18,9 +18,7 @@ package templates
 
 import (
 	"fmt"
-	"hash/fnv"
 	"path/filepath"
-	"text/template"
 
 	"sigs.k8s.io/kubebuilder/v2/pkg/model/file"
 )
@@ -28,7 +26,6 @@ import (
 const defaultMainPath = "main.go"
 
 var _ file.Template = &Main{}
-var _ file.UseCustomFuncMap = &Main{}
 
 // Main scaffolds a file that defines the controller manager entry point
 type Main struct {
@@ -51,21 +48,6 @@ func (f *Main) SetTemplateDefaults() error {
 	)
 
 	return nil
-}
-
-func hash(s string) (string, error) {
-	hasher := fnv.New32a()
-	if _, err := hasher.Write([]byte(s)); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
-}
-
-// GetFuncMap implements file.UseCustomFuncMap
-func (f *Main) GetFuncMap() template.FuncMap {
-	fm := file.DefaultFuncMap()
-	fm["hash"] = hash
-	return fm
 }
 
 var _ file.Inserter = &MainUpdater{}
@@ -249,9 +231,9 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		Port:               9443, 
-		LeaderElection:     enableLeaderElection, 
-		LeaderElectionID:   "{{ hash .Repo }}.{{ .Domain }}",
+		Port:               9443,
+		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "{{ hashFNV .Repo }}.{{ .Domain }}",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This change was sparked from the conversation on #722 see https://github.com/kubernetes-sigs/kubebuilder/pull/1790/files#r518340728 for the suggestion.

This moves a reused func to the global funcmap to reduced the need to copy it a third time for 

Signed-off-by: Chris Hein <me@chrishein.com>