### PR TITLE
:warning: change structure to store crdVersion and webhookversion (go/v3-alpha)

### DIFF
--- a/pkg/model/config/config_test.go
+++ b/pkg/model/config/config_test.go
@@ -30,6 +30,28 @@ var _ = Describe("PluginConfig", func() {
 		Data1 string `json:"data-1"`
 		Data2 string `json:"data-2"`
 	}
+	const defaultWebhookVersion = "v1"
+
+	resource := ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"}
+	resource.Webhooks = &Webhooks{defaultWebhookVersion}
+
+	It("should return true when has the ResourceData is equals", func() {
+		Expect(resource.isGVKEqualTo(ResourceData{Group: "Foo", Kind: "Baz", Version: "v1"})).To(BeTrue())
+	})
+
+	It("should return false when ResourceData is NOT equals", func() {
+		Expect(resource.isGVKEqualTo(ResourceData{Group: "Foo", Kind: "Baz", Version: "v2"})).To(BeFalse())
+	})
+
+	It("IsV2 should return true when the config is V2", func() {
+		cfg := Config{Version: Version2}
+		Expect(cfg.IsV2()).To(BeTrue())
+	})
+
+	It("IsV3 should return true when the config is V3", func() {
+		cfg := Config{Version: Version3Alpha}
+		Expect(cfg.IsV3()).To(BeTrue())
+	})
 
 	It("should encode correctly", func() {
 		var (
@@ -165,56 +187,61 @@ var _ = Describe("PluginConfig", func() {
 	})
 })
 
-var _ = Describe("Resource Version Compatibility", func() {
+var _ = Describe("ResourceData Version Compatibility", func() {
 
 	var (
-		c          *Config
-		gvk1, gvk2 GVK
+		c                    *Config
+		resource1, resource2 ResourceData
 
 		defaultVersion = "v1"
 	)
 
 	BeforeEach(func() {
 		c = &Config{}
-		gvk1 = GVK{Group: "example", Version: "v1", Kind: "TestKind"}
-		gvk2 = GVK{Group: "example", Version: "v1", Kind: "TestKind2"}
+		resource1 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind"}
+		resource2 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind2"}
 	})
 
 	Context("resourceAPIVersionCompatible", func() {
 		It("returns true for a list of empty resources", func() {
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns true for one resource with an empty version", func() {
-			c.Resources = []GVK{gvk1}
+			c.Resources = []ResourceData{resource1}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns true for one resource with matching version", func() {
-			gvk1.CRDVersion = defaultVersion
-			c.Resources = []GVK{gvk1}
+			resource1.API = &API{CRDVersion: defaultVersion}
+			resource1.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			c.Resources = []ResourceData{resource1}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns true for two resources with matching versions", func() {
-			gvk1.CRDVersion = defaultVersion
-			gvk2.CRDVersion = defaultVersion
-			c.Resources = []GVK{gvk1, gvk2}
+			resource1.API = &API{CRDVersion: defaultVersion}
+			resource1.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			resource2.API = &API{CRDVersion: defaultVersion}
+			resource2.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			c.Resources = []ResourceData{resource1, resource2}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeTrue())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeTrue())
 		})
 		It("returns false for one resource with a non-matching version", func() {
-			gvk1.CRDVersion = v1beta1
-			c.Resources = []GVK{gvk1}
+			resource1.API = &API{CRDVersion: v1beta1}
+			resource1.Webhooks = &Webhooks{WebhookVersion: v1beta1}
+			c.Resources = []ResourceData{resource1}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeFalse())
+			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeFalse())
 		})
 		It("returns false for two resources containing a non-matching version", func() {
-			gvk1.CRDVersion = v1beta1
-			gvk2.CRDVersion = defaultVersion
-			c.Resources = []GVK{gvk1, gvk2}
+			resource1.API = &API{CRDVersion: v1beta1}
+			resource1.Webhooks = &Webhooks{WebhookVersion: v1beta1}
+			resource2.API = &API{CRDVersion: defaultVersion}
+			resource2.Webhooks = &Webhooks{WebhookVersion: defaultVersion}
+			c.Resources = []ResourceData{resource1, resource2}
 			Expect(c.resourceAPIVersionCompatible("crd", defaultVersion)).To(BeFalse())
-		})
-
-		It("returns false for two resources containing a non-matching version (webhooks)", func() {
-			gvk1.WebhookVersion = v1beta1
-			gvk2.WebhookVersion = defaultVersion
-			c.Resources = []GVK{gvk1, gvk2}
 			Expect(c.resourceAPIVersionCompatible("webhook", defaultVersion)).To(BeFalse())
 		})
 	})
@@ -223,35 +250,49 @@ var _ = Describe("Resource Version Compatibility", func() {
 var _ = Describe("Config", func() {
 	var (
 		c          *Config
-		gvk1, gvk2 GVK
+		gvk1, gvk2 ResourceData
 	)
 
 	BeforeEach(func() {
 		c = &Config{}
-		gvk1 = GVK{Group: "example", Version: "v1", Kind: "TestKind"}
-		gvk2 = GVK{Group: "example", Version: "v1", Kind: "TestKind2"}
+		gvk1 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind"}
+		gvk2 = ResourceData{Group: "example", Version: "v1", Kind: "TestKind2"}
 	})
 
 	Context("UpdateResource", func() {
 		It("Adds a non-existing resource", func() {
 			c.UpdateResources(gvk1)
-			Expect(c.Resources).To(Equal([]GVK{gvk1}))
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
 			// Update again to ensure idempotency.
 			c.UpdateResources(gvk1)
-			Expect(c.Resources).To(Equal([]GVK{gvk1}))
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
 		})
 		It("Updates an existing resource", func() {
 			c.UpdateResources(gvk1)
-			gvk := GVK{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind, CRDVersion: "v1"}
-			c.UpdateResources(gvk)
-			Expect(c.Resources).To(Equal([]GVK{gvk}))
+			resource := ResourceData{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind}
+			c.UpdateResources(resource)
+			Expect(c.Resources).To(Equal([]ResourceData{resource}))
 		})
 		It("Updates an existing resource with more than one resource present", func() {
 			c.UpdateResources(gvk1)
 			c.UpdateResources(gvk2)
-			gvk := GVK{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind, CRDVersion: "v1"}
+			gvk := ResourceData{Group: gvk1.Group, Version: gvk1.Version, Kind: gvk1.Kind}
 			c.UpdateResources(gvk)
-			Expect(c.Resources).To(Equal([]GVK{gvk, gvk2}))
+			Expect(c.Resources).To(Equal([]ResourceData{gvk, gvk2}))
 		})
+	})
+
+	Context("HasGroup", func() {
+		It("should return true when config has a resource with the group", func() {
+			c.UpdateResources(gvk1)
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
+			Expect(c.HasGroup(gvk1.Group)).To(BeTrue())
+		})
+		It("should return false when config has a resource with not the same group", func() {
+			c.UpdateResources(gvk1)
+			Expect(c.Resources).To(Equal([]ResourceData{gvk1}))
+			Expect(c.HasGroup("hasNot")).To(BeFalse())
+		})
+
 	})
 })

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -52,20 +52,21 @@ type Resource struct {
 	// Namespaced is true if the resource is namespaced.
 	Namespaced bool `json:"namespaced,omitempty"`
 
-	// CRDVersion holds the CustomResourceDefinition API version used for the Resource.
-	CRDVersion string `json:"crdVersion,omitempty"`
-	// WebhookVersion holds the {Validating,Mutating}WebhookConfiguration API version used for the Resource.
-	WebhookVersion string `json:"webhookVersion,omitempty"`
+	// API holds the the api data that is scaffolded
+	API config.API `json:"api,omitempty"`
+
+	// Webhooks holds webhooks data that is scaffolded
+	Webhooks config.Webhooks `json:"webhooks,omitempty"`
 }
 
-// GVK returns the group-version-kind information to check against tracked resources in the configuration file
-func (r *Resource) GVK() config.GVK {
-	return config.GVK{
-		Group:          r.Group,
-		Version:        r.Version,
-		Kind:           r.Kind,
-		CRDVersion:     r.CRDVersion,
-		WebhookVersion: r.WebhookVersion,
+// Data returns the ResourceData information to check against tracked resources in the configuration file
+func (r *Resource) Data() config.ResourceData {
+	return config.ResourceData{
+		Group:    r.Group,
+		Version:  r.Version,
+		Kind:     r.Kind,
+		API:      &r.API,
+		Webhooks: &r.Webhooks,
 	}
 }
 

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -143,7 +143,7 @@ func (p *createAPISubcommand) Validate() error {
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.doResource {
 		// Check that resource doesn't exist or flag force was set
-		if !p.force && p.config.HasResource(p.resource.GVK()) {
+		if !p.force && p.config.GetResource(p.resource.Data()) != nil {
 			return errors.New("API resource already exists")
 		}
 

--- a/pkg/plugins/golang/v2/scaffolds/api.go
+++ b/pkg/plugins/golang/v2/scaffolds/api.go
@@ -93,7 +93,7 @@ func (s *apiScaffolder) newUniverse() *model.Universe {
 
 func (s *apiScaffolder) scaffold() error {
 	if s.doResource {
-		s.config.UpdateResources(s.resource.GVK())
+		s.config.UpdateResources(s.resource.Data())
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -96,7 +96,7 @@ func (p *createWebhookSubcommand) Validate() error {
 	}
 
 	// check if resource exist to create webhook
-	if !p.config.HasResource(p.resource.GVK()) {
+	if p.config.GetResource(p.resource.Data()) == nil {
 		return fmt.Errorf("%s create webhook requires an api with the group,"+
 			" kind and version provided", p.commandName)
 	}

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -129,7 +129,7 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.resource.Group, "group", "", "resource Group")
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
 	fs.BoolVar(&p.resource.Namespaced, "namespaced", true, "resource is namespaced")
-	fs.StringVar(&p.resource.CRDVersion, "crd-version", defaultCRDVersion,
+	fs.StringVar(&p.resource.API.CRDVersion, "crd-version", defaultCRDVersion,
 		"version of CustomResourceDefinition to scaffold. Options: [v1, v1beta1]")
 }
 
@@ -170,7 +170,8 @@ func (p *createAPISubcommand) Validate() error {
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.doResource {
 		// Check that resource doesn't exist or flag force was set
-		if !p.force && p.config.HasResource(p.resource.GVK()) {
+		res := p.config.GetResource(p.resource.Data())
+		if !p.force && (res != nil && res.API != nil) {
 			return errors.New("API resource already exists")
 		}
 
@@ -181,9 +182,9 @@ func (p *createAPISubcommand) Validate() error {
 		}
 
 		// Check CRDVersion against all other CRDVersions in p.config for compatibility.
-		if !p.config.IsCRDVersionCompatible(p.resource.CRDVersion) {
+		if !p.config.IsCRDVersionCompatible(p.resource.API.CRDVersion) {
 			return fmt.Errorf("only one CRD version can be used for all resources, cannot add %q",
-				p.resource.CRDVersion)
+				p.resource.API.CRDVersion)
 		}
 	}
 

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -85,7 +85,7 @@ func (s *apiScaffolder) newUniverse() *model.Universe {
 func (s *apiScaffolder) scaffold() error {
 	if s.doResource {
 
-		s.config.UpdateResources(s.resource.GVK())
+		s.config.UpdateResources(s.resource.Data())
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),
@@ -94,8 +94,8 @@ func (s *apiScaffolder) scaffold() error {
 			&samples.CRDSample{},
 			&rbac.CRDEditorRole{},
 			&rbac.CRDViewerRole{},
-			&patches.EnableWebhookPatch{CRDVersion: s.resource.CRDVersion},
-			&patches.EnableCAInjectionPatch{CRDVersion: s.resource.CRDVersion},
+			&patches.EnableWebhookPatch{CRDVersion: s.resource.API.CRDVersion},
+			&patches.EnableCAInjectionPatch{CRDVersion: s.resource.API.CRDVersion},
 		); err != nil {
 			return fmt.Errorf("error scaffolding APIs: %v", err)
 		}
@@ -103,7 +103,7 @@ func (s *apiScaffolder) scaffold() error {
 		if err := machinery.NewScaffold().Execute(
 			s.newUniverse(),
 			&crd.Kustomization{},
-			&crd.KustomizeConfig{CRDVersion: s.resource.CRDVersion},
+			&crd.KustomizeConfig{CRDVersion: s.resource.API.CRDVersion},
 		); err != nil {
 			return fmt.Errorf("error scaffolding kustomization: %v", err)
 		}

--- a/pkg/plugins/golang/v3/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v3/scaffolds/webhook.go
@@ -80,19 +80,19 @@ func (s *webhookScaffolder) scaffold() error {
 You need to implement the conversion.Hub and conversion.Convertible interfaces for your CRD types.`)
 	}
 
-	s.config.UpdateResources(s.resource.GVK())
+	s.config.UpdateResources(s.resource.Data())
 
 	if err := machinery.NewScaffold().Execute(
 		s.newUniverse(),
 		&api.Webhook{
-			WebhookVersion: s.resource.WebhookVersion,
+			WebhookVersion: s.resource.Webhooks.WebhookVersion,
 			Defaulting:     s.defaulting,
 			Validating:     s.validation,
 		},
 		&templates.MainUpdater{WireWebhook: true},
-		&kdefault.WebhookCAInjectionPatch{WebhookVersion: s.resource.WebhookVersion},
+		&kdefault.WebhookCAInjectionPatch{WebhookVersion: s.resource.Webhooks.WebhookVersion},
 		&kdefault.ManagerWebhookPatch{},
-		&webhook.Kustomization{WebhookVersion: s.resource.WebhookVersion},
+		&webhook.Kustomization{WebhookVersion: s.resource.Webhooks.WebhookVersion},
 		&webhook.KustomizeConfig{},
 		&webhook.Service{},
 	); err != nil {

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -75,7 +75,7 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.resource.Version, "version", "", "resource Version")
 	fs.StringVar(&p.resource.Kind, "kind", "", "resource Kind")
 	fs.StringVar(&p.resource.Plural, "resource", "", "resource Resource")
-	fs.StringVar(&p.resource.WebhookVersion, "webhook-version", defaultWebhookVersion,
+	fs.StringVar(&p.resource.Webhooks.WebhookVersion, "webhook-version", defaultWebhookVersion,
 		"version of {Mutating,Validating}WebhookConfigurations to scaffold. Options: [v1, v1beta1]")
 
 	fs.BoolVar(&p.runMake, "make", true, "if true, run make after generating files")
@@ -107,14 +107,14 @@ func (p *createWebhookSubcommand) Validate() error {
 	}
 
 	// check if resource exist to create webhook
-	if !p.config.HasResource(p.resource.GVK()) {
+	if p.config.GetResource(p.resource.Data()) == nil {
 		return fmt.Errorf("%s create webhook requires an api with the group,"+
 			" kind and version provided", p.commandName)
 	}
 
-	if !p.config.IsWebhookVersionCompatible(p.resource.WebhookVersion) {
+	if !p.config.IsWebhookVersionCompatible(p.resource.Webhooks.WebhookVersion) {
 		return fmt.Errorf("only one webhook version can be used for all resources, cannot add %q",
-			p.resource.WebhookVersion)
+			p.resource.Webhooks.WebhookVersion)
 	}
 
 	return nil

--- a/testdata/project-v3-addon/PROJECT
+++ b/testdata/project-v3-addon/PROJECT
@@ -3,15 +3,18 @@ layout: go.kubebuilder.io/v3
 projectName: project-v3-addon
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Captain
   version: v1
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: FirstMate
   version: v1
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Admiral
   version: v1

--- a/testdata/project-v3-config/PROJECT
+++ b/testdata/project-v3-config/PROJECT
@@ -4,19 +4,25 @@ layout: go.kubebuilder.io/v3
 projectName: project-v3-config
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-config
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Captain
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: FirstMate
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Admiral
   version: v1
-  webhookVersion: v1
+  webhooks:
+    webhookVersion: v1
 version: 3-alpha

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -4,40 +4,53 @@ multigroup: true
 projectName: project-v3-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Captain
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: ship
   kind: Frigate
   version: v1beta1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: ship
   kind: Destroyer
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: ship
   kind: Cruiser
   version: v2alpha1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: sea-creatures
   kind: Kraken
   version: v1beta1
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: sea-creatures
   kind: Leviathan
   version: v1beta2
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: foo.policy
   kind: HealthCheckPolicy
   version: v1
-- crdVersion: v1
+- api:
+    crdVersion: v1
   kind: Lakers
   version: v1
-  webhookVersion: v1
+  webhooks:
+    webhookVersion: v1
 version: 3-alpha

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -3,19 +3,25 @@ layout: go.kubebuilder.io/v3
 projectName: project-v3
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Captain
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: FirstMate
   version: v1
-  webhookVersion: v1
-- crdVersion: v1
+  webhooks:
+    webhookVersion: v1
+- api:
+    crdVersion: v1
   group: crew
   kind: Admiral
   version: v1
-  webhookVersion: v1
+  webhooks:
+    webhookVersion: v1
 version: 3-alpha


### PR DESCRIPTION
**Description**
Only does the changes required to store the new attributes crdVersion and webhookVersion in the format/layout define on  https://github.com/kubernetes-sigs/kubebuilder/issues/1772 and  https://github.com/kubernetes-sigs/kubebuilder/issues/1826.


**Motivation**
- https://github.com/kubernetes-sigs/kubebuilder/issues/1772
- https://github.com/kubernetes-sigs/kubebuilder/issues/1826