### PR TITLE
:book: adding kind-config.yaml back for documentation

### DIFF
--- a/docs/book/src/reference/kind-config.yaml
+++ b/docs/book/src/reference/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker

--- a/docs/book/src/reference/kind.md
+++ b/docs/book/src/reference/kind.md
@@ -20,7 +20,7 @@ To customize your cluster, you can provide additional configuration.
 For example, the following is a sample `kind` configuration.
 
 ```yaml
-{{#include ../cronjob-tutorial/testdata/project/hack/kind-config.yaml}}
+{{#include ./kind-config.yaml}}
 ```
 
 Using the configuration above, run the following command will give you a k8s


### PR DESCRIPTION
This file used to be in the hack directory, this moves it to the reference directory.

Fixes #1871

Signed-off-by: Chris Hein <me@chrishein.com>
