### PR TITLE
:sparkles: upgrade controller-runtime from v0.6.3 to v0.6.4 (go/v2 only)

### DIFF
--- a/pkg/plugins/golang/v2/scaffolds/init.go
+++ b/pkg/plugins/golang/v2/scaffolds/init.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
-	ControllerRuntimeVersion = "v0.6.3"
+	ControllerRuntimeVersion = "v0.6.4"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
 	ControllerToolsVersion = "v0.3.0"
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project

--- a/testdata/project-v2-addon/go.mod
+++ b/testdata/project-v2-addon/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/onsi/gomega v1.10.1
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
-	sigs.k8s.io/controller-runtime v0.6.3
+	sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20200522144838-848d48e5b073
 )

--- a/testdata/project-v2-multigroup/go.mod
+++ b/testdata/project-v2-multigroup/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/onsi/gomega v1.10.1
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
-	sigs.k8s.io/controller-runtime v0.6.3
+	sigs.k8s.io/controller-runtime v0.6.4
 )

--- a/testdata/project-v2/go.mod
+++ b/testdata/project-v2/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/onsi/gomega v1.10.1
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
-	sigs.k8s.io/controller-runtime v0.6.3
+	sigs.k8s.io/controller-runtime v0.6.4
 )


### PR DESCRIPTION
**Description**
- upgrade controller-runtime from v0.6.3 to v0.6.4

**Motivation**
Get bugfixes and solve tech debts