### PR TITLE
🌱 Enhance Subcommand API

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -473,6 +473,13 @@ func (c cli) printDeprecationWarnings() {
 	}
 }
 
+// metadata returns CLI's metadata.
+func (c cli) metadata() plugin.CLIMetadata {
+	return plugin.CLIMetadata{
+		CommandName: c.commandName,
+	}
+}
+
 // Run implements CLI.Run.
 func (c cli) Run() error {
 	return c.cmd.Execute()

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -26,31 +26,22 @@ import (
 )
 
 func (c cli) newEditCmd() *cobra.Command {
-	ctx := c.newEditContext()
 	cmd := &cobra.Command{
-		Use:     "edit",
-		Short:   "This command will edit the project configuration",
-		Long:    ctx.Description,
-		Example: ctx.Examples,
+		Use:   "edit",
+		Short: "This command will edit the project configuration",
+		Long: `Edit the project configuration.
+`,
 		RunE: errCmdFunc(
 			fmt.Errorf("project must be initialized"),
 		),
 	}
 
 	// Lookup the plugin for projectVersion and bind it to the command.
-	c.bindEdit(ctx, cmd)
+	c.bindEdit(cmd)
 	return cmd
 }
 
-func (c cli) newEditContext() plugin.Context {
-	return plugin.Context{
-		CommandName: c.commandName,
-		Description: `Edit the project configuration.
-`,
-	}
-}
-
-func (c cli) bindEdit(ctx plugin.Context, cmd *cobra.Command) {
+func (c cli) bindEdit(cmd *cobra.Command) {
 	if len(c.resolvedPlugins) == 0 {
 		cmdErr(cmd, fmt.Errorf(noPluginError))
 		return
@@ -84,10 +75,14 @@ func (c cli) bindEdit(ctx plugin.Context, cmd *cobra.Command) {
 
 	subcommand := editPlugin.GetEditSubcommand()
 	subcommand.InjectConfig(cfg.Config)
+	meta := subcommand.UpdateMetadata(c.metadata())
 	subcommand.BindFlags(cmd.Flags())
-	subcommand.UpdateContext(&ctx)
-	cmd.Long = ctx.Description
-	cmd.Example = ctx.Examples
+	if meta.Description != "" {
+		cmd.Long = meta.Description
+	}
+	if meta.Examples != "" {
+		cmd.Example = meta.Examples
+	}
 	cmd.RunE = runECmdFunc(cfg, subcommand,
 		fmt.Sprintf("failed to edit project with %q", plugin.KeyFor(editPlugin)))
 }

--- a/pkg/plugin/interfaces.go
+++ b/pkg/plugin/interfaces.go
@@ -45,10 +45,9 @@ type Deprecated interface {
 
 // Subcommand is an interface that defines the common base for subcommands returned by plugins
 type Subcommand interface {
-	// UpdateContext updates a Context with subcommand-specific help text, like description and examples. It also serves
-	// to pass context from the CLI to the subcommand, such as the command name.
-	// Can be a no-op if default help text is desired.
-	UpdateContext(*Context)
+	// UpdateMetadata injects CLI meta-data into the Subcommand and returns the Subcommand's metadata for the CLI.
+	// Any zero field in the returned object will use the default value.
+	UpdateMetadata(CLIMetadata) CommandMetadata
 	// BindFlags binds the subcommand's flags to the CLI. This allows each subcommand to define its own
 	// command line flags.
 	BindFlags(*pflag.FlagSet)
@@ -57,16 +56,6 @@ type Subcommand interface {
 	// InjectConfig passes a config to a plugin. The plugin may modify the config.
 	// Initializing, loading, and saving the config is managed by the cli package.
 	InjectConfig(config.Config)
-}
-
-// Context is the runtime context for a subcommand.
-type Context struct {
-	// CommandName sets the command name for a subcommand.
-	CommandName string
-	// Description is a description of what this subcommand does. It is used to display help.
-	Description string
-	// Examples are one or more examples of the command-line usage of this subcommand. It is used to display help.
-	Examples string
 }
 
 // Init is an interface for plugins that provide an `init` subcommand

--- a/pkg/plugin/interfaces.go
+++ b/pkg/plugin/interfaces.go
@@ -45,6 +45,9 @@ type Deprecated interface {
 
 // Subcommand is an interface that defines the common base for subcommands returned by plugins
 type Subcommand interface {
+	// InjectConfig passes a config to a plugin. The plugin may modify the config.
+	// Initializing, loading, and saving the config is managed by the cli package.
+	InjectConfig(config.Config)
 	// UpdateMetadata injects CLI meta-data into the Subcommand and returns the Subcommand's metadata for the CLI.
 	// Any zero field in the returned object will use the default value.
 	UpdateMetadata(CLIMetadata) CommandMetadata
@@ -53,9 +56,6 @@ type Subcommand interface {
 	BindFlags(*pflag.FlagSet)
 	// Run runs the subcommand.
 	Run() error
-	// InjectConfig passes a config to a plugin. The plugin may modify the config.
-	// Initializing, loading, and saving the config is managed by the cli package.
-	InjectConfig(config.Config)
 }
 
 // Init is an interface for plugins that provide an `init` subcommand

--- a/pkg/plugin/metadata.go
+++ b/pkg/plugin/metadata.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+// CLIMetadata is the runtime meta-data of the CLI
+type CLIMetadata struct {
+	// CommandName is the root command name.
+	CommandName string
+}
+
+// CommandMetadata is the runtime meta-data for a command
+type CommandMetadata struct {
+	// Description is a description of what this command does. It is used to display help.
+	Description string
+	// Examples are one or more examples of the command-line usage of this command. It is used to display help.
+	Examples string
+}

--- a/pkg/plugin/version_test.go
+++ b/pkg/plugin/version_test.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"testing"
 
-	g "github.com/onsi/ginkgo" // An alias is required because Context is defined elsewhere in this package.
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
@@ -28,12 +28,12 @@ import (
 )
 
 func TestPlugin(t *testing.T) {
-	RegisterFailHandler(g.Fail)
-	g.RunSpecs(t, "Plugin Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugin Suite")
 }
 
-var _ = g.Describe("Version", func() {
-	g.Context("Parse", func() {
+var _ = Describe("Version", func() {
+	Context("Parse", func() {
 		DescribeTable("should be correctly parsed for valid version strings",
 			func(str string, number int, s stage.Stage) {
 				var v Version
@@ -72,7 +72,7 @@ var _ = g.Describe("Version", func() {
 		)
 	})
 
-	g.Context("String", func() {
+	Context("String", func() {
 		DescribeTable("should return the correct string value",
 			func(version Version, str string) { Expect(version.String()).To(Equal(str)) },
 			Entry("for version 0", Version{Number: 0}, "v0"),
@@ -94,7 +94,7 @@ var _ = g.Describe("Version", func() {
 		)
 	})
 
-	g.Context("Validate", func() {
+	Context("Validate", func() {
 		DescribeTable("should validate valid versions",
 			func(version Version) { Expect(version.Validate()).To(Succeed()) },
 			Entry("for version 0", Version{Number: 0}),
@@ -125,7 +125,7 @@ var _ = g.Describe("Version", func() {
 		)
 	})
 
-	g.Context("Compare", func() {
+	Context("Compare", func() {
 		// Test Compare() by sorting a list.
 		var (
 			versions = []Version{
@@ -155,7 +155,7 @@ var _ = g.Describe("Version", func() {
 			}
 		)
 
-		g.It("sorts a valid list of versions correctly", func() {
+		It("sorts a valid list of versions correctly", func() {
 			sort.Slice(versions, func(i int, j int) bool {
 				return versions[i].Compare(versions[j]) == -1
 			})
@@ -164,7 +164,7 @@ var _ = g.Describe("Version", func() {
 
 	})
 
-	g.Context("IsStable", func() {
+	Context("IsStable", func() {
 		DescribeTable("should return true for stable versions",
 			func(version Version) { Expect(version.IsStable()).To(BeTrue()) },
 			Entry("for version 1", Version{Number: 1}),
@@ -189,4 +189,5 @@ var _ = g.Describe("Version", func() {
 			Entry("for version 22 (beta)", Version{Number: 22, Stage: stage.Beta}),
 		)
 	})
+
 })

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -60,6 +60,10 @@ var (
 	_ cmdutil.RunOptions         = &createAPISubcommand{}
 )
 
+func (p *createAPISubcommand) InjectConfig(c config.Config) {
+	p.config = c
+}
+
 func (p *createAPISubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	return plugin.CommandMetadata{
 		Description: `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
@@ -119,10 +123,6 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.options.DoController, "controller", true,
 		"if set, generate the controller without prompting the user")
 	p.controllerFlag = fs.Lookup("controller")
-}
-
-func (p *createAPISubcommand) InjectConfig(c config.Config) {
-	p.config = c
 }
 
 func (p *createAPISubcommand) Run() error {

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -60,16 +60,17 @@ var (
 	_ cmdutil.RunOptions         = &createAPISubcommand{}
 )
 
-func (p createAPISubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
+func (p *createAPISubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	return plugin.CommandMetadata{
+		Description: `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
 
 create resource will prompt the user for if it should scaffold the Resource and / or Controller.  To only
 scaffold a Controller for an existing Resource, select "n" for Resource.  To only define
 the schema for a Resource without writing a Controller, select "n" for Controller.
 
 After the scaffold is written, api will run make on the project.
-`
-	ctx.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
+`,
+		Examples: fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
   %s create api --group ship --version v1beta1 --kind Frigate
 
   # Edit the API Scheme
@@ -87,7 +88,8 @@ After the scaffold is written, api will run make on the project.
   # Regenerate code and run against the Kubernetes cluster configured by ~/.kube/config
   make run
 	`,
-		ctx.CommandName)
+			meta.CommandName),
+	}
 }
 
 func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v2/edit.go
+++ b/pkg/plugins/golang/v2/edit.go
@@ -38,15 +38,16 @@ var (
 	_ cmdutil.RunOptions    = &editSubcommand{}
 )
 
-func (p *editSubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `This command will edit the project configuration. You can have single or multi group project.`
-
-	ctx.Examples = fmt.Sprintf(`# Enable the multigroup layout
-        %s edit --multigroup
+func (p *editSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	return plugin.CommandMetadata{
+		Description: `This command will edit the project configuration. You can have single or multi group project.`,
+		Examples: fmt.Sprintf(`# Enable the multigroup layout
+        %[1]s edit --multigroup
 
         # Disable the multigroup layout
-        %s edit --multigroup=false
-	`, ctx.CommandName, ctx.CommandName)
+        %[1]s edit --multigroup=false
+	`, meta.CommandName),
+	}
 }
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v2/edit.go
+++ b/pkg/plugins/golang/v2/edit.go
@@ -38,6 +38,10 @@ var (
 	_ cmdutil.RunOptions    = &editSubcommand{}
 )
 
+func (p *editSubcommand) InjectConfig(c config.Config) {
+	p.config = c
+}
+
 func (p *editSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	return plugin.CommandMetadata{
 		Description: `This command will edit the project configuration. You can have single or multi group project.`,
@@ -52,10 +56,6 @@ func (p *editSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandM
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.multigroup, "multigroup", false, "enable or disable multigroup layout")
-}
-
-func (p *editSubcommand) InjectConfig(c config.Config) {
-	p.config = c
 }
 
 func (p *editSubcommand) Run() error {

--- a/pkg/plugins/golang/v2/init.go
+++ b/pkg/plugins/golang/v2/init.go
@@ -58,6 +58,15 @@ var (
 	_ cmdutil.RunOptions    = &initSubcommand{}
 )
 
+func (p *initSubcommand) InjectConfig(c config.Config) {
+	// v2+ project configs get a 'layout' value.
+	if c.GetVersion().Compare(cfgv3alpha.Version) >= 0 {
+		_ = c.SetLayout(plugin.KeyFor(Plugin{}))
+	}
+
+	p.config = c
+}
+
 func (p *initSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	p.commandName = meta.CommandName
 
@@ -100,15 +109,6 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	if p.config.GetVersion().Compare(cfgv3alpha.Version) >= 0 {
 		fs.StringVar(&p.name, "project-name", "", "name of this project")
 	}
-}
-
-func (p *initSubcommand) InjectConfig(c config.Config) {
-	// v2+ project configs get a 'layout' value.
-	if c.GetVersion().Compare(cfgv3alpha.Version) >= 0 {
-		_ = c.SetLayout(plugin.KeyFor(Plugin{}))
-	}
-
-	p.config = c
 }
 
 func (p *initSubcommand) Run() error {

--- a/pkg/plugins/golang/v2/init.go
+++ b/pkg/plugins/golang/v2/init.go
@@ -58,8 +58,11 @@ var (
 	_ cmdutil.RunOptions    = &initSubcommand{}
 )
 
-func (p *initSubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
+func (p *initSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	p.commandName = meta.CommandName
+
+	return plugin.CommandMetadata{
+		Description: `Initialize a new project including vendor/ directory and Go package directories.
 
 Writes the following files:
 - a boilerplate license file
@@ -70,13 +73,12 @@ Writes the following files:
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics
 - a main.go to run
-`
-	ctx.Examples = fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
+`,
+		Examples: fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
   %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"
 `,
-		ctx.CommandName)
-
-	p.commandName = ctx.CommandName
+			meta.CommandName),
+	}
 }
 
 func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -42,20 +42,22 @@ var (
 	_ cmdutil.RunOptions             = &createWebhookSubcommand{}
 )
 
-func (p *createWebhookSubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
+func (p *createWebhookSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	p.commandName = meta.CommandName
+
+	return plugin.CommandMetadata{
+		Description: `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
-`
-	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group ship, version v1beta1
+`,
+		Examples: fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group ship, version v1beta1
   # and kind Frigate.
-  %s create webhook --group ship --version v1beta1 --kind Frigate --defaulting --programmatic-validation
+  %[1]s create webhook --group ship --version v1beta1 --kind Frigate --defaulting --programmatic-validation
 
   # Create conversion webhook for CRD of group shio, version v1beta1 and kind Frigate.
-  %s create webhook --group ship --version v1beta1 --kind Frigate --conversion
+  %[1]s create webhook --group ship --version v1beta1 --kind Frigate --conversion
 `,
-		ctx.CommandName, ctx.CommandName)
-
-	p.commandName = ctx.CommandName
+			meta.CommandName),
+	}
 }
 
 func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -23,14 +23,14 @@ import (
 
 	"github.com/spf13/pflag"
 
-	newconfig "sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
 )
 
 type createWebhookSubcommand struct {
-	config newconfig.Config
+	config config.Config
 	// For help text.
 	commandName string
 
@@ -41,6 +41,10 @@ var (
 	_ plugin.CreateWebhookSubcommand = &createWebhookSubcommand{}
 	_ cmdutil.RunOptions             = &createWebhookSubcommand{}
 )
+
+func (p *createWebhookSubcommand) InjectConfig(c config.Config) {
+	p.config = c
+}
 
 func (p *createWebhookSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	p.commandName = meta.CommandName
@@ -75,10 +79,6 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 		"if set, scaffold the validating webhook")
 	fs.BoolVar(&p.options.DoConversion, "conversion", false,
 		"if set, scaffold the conversion webhook")
-}
-
-func (p *createWebhookSubcommand) InjectConfig(c newconfig.Config) {
-	p.config = c
 }
 
 func (p *createWebhookSubcommand) Run() error {

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -74,16 +74,17 @@ var (
 	_ cmdutil.RunOptions         = &createAPISubcommand{}
 )
 
-func (p createAPISubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
+func (p *createAPISubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	return plugin.CommandMetadata{
+		Description: `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
 
 create resource will prompt the user for if it should scaffold the Resource and / or Controller.  To only
 scaffold a Controller for an existing Resource, select "n" for Resource.  To only define
 the schema for a Resource without writing a Controller, select "n" for Controller.
 
 After the scaffold is written, api will run make on the project.
-`
-	ctx.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
+`,
+		Examples: fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
   %s create api --group ship --version v1beta1 --kind Frigate
 
   # Edit the API Scheme
@@ -101,7 +102,8 @@ After the scaffold is written, api will run make on the project.
   # Regenerate code and run against the Kubernetes cluster configured by ~/.kube/config
   make run
 	`,
-		ctx.CommandName)
+			meta.CommandName),
+	}
 }
 
 func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -74,6 +74,10 @@ var (
 	_ cmdutil.RunOptions         = &createAPISubcommand{}
 )
 
+func (p *createAPISubcommand) InjectConfig(c config.Config) {
+	p.config = c
+}
+
 func (p *createAPISubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	return plugin.CommandMetadata{
 		Description: `Scaffold a Kubernetes API by creating a Resource definition and / or a Controller.
@@ -135,10 +139,6 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.options.DoController, "controller", true,
 		"if set, generate the controller without prompting the user")
 	p.controllerFlag = fs.Lookup("controller")
-}
-
-func (p *createAPISubcommand) InjectConfig(c config.Config) {
-	p.config = c
 }
 
 func (p *createAPISubcommand) Run() error {

--- a/pkg/plugins/golang/v3/edit.go
+++ b/pkg/plugins/golang/v3/edit.go
@@ -38,15 +38,16 @@ var (
 	_ cmdutil.RunOptions    = &editSubcommand{}
 )
 
-func (p *editSubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `This command will edit the project configuration. You can have single or multi group project.`
-
-	ctx.Examples = fmt.Sprintf(`# Enable the multigroup layout
-        %s edit --multigroup
+func (p *editSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	return plugin.CommandMetadata{
+		Description: `This command will edit the project configuration. You can have single or multi group project.`,
+		Examples: fmt.Sprintf(`# Enable the multigroup layout
+        %[1]s edit --multigroup
 
         # Disable the multigroup layout
-        %s edit --multigroup=false
-	`, ctx.CommandName, ctx.CommandName)
+        %[1]s edit --multigroup=false
+	`, meta.CommandName),
+	}
 }
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v3/edit.go
+++ b/pkg/plugins/golang/v3/edit.go
@@ -38,6 +38,10 @@ var (
 	_ cmdutil.RunOptions    = &editSubcommand{}
 )
 
+func (p *editSubcommand) InjectConfig(c config.Config) {
+	p.config = c
+}
+
 func (p *editSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	return plugin.CommandMetadata{
 		Description: `This command will edit the project configuration. You can have single or multi group project.`,
@@ -52,10 +56,6 @@ func (p *editSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandM
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.multigroup, "multigroup", false, "enable or disable multigroup layout")
-}
-
-func (p *editSubcommand) InjectConfig(c config.Config) {
-	p.config = c
 }
 
 func (p *editSubcommand) Run() error {

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -80,7 +80,7 @@ Writes the following files:
 - a main.go to run
 `,
 		Examples: fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
-  %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"
+  %s init --project-version=3-alpha --domain example.org --license apache2 --owner "The Kubernetes authors"
 `,
 			meta.CommandName),
 	}

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -57,8 +57,11 @@ var (
 	_ cmdutil.RunOptions    = &initSubcommand{}
 )
 
-func (p *initSubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `Initialize a new project including vendor/ directory and Go package directories.
+func (p *initSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	p.commandName = meta.CommandName
+
+	return plugin.CommandMetadata{
+		Description: `Initialize a new project including vendor/ directory and Go package directories.
 
 Writes the following files:
 - a boilerplate license file
@@ -69,13 +72,12 @@ Writes the following files:
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics
 - a main.go to run
-`
-	ctx.Examples = fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
+`,
+		Examples: fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
   %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"
 `,
-		ctx.CommandName)
-
-	p.commandName = ctx.CommandName
+			meta.CommandName),
+	}
 }
 
 func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -57,6 +57,12 @@ var (
 	_ cmdutil.RunOptions    = &initSubcommand{}
 )
 
+func (p *initSubcommand) InjectConfig(c config.Config) {
+	_ = c.SetLayout(plugin.KeyFor(Plugin{}))
+
+	p.config = c
+}
+
 func (p *initSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	p.commandName = meta.CommandName
 
@@ -99,12 +105,6 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.name, "project-name", "", "name of this project")
 	fs.BoolVar(&p.componentConfig, "component-config", false,
 		"create a versioned ComponentConfig file, may be 'true' or 'false'")
-}
-
-func (p *initSubcommand) InjectConfig(c config.Config) {
-	_ = c.SetLayout(plugin.KeyFor(Plugin{}))
-
-	p.config = c
 }
 
 func (p *initSubcommand) Run() error {

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -54,6 +54,10 @@ var (
 	_ cmdutil.RunOptions             = &createWebhookSubcommand{}
 )
 
+func (p *createWebhookSubcommand) InjectConfig(c config.Config) {
+	p.config = c
+}
+
 func (p *createWebhookSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
 	p.commandName = meta.CommandName
 
@@ -92,10 +96,6 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.runMake, "make", true, "if true, run make after generating files")
 	fs.BoolVar(&p.force, "force", false,
 		"attempt to create resource even if it already exists")
-}
-
-func (p *createWebhookSubcommand) InjectConfig(c config.Config) {
-	p.config = c
 }
 
 func (p *createWebhookSubcommand) Run() error {

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -54,20 +54,22 @@ var (
 	_ cmdutil.RunOptions             = &createWebhookSubcommand{}
 )
 
-func (p *createWebhookSubcommand) UpdateContext(ctx *plugin.Context) {
-	ctx.Description = `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
+func (p *createWebhookSubcommand) UpdateMetadata(meta plugin.CLIMetadata) plugin.CommandMetadata {
+	p.commandName = meta.CommandName
+
+	return plugin.CommandMetadata{
+		Description: `Scaffold a webhook for an API resource. You can choose to scaffold defaulting,
 validating and (or) conversion webhooks.
-`
-	ctx.Examples = fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group ship, version v1beta1
+`,
+		Examples: fmt.Sprintf(`  # Create defaulting and validating webhooks for CRD of group ship, version v1beta1
   # and kind Frigate.
-  %s create webhook --group ship --version v1beta1 --kind Frigate --defaulting --programmatic-validation
+  %[1]s create webhook --group ship --version v1beta1 --kind Frigate --defaulting --programmatic-validation
 
   # Create conversion webhook for CRD of group ship, version v1beta1 and kind Frigate.
-  %s create webhook --group ship --version v1beta1 --kind Frigate --conversion
+  %[1]s create webhook --group ship --version v1beta1 --kind Frigate --conversion
 `,
-		ctx.CommandName, ctx.CommandName)
-
-	p.commandName = ctx.CommandName
+			meta.CommandName),
+	}
 }
 
 func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION
# Description
`Subcommand.UpdateContext` method was being used for both inserting cli related metadata to the subcommands and returning subcommand related metadata to the command constructor (cli). The `Context` struct didn't have anything to do with Go's `context` pacvkage which could also lead to harder to read code.

This PR uses the term `Metadata` instead of `Context` (which also has the advantage of not conflicting with `onsi/ginkgo`) and makes clearer differentioation between the input and output metadatas (cli->subcommand and subcommand->cli).
