### PR TITLE
:seedling: Bash is terrible

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -34,7 +34,8 @@ for a in ${ARCHES[@]}; do
   docker tag "${SOURCE_IMAGE_TAG}-$a" "${TARGET_IMAGE_TAG}-$a"
   # These images must exist remotely to build a manifest list.
   docker push "${TARGET_IMAGE_TAG}-$a"
-  IMAGES=( ${IMAGES[@]} "${TARGET_IMAGE_TAG}-$a" )
+  # weird syntax for bash<4.4
+  IMAGES=( ${IMAGES[@]+"${IMAGES[@]}"} "${TARGET_IMAGE_TAG}-$a" )
 done
 
 # If $TARGET_IMAGE_TAG exists, `manifest create` will fail.


### PR DESCRIPTION
No seriously.  Terrible.  Horrible.  No good.

(it's not possible to simply append to an empty array using bash<4.4,
because a zero element array does not exist, EVEN IF YOU DECLARE IT,
apparently).

Instead, use a weird idiomatic hack with `+` expansion.  You need to use
this *specific* expansion, apparently -- other similar ones break for
weird reasons:
https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u.

