### PR TITLE
:sparkles: (go/v3-alpha) *: Replace 'docker build . -t ${IMG}' with '-t ${IMG} .'

### DIFF
--- a/pkg/plugin/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugin/v3/scaffolds/internal/templates/makefile.go
@@ -121,7 +121,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -63,7 +63,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -63,7 +63,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -63,7 +63,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	docker build -t ${IMG} .
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
Because folks may have `docker` aliased to `podman`, and Podman prefers options before positional arguments (containers/podman#2811):

```console
$ podman build --help | grep CONTEXT-DIRECTORY
   podman build [command options] CONTEXT-DIRECTORY | URL
```

Generated with:

```console
$ sed -i 's/ . -t \([^ ]*\)/build -t \1 ./' $(git grep -l 'docker.*build.* \. ')
```