### PR TITLE
:book: update the docs for v3 as default plugin version for the init

### DIFF
--- a/docs/book/src/component-config-tutorial/api-changes.md
+++ b/docs/book/src/component-config-tutorial/api-changes.md
@@ -11,7 +11,7 @@ steps](/quick-start.md#installation) before continuing.
 ```bash
 # we'll use a domain of tutorial.kubebuilder.io,
 # so all API groups will be <group>.tutorial.kubebuilder.io.
-kubebuilder init --plugins=go/v3-alpha --domain tutorial.kubebuilder.io --component-config
+kubebuilder init --domain tutorial.kubebuilder.io --component-config
 ```
 
 ## Setting up an exising project

--- a/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
@@ -46,7 +46,7 @@ project:
 ```bash
 # we'll use a domain of tutorial.kubebuilder.io,
 # so all API groups will be <group>.tutorial.kubebuilder.io.
-kubebuilder init --plugins=go/v3-alpha --domain tutorial.kubebuilder.io
+kubebuilder init --domain tutorial.kubebuilder.io
 ```
 
 <aside class="note">


### PR DESCRIPTION
**Description**
Now it has no longer v3-alpha plugin and the init by default will use this version. So, we need to have the docs updated accordingly. 