### PR TITLE
✨ Remove spaces from machine-readable comments

### DIFF
--- a/pkg/model/file/marker.go
+++ b/pkg/model/file/marker.go
@@ -19,15 +19,14 @@ package file
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 const prefix = "+kubebuilder:scaffold:"
 
 var commentsByExt = map[string]string{
-	// TODO(v3): machine-readable comments should not have spaces by Go convention. However,
-	//  this is a backwards incompatible change, and thus should be done for next project version.
-	".go":   "// ",
-	".yaml": "# ",
+	".go":   "//",
+	".yaml": "#",
 	".yml":  "#",
 	// When adding additional file extensions, update also the NewMarkerFor documentation and error
 }
@@ -52,6 +51,12 @@ func NewMarkerFor(path string, value string) Marker {
 // String implements Stringer
 func (m Marker) String() string {
 	return m.comment + prefix + m.value
+}
+
+// EqualsLine compares a marker with a string representation to check if they are the same marker
+func (m Marker) EqualsLine(line string) bool {
+	line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), m.comment))
+	return line == prefix+m.value
 }
 
 // CodeFragments represents a set of code fragments

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/api/group.go
@@ -52,8 +52,8 @@ func (f *Group) SetTemplateDefaults() error {
 const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
-// +kubebuilder:object:generate=true
-// +groupName={{ .Resource.Domain }}
+//+kubebuilder:object:generate=true
+//+groupName={{ .Resource.Domain }}
 package {{ .Resource.Version }}
 
 import (

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/api/types.go
@@ -78,9 +78,9 @@ type {{ .Resource.Kind }}Status struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-{{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+{{ if not .Resource.Namespaced }} //+kubebuilder:resource:scope=Cluster {{ end }}
 
 // {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
 type {{ .Resource.Kind }} struct {
@@ -91,7 +91,7 @@ type {{ .Resource.Kind }} struct {
 	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}List struct {

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/api/webhook.go
@@ -100,7 +100,7 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 	//nolint:lll
 	defaultingWebhookTemplate = `
-// +kubebuilder:webhook:path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io
+//+kubebuilder:webhook:path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io
 
 var _ webhook.Defaulter = &{{ .Resource.Kind }}{}
 
@@ -114,7 +114,7 @@ func (r *{{ .Resource.Kind }}) Default() {
 	//nolint:lll
 	validatingWebhookTemplate = `
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io
 
 var _ webhook.Validator = &{{ .Resource.Kind }}{}
 

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
@@ -79,8 +79,8 @@ type {{ .Resource.Kind }}Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
 func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/group.go
@@ -56,8 +56,8 @@ func (f *Group) SetTemplateDefaults() error {
 const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
-// +kubebuilder:object:generate=true
-// +groupName={{ .Resource.Domain }}
+//+kubebuilder:object:generate=true
+//+groupName={{ .Resource.Domain }}
 package {{ .Resource.Version }}
 
 import (

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go
@@ -82,9 +82,9 @@ type {{ .Resource.Kind }}Status struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-{{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+{{ if not .Resource.Namespaced }} //+kubebuilder:resource:scope=Cluster {{ end }}
 
 // {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
 type {{ .Resource.Kind }} struct {
@@ -95,7 +95,7 @@ type {{ .Resource.Kind }} struct {
 	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}List struct {

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook.go
@@ -117,7 +117,7 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	// TODO(estroz): update admissionReviewVersions to include v1 when controller-runtime supports that version.
 	//nolint:lll
 	defaultingWebhookTemplate = `
-// +kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &{{ .Resource.Kind }}{}
 
@@ -133,7 +133,7 @@ func (r *{{ .Resource.Kind }}) Default() {
 	//nolint:lll
 	validatingWebhookTemplate = `
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:{{ if ne .WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .GroupDomainWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &{{ .Resource.Kind }}{}
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -114,8 +114,7 @@ func (f *WebhookSuite) GetCodeFragments() file.CodeFragmentsMap {
 	return fragments
 }
 
-const (
-	webhookTestSuiteTemplate = `{{ .Boilerplate }}
+const webhookTestSuiteTemplate = `{{ .Boilerplate }}
 
 package {{ .Resource.Version }}
 
@@ -225,4 +224,3 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 `
-)

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
@@ -85,9 +85,9 @@ type {{ .Resource.Kind }}Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/finalizers,verbs=update
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/plugins/internal/machinery/scaffold.go
+++ b/pkg/plugins/internal/machinery/scaffold.go
@@ -343,7 +343,7 @@ func insertStrings(content string, codeFragmentsMap file.CodeFragmentsMap) ([]by
 		line := scanner.Text()
 
 		for marker, codeFragments := range codeFragmentsMap {
-			if strings.TrimSpace(line) == strings.TrimSpace(marker.String()) {
+			if marker.EqualsLine(line) {
 				for _, codeFragment := range codeFragments {
 					_, _ = out.WriteString(codeFragment) // bytes.Buffer.WriteString always returns nil errors
 				}

--- a/pkg/plugins/internal/machinery/scaffold_test.go
+++ b/pkg/plugins/internal/machinery/scaffold_test.go
@@ -206,12 +206,12 @@ var _ = Describe("Scaffold", func() {
 			},
 			Entry("should insert lines for go files",
 				`
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				`
 1
 2
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				fakeInserter{codeFragments: file.CodeFragmentsMap{
 					file.NewMarkerFor("file.go", "-"): {"1\n", "2\n"}},
@@ -219,12 +219,12 @@ var _ = Describe("Scaffold", func() {
 			),
 			Entry("should insert lines for yaml files",
 				`
-# +kubebuilder:scaffold:-
+#+kubebuilder:scaffold:-
 `,
 				`
 1
 2
-# +kubebuilder:scaffold:-
+#+kubebuilder:scaffold:-
 `,
 				fakeInserter{codeFragments: file.CodeFragmentsMap{
 					file.NewMarkerFor("file.yaml", "-"): {"1\n", "2\n"}},
@@ -235,10 +235,10 @@ var _ = Describe("Scaffold", func() {
 				`
 1
 2
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				fakeTemplate{fakeBuilder: fakeBuilder{ifExistsAction: file.Overwrite}, body: `
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `},
 				fakeInserter{codeFragments: file.CodeFragmentsMap{
 					file.NewMarkerFor("file.go", "-"): {"1\n", "2\n"}},
@@ -249,10 +249,10 @@ var _ = Describe("Scaffold", func() {
 				`
 1
 2
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				fakeTemplate{fakeBuilder: fakeBuilder{ifExistsAction: file.Overwrite}, body: `
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `},
 				fakeInserter{codeFragments: file.CodeFragmentsMap{
 					file.NewMarkerFor("file.go", "-"): {"1\n", "2\n"}},
@@ -260,12 +260,12 @@ var _ = Describe("Scaffold", func() {
 			),
 			Entry("should use files over optional models",
 				`
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				`
 1
 2
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				fakeTemplate{body: fileContent},
 				fakeInserter{
@@ -276,14 +276,14 @@ var _ = Describe("Scaffold", func() {
 			),
 			Entry("should filter invalid markers",
 				`
-// +kubebuilder:scaffold:-
-// +kubebuilder:scaffold:*
+//+kubebuilder:scaffold:-
+//+kubebuilder:scaffold:*
 `,
 				`
 1
 2
-// +kubebuilder:scaffold:-
-// +kubebuilder:scaffold:*
+//+kubebuilder:scaffold:-
+//+kubebuilder:scaffold:*
 `,
 				fakeInserter{
 					markers: []file.Marker{file.NewMarkerFor("file.go", "-")},
@@ -296,18 +296,18 @@ var _ = Describe("Scaffold", func() {
 			Entry("should filter already existing one-line code fragments",
 				`
 1
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 3
 4
-// +kubebuilder:scaffold:*
+//+kubebuilder:scaffold:*
 `,
 				`
 1
 2
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 3
 4
-// +kubebuilder:scaffold:*
+//+kubebuilder:scaffold:*
 `,
 				fakeInserter{
 					codeFragments: file.CodeFragmentsMap{
@@ -319,10 +319,10 @@ var _ = Describe("Scaffold", func() {
 			Entry("should not insert anything if no code fragment",
 				"", // input is provided through a template as mock fs doesn't copy it to the output buffer if no-op
 				`
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `,
 				fakeTemplate{body: `
-// +kubebuilder:scaffold:-
+//+kubebuilder:scaffold:-
 `},
 				fakeInserter{
 					codeFragments: file.CodeFragmentsMap{

--- a/plugins/addon/controller.go
+++ b/plugins/addon/controller.go
@@ -62,8 +62,8 @@ type {{ .Resource.Kind }}Reconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups={{ .Resource.Domain }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/plugins/addon/type.go
+++ b/plugins/addon/type.go
@@ -74,9 +74,9 @@ type {{.Resource.Kind}}Status struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-{{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+{{ if not .Resource.Namespaced }} //+kubebuilder:resource:scope=Cluster {{ end }}
 
 // {{.Resource.Kind}} is the Schema for the {{ .Resource.Plural }} API
 type {{.Resource.Kind}} struct {
@@ -109,8 +109,8 @@ func (o *{{.Resource.Kind}}) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
-{{ if not .Resource.Namespaced }} // +kubebuilder:resource:scope=Cluster {{ end }}
+//+kubebuilder:object:root=true
+{{ if not .Resource.Namespaced }} //+kubebuilder:resource:scope=Cluster {{ end }}
 
 // {{.Resource.Kind}}List contains a list of {{.Resource.Kind}}
 type {{.Resource.Kind}}List struct {

--- a/testdata/project-v2-addon/api/v1/admiral_types.go
+++ b/testdata/project-v2-addon/api/v1/admiral_types.go
@@ -41,9 +41,9 @@ type AdmiralStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Admiral is the Schema for the admirals API
 type Admiral struct {
@@ -76,8 +76,8 @@ func (o *Admiral) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster
 
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {

--- a/testdata/project-v2-addon/api/v1/captain_types.go
+++ b/testdata/project-v2-addon/api/v1/captain_types.go
@@ -41,8 +41,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -75,7 +75,7 @@ func (o *Captain) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v2-addon/api/v1/firstmate_types.go
+++ b/testdata/project-v2-addon/api/v1/firstmate_types.go
@@ -41,8 +41,8 @@ type FirstMateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // FirstMate is the Schema for the firstmates API
 type FirstMate struct {
@@ -75,7 +75,7 @@ func (o *FirstMate) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {

--- a/testdata/project-v2-addon/api/v1/groupversion_info.go
+++ b/testdata/project-v2-addon/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v2-addon/config/crd/kustomization.yaml
+++ b/testdata/project-v2-addon/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/crew.testproject.org_captains.yaml
 - bases/crew.testproject.org_firstmates.yaml
 - bases/crew.testproject.org_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -13,14 +13,14 @@ patchesStrategicMerge:
 #- patches/webhook_in_captains.yaml
 #- patches/webhook_in_firstmates.yaml
 #- patches/webhook_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml
 #- patches/cainjection_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v2-addon/controllers/admiral_controller.go
+++ b/testdata/project-v2-addon/controllers/admiral_controller.go
@@ -44,8 +44,8 @@ type AdmiralReconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
 
 func (r *AdmiralReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v2-addon/controllers/captain_controller.go
+++ b/testdata/project-v2-addon/controllers/captain_controller.go
@@ -44,8 +44,8 @@ type CaptainReconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
 func (r *CaptainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v2-addon/controllers/firstmate_controller.go
+++ b/testdata/project-v2-addon/controllers/firstmate_controller.go
@@ -44,8 +44,8 @@ type FirstMateReconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 
 func (r *FirstMateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v2-addon/controllers/suite_test.go
+++ b/testdata/project-v2-addon/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2-addon/api/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2-addon/main.go
+++ b/testdata/project-v2-addon/main.go
@@ -29,7 +29,7 @@ import (
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2-addon/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v2-addon/controllers"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -41,7 +41,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(crewv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -91,7 +91,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Admiral")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/testdata/project-v2-multigroup/apis/crew/v1/captain_types.go
+++ b/testdata/project-v2-multigroup/apis/crew/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v2-multigroup/apis/crew/v1/captain_webhook.go
+++ b/testdata/project-v2-multigroup/apis/crew/v1/captain_webhook.go
@@ -34,7 +34,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -46,7 +46,7 @@ func (r *Captain) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,groups=crew.testproject.org,resources=captains,versions=v1,name=vcaptain.kb.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,groups=crew.testproject.org,resources=captains,versions=v1,name=vcaptain.kb.io
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v2-multigroup/apis/crew/v1/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/crew/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v2-multigroup/apis/foo.policy/v1/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/foo.policy/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the foo.policy v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=foo.policy.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=foo.policy.testproject.org
 package v1
 
 import (

--- a/testdata/project-v2-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v2-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
@@ -38,8 +38,8 @@ type HealthCheckPolicyStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // HealthCheckPolicy is the Schema for the healthcheckpolicies API
 type HealthCheckPolicy struct {
@@ -50,7 +50,7 @@ type HealthCheckPolicy struct {
 	Status HealthCheckPolicyStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // HealthCheckPolicyList contains a list of HealthCheckPolicy
 type HealthCheckPolicyList struct {

--- a/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the sea-creatures v1beta1 API group
-// +kubebuilder:object:generate=true
-// +groupName=sea-creatures.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=sea-creatures.testproject.org
 package v1beta1
 
 import (

--- a/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
@@ -38,8 +38,8 @@ type KrakenStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Kraken is the Schema for the krakens API
 type Kraken struct {
@@ -50,7 +50,7 @@ type Kraken struct {
 	Status KrakenStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // KrakenList contains a list of Kraken
 type KrakenList struct {

--- a/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta2 contains API Schema definitions for the sea-creatures v1beta2 API group
-// +kubebuilder:object:generate=true
-// +groupName=sea-creatures.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=sea-creatures.testproject.org
 package v1beta2
 
 import (

--- a/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
@@ -38,8 +38,8 @@ type LeviathanStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Leviathan is the Schema for the leviathans API
 type Leviathan struct {
@@ -50,7 +50,7 @@ type Leviathan struct {
 	Status LeviathanStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // LeviathanList contains a list of Leviathan
 type LeviathanList struct {

--- a/testdata/project-v2-multigroup/apis/ship/v1/destroyer_types.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1/destroyer_types.go
@@ -38,9 +38,9 @@ type DestroyerStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Destroyer is the Schema for the destroyers API
 type Destroyer struct {
@@ -51,7 +51,7 @@ type Destroyer struct {
 	Status DestroyerStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // DestroyerList contains a list of Destroyer
 type DestroyerList struct {

--- a/testdata/project-v2-multigroup/apis/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1/destroyer_webhook.go
@@ -33,7 +33,7 @@ func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io
+//+kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io
 
 var _ webhook.Defaulter = &Destroyer{}
 

--- a/testdata/project-v2-multigroup/apis/ship/v1/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the ship v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=ship.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=ship.testproject.org
 package v1
 
 import (

--- a/testdata/project-v2-multigroup/apis/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1beta1/frigate_types.go
@@ -38,8 +38,8 @@ type FrigateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Frigate is the Schema for the frigates API
 type Frigate struct {
@@ -50,7 +50,7 @@ type Frigate struct {
 	Status FrigateStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FrigateList contains a list of Frigate
 type FrigateList struct {

--- a/testdata/project-v2-multigroup/apis/ship/v1beta1/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the ship v1beta1 API group
-// +kubebuilder:object:generate=true
-// +groupName=ship.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=ship.testproject.org
 package v1beta1
 
 import (

--- a/testdata/project-v2-multigroup/apis/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v2-multigroup/apis/ship/v2alpha1/cruiser_types.go
@@ -38,9 +38,9 @@ type CruiserStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Cruiser is the Schema for the cruisers API
 type Cruiser struct {
@@ -51,7 +51,7 @@ type Cruiser struct {
 	Status CruiserStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CruiserList contains a list of Cruiser
 type CruiserList struct {

--- a/testdata/project-v2-multigroup/apis/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v2-multigroup/apis/ship/v2alpha1/cruiser_webhook.go
@@ -35,7 +35,7 @@ func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,groups=ship.testproject.org,resources=cruisers,versions=v2alpha1,name=vcruiser.kb.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,groups=ship.testproject.org,resources=cruisers,versions=v2alpha1,name=vcruiser.kb.io
 
 var _ webhook.Validator = &Cruiser{}
 

--- a/testdata/project-v2-multigroup/apis/ship/v2alpha1/groupversion_info.go
+++ b/testdata/project-v2-multigroup/apis/ship/v2alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v2alpha1 contains API Schema definitions for the ship v2alpha1 API group
-// +kubebuilder:object:generate=true
-// +groupName=ship.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=ship.testproject.org
 package v2alpha1
 
 import (

--- a/testdata/project-v2-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v2-multigroup/config/crd/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - bases/sea-creatures.testproject.org_krakens.yaml
 - bases/sea-creatures.testproject.org_leviathans.yaml
 - bases/foo.policy.testproject.org_healthcheckpolicies.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -21,7 +21,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_krakens.yaml
 #- patches/webhook_in_leviathans.yaml
 #- patches/webhook_in_healthcheckpolicies.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 #- patches/cainjection_in_krakens.yaml
 #- patches/cainjection_in_leviathans.yaml
 #- patches/cainjection_in_healthcheckpolicies.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v2-multigroup/controllers/apps/pod_controller.go
+++ b/testdata/project-v2-multigroup/controllers/apps/pod_controller.go
@@ -32,8 +32,8 @@ type PodReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
 
 func (r *PodReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/apps/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/apps/suite_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2-multigroup/controllers/crew/captain_controller.go
+++ b/testdata/project-v2-multigroup/controllers/crew/captain_controller.go
@@ -34,8 +34,8 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
 func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/crew/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/crew/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/crew/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v2-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
@@ -34,8 +34,8 @@ type HealthCheckPolicyReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
 
 func (r *HealthCheckPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/foo.policy/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/foo.policy/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	foopolicyv1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/foo.policy/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = foopolicyv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2-multigroup/controllers/sea-creatures/kraken_controller.go
+++ b/testdata/project-v2-multigroup/controllers/sea-creatures/kraken_controller.go
@@ -34,8 +34,8 @@ type KrakenReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
 
 func (r *KrakenReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v2-multigroup/controllers/sea-creatures/leviathan_controller.go
@@ -34,8 +34,8 @@ type LeviathanReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
 
 func (r *LeviathanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/sea-creatures/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/sea-creatures/suite_test.go
@@ -32,7 +32,7 @@ import (
 
 	seacreaturesv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1"
 	seacreaturesv1beta2 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = seacreaturesv1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2-multigroup/controllers/ship/cruiser_controller.go
+++ b/testdata/project-v2-multigroup/controllers/ship/cruiser_controller.go
@@ -34,8 +34,8 @@ type CruiserReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
 
 func (r *CruiserReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/ship/destroyer_controller.go
+++ b/testdata/project-v2-multigroup/controllers/ship/destroyer_controller.go
@@ -34,8 +34,8 @@ type DestroyerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
 
 func (r *DestroyerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/ship/frigate_controller.go
+++ b/testdata/project-v2-multigroup/controllers/ship/frigate_controller.go
@@ -34,8 +34,8 @@ type FrigateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
 
 func (r *FrigateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2-multigroup/controllers/ship/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/ship/suite_test.go
@@ -33,7 +33,7 @@ import (
 	shipv1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/ship/v1"
 	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/ship/v1beta1"
 	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/apis/ship/v2alpha1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -73,7 +73,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2-multigroup/main.go
+++ b/testdata/project-v2-multigroup/main.go
@@ -39,7 +39,7 @@ import (
 	foopolicycontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/foo.policy"
 	seacreaturescontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/sea-creatures"
 	shipcontroller "sigs.k8s.io/kubebuilder/testdata/project-v2-multigroup/controllers/ship"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -57,7 +57,7 @@ func init() {
 	utilruntime.Must(seacreaturesv1beta1.AddToScheme(scheme))
 	utilruntime.Must(seacreaturesv1beta2.AddToScheme(scheme))
 	utilruntime.Must(foopolicyv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -163,7 +163,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/testdata/project-v2/api/v1/admiral_types.go
+++ b/testdata/project-v2/api/v1/admiral_types.go
@@ -38,9 +38,9 @@ type AdmiralStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Admiral is the Schema for the admirals API
 type Admiral struct {
@@ -51,7 +51,7 @@ type Admiral struct {
 	Status AdmiralStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {

--- a/testdata/project-v2/api/v1/admiral_webhook.go
+++ b/testdata/project-v2/api/v1/admiral_webhook.go
@@ -33,7 +33,7 @@ func (r *Admiral) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,groups=crew.testproject.org,resources=admirals,verbs=create;update,versions=v1,name=madmiral.kb.io
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,groups=crew.testproject.org,resources=admirals,verbs=create;update,versions=v1,name=madmiral.kb.io
 
 var _ webhook.Defaulter = &Admiral{}
 

--- a/testdata/project-v2/api/v1/captain_types.go
+++ b/testdata/project-v2/api/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v2/api/v1/captain_webhook.go
+++ b/testdata/project-v2/api/v1/captain_webhook.go
@@ -34,7 +34,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -46,7 +46,7 @@ func (r *Captain) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:verbs=create;update,path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,groups=crew.testproject.org,resources=captains,versions=v1,name=vcaptain.kb.io
+//+kubebuilder:webhook:verbs=create;update,path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,groups=crew.testproject.org,resources=captains,versions=v1,name=vcaptain.kb.io
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v2/api/v1/firstmate_types.go
+++ b/testdata/project-v2/api/v1/firstmate_types.go
@@ -38,8 +38,8 @@ type FirstMateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // FirstMate is the Schema for the firstmates API
 type FirstMate struct {
@@ -50,7 +50,7 @@ type FirstMate struct {
 	Status FirstMateStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {

--- a/testdata/project-v2/api/v1/groupversion_info.go
+++ b/testdata/project-v2/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v2/config/crd/kustomization.yaml
+++ b/testdata/project-v2/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/crew.testproject.org_captains.yaml
 - bases/crew.testproject.org_firstmates.yaml
 - bases/crew.testproject.org_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -13,14 +13,14 @@ patchesStrategicMerge:
 #- patches/webhook_in_captains.yaml
 #- patches/webhook_in_firstmates.yaml
 #- patches/webhook_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml
 #- patches/cainjection_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v2/controllers/admiral_controller.go
+++ b/testdata/project-v2/controllers/admiral_controller.go
@@ -34,8 +34,8 @@ type AdmiralReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
 
 func (r *AdmiralReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2/controllers/captain_controller.go
+++ b/testdata/project-v2/controllers/captain_controller.go
@@ -34,8 +34,8 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
 func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2/controllers/firstmate_controller.go
+++ b/testdata/project-v2/controllers/firstmate_controller.go
@@ -34,8 +34,8 @@ type FirstMateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 
 func (r *FirstMateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2/controllers/laker_controller.go
+++ b/testdata/project-v2/controllers/laker_controller.go
@@ -32,8 +32,8 @@ type LakerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
 
 func (r *LakerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/testdata/project-v2/controllers/suite_test.go
+++ b/testdata/project-v2/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2/api/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())

--- a/testdata/project-v2/main.go
+++ b/testdata/project-v2/main.go
@@ -29,7 +29,7 @@ import (
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v2/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v2/controllers"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -41,7 +41,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(crewv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -111,7 +111,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Laker")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/testdata/project-v3-addon/api/v1/admiral_types.go
+++ b/testdata/project-v3-addon/api/v1/admiral_types.go
@@ -41,9 +41,9 @@ type AdmiralStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Admiral is the Schema for the admirals API
 type Admiral struct {
@@ -76,8 +76,8 @@ func (o *Admiral) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster
 
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {

--- a/testdata/project-v3-addon/api/v1/captain_types.go
+++ b/testdata/project-v3-addon/api/v1/captain_types.go
@@ -41,8 +41,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -75,7 +75,7 @@ func (o *Captain) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v3-addon/api/v1/firstmate_types.go
+++ b/testdata/project-v3-addon/api/v1/firstmate_types.go
@@ -41,8 +41,8 @@ type FirstMateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // FirstMate is the Schema for the firstmates API
 type FirstMate struct {
@@ -75,7 +75,7 @@ func (o *FirstMate) SetCommonStatus(s addonv1alpha1.CommonStatus) {
 	o.Status.CommonStatus = s
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {

--- a/testdata/project-v3-addon/api/v1/groupversion_info.go
+++ b/testdata/project-v3-addon/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v3-addon/config/crd/kustomization.yaml
+++ b/testdata/project-v3-addon/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/crew.testproject.org_captains.yaml
 - bases/crew.testproject.org_firstmates.yaml
 - bases/crew.testproject.org_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -13,14 +13,14 @@ patchesStrategicMerge:
 #- patches/webhook_in_captains.yaml
 #- patches/webhook_in_firstmates.yaml
 #- patches/webhook_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml
 #- patches/cainjection_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v3-addon/controllers/admiral_controller.go
+++ b/testdata/project-v3-addon/controllers/admiral_controller.go
@@ -44,8 +44,8 @@ type AdmiralReconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
 
 func (r *AdmiralReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v3-addon/controllers/captain_controller.go
+++ b/testdata/project-v3-addon/controllers/captain_controller.go
@@ -44,8 +44,8 @@ type CaptainReconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
 func (r *CaptainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v3-addon/controllers/firstmate_controller.go
+++ b/testdata/project-v3-addon/controllers/firstmate_controller.go
@@ -44,8 +44,8 @@ type FirstMateReconciler struct {
 	declarative.Reconciler
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 
 func (r *FirstMateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()

--- a/testdata/project-v3-addon/controllers/suite_test.go
+++ b/testdata/project-v3-addon/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-addon/api/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-addon/main.go
+++ b/testdata/project-v3-addon/main.go
@@ -33,7 +33,7 @@ import (
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-addon/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v3-addon/controllers"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -45,7 +45,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(crewv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -102,7 +102,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Admiral")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v3-config/api/v1/admiral_types.go
+++ b/testdata/project-v3-config/api/v1/admiral_types.go
@@ -38,9 +38,9 @@ type AdmiralStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Admiral is the Schema for the admirals API
 type Admiral struct {
@@ -51,7 +51,7 @@ type Admiral struct {
 	Status AdmiralStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {

--- a/testdata/project-v3-config/api/v1/admiral_webhook.go
+++ b/testdata/project-v3-config/api/v1/admiral_webhook.go
@@ -33,7 +33,7 @@ func (r *Admiral) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirals,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirals,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Admiral{}
 

--- a/testdata/project-v3-config/api/v1/captain_types.go
+++ b/testdata/project-v3-config/api/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v3-config/api/v1/captain_webhook.go
+++ b/testdata/project-v3-config/api/v1/captain_webhook.go
@@ -34,7 +34,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -46,7 +46,7 @@ func (r *Captain) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v3-config/api/v1/firstmate_types.go
+++ b/testdata/project-v3-config/api/v1/firstmate_types.go
@@ -38,8 +38,8 @@ type FirstMateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // FirstMate is the Schema for the firstmates API
 type FirstMate struct {
@@ -50,7 +50,7 @@ type FirstMate struct {
 	Status FirstMateStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {

--- a/testdata/project-v3-config/api/v1/groupversion_info.go
+++ b/testdata/project-v3-config/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v3-config/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3-config/api/v1/webhook_suite_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -108,7 +108,7 @@ var _ = BeforeSuite(func() {
 	err = (&Admiral{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
+	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)

--- a/testdata/project-v3-config/config/crd/kustomization.yaml
+++ b/testdata/project-v3-config/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/crew.testproject.org_captains.yaml
 - bases/crew.testproject.org_firstmates.yaml
 - bases/crew.testproject.org_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -13,14 +13,14 @@ patchesStrategicMerge:
 #- patches/webhook_in_captains.yaml
 #- patches/webhook_in_firstmates.yaml
 #- patches/webhook_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml
 #- patches/cainjection_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v3-config/controllers/admiral_controller.go
+++ b/testdata/project-v3-config/controllers/admiral_controller.go
@@ -34,9 +34,9 @@ type AdmiralReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-config/controllers/captain_controller.go
+++ b/testdata/project-v3-config/controllers/captain_controller.go
@@ -34,9 +34,9 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-config/controllers/firstmate_controller.go
+++ b/testdata/project-v3-config/controllers/firstmate_controller.go
@@ -34,9 +34,9 @@ type FirstMateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-config/controllers/laker_controller.go
+++ b/testdata/project-v3-config/controllers/laker_controller.go
@@ -32,9 +32,9 @@ type LakerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-config/controllers/suite_test.go
+++ b/testdata/project-v3-config/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-config/api/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-config/main.go
+++ b/testdata/project-v3-config/main.go
@@ -33,7 +33,7 @@ import (
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-config/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v3-config/controllers"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -45,7 +45,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(crewv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -122,7 +122,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Laker")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v3-multigroup/apis/crew/v1/captain_types.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v3-multigroup/apis/crew/v1/captain_webhook.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/captain_webhook.go
@@ -34,7 +34,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -46,7 +46,7 @@ func (r *Captain) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v3-multigroup/apis/crew/v1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v3-multigroup/apis/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/webhook_suite_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 	err = (&Captain{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
+	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)

--- a/testdata/project-v3-multigroup/apis/foo.policy/v1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/foo.policy/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the foo.policy v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=foo.policy.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=foo.policy.testproject.org
 package v1
 
 import (

--- a/testdata/project-v3-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v3-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
@@ -38,8 +38,8 @@ type HealthCheckPolicyStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // HealthCheckPolicy is the Schema for the healthcheckpolicies API
 type HealthCheckPolicy struct {
@@ -50,7 +50,7 @@ type HealthCheckPolicy struct {
 	Status HealthCheckPolicyStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // HealthCheckPolicyList contains a list of HealthCheckPolicy
 type HealthCheckPolicyList struct {

--- a/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the sea-creatures v1beta1 API group
-// +kubebuilder:object:generate=true
-// +groupName=sea-creatures.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=sea-creatures.testproject.org
 package v1beta1
 
 import (

--- a/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
@@ -38,8 +38,8 @@ type KrakenStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Kraken is the Schema for the krakens API
 type Kraken struct {
@@ -50,7 +50,7 @@ type Kraken struct {
 	Status KrakenStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // KrakenList contains a list of Kraken
 type KrakenList struct {

--- a/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta2 contains API Schema definitions for the sea-creatures v1beta2 API group
-// +kubebuilder:object:generate=true
-// +groupName=sea-creatures.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=sea-creatures.testproject.org
 package v1beta2
 
 import (

--- a/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
@@ -38,8 +38,8 @@ type LeviathanStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Leviathan is the Schema for the leviathans API
 type Leviathan struct {
@@ -50,7 +50,7 @@ type Leviathan struct {
 	Status LeviathanStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // LeviathanList contains a list of Leviathan
 type LeviathanList struct {

--- a/testdata/project-v3-multigroup/apis/ship/v1/destroyer_types.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/destroyer_types.go
@@ -38,9 +38,9 @@ type DestroyerStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Destroyer is the Schema for the destroyers API
 type Destroyer struct {
@@ -51,7 +51,7 @@ type Destroyer struct {
 	Status DestroyerStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // DestroyerList contains a list of Destroyer
 type DestroyerList struct {

--- a/testdata/project-v3-multigroup/apis/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/destroyer_webhook.go
@@ -33,7 +33,7 @@ func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Destroyer{}
 

--- a/testdata/project-v3-multigroup/apis/ship/v1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the ship v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=ship.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=ship.testproject.org
 package v1
 
 import (

--- a/testdata/project-v3-multigroup/apis/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/webhook_suite_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 	err = (&Destroyer{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
+	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)

--- a/testdata/project-v3-multigroup/apis/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1beta1/frigate_types.go
@@ -38,8 +38,8 @@ type FrigateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Frigate is the Schema for the frigates API
 type Frigate struct {
@@ -50,7 +50,7 @@ type Frigate struct {
 	Status FrigateStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FrigateList contains a list of Frigate
 type FrigateList struct {

--- a/testdata/project-v3-multigroup/apis/ship/v1beta1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the ship v1beta1 API group
-// +kubebuilder:object:generate=true
-// +groupName=ship.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=ship.testproject.org
 package v1beta1
 
 import (

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/cruiser_types.go
@@ -38,9 +38,9 @@ type CruiserStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Cruiser is the Schema for the cruisers API
 type Cruiser struct {
@@ -51,7 +51,7 @@ type Cruiser struct {
 	Status CruiserStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CruiserList contains a list of Cruiser
 type CruiserList struct {

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/cruiser_webhook.go
@@ -35,7 +35,7 @@ func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Cruiser{}
 

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v2alpha1 contains API Schema definitions for the ship v2alpha1 API group
-// +kubebuilder:object:generate=true
-// +groupName=ship.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=ship.testproject.org
 package v2alpha1
 
 import (

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/webhook_suite_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 	err = (&Cruiser{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
+	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)

--- a/testdata/project-v3-multigroup/apis/v1/groupversion_info.go
+++ b/testdata/project-v3-multigroup/apis/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the  v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=testproject.org
 package v1
 
 import (

--- a/testdata/project-v3-multigroup/apis/v1/lakers_types.go
+++ b/testdata/project-v3-multigroup/apis/v1/lakers_types.go
@@ -38,8 +38,8 @@ type LakersStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Lakers is the Schema for the lakers API
 type Lakers struct {
@@ -50,7 +50,7 @@ type Lakers struct {
 	Status LakersStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // LakersList contains a list of Lakers
 type LakersList struct {

--- a/testdata/project-v3-multigroup/apis/v1/lakers_webhook.go
+++ b/testdata/project-v3-multigroup/apis/v1/lakers_webhook.go
@@ -34,7 +34,7 @@ func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Lakers{}
 
@@ -46,7 +46,7 @@ func (r *Lakers) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Lakers{}
 

--- a/testdata/project-v3-multigroup/apis/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/v1/webhook_suite_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 	err = (&Lakers{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
+	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)

--- a/testdata/project-v3-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/crd/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 - bases/sea-creatures.testproject.org_leviathans.yaml
 - bases/foo.policy.testproject.org_healthcheckpolicies.yaml
 - bases/testproject.org_lakers.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -23,7 +23,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_leviathans.yaml
 #- patches/webhook_in_healthcheckpolicies.yaml
 #- patches/webhook_in_lakers.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
@@ -35,7 +35,7 @@ patchesStrategicMerge:
 #- patches/cainjection_in_leviathans.yaml
 #- patches/cainjection_in_healthcheckpolicies.yaml
 #- patches/cainjection_in_lakers.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v3-multigroup/controllers/apps/pod_controller.go
+++ b/testdata/project-v3-multigroup/controllers/apps/pod_controller.go
@@ -32,9 +32,9 @@ type PodReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=apps,resources=pods/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps,resources=pods/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/apps/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/apps/suite_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-multigroup/controllers/crew/captain_controller.go
+++ b/testdata/project-v3-multigroup/controllers/crew/captain_controller.go
@@ -34,9 +34,9 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/crew/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/crew/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/crew/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
@@ -34,9 +34,9 @@ type HealthCheckPolicyReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
+//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/foo.policy/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	foopolicyv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/foo.policy/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 	err = foopolicyv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-multigroup/controllers/lakers_controller.go
+++ b/testdata/project-v3-multigroup/controllers/lakers_controller.go
@@ -34,9 +34,9 @@ type LakersReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=testproject.org,resources=lakers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=testproject.org,resources=lakers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=testproject.org,resources=lakers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=testproject.org,resources=lakers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/kraken_controller.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/kraken_controller.go
@@ -34,9 +34,9 @@ type KrakenReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/leviathan_controller.go
@@ -34,9 +34,9 @@ type LeviathanReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/sea-creatures/suite_test.go
@@ -32,7 +32,7 @@ import (
 
 	seacreaturesv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1"
 	seacreaturesv1beta2 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	err = seacreaturesv1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-multigroup/controllers/ship/cruiser_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/cruiser_controller.go
@@ -34,9 +34,9 @@ type CruiserReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/ship/destroyer_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/destroyer_controller.go
@@ -34,9 +34,9 @@ type DestroyerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/ship/frigate_controller.go
+++ b/testdata/project-v3-multigroup/controllers/ship/frigate_controller.go
@@ -34,9 +34,9 @@ type FrigateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3-multigroup/controllers/ship/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/ship/suite_test.go
@@ -33,7 +33,7 @@ import (
 	shipv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/ship/v1"
 	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/ship/v1beta1"
 	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/ship/v2alpha1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-multigroup/controllers/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	testprojectorgv1 "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 	err = testprojectorgv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -45,7 +45,7 @@ import (
 	foopolicycontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/foo.policy"
 	seacreaturescontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/sea-creatures"
 	shipcontrollers "sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/controllers/ship"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -64,7 +64,7 @@ func init() {
 	utilruntime.Must(seacreaturesv1beta2.AddToScheme(scheme))
 	utilruntime.Must(foopolicyv1.AddToScheme(scheme))
 	utilruntime.Must(testprojectorgv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -189,7 +189,7 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Lakers")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v3/api/v1/admiral_types.go
+++ b/testdata/project-v3/api/v1/admiral_types.go
@@ -38,9 +38,9 @@ type AdmiralStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // Admiral is the Schema for the admirals API
 type Admiral struct {
@@ -51,7 +51,7 @@ type Admiral struct {
 	Status AdmiralStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {

--- a/testdata/project-v3/api/v1/admiral_webhook.go
+++ b/testdata/project-v3/api/v1/admiral_webhook.go
@@ -33,7 +33,7 @@ func (r *Admiral) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirals,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirals,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Admiral{}
 

--- a/testdata/project-v3/api/v1/captain_types.go
+++ b/testdata/project-v3/api/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v3/api/v1/captain_webhook.go
+++ b/testdata/project-v3/api/v1/captain_webhook.go
@@ -34,7 +34,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -46,7 +46,7 @@ func (r *Captain) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v3/api/v1/firstmate_types.go
+++ b/testdata/project-v3/api/v1/firstmate_types.go
@@ -38,8 +38,8 @@ type FirstMateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 
 // FirstMate is the Schema for the firstmates API
 type FirstMate struct {
@@ -50,7 +50,7 @@ type FirstMate struct {
 	Status FirstMateStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {

--- a/testdata/project-v3/api/v1/groupversion_info.go
+++ b/testdata/project-v3/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the crew v1 API group
-// +kubebuilder:object:generate=true
-// +groupName=crew.testproject.org
+//+kubebuilder:object:generate=true
+//+groupName=crew.testproject.org
 package v1
 
 import (

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -114,7 +114,7 @@ var _ = BeforeSuite(func() {
 	err = (&Captain{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:webhook
+	//+kubebuilder:scaffold:webhook
 
 	go func() {
 		err = mgr.Start(ctx)

--- a/testdata/project-v3/config/crd/kustomization.yaml
+++ b/testdata/project-v3/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/crew.testproject.org_captains.yaml
 - bases/crew.testproject.org_firstmates.yaml
 - bases/crew.testproject.org_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizeresource
+#+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -13,14 +13,14 @@ patchesStrategicMerge:
 #- patches/webhook_in_captains.yaml
 #- patches/webhook_in_firstmates.yaml
 #- patches/webhook_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizewebhookpatch
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml
 #- patches/cainjection_in_admirals.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v3/controllers/admiral_controller.go
+++ b/testdata/project-v3/controllers/admiral_controller.go
@@ -34,9 +34,9 @@ type AdmiralReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3/controllers/captain_controller.go
+++ b/testdata/project-v3/controllers/captain_controller.go
@@ -34,9 +34,9 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3/controllers/firstmate_controller.go
+++ b/testdata/project-v3/controllers/firstmate_controller.go
@@ -34,9 +34,9 @@ type FirstMateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3/controllers/laker_controller.go
+++ b/testdata/project-v3/controllers/laker_controller.go
@@ -32,9 +32,9 @@ type LakerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v3/controllers/suite_test.go
+++ b/testdata/project-v3/controllers/suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3/api/v1"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3/main.go
+++ b/testdata/project-v3/main.go
@@ -33,7 +33,7 @@ import (
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v3/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v3/controllers"
-	// +kubebuilder:scaffold:imports
+	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -45,7 +45,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(crewv1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
+	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -126,7 +126,7 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
 		os.Exit(1)
 	}
-	// +kubebuilder:scaffold:builder
+	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")


### PR DESCRIPTION
# Description
Machine-readable comments used for markers have spaces after the comment character (`//` or `#`), they have been removed to follow common coding practices.

Closes: #1384

# Comments to reviewers
131/144 files are from the `testdata` directory, this PR is smaller than what it looks like by the number of files changed.