### PR TITLE
:sparkles: Change the webhook GVK in help text to match kb create api

### DIFF
--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -50,12 +50,12 @@ func (p *createWebhookSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
 `
-	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group crew, version v1
-  # and kind FirstMate.
-  %s create webhook --group crew --version v1 --kind FirstMate --defaulting --programmatic-validation
+	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group ship, version v1beta1
+  # and kind Frigate.
+  %s create webhook --group ship --version v1beta1 --kind Frigate --defaulting --programmatic-validation
 
-  # Create conversion webhook for CRD of group crew, version v1 and kind FirstMate.
-  %s create webhook --group crew --version v1 --kind FirstMate --conversion
+  # Create conversion webhook for CRD of group shio, version v1beta1 and kind Frigate.
+  %s create webhook --group ship --version v1beta1 --kind Frigate --conversion
 `,
 		ctx.CommandName, ctx.CommandName)
 

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -57,12 +57,12 @@ func (p *createWebhookSubcommand) UpdateContext(ctx *plugin.Context) {
 	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
 `
-	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group crew, version v1
-  # and kind FirstMate.
-  %s create webhook --group crew --version v1 --kind FirstMate --defaulting --programmatic-validation
+	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group ship, version v1beta1
+  # and kind Frigate.
+  %s create webhook --group ship --version v1beta1 --kind Frigate --defaulting --programmatic-validation
 
-  # Create conversion webhook for CRD of group crew, version v1 and kind FirstMate.
-  %s create webhook --group crew --version v1 --kind FirstMate --conversion
+  # Create conversion webhook for CRD of group ship, version v1beta1 and kind Frigate.
+  %s create webhook --group ship --version v1beta1 --kind Frigate --conversion
 `,
 		ctx.CommandName, ctx.CommandName)
 


### PR DESCRIPTION
**Description**
Change the help text on create webhook command to match the create api command.

**Motivation**
Users who is trying out kubebuilder layout with the --help command should able to run the commands generated by kubebuilder --help. Hence, the create api command GVK and create command GVK should be same in the help text.