### PR TITLE
:bug: Fix cronjob tutorial project issues

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -16,6 +16,15 @@ patchesStrategicMerge:
 #- patches/cainjection_in_cronjobs.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
+# https://github.com/kubernetes-sigs/kubebuilder/issues/1466#issuecomment-712444882
+patchesJson6902:
+- target:
+    group: apiextensions.k8s.io
+    version: v1beta1
+    kind: CustomResourceDefinition
+    name: cronjobs.batch.tutorial.kubebuilder.io
+  path: patches/k8s_list_map_keys.yaml
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/k8s_list_map_keys.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/k8s_list_map_keys.yaml
@@ -1,0 +1,11 @@
+- op: replace
+  path: /spec/validation/openAPIV3Schema/properties/spec/properties/jobTemplate/properties/spec/properties/template/properties/spec/properties/initContainers/items/properties/ports/items/required
+  value:
+  - containerPort
+  - protocol
+
+- op: replace
+  path: /spec/validation/openAPIV3Schema/properties/spec/properties/jobTemplate/properties/spec/properties/template/properties/spec/properties/containers/items/properties/ports/items/required
+  value:
+  - containerPort
+  - protocol

--- a/docs/book/src/cronjob-tutorial/testdata/project/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/main.go
@@ -95,10 +95,6 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "CronJob")
 		os.Exit(1)
 	}
-	if err = (&batchv1.CronJob{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "CronJob")
-		os.Exit(1)
-	}
 
 	/*
 		We'll also set up webhooks for our type, which we'll talk about next.


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

 (:bug:): Fix cronjob tutorial project issues
- disabling webhook by `ENABLE_WEBHOOKS=false` won't help as the code is duplicated
- as of now, we still have to apply the workaround to make sure CRDs generated is valid and installable, see https://github.com/kubernetes-sigs/kubebuilder/issues/1466#issuecomment-712444882.