### PR TITLE
:book: fixing documentation links for makefile_helpers.md

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -83,7 +83,7 @@
   - [Configuring EnvTest](./reference/envtest.md)
 
   - [Metrics](./reference/metrics.md)
-  - [Makefile Helpers](makefile-helpers.md)
+  - [Makefile Helpers](./reference/makefile-helpers.md)
   - [CLI Plugins](./reference/cli-plugins.md)
 
 ---


### PR DESCRIPTION
This fixes the doc links for the `makefile_helpers.md`.

Fixes #1873 

Signed-off-by: Chris Hein <me@chrishein.com>
