### PR TITLE
:seedling: build and push a kube-rbac-proxy (v0.8.0)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,43 @@
+#  Copyright 2021 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#!/usr/bin/env bash
+
+# This script effectively retags the quay.io/brancz/kube-rbac-proxy image
+# as a grc.io/kubebuilder registry image and pushes it (and all constituent images).
+# This script cannot be inlined due to:
+# https://github.com/GoogleCloudPlatform/cloud-build-local/issues/129
+
+set -eu
+
+SOURCE_IMAGE_TAG="quay.io/brancz/kube-rbac-proxy:${KUBE_RBAC_PROXY_VERSION}"
+TARGET_IMAGE_TAG="gcr.io/kubebuilder/kube-rbac-proxy:${KUBE_RBAC_PROXY_VERSION}"
+
+# Each arch to pull an image for.
+declare ARCHES
+ARCHES=( amd64 arm64 ppc64le s390x )
+
+declare IMAGES
+for a in ${ARCHES[@]}; do
+  docker pull "${SOURCE_IMAGE_TAG}-$a"
+  docker tag "${SOURCE_IMAGE_TAG}-$a" "${TARGET_IMAGE_TAG}-$a"
+  # These images must exist remotely to build a manifest list.
+  docker push "${TARGET_IMAGE_TAG}-$a"
+  IMAGES=( ${IMAGES[@]} "${TARGET_IMAGE_TAG}-$a" )
+done
+
+# If $TARGET_IMAGE_TAG exists, `manifest create` will fail.
+docker manifest rm "$TARGET_IMAGE_TAG" || true
+docker manifest create "$TARGET_IMAGE_TAG" ${IMAGES[@]}
+docker manifest push "$TARGET_IMAGE_TAG"

--- a/build/cloudbuild_kube-rbac-proxy.yaml
+++ b/build/cloudbuild_kube-rbac-proxy.yaml
@@ -1,0 +1,23 @@
+#  Copyright 2021 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+substitutions:
+  # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
+  _KUBE_RBAC_PROXY_VERSION: v0.8.0
+steps:
+- name: "gcr.io/cloud-builders/docker"
+  env:
+  - "KUBE_RBAC_PROXY_VERSION=${_KUBE_RBAC_PROXY_VERSION}"
+  entrypoint: "./build/build.sh"
+images: ["gcr.io/kubebuilder/kube-rbac-proxy:${_KUBE_RBAC_PROXY_VERSION}"]


### PR DESCRIPTION
This PR adds a cloudbuild config for building a versioned `grc.io/kubebuilder/kube-rbac-proxy`.

- build/cloudbuild_kube-rbac-proxy.yaml: build and push a kube-rbac-proxy (v0.8.0) by retagging manifests
- build/build.sh: pull and retag images