### PR TITLE
:seedling: Makefile,build/.goreleaser.yml: fix ldflag variable setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ help:  ## Display this help
 ##@ Build
 
 LD_FLAGS=-ldflags " \
-    -X sigs.k8s.io/kubebuilder/v2/cmd.kubeBuilderVersion=$(shell git describe --tags --dirty --broken) \
-    -X sigs.k8s.io/kubebuilder/v2/cmd.goos=$(shell go env GOOS) \
-    -X sigs.k8s.io/kubebuilder/v2/cmd.goarch=$(shell go env GOARCH) \
-    -X sigs.k8s.io/kubebuilder/v2/cmd.gitCommit=$(shell git rev-parse HEAD) \
-    -X sigs.k8s.io/kubebuilder/v2/cmd.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+    -X main.kubeBuilderVersion=$(shell git describe --tags --dirty --broken) \
+    -X main.goos=$(shell go env GOOS) \
+    -X main.goarch=$(shell go env GOARCH) \
+    -X main.gitCommit=$(shell git rev-parse HEAD) \
+    -X main.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
     "
 .PHONY: build
 build: ## Build the project locally

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -17,7 +17,14 @@
 builds:
 - main: ./cmd
   binary: kubebuilder
-  ldflags: -s -X sigs.k8s.io/kubebuilder/v2/cmd.kubeBuilderVersion={{.Version}} -X sigs.k8s.io/kubebuilder/v2/cmd.gitCommit={{.Commit}} -X sigs.k8s.io/kubebuilder/v2/cmd.buildDate={{.Date}} -X sigs.k8s.io/kubebuilder/v2/cmd.kubernetesVendorVersion={{.Env.KUBERNETES_VERSION}}
+  ldflags:
+    - -s
+    - -X main.kubeBuilderVersion={{.Version}}
+    - -X main.goos={{.Os}}
+    - -X main.goarch={{.Arch}}
+    - -X main.gitCommit={{.Commit}}
+    - -X main.buildDate={{.Date}}
+    - -X main.kubernetesVendorVersion={{.Env.KUBERNETES_VERSION}}
   goos:
    - darwin
    - linux


### PR DESCRIPTION
This PR fixes `-ldflags -X ...` settings in `build` and `install` make targets and in goreleaser's config, which should point to the `main` package.

/cc @Adirio 