### PR TITLE
🐛 Use correct file name in the comments of `[kind]_types.go`

### DIFF
--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/api/types.go
@@ -75,7 +75,7 @@ type {{ .Resource.Kind }}Spec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of {{ .Resource.Kind }}. Edit {{ .Resource.Kind }}_types.go to remove/update
+	// Foo is an example field of {{ .Resource.Kind }}. Edit {{ lower .Resource.Kind }}_types.go to remove/update
 	Foo string ` + "`" + `json:"foo,omitempty"` + "`" + `
 }
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go
@@ -79,7 +79,7 @@ type {{ .Resource.Kind }}Spec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of {{ .Resource.Kind }}. Edit {{ .Resource.Kind }}_types.go to remove/update
+	// Foo is an example field of {{ .Resource.Kind }}. Edit {{ lower .Resource.Kind }}_types.go to remove/update
 	Foo string ` + "`" + `json:"foo,omitempty"` + "`" + `
 }
 

--- a/testdata/project-v2-multigroup/apis/crew/v1/captain_types.go
+++ b/testdata/project-v2-multigroup/apis/crew/v1/captain_types.go
@@ -28,7 +28,7 @@ type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Captain. Edit Captain_types.go to remove/update
+	// Foo is an example field of Captain. Edit captain_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v2-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
@@ -28,7 +28,7 @@ type HealthCheckPolicySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of HealthCheckPolicy. Edit HealthCheckPolicy_types.go to remove/update
+	// Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v2-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
@@ -28,7 +28,7 @@ type KrakenSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Kraken. Edit Kraken_types.go to remove/update
+	// Foo is an example field of Kraken. Edit kraken_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v2-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
@@ -28,7 +28,7 @@ type LeviathanSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Leviathan. Edit Leviathan_types.go to remove/update
+	// Foo is an example field of Leviathan. Edit leviathan_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/apis/ship/v1/destroyer_types.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1/destroyer_types.go
@@ -28,7 +28,7 @@ type DestroyerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Destroyer. Edit Destroyer_types.go to remove/update
+	// Foo is an example field of Destroyer. Edit destroyer_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/apis/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v2-multigroup/apis/ship/v1beta1/frigate_types.go
@@ -28,7 +28,7 @@ type FrigateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Frigate. Edit Frigate_types.go to remove/update
+	// Foo is an example field of Frigate. Edit frigate_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/apis/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v2-multigroup/apis/ship/v2alpha1/cruiser_types.go
@@ -28,7 +28,7 @@ type CruiserSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Cruiser. Edit Cruiser_types.go to remove/update
+	// Foo is an example field of Cruiser. Edit cruiser_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
@@ -37,7 +37,7 @@ spec:
           description: CaptainSpec defines the desired state of Captain
           properties:
             foo:
-              description: Foo is an example field of Captain. Edit Captain_types.go
+              description: Foo is an example field of Captain. Edit captain_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -37,7 +37,7 @@ spec:
           description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
           properties:
             foo:
-              description: Foo is an example field of HealthCheckPolicy. Edit HealthCheckPolicy_types.go
+              description: Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -37,7 +37,7 @@ spec:
           description: KrakenSpec defines the desired state of Kraken
           properties:
             foo:
-              description: Foo is an example field of Kraken. Edit Kraken_types.go
+              description: Foo is an example field of Kraken. Edit kraken_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -37,7 +37,7 @@ spec:
           description: LeviathanSpec defines the desired state of Leviathan
           properties:
             foo:
-              description: Foo is an example field of Leviathan. Edit Leviathan_types.go
+              description: Foo is an example field of Leviathan. Edit leviathan_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -37,7 +37,7 @@ spec:
           description: CruiserSpec defines the desired state of Cruiser
           properties:
             foo:
-              description: Foo is an example field of Cruiser. Edit Cruiser_types.go
+              description: Foo is an example field of Cruiser. Edit cruiser_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -37,7 +37,7 @@ spec:
           description: DestroyerSpec defines the desired state of Destroyer
           properties:
             foo:
-              description: Foo is an example field of Destroyer. Edit Destroyer_types.go
+              description: Foo is an example field of Destroyer. Edit destroyer_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v2-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -37,7 +37,7 @@ spec:
           description: FrigateSpec defines the desired state of Frigate
           properties:
             foo:
-              description: Foo is an example field of Frigate. Edit Frigate_types.go
+              description: Foo is an example field of Frigate. Edit frigate_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2/api/v1/admiral_types.go
+++ b/testdata/project-v2/api/v1/admiral_types.go
@@ -28,7 +28,7 @@ type AdmiralSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Admiral. Edit Admiral_types.go to remove/update
+	// Foo is an example field of Admiral. Edit admiral_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2/api/v1/captain_types.go
+++ b/testdata/project-v2/api/v1/captain_types.go
@@ -28,7 +28,7 @@ type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Captain. Edit Captain_types.go to remove/update
+	// Foo is an example field of Captain. Edit captain_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2/api/v1/firstmate_types.go
+++ b/testdata/project-v2/api/v1/firstmate_types.go
@@ -28,7 +28,7 @@ type FirstMateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of FirstMate. Edit FirstMate_types.go to remove/update
+	// Foo is an example field of FirstMate. Edit firstmate_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -37,7 +37,7 @@ spec:
           description: AdmiralSpec defines the desired state of Admiral
           properties:
             foo:
-              description: Foo is an example field of Admiral. Edit Admiral_types.go
+              description: Foo is an example field of Admiral. Edit admiral_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
@@ -37,7 +37,7 @@ spec:
           description: CaptainSpec defines the desired state of Captain
           properties:
             foo:
-              description: Foo is an example field of Captain. Edit Captain_types.go
+              description: Foo is an example field of Captain. Edit captain_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -37,7 +37,7 @@ spec:
           description: FirstMateSpec defines the desired state of FirstMate
           properties:
             foo:
-              description: Foo is an example field of FirstMate. Edit FirstMate_types.go
+              description: Foo is an example field of FirstMate. Edit firstmate_types.go
                 to remove/update
               type: string
           type: object

--- a/testdata/project-v3-config/api/v1/admiral_types.go
+++ b/testdata/project-v3-config/api/v1/admiral_types.go
@@ -28,7 +28,7 @@ type AdmiralSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Admiral. Edit Admiral_types.go to remove/update
+	// Foo is an example field of Admiral. Edit admiral_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-config/api/v1/captain_types.go
+++ b/testdata/project-v3-config/api/v1/captain_types.go
@@ -28,7 +28,7 @@ type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Captain. Edit Captain_types.go to remove/update
+	// Foo is an example field of Captain. Edit captain_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-config/api/v1/firstmate_types.go
+++ b/testdata/project-v3-config/api/v1/firstmate_types.go
@@ -28,7 +28,7 @@ type FirstMateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of FirstMate. Edit FirstMate_types.go to remove/update
+	// Foo is an example field of FirstMate. Edit firstmate_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-config/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3-config/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -37,7 +37,7 @@ spec:
             description: AdmiralSpec defines the desired state of Admiral
             properties:
               foo:
-                description: Foo is an example field of Admiral. Edit Admiral_types.go
+                description: Foo is an example field of Admiral. Edit admiral_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-config/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-config/config/crd/bases/crew.testproject.org_captains.yaml
@@ -37,7 +37,7 @@ spec:
             description: CaptainSpec defines the desired state of Captain
             properties:
               foo:
-                description: Foo is an example field of Captain. Edit Captain_types.go
+                description: Foo is an example field of Captain. Edit captain_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-config/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3-config/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -37,7 +37,7 @@ spec:
             description: FirstMateSpec defines the desired state of FirstMate
             properties:
               foo:
-                description: Foo is an example field of FirstMate. Edit FirstMate_types.go
+                description: Foo is an example field of FirstMate. Edit firstmate_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/apis/crew/v1/captain_types.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/captain_types.go
@@ -28,7 +28,7 @@ type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Captain. Edit Captain_types.go to remove/update
+	// Foo is an example field of Captain. Edit captain_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v3-multigroup/apis/foo.policy/v1/healthcheckpolicy_types.go
@@ -28,7 +28,7 @@ type HealthCheckPolicySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of HealthCheckPolicy. Edit HealthCheckPolicy_types.go to remove/update
+	// Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v3-multigroup/apis/sea-creatures/v1beta1/kraken_types.go
@@ -28,7 +28,7 @@ type KrakenSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Kraken. Edit Kraken_types.go to remove/update
+	// Foo is an example field of Kraken. Edit kraken_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v3-multigroup/apis/sea-creatures/v1beta2/leviathan_types.go
@@ -28,7 +28,7 @@ type LeviathanSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Leviathan. Edit Leviathan_types.go to remove/update
+	// Foo is an example field of Leviathan. Edit leviathan_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/ship/v1/destroyer_types.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/destroyer_types.go
@@ -28,7 +28,7 @@ type DestroyerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Destroyer. Edit Destroyer_types.go to remove/update
+	// Foo is an example field of Destroyer. Edit destroyer_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1beta1/frigate_types.go
@@ -28,7 +28,7 @@ type FrigateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Frigate. Edit Frigate_types.go to remove/update
+	// Foo is an example field of Frigate. Edit frigate_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/cruiser_types.go
@@ -28,7 +28,7 @@ type CruiserSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Cruiser. Edit Cruiser_types.go to remove/update
+	// Foo is an example field of Cruiser. Edit cruiser_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/apis/v1/lakers_types.go
+++ b/testdata/project-v3-multigroup/apis/v1/lakers_types.go
@@ -28,7 +28,7 @@ type LakersSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Lakers. Edit Lakers_types.go to remove/update
+	// Foo is an example field of Lakers. Edit lakers_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
@@ -37,7 +37,7 @@ spec:
             description: CaptainSpec defines the desired state of Captain
             properties:
               foo:
-                description: Foo is an example field of Captain. Edit Captain_types.go
+                description: Foo is an example field of Captain. Edit captain_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -37,7 +37,7 @@ spec:
             description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
             properties:
               foo:
-                description: Foo is an example field of HealthCheckPolicy. Edit HealthCheckPolicy_types.go
+                description: Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -37,7 +37,7 @@ spec:
             description: KrakenSpec defines the desired state of Kraken
             properties:
               foo:
-                description: Foo is an example field of Kraken. Edit Kraken_types.go
+                description: Foo is an example field of Kraken. Edit kraken_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -37,7 +37,7 @@ spec:
             description: LeviathanSpec defines the desired state of Leviathan
             properties:
               foo:
-                description: Foo is an example field of Leviathan. Edit Leviathan_types.go
+                description: Foo is an example field of Leviathan. Edit leviathan_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -37,7 +37,7 @@ spec:
             description: CruiserSpec defines the desired state of Cruiser
             properties:
               foo:
-                description: Foo is an example field of Cruiser. Edit Cruiser_types.go
+                description: Foo is an example field of Cruiser. Edit cruiser_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -37,7 +37,7 @@ spec:
             description: DestroyerSpec defines the desired state of Destroyer
             properties:
               foo:
-                description: Foo is an example field of Destroyer. Edit Destroyer_types.go
+                description: Foo is an example field of Destroyer. Edit destroyer_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -37,7 +37,7 @@ spec:
             description: FrigateSpec defines the desired state of Frigate
             properties:
               foo:
-                description: Foo is an example field of Frigate. Edit Frigate_types.go
+                description: Foo is an example field of Frigate. Edit frigate_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3-multigroup/config/crd/bases/testproject.org_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/testproject.org_lakers.yaml
@@ -37,7 +37,7 @@ spec:
             description: LakersSpec defines the desired state of Lakers
             properties:
               foo:
-                description: Foo is an example field of Lakers. Edit Lakers_types.go
+                description: Foo is an example field of Lakers. Edit lakers_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3/api/v1/admiral_types.go
+++ b/testdata/project-v3/api/v1/admiral_types.go
@@ -28,7 +28,7 @@ type AdmiralSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Admiral. Edit Admiral_types.go to remove/update
+	// Foo is an example field of Admiral. Edit admiral_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3/api/v1/captain_types.go
+++ b/testdata/project-v3/api/v1/captain_types.go
@@ -28,7 +28,7 @@ type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of Captain. Edit Captain_types.go to remove/update
+	// Foo is an example field of Captain. Edit captain_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3/api/v1/firstmate_types.go
+++ b/testdata/project-v3/api/v1/firstmate_types.go
@@ -28,7 +28,7 @@ type FirstMateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of FirstMate. Edit FirstMate_types.go to remove/update
+	// Foo is an example field of FirstMate. Edit firstmate_types.go to remove/update
 	Foo string `json:"foo,omitempty"`
 }
 

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -37,7 +37,7 @@ spec:
             description: AdmiralSpec defines the desired state of Admiral
             properties:
               foo:
-                description: Foo is an example field of Admiral. Edit Admiral_types.go
+                description: Foo is an example field of Admiral. Edit admiral_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_captains.yaml
@@ -37,7 +37,7 @@ spec:
             description: CaptainSpec defines the desired state of Captain
             properties:
               foo:
-                description: Foo is an example field of Captain. Edit Captain_types.go
+                description: Foo is an example field of Captain. Edit captain_types.go
                   to remove/update
                 type: string
             type: object

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -37,7 +37,7 @@ spec:
             description: FirstMateSpec defines the desired state of FirstMate
             properties:
               foo:
-                description: Foo is an example field of FirstMate. Edit FirstMate_types.go
+                description: Foo is an example field of FirstMate. Edit firstmate_types.go
                   to remove/update
                 type: string
             type: object


### PR DESCRIPTION
## WHY (= Motivation)
> ### What broke (please include exact error messages if you can) 
> When we use `$ kubebuilder create api`, it generates a file like `[kind]_types.go`. In this file, there is a comment that indicates which file to change when adding a field.
> 
> However, the file name in the comment is different from the generated file name. This difference can confuse people.
> 
> The example is shown below.
> 
> ```console
> $ kubebuilder create api --group webapp --version v1 --kind Guestbook
> Create Resource [y/n]
> y
> Create Controller [y/n]
> y
> Writing scaffold for you to edit...
> api/v1/guestbook_types.go
> controllers/guestbook_controller.go
> Running make:
> $ make
> $PATH/.go/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
> go fmt ./...
> go vet ./...
> go build -o bin/manager main.go
> kubebuilder create api --group webapp --version v1 --kind Guestbook  6.82s user 5.43s system 153% cpu 7.959 total
> ```
> 
> ```console
> $ cat api/v1/guestbook_types.go | grep 'Edit Guestbook_types\.go'
>         // Foo is an example field of Guestbook. Edit Guestbook_types.go to remove/update
> ```
> 
> In the above example, `Guestbook_types.go` is written in a comment. This is different from the correct file name `guestbook_types.go`.
> 
> ### What did you expect to happen?  What do you think went wrong? 
> 
> A comment should use a correct file name. In the above example, `guestbook_types.go` should be used.

cf. [The correct file name should be used in the comments of `[kind]_types.go` #1925](https://github.com/kubernetes-sigs/kubebuilder/issues/1925)

## WHAT (= A description of the change)
Fixed the comments in `[kind]_types.go`. The file names in the comments are now correct.

To be more specific, I updated the following files.

- ~~pkg/model/file/mixins.go~~
  - I reverted this change later. cf. https://github.com/kubernetes-sigs/kubebuilder/pull/1927#pullrequestreview-560804582
- pkg/plugins/golang/v2/scaffolds/internal/templates/api/types.go
- pkg/plugins/golang/v3/scaffolds/internal/templates/api/types.go

Then executed `$ make generate`. This execution updated the mock data used in the e2e test.

Fixes #1925