### PR TITLE
:sparkles: add make run option for webhooks (go/v3-alpha)

### DIFF
--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v2/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v2/pkg/plugins/golang/v3/scaffolds"
 	"sigs.k8s.io/kubebuilder/v2/pkg/plugins/internal/cmdutil"
+	"sigs.k8s.io/kubebuilder/v2/pkg/plugins/internal/util"
 )
 
 // defaultWebhookVersion is the default mutating/validating webhook config API version to scaffold.
@@ -42,6 +43,9 @@ type createWebhookSubcommand struct {
 	defaulting bool
 	validation bool
 	conversion bool
+
+	// runMake indicates whether to run make or not after scaffolding webhooks
+	runMake bool
 }
 
 var (
@@ -73,6 +77,8 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.resource.Plural, "resource", "", "resource Resource")
 	fs.StringVar(&p.resource.WebhookVersion, "webhook-version", defaultWebhookVersion,
 		"version of {Mutating,Validating}WebhookConfigurations to scaffold. Options: [v1, v1beta1]")
+
+	fs.BoolVar(&p.runMake, "make", true, "if true, run make after generating files")
 
 	fs.BoolVar(&p.defaulting, "defaulting", false,
 		"if set, scaffold the defaulting webhook")
@@ -127,5 +133,8 @@ func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 }
 
 func (p *createWebhookSubcommand) PostScaffold() error {
+	if p.runMake {
+		return util.RunCmd("Running make", "make")
+	}
 	return nil
 }


### PR DESCRIPTION
**Description**

Add make run option for webhooks

**Motivation**
- Keep the consistence across the project
- Allows users scaffold webhooks without run make targets