### PR TITLE
:sparkles: (go/v3) Add the --force option for the webhook

### DIFF
--- a/generate_testdata.sh
+++ b/generate_testdata.sh
@@ -63,6 +63,9 @@ scaffold_test_project() {
     $kb create api --group crew --version v1 --kind Admiral --controller=true --resource=true --namespaced=false --make=false
     $kb create webhook --group crew --version v1 --kind Admiral --defaulting
     $kb create api --group crew --version v1 --kind Laker --controller=true --resource=false --make=false
+    if [ $project == "project-v3" ]; then
+      $kb create webhook --group crew --version v1 --kind Captain --defaulting --programmatic-validation --force
+    fi
   elif [[ $project =~ multigroup ]]; then
     header_text 'Switching to multigroup layout ...'
     $kb edit --multigroup=true

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -67,7 +67,7 @@ type CLI interface {
 
 // cli defines the command line structure and interfaces that are used to
 // scaffold kubebuilder project files.
-type cli struct {
+type cli struct { //nolint:maligned
 	/* Fields set by Option */
 
 	// Root command name. It is injected downstream to provide correct help, usage, examples and errors.

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cli
+package cli // nolint:dupl
 
 import (
 	"fmt"
@@ -50,7 +50,6 @@ func (c cli) newEditContext() plugin.Context {
 	}
 }
 
-// nolint:dupl
 func (c cli) bindEdit(ctx plugin.Context, cmd *cobra.Command) {
 	if len(c.resolvedPlugins) == 0 {
 		cmdErr(cmd, fmt.Errorf(noPluginError))

--- a/pkg/model/config/config.go
+++ b/pkg/model/config/config.go
@@ -117,6 +117,17 @@ func (c Config) HasGroup(group string) bool {
 	return false
 }
 
+// HasWebhook returns true if webhook is already present
+func (c Config) HasWebhook(resource ResourceData) bool {
+	for _, r := range c.Resources {
+		if r.isGVKEqualTo(resource) {
+			return r.Webhooks != nil
+		}
+	}
+
+	return false
+}
+
 // IsCRDVersionCompatible returns true if crdVersion can be added to the existing set of CRD versions.
 func (c Config) IsCRDVersionCompatible(crdVersion string) bool {
 	return c.resourceAPIVersionCompatible("crd", crdVersion)

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook.go
@@ -42,6 +42,8 @@ type Webhook struct { // nolint:maligned
 	Defaulting bool
 	// If scaffold the validating webhook
 	Validating bool
+
+	Force bool
 }
 
 // SetTemplateDefaults implements file.Template
@@ -69,7 +71,11 @@ func (f *Webhook) SetTemplateDefaults() error {
 	}
 	f.TemplateBody = webhookTemplate
 
-	f.IfExistsAction = file.Error
+	if f.Force {
+		f.IfExistsAction = file.Overwrite
+	} else {
+		f.IfExistsAction = file.Error
+	}
 
 	f.GroupDomainWithDash = strings.Replace(f.Resource.Domain, ".", "-", -1)
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
@@ -27,6 +27,8 @@ var _ file.Template = &ManagerWebhookPatch{}
 // ManagerWebhookPatch scaffolds a file that defines the patch that enables webhooks on the manager
 type ManagerWebhookPatch struct {
 	file.TemplateMixin
+
+	Force bool
 }
 
 // SetTemplateDefaults implements file.Template
@@ -37,8 +39,12 @@ func (f *ManagerWebhookPatch) SetTemplateDefaults() error {
 
 	f.TemplateBody = managerWebhookPatchTemplate
 
-	// If file exists (ex. because a webhook was already created), skip creation.
-	f.IfExistsAction = file.Skip
+	if f.Force {
+		f.IfExistsAction = file.Overwrite
+	} else {
+		// If file exists (ex. because a webhook was already created), skip creation.
+		f.IfExistsAction = file.Skip
+	}
 
 	return nil
 }

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/webhook/kustomization.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/webhook/kustomization.go
@@ -30,6 +30,8 @@ type Kustomization struct {
 
 	// Version of webhook the project was configured with.
 	WebhookVersion string
+
+	Force bool
 }
 
 // SetTemplateDefaults implements file.Template
@@ -40,8 +42,12 @@ func (f *Kustomization) SetTemplateDefaults() error {
 
 	f.TemplateBody = kustomizeWebhookTemplate
 
-	// If file exists (ex. because a webhook was already created), skip creation.
-	f.IfExistsAction = file.Skip
+	if f.Force {
+		f.IfExistsAction = file.Overwrite
+	} else {
+		// If file exists (ex. because a webhook was already created), skip creation.
+		f.IfExistsAction = file.Skip
+	}
 
 	if f.WebhookVersion == "" {
 		f.WebhookVersion = "v1"

--- a/pkg/plugins/golang/v3/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v3/scaffolds/webhook.go
@@ -38,7 +38,7 @@ type webhookScaffolder struct {
 	resource    *resource.Resource
 
 	// Webhook type options.
-	defaulting, validation, conversion bool
+	defaulting, validation, conversion, force bool
 }
 
 // NewWebhookScaffolder returns a new Scaffolder for v2 webhook creation operations
@@ -49,6 +49,7 @@ func NewWebhookScaffolder(
 	defaulting bool,
 	validation bool,
 	conversion bool,
+	force bool,
 ) cmdutil.Scaffolder {
 	return &webhookScaffolder{
 		config:      config,
@@ -57,6 +58,7 @@ func NewWebhookScaffolder(
 		defaulting:  defaulting,
 		validation:  validation,
 		conversion:  conversion,
+		force:       force,
 	}
 }
 
@@ -88,11 +90,12 @@ You need to implement the conversion.Hub and conversion.Convertible interfaces f
 			WebhookVersion: s.resource.Webhooks.WebhookVersion,
 			Defaulting:     s.defaulting,
 			Validating:     s.validation,
+			Force:          s.force,
 		},
 		&templates.MainUpdater{WireWebhook: true},
 		&kdefault.WebhookCAInjectionPatch{WebhookVersion: s.resource.Webhooks.WebhookVersion},
 		&kdefault.ManagerWebhookPatch{},
-		&webhook.Kustomization{WebhookVersion: s.resource.Webhooks.WebhookVersion},
+		&webhook.Kustomization{WebhookVersion: s.resource.Webhooks.WebhookVersion, Force: s.force},
 		&webhook.KustomizeConfig{},
 		&webhook.Service{},
 	); err != nil {

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -84,6 +84,9 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = admissionv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
@@ -106,6 +109,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Admiral{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&Captain{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook

--- a/testdata/project-v3/main.go
+++ b/testdata/project-v3/main.go
@@ -122,6 +122,10 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Laker")
 		os.Exit(1)
 	}
+	if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {


### PR DESCRIPTION
**Description**
Add the --force option to overwrite already generated webhook code.

**Motivation**
Currently, user do not have a way to overwrite already scaffold code other than deleting the scaffold code manually.