### PR TITLE
:seedling: test_e2e.sh,test_e2e_local.sh: bump timeout to 20m

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -39,4 +39,4 @@ function cleanup() {
 
 trap cleanup EXIT
 go test ./test/e2e/v2
-go test ./test/e2e/v3 -timeout 15m
+go test ./test/e2e/v3 -timeout 20m

--- a/test_e2e_local.sh
+++ b/test_e2e_local.sh
@@ -50,4 +50,4 @@ fi
 
 # when changing these commands, make sure to keep in sync with ./test_e2e.sh
 go test ./test/e2e/v2 -v -ginkgo.v
-go test ./test/e2e/v3 -v -ginkgo.v -timeout 15m
+go test ./test/e2e/v3 -v -ginkgo.v -timeout 20m


### PR DESCRIPTION
e2e tests seem to be timing out often across several PRs. This PR bumps the timeout from 15 to 20 minutes.

/kind flake