### PR TITLE
:seedling: Makefile: fix typo in 'git describe' invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ help:  ## Display this help
 ##@ Build
 
 LD_FLAGS=-ldflags " \
-    -X sigs.k8s.io/kubebuilder/v2/cmd.kubeBuilderVersion=$(shell git descripe --tags --dirty --broken) \
+    -X sigs.k8s.io/kubebuilder/v2/cmd.kubeBuilderVersion=$(shell git describe --tags --dirty --broken) \
     -X sigs.k8s.io/kubebuilder/v2/cmd.goos=$(shell go env GOOS) \
     -X sigs.k8s.io/kubebuilder/v2/cmd.goarch=$(shell go env GOARCH) \
     -X sigs.k8s.io/kubebuilder/v2/cmd.gitCommit=$(shell git rev-parse HEAD) \


### PR DESCRIPTION
The PR fixes a small typo in `git describe` invocation resulting in `kubeBuilderVersion` variable not being properly set
during the final binary linking phase.

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
