### PR TITLE
:sparkles: (go/v3) upgrade kubebuilder-declarative-pattern to k8s v1.19

### DIFF
--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -41,7 +41,7 @@ const (
 	// KbDeclarativePatternVersion is the sigs.k8s.io/kubebuilder-declarative-pattern version
 	// (used only to gen api with --pattern=addon)
 	// TODO: remove this when a better solution for using addons is implemented.
-	KbDeclarativePatternVersion = "1cbf859290cab81ae8e73fc5caebe792280175d1"
+	KbDeclarativePatternVersion = "b84d99da021778217217885dd9582ed3cc879ebe"
 
 	// defaultCRDVersion is the default CRD API version to scaffold.
 	defaultCRDVersion = "v1"

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -9,5 +9,5 @@ require (
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	sigs.k8s.io/controller-runtime v0.7.0
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20201109180626-1cbf859290ca
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20210113160450-b84d99da0217
 )


### PR DESCRIPTION
This PR upgrades go/v3's kubebuilder-declarative-pattern dependency to the k8s v1.19 equivalent tag.

/area dependency