### PR TITLE
:sparkles: (go/v3-alpha) store data info to know if the controller and/or api were scaffolded

### DIFF
--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -78,17 +78,14 @@ func (c Config) IsV3() bool {
 	return c.Version == Version3Alpha
 }
 
-// HasResource returns true if API resource is already tracked
-func (c Config) HasResource(target GVK) bool {
-	// Return true if the target resource is found in the tracked resources
+// GetResource returns the GKV if the resource is found
+func (c Config) GetResource(target GVK) *GVK {
 	for _, r := range c.Resources {
 		if r.isEqualTo(target) {
-			return true
+			return &r
 		}
 	}
-
-	// Return false otherwise
-	return false
+	return nil
 }
 
 // UpdateResources either adds gvk to the tracked set or, if the resource already exists,
@@ -157,6 +154,11 @@ type GVK struct {
 	CRDVersion string `json:"crdVersion,omitempty"`
 	// WebhookVersion holds the {Validating,Mutating}WebhookConfiguration API version used for the GVK.
 	WebhookVersion string `json:"webhookVersion,omitempty"`
+
+	// API holds true when the api is scaffolded
+	API bool `json:"api,omitempty"`
+	// Controller holds true when the controller is scaffolded
+	Controller bool `json:"controller,omitempty"`
 }
 
 // isEqualTo compares it with another resource
@@ -175,6 +177,8 @@ func (r *GVK) merge(other GVK) {
 	if r.WebhookVersion == "" && other.WebhookVersion != "" {
 		r.WebhookVersion = other.WebhookVersion
 	}
+	r.API = r.API || other.Controller
+	r.Controller = r.Controller || other.Controller
 }
 
 // Marshal returns the bytes of c.

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -49,13 +49,19 @@ type Resource struct {
 	// Domain is the Group + "." + Domain of the Resource.
 	Domain string `json:"domain,omitempty"`
 
-	// Namespaced is true if the resource is namespaced.
-	Namespaced bool `json:"namespaced,omitempty"`
-
 	// CRDVersion holds the CustomResourceDefinition API version used for the Resource.
 	CRDVersion string `json:"crdVersion,omitempty"`
 	// WebhookVersion holds the {Validating,Mutating}WebhookConfiguration API version used for the Resource.
 	WebhookVersion string `json:"webhookVersion,omitempty"`
+
+	// API holds true when the api is scaffolded
+	API bool `json:"api,omitempty"`
+
+	// Controller holds true when the controller is scaffolded
+	Controller bool `json:"controller,omitempty"`
+
+	// Namespaced is true if the resource is namespaced.
+	Namespaced bool `json:"namespaced,omitempty"`
 }
 
 // GVK returns the group-version-kind information to check against tracked resources in the configuration file
@@ -66,6 +72,8 @@ func (r *Resource) GVK() config.GVK {
 		Kind:           r.Kind,
 		CRDVersion:     r.CRDVersion,
 		WebhookVersion: r.WebhookVersion,
+		API:            r.API,
+		Controller:     r.Controller,
 	}
 }
 

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Resource", func() {
 					Domain:  "test.io",
 					Repo:    "test",
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Namespaced).To(Equal(options.Namespaced))
 			Expect(resource.Group).To(Equal(options.Group))
@@ -57,7 +57,7 @@ var _ = Describe("Resource", func() {
 					Repo:       "test",
 					MultiGroup: true,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Namespaced).To(Equal(options.Namespaced))
 			Expect(resource.Group).To(Equal(options.Group))
@@ -82,28 +82,28 @@ var _ = Describe("Resource", func() {
 			options := &Options{Group: "crew", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource := options.NewResource(singleGroupConfig, true)
+			resource := options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("firstmates"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("firstmates"))
 
 			options = &Options{Group: "crew", Version: "v1", Kind: "Fish"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, true)
+			resource = options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("fish"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("fish"))
 
 			options = &Options{Group: "crew", Version: "v1", Kind: "Helmswoman"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, true)
+			resource = options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("helmswomen"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Plural).To(Equal("helmswomen"))
 		})
 
@@ -115,7 +115,7 @@ var _ = Describe("Resource", func() {
 				&config.Config{
 					Version: config.Version2,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Plural).To(Equal("mates"))
 
@@ -124,7 +124,7 @@ var _ = Describe("Resource", func() {
 					Version:    config.Version2,
 					MultiGroup: true,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Plural).To(Equal("mates"))
 		})
@@ -145,7 +145,7 @@ var _ = Describe("Resource", func() {
 			options := &Options{Group: "my-project", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource := options.NewResource(singleGroupConfig, true)
+			resource := options.NewResource(singleGroupConfig, true, true)
 
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
@@ -153,7 +153,7 @@ var _ = Describe("Resource", func() {
 			Expect(resource.Package).To(Equal(path.Join("test", "api", "v1")))
 			Expect(resource.Domain).To(Equal("my-project.test.io"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
@@ -163,14 +163,14 @@ var _ = Describe("Resource", func() {
 			options = &Options{Group: "my.project", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, true)
+			resource = options.NewResource(singleGroupConfig, true, true)
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
 			Expect(resource.Package).To(Equal(path.Join("test", "api", "v1")))
 			Expect(resource.Domain).To(Equal("my.project.test.io"))
 
-			resource = options.NewResource(multiGroupConfig, true)
+			resource = options.NewResource(multiGroupConfig, true, true)
 			Expect(resource.Group).To(Equal(options.Group))
 			Expect(resource.GroupPackageName).To(Equal("myproject"))
 			Expect(resource.ImportAlias).To(Equal("myprojectv1"))
@@ -186,7 +186,7 @@ var _ = Describe("Resource", func() {
 				&config.Config{
 					Version: config.Version2,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Domain).To(Equal("crew"))
 
@@ -195,7 +195,7 @@ var _ = Describe("Resource", func() {
 					Version:    config.Version2,
 					MultiGroup: true,
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Domain).To(Equal("crew"))
 		})
@@ -216,22 +216,22 @@ var _ = Describe("Resource", func() {
 			options := &Options{Group: "apps", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource := options.NewResource(singleGroupConfig, false)
+			resource := options.NewResource(singleGroupConfig, false, true)
 			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
 			Expect(resource.Domain).To(Equal("apps"))
 
-			resource = options.NewResource(multiGroupConfig, false)
+			resource = options.NewResource(multiGroupConfig, false, true)
 			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
 			Expect(resource.Domain).To(Equal("apps"))
 
 			options = &Options{Group: "authentication", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
-			resource = options.NewResource(singleGroupConfig, false)
+			resource = options.NewResource(singleGroupConfig, false, true)
 			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
 			Expect(resource.Domain).To(Equal("authentication.k8s.io"))
 
-			resource = options.NewResource(multiGroupConfig, false)
+			resource = options.NewResource(multiGroupConfig, false, true)
 			Expect(resource.Package).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
 			Expect(resource.Domain).To(Equal("authentication.k8s.io"))
 		})
@@ -245,7 +245,7 @@ var _ = Describe("Resource", func() {
 					Domain:  "test.io",
 					Repo:    "test",
 				},
-				true,
+				true, true,
 			)
 			Expect(resource.Namespaced).To(Equal(options.Namespaced))
 			Expect(resource.Group).To(Equal(""))

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -143,7 +143,7 @@ func (p *createAPISubcommand) Validate() error {
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.doResource {
 		// Check that resource doesn't exist or flag force was set
-		if !p.force && p.config.HasResource(p.resource.GVK()) {
+		if !p.force && p.config.GetResource(p.resource.GVK()) != nil {
 			return errors.New("API resource already exists")
 		}
 
@@ -176,7 +176,7 @@ func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewResource(p.config, p.doResource)
+	res := p.resource.NewResource(p.config, p.doResource, p.doController)
 	return scaffolds.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
 }
 

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -96,7 +96,7 @@ func (p *createWebhookSubcommand) Validate() error {
 	}
 
 	// check if resource exist to create webhook
-	if !p.config.HasResource(p.resource.GVK()) {
+	if p.config.GetResource(p.resource.GVK()) == nil {
 		return fmt.Errorf("%s create webhook requires an api with the group,"+
 			" kind and version provided", p.commandName)
 	}
@@ -112,7 +112,7 @@ func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewResource(p.config, false)
+	res := p.resource.NewResource(p.config, false, false)
 	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.defaulting, p.validation, p.conversion), nil
 }
 

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -170,7 +170,8 @@ func (p *createAPISubcommand) Validate() error {
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.doResource {
 		// Check that resource doesn't exist or flag force was set
-		if !p.force && p.config.HasResource(p.resource.GVK()) {
+		res := p.config.GetResource(p.resource.GVK())
+		if !p.force && (res != nil && res.API) {
 			return errors.New("API resource already exists")
 		}
 
@@ -209,7 +210,7 @@ func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewResource(p.config, p.doResource)
+	res := p.resource.NewResource(p.config, p.doResource, p.doController)
 	return scaffolds.NewAPIScaffolder(p.config, string(bp), res, p.doResource, p.doController, plugins), nil
 }
 

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -83,10 +83,10 @@ func (s *apiScaffolder) newUniverse() *model.Universe {
 
 // TODO: re-use universe created by s.newUniverse() if possible.
 func (s *apiScaffolder) scaffold() error {
+
+	s.config.UpdateResources(s.resource.GVK())
+
 	if s.doResource {
-
-		s.config.UpdateResources(s.resource.GVK())
-
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),
 			&api.Types{},
@@ -107,7 +107,6 @@ func (s *apiScaffolder) scaffold() error {
 		); err != nil {
 			return fmt.Errorf("error scaffolding kustomization: %v", err)
 		}
-
 	}
 
 	if s.doController {

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -107,7 +107,7 @@ func (p *createWebhookSubcommand) Validate() error {
 	}
 
 	// check if resource exist to create webhook
-	if !p.config.HasResource(p.resource.GVK()) {
+	if p.config.GetResource(p.resource.GVK()) == nil {
 		return fmt.Errorf("%s create webhook requires an api with the group,"+
 			" kind and version provided", p.commandName)
 	}
@@ -128,7 +128,7 @@ func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 	}
 
 	// Create the actual resource from the resource options
-	res := p.resource.NewResource(p.config, false)
+	res := p.resource.NewResource(p.config, false, false)
 	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.defaulting, p.validation, p.conversion), nil
 }
 

--- a/testdata/project-v3-addon/PROJECT
+++ b/testdata/project-v3-addon/PROJECT
@@ -3,15 +3,21 @@ layout: go.kubebuilder.io/v3-alpha
 projectName: project-v3-addon
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 resources:
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Captain
   version: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: FirstMate
   version: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Admiral
   version: v1

--- a/testdata/project-v3-config/PROJECT
+++ b/testdata/project-v3-config/PROJECT
@@ -4,19 +4,30 @@ layout: go.kubebuilder.io/v3-alpha
 projectName: project-v3-config
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-config
 resources:
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Captain
   version: v1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: FirstMate
   version: v1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Admiral
   version: v1
   webhookVersion: v1
+- controller: true
+  crdVersion: v1
+  group: crew
+  kind: Laker
+  version: v1
 version: 3-alpha

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -4,39 +4,60 @@ multigroup: true
 projectName: project-v3-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 resources:
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Captain
   version: v1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: ship
   kind: Frigate
   version: v1beta1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: ship
   kind: Destroyer
   version: v1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: ship
   kind: Cruiser
   version: v2alpha1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: sea-creatures
   kind: Kraken
   version: v1beta1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: sea-creatures
   kind: Leviathan
   version: v1beta2
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: foo.policy
   kind: HealthCheckPolicy
   version: v1
-- crdVersion: v1
+- controller: true
+  crdVersion: v1
+  group: apps
+  kind: Pod
+  version: v1
+- api: true
+  controller: true
+  crdVersion: v1
   kind: Lakers
   version: v1
   webhookVersion: v1

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -3,19 +3,30 @@ layout: go.kubebuilder.io/v3-alpha
 projectName: project-v3
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Captain
   version: v1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: FirstMate
   version: v1
   webhookVersion: v1
-- crdVersion: v1
+- api: true
+  controller: true
+  crdVersion: v1
   group: crew
   kind: Admiral
   version: v1
   webhookVersion: v1
+- controller: true
+  crdVersion: v1
+  group: crew
+  kind: Laker
+  version: v1
 version: 3-alpha


### PR DESCRIPTION
**Description**
- Add api and controller booleans to the config model
- Set their value when the scaffold of these types are made. 
- Ensure that if only the controller for a gkv was scaffold we will have this info stored. 

**Motivation**
Partial: https://github.com/kubernetes-sigs/kubebuilder/issues/1826