### PR TITLE
:bug: Don't recurse into hidden directories

### DIFF
--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -207,6 +207,9 @@ func checkDir() error {
 			if err != nil {
 				return err
 			}
+			if info.IsDir() && info.Name() != "." && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
 			if info.Name() != "go.mod" && !strings.HasPrefix(info.Name(), ".") {
 				return fmt.Errorf(
 					"target directory is not empty (only go.mod and files with the prefix \".\" are allowed); found existing file %q",


### PR DESCRIPTION
checkDir() currently recurses into hidden directories at the root. This
is a problem, because only the directory itself will have a . at the
root of it's path, but any files within it won't when calling info.Name.
This causes init to fail on a directory containing any hidden directory
with files within them, such as .git.

Since we use filepath.Walk(".") we can't skip a directory that just
starts with ., as that would include the current directory. So instead
we also check that Name() doesn't return just "."

Fixes #1971 
