### PR TITLE
:sparkles: *: upgrade kube-rbac-proxy to v0.8.0

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/PROJECT
+++ b/docs/book/src/component-config-tutorial/testdata/project/PROJECT
@@ -1,6 +1,6 @@
 componentConfig: true
 domain: tutorial.kubebuilder.io
-layout: go.kubebuilder.io/v3-alpha
+layout: go.kubebuilder.io/v3
 multigroup: true
 projectName: project
 repo: tutorial.kubebuilder.io/project

--- a/docs/book/src/component-config-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -55,7 +55,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/test/e2e/v3/plugin_cluster_test.go
+++ b/test/e2e/v3/plugin_cluster_test.go
@@ -155,6 +155,11 @@ func Run(kbc *utils.TestContext) {
 		}
 		return nil
 	}
+	defer func() {
+		out, err := kbc.Kubectl.CommandInNamespace("describe", "all")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		fmt.Fprintln(GinkgoWriter, out)
+	}()
 	EventuallyWithOffset(1, verifyControllerUp, time.Minute, time.Second).Should(Succeed())
 
 	By("granting permissions to access the metrics")

--- a/test/e2e/v3/plugin_cluster_test.go
+++ b/test/e2e/v3/plugin_cluster_test.go
@@ -74,7 +74,7 @@ var _ = Describe("kubebuilder", func() {
 			})
 		})
 
-		Context("plugin go.kubebuilder.io/v3-alpha", func() {
+		Context("plugin go.kubebuilder.io/v3", func() {
 			// Use cert-manager with v1 CRs.
 			BeforeEach(func() {
 				By("installing the cert-manager bundle")

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -29,8 +29,6 @@ build_kb
 setup_envs
 
 source "$(pwd)/scripts/setup.sh" ${KIND_K8S_VERSION}
-docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-kind load docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
 
 # remove running containers on exit
 function cleanup() {

--- a/test_e2e_local.sh
+++ b/test_e2e_local.sh
@@ -32,8 +32,6 @@ setup_envs
 export KIND_CLUSTER=local-kubebuilder-e2e
 if ! kind get clusters | grep -q $KIND_CLUSTER ; then
     source "$(pwd)/scripts/setup.sh" ${KIND_K8S_VERSION} $KIND_CLUSTER
-    docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
-    kind load --name $KIND_CLUSTER docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
 fi
 
 kind export kubeconfig --kubeconfig $tmp_root/kubeconfig --name $KIND_CLUSTER

--- a/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
This PR upgrades kube-rbac-proxy image version from v0.5.0 to v0.8.0, which has a rootless feature and no breaking changes (afaik).

Closes #1785 