### PR TITLE
:warning: (go/v3) stabilize and default the plugin

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,12 +34,8 @@ func main() {
 			&pluginv2.Plugin{},
 			&pluginv3.Plugin{},
 		),
-		cli.WithDefaultPlugins(config.Version2,
-			&pluginv2.Plugin{},
-		),
-		cli.WithDefaultPlugins(config.Version3Alpha,
-			&pluginv2.Plugin{},
-		),
+		cli.WithDefaultPlugins(config.Version2, &pluginv2.Plugin{}),
+		cli.WithDefaultPlugins(config.Version3Alpha, &pluginv3.Plugin{}),
 		cli.WithCompletion,
 	)
 	if err != nil {

--- a/generate_testdata.sh
+++ b/generate_testdata.sh
@@ -40,9 +40,9 @@ scaffold_test_project() {
   cd testdata/$project
   local kb=$testdata_dir/../bin/kubebuilder
 
-  # Remove tool binaries for non-plugin projects, which don't have locally-configured binaries,
+  # Remove tool binaries for projects of version 2, which don't have locally-configured binaries,
   # so the correct versions are used.
-  if [[ ! $init_flags =~ --plugins ]]; then
+  if [[ $init_flags =~ --project-version=2 ]]; then
     rm -f "$(command -v controller-gen)"
     rm -f "$(command -v kustomize)"
   fi
@@ -106,10 +106,12 @@ export GO111MODULE=on
 export PATH="$PATH:$(go env GOPATH)/bin"
 
 build_kb
+# Project version 2 uses plugin go/v2 (default).
 scaffold_test_project project-v2 --project-version=2
 scaffold_test_project project-v2-multigroup --project-version=2
 scaffold_test_project project-v2-addon --project-version=2
-scaffold_test_project project-v3 --project-version=3-alpha --plugins=go/v3-alpha
-scaffold_test_project project-v3-multigroup --project-version=3-alpha --plugins=go/v3-alpha
-scaffold_test_project project-v3-addon --project-version=3-alpha --plugins=go/v3-alpha
-scaffold_test_project project-v3-config --project-version=3-alpha --plugins=go/v3-alpha --component-config
+# Project version 3 (default) uses plugin go/v3 (default).
+scaffold_test_project project-v3
+scaffold_test_project project-v3-multigroup
+scaffold_test_project project-v3-addon
+scaffold_test_project project-v3-config --component-config

--- a/pkg/plugins/golang/v3/plugin.go
+++ b/pkg/plugins/golang/v3/plugin.go
@@ -26,7 +26,7 @@ const pluginName = "go" + plugins.DefaultNameQualifier
 
 var (
 	supportedProjectVersions = []string{config.Version3Alpha}
-	pluginVersion            = plugin.Version{Number: 3, Stage: plugin.AlphaStage}
+	pluginVersion            = plugin.Version{Number: 3}
 )
 
 var _ plugin.Full = Plugin{}

--- a/test.sh
+++ b/test.sh
@@ -155,5 +155,6 @@ test_project project-v2-addon 2
 test_project project-v3 3-alpha
 test_project project-v3-multigroup 3-alpha
 test_project project-v3-addon 3-alpha
+test_project project-v3-config 3-alpha
 
 exit $rc

--- a/test/e2e/v3/generate_test.go
+++ b/test/e2e/v3/generate_test.go
@@ -32,9 +32,10 @@ import (
 func GenerateV2(kbc *utils.TestContext) {
 	var err error
 
-	By("initializing a v3 project")
+	By("initializing a project")
 	err = kbc.Init(
 		"--project-version", "3-alpha",
+		"--plugins", "go/v2",
 		"--domain", kbc.Domain,
 		"--fetch-deps=false",
 	)
@@ -126,10 +127,10 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 func GenerateV3(kbc *utils.TestContext, crdAndWebhookVersion string) {
 	var err error
 
-	By("initializing a v3 project")
+	By("initializing a project")
 	err = kbc.Init(
-		"--plugins", "go/v3-alpha",
 		"--project-version", "3-alpha",
+		"--plugins", "go/v3",
 		"--domain", kbc.Domain,
 		"--fetch-deps=false",
 	)

--- a/testdata/project-v3-addon/PROJECT
+++ b/testdata/project-v3-addon/PROJECT
@@ -1,5 +1,5 @@
 domain: testproject.org
-layout: go.kubebuilder.io/v3-alpha
+layout: go.kubebuilder.io/v3
 projectName: project-v3-addon
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 resources:

--- a/testdata/project-v3-config/PROJECT
+++ b/testdata/project-v3-config/PROJECT
@@ -1,6 +1,6 @@
 componentConfig: true
 domain: testproject.org
-layout: go.kubebuilder.io/v3-alpha
+layout: go.kubebuilder.io/v3
 projectName: project-v3-config
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-config
 resources:

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -1,5 +1,5 @@
 domain: testproject.org
-layout: go.kubebuilder.io/v3-alpha
+layout: go.kubebuilder.io/v3
 multigroup: true
 projectName: project-v3-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -1,5 +1,5 @@
 domain: testproject.org
-layout: go.kubebuilder.io/v3-alpha
+layout: go.kubebuilder.io/v3
 projectName: project-v3
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:


### PR DESCRIPTION
This PR stabilizes plugin go/v3-alpha to go/v3 and makes it the default plugin.

- cmd/main.go: make go/v3 the default plugin
- *.sh: update tests to create projects for the correct plugin version

Closes #1834
