### PR TITLE
:warning: (go/v3-alpha) bump cert-manager CRs to v1

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/certmanager/certificate.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/certmanager/certificate.go
@@ -42,9 +42,8 @@ func (f *Certificate) SetTemplateDefaults() error {
 
 const certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
-apiVersion: cert-manager.io/v1alpha2
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -52,7 +51,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -91,7 +91,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -99,7 +99,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:

--- a/test/e2e/utils/kubectl.go
+++ b/test/e2e/utils/kubectl.go
@@ -120,13 +120,13 @@ func (vi *VersionInfo) parseVersionInts() (err error) {
 	return nil
 }
 
-// KubectlVersion holds a subset of both client and server versions.
-type KubectlVersion struct {
+// KubernetesVersion holds a subset of both client and server versions.
+type KubernetesVersion struct {
 	ClientVersion VersionInfo `json:"clientVersion,omitempty"`
 	ServerVersion VersionInfo `json:"serverVersion,omitempty"`
 }
 
-func (v *KubectlVersion) prepare() (err error) {
+func (v *KubernetesVersion) prepare() (err error) {
 	if err = v.ClientVersion.parseVersionInts(); err != nil {
 		return err
 	}
@@ -137,16 +137,16 @@ func (v *KubectlVersion) prepare() (err error) {
 }
 
 // Version is a func to run kubectl version command
-func (k *Kubectl) Version() (ver KubectlVersion, err error) {
+func (k *Kubectl) Version() (ver KubernetesVersion, err error) {
 	var out string
 	if out, err = k.Command("version", "-o", "json"); err != nil {
-		return KubectlVersion{}, err
+		return KubernetesVersion{}, err
 	}
 	if err = json.Unmarshal([]byte(out), &ver); err != nil {
-		return KubectlVersion{}, err
+		return KubernetesVersion{}, err
 	}
 	if err = ver.prepare(); err != nil {
-		return KubectlVersion{}, err
+		return KubernetesVersion{}, err
 	}
 	return ver, nil
 }

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -27,11 +27,6 @@ import (
 	. "github.com/onsi/ginkgo" //nolint:golint
 )
 
-const certmanagerVersion = "v0.11.0"
-const prometheusOperatorVersion = "0.33"
-const certmanagerURL = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
-const prometheusOperatorURL = "https://raw.githubusercontent.com/coreos/prometheus-operator/release-%s/bundle.yaml"
-
 // TestContext specified to run e2e tests
 type TestContext struct {
 	*CmdContext
@@ -42,8 +37,9 @@ type TestContext struct {
 	Kind       string
 	Resources  string
 	ImageName  string
-	Kubectl    *Kubectl
 	BinaryName string
+	Kubectl    *Kubectl
+	K8sVersion *KubernetesVersion
 }
 
 // NewTestContext init with a random suffix for test TestContext stuff,
@@ -54,30 +50,36 @@ func NewTestContext(binaryName string, env ...string) (*TestContext, error) {
 		return nil, err
 	}
 
-	testGroup := "bar" + testSuffix
-	path, err := filepath.Abs("e2e-" + testSuffix)
+	cc := &CmdContext{
+		Env: env,
+	}
+
+	// Use kubectl to get Kubernetes client and cluster version.
+	kubectl := &Kubectl{
+		Namespace:  fmt.Sprintf("e2e-%s-system", testSuffix),
+		CmdContext: cc,
+	}
+	k8sVersion, err := kubectl.Version()
 	if err != nil {
 		return nil, err
 	}
 
-	cc := &CmdContext{
-		Env: env,
-		Dir: path,
+	// Set CmdContext.Dir after running Kubectl.Version() because dir does not exist yet.
+	if cc.Dir, err = filepath.Abs("e2e-" + testSuffix); err != nil {
+		return nil, err
 	}
 
 	return &TestContext{
 		TestSuffix: testSuffix,
 		Domain:     "example.com" + testSuffix,
-		Group:      testGroup,
+		Group:      "bar" + testSuffix,
 		Version:    "v1alpha1",
 		Kind:       "Foo" + testSuffix,
 		Resources:  "foo" + testSuffix + "s",
 		ImageName:  "e2e-test/controller-manager:" + testSuffix,
 		CmdContext: cc,
-		Kubectl: &Kubectl{
-			Namespace:  fmt.Sprintf("e2e-%s-system", testSuffix),
-			CmdContext: cc,
-		},
+		Kubectl:    kubectl,
+		K8sVersion: &k8sVersion,
 		BinaryName: binaryName,
 	}, nil
 }
@@ -98,12 +100,33 @@ func (t *TestContext) Prepare() error {
 	return os.MkdirAll(t.Dir, 0755)
 }
 
-// InstallCertManager installs the cert manager bundle.
-func (t *TestContext) InstallCertManager() error {
-	if _, err := t.Kubectl.Command("create", "namespace", "cert-manager"); err != nil {
-		return err
+const (
+	certmanagerVersionWithv1beta2CRs = "v0.11.0"
+	certmanagerVersion               = "v1.0.4"
+
+	certmanagerURLTmplLegacy = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager-legacy.yaml"
+	certmanagerURLTmpl       = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+)
+
+// makeCertManagerURL returns a kubectl-able URL for the cert-manager bundle.
+func (t *TestContext) makeCertManagerURL(hasv1beta1CRs bool) string {
+	// Return a URL for the manifest bundle with v1beta1 CRs.
+	if hasv1beta1CRs {
+		return fmt.Sprintf(certmanagerURLTmpl, certmanagerVersionWithv1beta2CRs)
 	}
-	url := fmt.Sprintf(certmanagerURL, certmanagerVersion)
+
+	// Determine which URL to use for a manifest bundle with v1 CRs.
+	// The most up-to-date bundle uses v1 CRDs, which were introduced in k8s v1.16.
+	if ver := t.K8sVersion.ServerVersion; ver.GetMajorInt() <= 1 && ver.GetMinorInt() < 16 {
+		return fmt.Sprintf(certmanagerURLTmplLegacy, certmanagerVersion)
+	}
+	return fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
+}
+
+// InstallCertManager installs the cert manager bundle. If hasv1beta1CRs is true,
+// the legacy version (which uses v1alpha2 CRs) is installed.
+func (t *TestContext) InstallCertManager(hasv1beta1CRs bool) error {
+	url := t.makeCertManagerURL(hasv1beta1CRs)
 	if _, err := t.Kubectl.Apply(false, "-f", url, "--validate=false"); err != nil {
 		return err
 	}
@@ -117,6 +140,24 @@ func (t *TestContext) InstallCertManager() error {
 	return err
 }
 
+// UninstallCertManager uninstalls the cert manager bundle. If hasv1beta1CRs is true,
+// the legacy version (which uses v1alpha2 CRs) is installed.
+func (t *TestContext) UninstallCertManager(hasv1beta1CRs bool) {
+	url := t.makeCertManagerURL(hasv1beta1CRs)
+	if _, err := t.Kubectl.Delete(false, "-f", url); err != nil {
+		fmt.Fprintf(GinkgoWriter,
+			"warning: error when running kubectl delete during cleaning up cert manager: %v\n", err)
+	}
+	if _, err := t.Kubectl.Delete(false, "namespace", "cert-manager"); err != nil {
+		fmt.Fprintf(GinkgoWriter, "warning: error when cleaning up the cert manager namespace: %v\n", err)
+	}
+}
+
+const (
+	prometheusOperatorVersion = "0.33"
+	prometheusOperatorURL     = "https://raw.githubusercontent.com/coreos/prometheus-operator/release-%s/bundle.yaml"
+)
+
 // InstallPrometheusOperManager installs the prometheus manager bundle.
 func (t *TestContext) InstallPrometheusOperManager() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
@@ -129,18 +170,6 @@ func (t *TestContext) UninstallPrometheusOperManager() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
 	if _, err := t.Kubectl.Delete(false, "-f", url); err != nil {
 		fmt.Fprintf(GinkgoWriter, "error when running kubectl delete during cleaning up prometheus bundle: %v\n", err)
-	}
-}
-
-// UninstallCertManager uninstalls the cert manager bundle.
-func (t *TestContext) UninstallCertManager() {
-	url := fmt.Sprintf(certmanagerURL, certmanagerVersion)
-	if _, err := t.Kubectl.Delete(false, "-f", url); err != nil {
-		fmt.Fprintf(GinkgoWriter,
-			"warning: error when running kubectl delete during cleaning up cert manager: %v\n", err)
-	}
-	if _, err := t.Kubectl.Delete(false, "namespace", "cert-manager"); err != nil {
-		fmt.Fprintf(GinkgoWriter, "warning: error when cleaning up the cert manager namespace: %v\n", err)
 	}
 }
 
@@ -231,7 +260,7 @@ func (cc *CmdContext) Run(cmd *exec.Cmd) ([]byte, error) {
 	fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return output, fmt.Errorf("%s failed with error: %s", command, string(output))
+		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
 	}
 
 	return output, nil

--- a/test/e2e/v2/plugin_cluster_test.go
+++ b/test/e2e/v2/plugin_cluster_test.go
@@ -39,8 +39,9 @@ var _ = Describe("kubebuilder", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kbc.Prepare()).To(Succeed())
 
+			// Install cert-manager with v1beta2 CRs.
 			By("installing cert manager bundle")
-			Expect(kbc.InstallCertManager()).To(Succeed())
+			Expect(kbc.InstallCertManager(true)).To(Succeed())
 
 			By("installing prometheus operator")
 			Expect(kbc.InstallPrometheusOperManager()).To(Succeed())
@@ -53,8 +54,9 @@ var _ = Describe("kubebuilder", func() {
 			By("uninstalling prometheus manager bundle")
 			kbc.UninstallPrometheusOperManager()
 
+			// Uninstall cert-manager with v1beta2 CRs.
 			By("uninstalling cert manager bundle")
-			kbc.UninstallCertManager()
+			kbc.UninstallCertManager(true)
 
 			By("remove container image and work dir")
 			kbc.Destroy()

--- a/test/e2e/v3/generate_test.go
+++ b/test/e2e/v3/generate_test.go
@@ -211,7 +211,7 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -219,7 +219,7 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:

--- a/testdata/project-v3-addon/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-addon/config/certmanager/certificate.yaml
@@ -1,8 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
-apiVersion: cert-manager.io/v1alpha2
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/testdata/project-v3-addon/config/default/kustomization.yaml
+++ b/testdata/project-v3-addon/config/default/kustomization.yaml
@@ -46,7 +46,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -54,7 +54,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:

--- a/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
@@ -1,8 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
-apiVersion: cert-manager.io/v1alpha2
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/testdata/project-v3-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/default/kustomization.yaml
@@ -46,7 +46,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -54,7 +54,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:

--- a/testdata/project-v3/config/certmanager/certificate.yaml
+++ b/testdata/project-v3/config/certmanager/certificate.yaml
@@ -1,8 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
-apiVersion: cert-manager.io/v1alpha2
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/testdata/project-v3/config/default/kustomization.yaml
+++ b/testdata/project-v3/config/default/kustomization.yaml
@@ -46,7 +46,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #  fieldref:
 #    fieldpath: metadata.namespace
@@ -54,7 +54,7 @@ vars:
 #  objref:
 #    kind: Certificate
 #    group: cert-manager.io
-#    version: v1alpha2
+#    version: v1
 #    name: serving-cert # this name should match the one in certificate.yaml
 #- name: SERVICE_NAMESPACE # namespace of the service
 #  objref:


### PR DESCRIPTION
This PR bumps cert-manager CR apiVersion to v1 from v1beta2 for go/v3-alpha. TestContext has been updated to be cluster version-aware such that the correct cert-manager bundle URL is applied.

- pkg/plugin/v3/scaffolds/internal/templates/config: cert-manager CRs have apiVersion v1
- test/e2e/utils: KubectlVersion -> KubernetesVersion, which now gets created in NewTestContext. cert-manager install funcs use this version to get the correct bundle for a particular cluster version
- test/e2e/{v2,v3}: update {Install,Uninstall}CertManager() to include new 'hasv1beta2CRs' boolean arg, which depends on plugin being tested

Closes #1666 
Closes #1667 
