### PR TITLE
✨  Allow Downstream Root Commands to add custom descriptions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,8 +26,11 @@ import (
 )
 
 func main() {
+	rootCmdCfg := cli.RootCommandConfig{
+		CommandName: "kubebuilder",
+	}
 	c, err := cli.New(
-		cli.WithCommandName("kubebuilder"),
+		cli.WithRootCommandConfig(rootCmdCfg),
 		cli.WithVersion(versionString()),
 		cli.WithDefaultProjectVersion(config.Version3Alpha),
 		cli.WithPlugins(

--- a/docs/book/src/reference/cli-plugins.md
+++ b/docs/book/src/reference/cli-plugins.md
@@ -171,8 +171,11 @@ import (
 // Go plugin version unless '--plugins' or 'layout' specify
 // one of the other plugins.
 func main() {
+  rootCmdCfg := cli.RootCommandConfig{
+        CommandName: "controller-builder",
+	}
   c, err := cli.New(
-    cli.WithCommandName("controller-builder"),
+    cli.WithRootCommandConfig(rootCmdCfg),
     cli.WithDefaultProjectVersion("3"),
     cli.WithExtraCommands(newCustomCobraCmd()),
     cli.WithPlugins(

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -44,7 +44,7 @@ func (c cli) newCreateAPICmd() *cobra.Command {
 
 func (c cli) newAPIContext() plugin.Context {
 	return plugin.Context{
-		CommandName: c.commandName,
+		CommandName: c.cmdCfg.CommandName,
 		Description: `Scaffold a Kubernetes API.
 `,
 	}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -562,7 +562,6 @@ var _ = Describe("CLI", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
-
 		When("an invalid plugin key is set", func() {
 			It("should fail", func() {
 				c = &cli{

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -35,7 +35,7 @@ Linux:
   $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
 MacOS:
   $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
-`, c.commandName),
+`, c.cmdCfg.CommandName),
 		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			return cmd.Root().GenBashCompletion(os.Stdout)
 		},
@@ -54,7 +54,7 @@ $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
 
 # You will need to start a new shell for this setup to take effect.
-`, c.commandName),
+`, c.cmdCfg.CommandName),
 		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
 			return cmd.Root().GenZshCompletion(os.Stdout)
 		},
@@ -98,7 +98,7 @@ func (c cli) newCompletionCmd() *cobra.Command {
 		Long: fmt.Sprintf(`Output shell completion code for the specified shell.
 The shell code must be evaluated to provide interactive completion of %[1]s commands.
 Detailed instructions on how to do this for each shell are provided in their own commands.
-`, c.commandName),
+`, c.cmdCfg.CommandName),
 	}
 	cmd.AddCommand(c.newBashCmd())
 	cmd.AddCommand(c.newZshCmd())

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -44,7 +44,7 @@ func (c cli) newEditCmd() *cobra.Command {
 
 func (c cli) newEditContext() plugin.Context {
 	return plugin.Context{
-		CommandName: c.commandName,
+		CommandName: c.cmdCfg.CommandName,
 		Description: `Edit the project configuration.
 `,
 	}

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -63,7 +63,7 @@ func (c cli) newInitCmd() *cobra.Command {
 
 func (c cli) newInitContext() plugin.Context {
 	return plugin.Context{
-		CommandName: c.commandName,
+		CommandName: c.cmdCfg.CommandName,
 		Description: `Initialize a new project.
 
 For further help about a specific project version, set --project-version.
@@ -79,7 +79,7 @@ func (c cli) getInitHelpExamples() string {
   %[1]s init --project-version=%[2]s -h
 
 `,
-			c.commandName, version)
+			c.cmdCfg.CommandName, version)
 		sb.WriteString(rendered)
 	}
 	return strings.TrimSuffix(sb.String(), "\n\n")

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -28,10 +28,28 @@ import (
 // Option is a function that can configure the cli
 type Option func(*cli) error
 
-// WithCommandName is an Option that sets the cli's root command name.
-func WithCommandName(name string) Option {
+// WithRootCommandConfig configures a cli's root command.
+func WithRootCommandConfig(cfg RootCommandConfig) Option {
 	return func(c *cli) error {
-		c.commandName = name
+		if cfg.CommandName != "" {
+			c.cmdCfg.CommandName = cfg.CommandName
+		}
+		shortDescription, longDescription, example := buildDefaultDescriptors(c.cmdCfg.CommandName)
+		if cfg.Short != "" {
+			c.cmdCfg.Short = cfg.Short
+		} else {
+			c.cmdCfg.Short = shortDescription
+		}
+		if cfg.Long != "" {
+			c.cmdCfg.Long = cfg.Long
+		} else {
+			c.cmdCfg.Long = longDescription
+		}
+		if cfg.Example != "" {
+			c.cmdCfg.Example = cfg.Example
+		} else {
+			c.cmdCfg.Example = example
+		}
 		return nil
 	}
 }

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -45,13 +45,46 @@ var _ = Describe("CLI options", func() {
 		np4 = newMockPlugin(pluginName, pluginVersion, "a")
 	)
 
-	Context("WithCommandName", func() {
-		It("should use provided command name", func() {
-			commandName := "other-command"
-			c, err = newCLI(WithCommandName(commandName))
+	Context("WithRootCommandConfig", func() {
+		It("should use the default command name and descriptions", func() {
+			c, err = newCLI()
+			shortDescription, longDescription, example := buildDefaultDescriptors(defaultCommandName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).NotTo(BeNil())
-			Expect(c.commandName).To(Equal(commandName))
+			Expect(c.cmdCfg.CommandName).To(Equal(defaultCommandName))
+			Expect(c.cmdCfg.Short).To(Equal(shortDescription))
+			Expect(c.cmdCfg.Long).To(Equal(longDescription))
+			Expect(c.cmdCfg.Example).To(Equal(example))
+		})
+
+		It("should use the provided command name and default descriptions", func() {
+			cfg := RootCommandConfig{
+				CommandName: "other-command",
+			}
+			c, err = newCLI(WithRootCommandConfig(cfg))
+			shortDescription, longDescription, example := buildDefaultDescriptors(cfg.CommandName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c).NotTo(BeNil())
+			Expect(c.cmdCfg.CommandName).To(Equal(cfg.CommandName))
+			Expect(c.cmdCfg.Short).To(Equal(shortDescription))
+			Expect(c.cmdCfg.Long).To(Equal(longDescription))
+			Expect(c.cmdCfg.Example).To(Equal(example))
+		})
+
+		It("should use the provided command name and descriptions", func() {
+			cfg := RootCommandConfig{
+				CommandName: "other-command",
+				Short:       "Short Description",
+				Long:        "Longer Description of the command",
+				Example:     "Example usage of the command",
+			}
+			c, err = newCLI(WithRootCommandConfig(cfg))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c).NotTo(BeNil())
+			Expect(c.cmdCfg.CommandName).To(Equal(cfg.CommandName))
+			Expect(c.cmdCfg.Short).To(Equal(cfg.Short))
+			Expect(c.cmdCfg.Long).To(Equal(cfg.Long))
+			Expect(c.cmdCfg.Example).To(Equal(cfg.Example))
 		})
 	})
 

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -25,9 +25,9 @@ import (
 func (c cli) newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "version",
-		Short:   fmt.Sprintf("Print the %s version", c.commandName),
-		Long:    fmt.Sprintf("Print the %s version", c.commandName),
-		Example: fmt.Sprintf("%s version", c.commandName),
+		Short:   fmt.Sprintf("Print the %s version", c.cmdCfg.CommandName),
+		Long:    fmt.Sprintf("Print the %s version", c.cmdCfg.CommandName),
+		Example: fmt.Sprintf("%s version", c.cmdCfg.CommandName),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println(c.version)
 			return nil

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -44,7 +44,7 @@ func (c cli) newCreateWebhookCmd() *cobra.Command {
 
 func (c cli) newWebhookContext() plugin.Context {
 	return plugin.Context{
-		CommandName: c.commandName,
+		CommandName: c.cmdCfg.CommandName,
 		Description: `Scaffold a webhook for an API resource.
 `,
 	}


### PR DESCRIPTION
Added 4 Options to configure command descriptions.
Downstream Projects may want to change the preset descriptions and examples to something more relevant to their projects so I am proposing the following Options to configure those by calling 
`WithRootCommandConfig(cmdCfg)`
The fields of `cmdCfg` can be set by using `RootCommandConfig struct` added in the cli pkg
