### PR TITLE
:book: docs: add CRD and webhook API version information

### DIFF
--- a/docs/book/src/cronjob-tutorial/new-api.md
+++ b/docs/book/src/cronjob-tutorial/new-api.md
@@ -11,6 +11,20 @@ kubebuilder create api --group batch --version v1 --kind CronJob
 The first time we call this command for each group-version, it will create
 a directory for the new group-version.
 
+<aside class="note">
+
+<h1>Supporting older cluster versions</h1>
+
+The default CustomResourceDefinition manifests created alongside your Go API types
+use API version `v1`. If your project intends to support Kubernetes cluster versions older
+than v1.16, you must set `--crd-version v1beta1` and remove `preserveUnknownFields=false`
+from the `CRD_OPTIONS` Makefile variable.
+See the [CustomResourceDefinition generation reference][crd-reference] for details.
+
+[crd-reference]: /reference/generating-crd.md#supporting-older-cluster-versions
+
+</aside>
+
 In this case, the
 [`api/v1/`](https://sigs.k8s.io/kubebuilder/docs/book/src/cronjob-tutorial/testdata/project/api/v1)
 directory is created, corresponding to the

--- a/docs/book/src/cronjob-tutorial/webhook-implementation.md
+++ b/docs/book/src/cronjob-tutorial/webhook-implementation.md
@@ -19,4 +19,17 @@ kubebuilder create webhook --group batch --version v1 --kind CronJob --defaultin
 
 This will scaffold the webhook functions and register your webhook with the manager in your `main.go` for you.
 
+<aside class="note">
+
+<h1>Supporting older cluster versions</h1>
+
+The default WebhookConfiguration manifests created alongside your Go webhook implementation
+use API version `v1`. If your project intends to support Kubernetes cluster versions older
+than v1.16, set `--webhook-version v1beta1`. See the [webhook reference][webhook-reference]
+for more information.
+
+[webhook-reference]: /reference/webhook-overview.md#supporting-older-cluster-versions
+
+</aside>
+
 {{#literatego ./testdata/project/api/v1/cronjob_webhook.go}}

--- a/docs/book/src/reference/generating-crd.md
+++ b/docs/book/src/reference/generating-crd.md
@@ -162,11 +162,34 @@ different versions of the Kind in your CRD, to be compatible with older
 Kubernetes versions.
 
 You'll need to enable this by switching the line in your makefile that
-says `CRD_OPTIONS ?= "crd:trivialVersions=true` to `CRD_OPTIONS ?= crd`
+says `CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false`
+to `CRD_OPTIONS ?= crd:preserveUnknownFields=false`
 
 Then, you can use the `+kubebuilder:storageversion` [marker][crd-markers]
 to indicate the [GVK](/cronjob-tutorial/gvks.md "Group-Version-Kind") that
 should be used to store data by the API server.
+
+### Supporting older cluster versions
+
+By default, `kubebuilder create api` will create CRDs of API version `v1`,
+a version introduced in Kubernetes v1.16. If your project intends to support
+Kubernetes cluster versions older than v1.16, you must use the `v1beta1` API version:
+
+```sh
+kubebuilder create api --crd-version v1beta1 ...
+```
+
+To support Kubernetes clusters of version v1.14 or lower, you'll also need to
+remove the controller-gen option `preserveUnknownFields=false` from your Makefile.
+This is done by switching the line that says
+`CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false`
+to `CRD_OPTIONS ?= crd:trivialVersions=true`
+
+<aside class="note">
+
+`v1beta1` is deprecated and will be removed in Kubernetes v1.22, so upgrading is recommended.
+
+</aside>
 
 ## Under the hood
 

--- a/docs/book/src/reference/webhook-overview.md
+++ b/docs/book/src/reference/webhook-overview.md
@@ -17,3 +17,19 @@ feature entered beta).
 
 Kubernetes supports the conversion webhooks as of version 1.15 (when the
 feature entered beta).
+
+### Supporting older cluster versions
+
+By default, `kubebuilder create webhook` will create webhook configs of API version `v1`,
+a version introduced in Kubernetes v1.16. If your project intends to support
+Kubernetes cluster versions older than v1.16, you must use the `v1beta1` API version:
+
+```sh
+kubebuilder create webhook --webhook-version v1beta1 ...
+```
+
+<aside class="note">
+
+`v1beta1` is deprecated and will be removed in a future Kubernetes release, so upgrading is recommended.
+
+</aside>


### PR DESCRIPTION
Add CRD and webhook API version information to docs, framed as relevant to older cluster support.

Follow up from #1644 and https://github.com/kubernetes-sigs/kubebuilder/issues/1065#issuecomment-729180067

/kind documentation
