### PR TITLE
:sparkles: add new extension to markers in order to allow work with .yml

### DIFF
--- a/pkg/model/file/marker.go
+++ b/pkg/model/file/marker.go
@@ -28,6 +28,7 @@ var commentsByExt = map[string]string{
 	//  this is a backwards incompatible change, and thus should be done for next project version.
 	".go":   "// ",
 	".yaml": "# ",
+	".yml":  "#",
 	// When adding additional file extensions, update also the NewMarkerFor documentation and error
 }
 
@@ -38,14 +39,14 @@ type Marker struct {
 }
 
 // NewMarkerFor creates a new marker customized for the specific file
-// Supported file extensions: .go, .ext
+// Supported file extensions: .go, .yaml, .yml
 func NewMarkerFor(path string, value string) Marker {
 	ext := filepath.Ext(path)
 	if comment, found := commentsByExt[ext]; found {
 		return Marker{comment, value}
 	}
 
-	panic(fmt.Errorf("unknown file extension: '%s', expected '.go' or '.yaml'", ext))
+	panic(fmt.Errorf("unknown file extension: '%s', expected '.go', '.yaml' or '.yml'", ext))
 }
 
 // String implements Stringer


### PR DESCRIPTION
**Description**

:sparkles: add a new extension to markers in order to allow work with .yml

**Motivation**
- SDK Ansible based-operators works with the ext ".yml" as other languages such as python, it will allow us to create markers for these files and types. 
- https://github.com/operator-framework/operator-sdk/issues/4311
 