### PR TITLE
:seedling: fix the breaking change to still allowing TestContext to be used for tests outside of the cluster 

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -59,10 +59,13 @@ func NewTestContext(binaryName string, env ...string) (*TestContext, error) {
 		Namespace:  fmt.Sprintf("e2e-%s-system", testSuffix),
 		CmdContext: cc,
 	}
-	k8sVersion, err := kubectl.Version()
-	if err != nil {
-		return nil, err
-	}
+
+	// Try to populate the k8sVersion and ignore any error that might be faced.
+	// Note that, the k8sVersion is not an mandatory info and it is
+	// not required for ANY context of tests. For example, the testContext
+	// might be used to run a test outside of the cluster where this info is not
+	// available and not required at all.
+	k8sVersion, _ := kubectl.Version()
 
 	// Set CmdContext.Dir after running Kubectl.Version() because dir does not exist yet.
 	if cc.Dir, err = filepath.Abs("e2e-" + testSuffix); err != nil {

--- a/test/e2e/v3/plugin_cluster_test.go
+++ b/test/e2e/v3/plugin_cluster_test.go
@@ -86,6 +86,13 @@ var _ = Describe("kubebuilder", func() {
 			})
 
 			It("should generate a runnable project", func() {
+				// Ensure that kbc.K8sVersion is populated.
+				if kbc.K8sVersion == nil {
+					K8sVersion, err := kbc.Kubectl.Version()
+					Expect(err).NotTo(HaveOccurred())
+					kbc.K8sVersion = &K8sVersion
+				}
+
 				// Skip if cluster version < 1.16, when v1 CRDs and webhooks did not exist.
 				if srvVer := kbc.K8sVersion.ServerVersion; srvVer.GetMajorInt() <= 1 && srvVer.GetMinorInt() < 16 {
 					Skip(fmt.Sprintf("cluster version %s does not support v1 CRDs or webhooks", srvVer.GitVersion))
@@ -95,6 +102,13 @@ var _ = Describe("kubebuilder", func() {
 				Run(kbc)
 			})
 			It("should generate a runnable project with v1beta1 CRDs and Webhooks", func() {
+				// Ensure that kbc.K8sVersion is populated.
+				if kbc.K8sVersion == nil {
+					K8sVersion, err := kbc.Kubectl.Version()
+					Expect(err).NotTo(HaveOccurred())
+					kbc.K8sVersion = &K8sVersion
+				}
+
 				// Skip if cluster version < 1.15, when `.spec.preserveUnknownFields` was not a v1beta1 CRD field.
 				if srvVer := kbc.K8sVersion.ServerVersion; srvVer.GetMajorInt() <= 1 && srvVer.GetMinorInt() < 15 {
 					Skip(fmt.Sprintf("cluster version %s does not support project defaults", srvVer.GitVersion))


### PR DESCRIPTION
**Description**

After the changes made in https://github.com/kubernetes-sigs/kubebuilder/commit/ea3a94a97ad4ba0cb148e711095530286d050d54#diff-7b614da29899d7d7eb4aa3b60ed598604da518c4f2dd1e6af954c942fb1c3dc3 in many scenarios, we have been facing panic issues when it was calling the kubectl.Version(). See that TextContext has *kubectl which can be nil. 

Note that, we ought to just look for the k8sVersion when/if it is required. It is not a mandatory attrs at all we might have tests that require knowing the k8sVersion and others that not. 
 