### PR TITLE
:bug: revert the change on the flag and came back it for enable-leader-election

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -69,6 +69,6 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - "--enable-leader-election"
 {{- end }}
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/config.go
@@ -75,7 +75,7 @@ spec:
         - /manager
 {{- if not .ComponentConfig }}
         args:
-        - --leader-elect
+        - --enable-leader-election
 {{- end }}
         image: {{ .Image }}
         name: manager

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
@@ -221,7 +221,7 @@ func main() {
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. " +
 		"Enabling this will ensure there is only one active controller manager.")
 {{- else }}

--- a/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
@@ -23,4 +23,4 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - "--enable-leader-election"

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
       - command:
         - /manager
         args:
-        - --leader-elect
+        - --enable-leader-election
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v3-addon/main.go
+++ b/testdata/project-v3-addon/main.go
@@ -54,7 +54,7 @@ func main() {
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -23,4 +23,4 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - "--enable-leader-election"

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
       - command:
         - /manager
         args:
-        - --leader-elect
+        - --enable-leader-election
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -73,7 +73,7 @@ func main() {
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -23,4 +23,4 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"
+        - "--enable-leader-election"

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
       - command:
         - /manager
         args:
-        - --leader-elect
+        - --enable-leader-election
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v3/main.go
+++ b/testdata/project-v3/main.go
@@ -54,7 +54,7 @@ func main() {
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{


### PR DESCRIPTION
**Description**
The manager provides the flag `enable-leader-election` which was changed in v3/ for `--leader-elect`. This PR reverts this change. 

**Motivation**
- The nomenclature `enable-leader-election` shows more aligned with its nomenclature in controller-runtime 
- Change the flag name to `--leader-elect` shows not make easier its understatement to users and only will bring more work necessary to migrate their project to v3