### PR TITLE
:sparkles: Remove misleading help that mentioned dep

### DIFF
--- a/pkg/plugins/golang/v2/init.go
+++ b/pkg/plugins/golang/v2/init.go
@@ -63,8 +63,6 @@ Writes the following files:
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics
 - a main.go to run
-
-project will prompt the user to run 'dep ensure' after writing the project files.
 `
 	ctx.Examples = fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
   %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -64,8 +64,6 @@ Writes the following files:
 - a Patch file for customizing image for manager manifests
 - a Patch file for enabling prometheus metrics
 - a main.go to run
-
-project will prompt the user to run 'dep ensure' after writing the project files.
 `
 	ctx.Examples = fmt.Sprintf(`  # Scaffold a project using the apache2 license with "The Kubernetes authors" as owners
   %s init --project-version=2 --domain example.org --license apache2 --owner "The Kubernetes authors"


### PR DESCRIPTION
dep is no longer used by the project (we use go mod instead); remove
the help test that suggests we will suggest it.