### PR TITLE
:sparkles: Changed the default shell to bash in the doc Makefile

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -1,4 +1,4 @@
-
+SHELL := /bin/bash
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)


### PR DESCRIPTION
Makefile default shell is `/bin/sh` which does not implement source `source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh` which is in the `test` target within the Makefile.

Changing shell to `/bin/bash` makes it possible:


 https://stackoverflow.com/a/43566158/19407
