### PR TITLE
⚠ Resource validation

### DIFF
--- a/pkg/model/resource/api.go
+++ b/pkg/model/resource/api.go
@@ -29,6 +29,16 @@ type API struct {
 	Namespaced bool `json:"namespaced,omitempty"`
 }
 
+// Validate checks that the API is valid.
+func (api API) Validate() error {
+	// Validate the CRD version
+	if err := validateAPIVersion(api.CRDVersion); err != nil {
+		return fmt.Errorf("invalid CRD version: %w", err)
+	}
+
+	return nil
+}
+
 // Copy returns a deep copy of the API that can be safely modified without affecting the original.
 func (api API) Copy() API {
 	// As this function doesn't use a pointer receiver, api is already a shallow copy.

--- a/pkg/model/resource/api_test.go
+++ b/pkg/model/resource/api_test.go
@@ -24,6 +24,19 @@ import (
 
 //nolint:dupl
 var _ = Describe("API", func() {
+	Context("Validate", func() {
+		It("should succeed for a valid API", func() {
+			Expect(API{CRDVersion: v1}.Validate()).To(Succeed())
+		})
+
+		DescribeTable("should fail for invalid APIs",
+			func(api API) { Expect(api.Validate()).NotTo(Succeed()) },
+			// Ensure that the rest of the fields are valid to check each part
+			Entry("empty CRD version", API{}),
+			Entry("invalid CRD version", API{CRDVersion: "1"}),
+		)
+	})
+
 	Context("Update", func() {
 		var api, other API
 

--- a/pkg/model/resource/utils.go
+++ b/pkg/model/resource/utils.go
@@ -17,11 +17,22 @@ limitations under the License.
 package resource
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
 	"github.com/gobuffalo/flect"
 )
+
+// validateAPIVersion validates CRD or Webhook versions
+func validateAPIVersion(version string) error {
+	switch version {
+	case "v1beta1", "v1":
+		return nil
+	default:
+		return fmt.Errorf("API version must be one of: v1beta1, v1")
+	}
+}
 
 // safeImport returns a cleaned version of the provided string that can be used for imports
 func safeImport(unsafe string) string {

--- a/pkg/model/resource/webhooks.go
+++ b/pkg/model/resource/webhooks.go
@@ -35,6 +35,16 @@ type Webhooks struct {
 	Conversion bool `json:"conversion,omitempty"`
 }
 
+// Validate checks that the Webhooks is valid.
+func (webhooks Webhooks) Validate() error {
+	// Validate the Webhook version
+	if err := validateAPIVersion(webhooks.WebhookVersion); err != nil {
+		return fmt.Errorf("invalid Webhook version: %w", err)
+	}
+
+	return nil
+}
+
 // Copy returns a deep copy of the API that can be safely modified without affecting the original.
 func (webhooks Webhooks) Copy() Webhooks {
 	// As this function doesn't use a pointer receiver, webhooks is already a shallow copy.

--- a/pkg/model/resource/webhooks_test.go
+++ b/pkg/model/resource/webhooks_test.go
@@ -24,6 +24,19 @@ import (
 
 //nolint:dupl
 var _ = Describe("Webhooks", func() {
+	Context("Validate", func() {
+		It("should succeed for a valid Webhooks", func() {
+			Expect(Webhooks{WebhookVersion: v1}.Validate()).To(Succeed())
+		})
+
+		DescribeTable("should fail for invalid Webhooks",
+			func(webhooks Webhooks) { Expect(webhooks.Validate()).NotTo(Succeed()) },
+			// Ensure that the rest of the fields are valid to check each part
+			Entry("empty webhook version", Webhooks{}),
+			Entry("invalid webhook version", Webhooks{WebhookVersion: "1"}),
+		)
+	})
+
 	Context("Update", func() {
 		var webhook, other Webhooks
 

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -19,26 +19,22 @@ package golang
 import (
 	"fmt"
 	"path"
-	"regexp"
 	"strings"
 
 	newconfig "sigs.k8s.io/kubebuilder/v3/pkg/config"
-	"sigs.k8s.io/kubebuilder/v3/pkg/internal/validation"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 )
 
 const (
-	versionPattern  = "^v\\d+(?:alpha\\d+|beta\\d+)?$"
 	groupPresent    = "group flag present but empty"
 	versionPresent  = "version flag present but empty"
 	kindPresent     = "kind flag present but empty"
+	groupRequired   = "group cannot be empty if the domain is empty"
 	versionRequired = "version cannot be empty"
 	kindRequired    = "kind cannot be empty"
 )
 
 var (
-	versionRegex = regexp.MustCompile(versionPattern)
-
 	coreGroups = map[string]string{
 		"admission":             "k8s.io",
 		"admissionregistration": "k8s.io",
@@ -112,7 +108,11 @@ func (opts Options) Validate() error {
 	if strings.HasPrefix(opts.Kind, "-") {
 		return fmt.Errorf(kindPresent)
 	}
+
 	// Now we can check that all the required flags are not empty
+	if len(opts.Group) == 0 && len(opts.Domain) == 0 {
+		return fmt.Errorf(groupRequired)
+	}
 	if len(opts.Version) == 0 {
 		return fmt.Errorf(versionRequired)
 	}
@@ -120,62 +120,7 @@ func (opts Options) Validate() error {
 		return fmt.Errorf(kindRequired)
 	}
 
-	// Check if the qualified group has a valid DNS1123 subdomain value
-	if err := validation.IsDNS1123Subdomain(opts.QualifiedGroup()); err != nil {
-		return fmt.Errorf("either group or domain is invalid: (%v)", err)
-	}
-
-	// Check if the version follows the valid pattern
-	if !versionRegex.MatchString(opts.Version) {
-		return fmt.Errorf("version must match %s (was %s)", versionPattern, opts.Version)
-	}
-
-	validationErrors := []string{}
-
-	// Require kind to start with an uppercase character
-	if string(opts.Kind[0]) == strings.ToLower(string(opts.Kind[0])) {
-		validationErrors = append(validationErrors, "kind must start with an uppercase character")
-	}
-
-	validationErrors = append(validationErrors, validation.IsDNS1035Label(strings.ToLower(opts.Kind))...)
-
-	if len(validationErrors) != 0 {
-		return fmt.Errorf("invalid Kind: %#v", validationErrors)
-	}
-
-	if opts.Plural != "" {
-		validationErrors = append(validationErrors, validation.IsDNS1035Label(opts.Plural)...)
-
-		if len(validationErrors) != 0 {
-			return fmt.Errorf("invalid Plural: %#v", validationErrors)
-		}
-	}
-
-	// Ensure apiVersions for k8s types are empty or valid.
-	for typ, apiVersion := range map[string]string{
-		"CRD":     opts.CRDVersion,
-		"Webhook": opts.WebhookVersion,
-	} {
-		switch apiVersion {
-		case "", "v1", "v1beta1":
-		default:
-			return fmt.Errorf("%s version must be one of: v1, v1beta1", typ)
-		}
-	}
-
 	return nil
-}
-
-// QualifiedGroup returns the fully qualified group name with the available information.
-func (opts Options) QualifiedGroup() string {
-	switch "" {
-	case opts.Domain:
-		return opts.Group
-	case opts.Group:
-		return opts.Domain
-	default:
-		return fmt.Sprintf("%s.%s", opts.Group, opts.Domain)
-	}
 }
 
 // GVK returns the GVK identifier of a resource.

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -18,7 +18,6 @@ package golang
 
 import (
 	"path"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -31,59 +30,20 @@ import (
 var _ = Describe("Options", func() {
 	Context("Validate", func() {
 		DescribeTable("should succeed for valid options",
-			func(options *Options) { Expect(options.Validate()).To(Succeed()) },
-			Entry("full GVK",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("missing domain",
-				&Options{Group: "crew", Version: "v1", Kind: "FirstMate"}),
-			Entry("missing group",
-				&Options{Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("kind with multiple initial uppercase characters",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FIRSTMate"}),
+			func(options Options) { Expect(options.Validate()).To(Succeed()) },
+			Entry("full GVK", Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
+			Entry("missing domain", Options{Group: "crew", Version: "v1", Kind: "FirstMate"}),
+			Entry("missing group", Options{Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
 		)
 
 		DescribeTable("should fail for invalid options",
-			func(options *Options) { Expect(options.Validate()).NotTo(Succeed()) },
-			Entry("group flag captured another flag",
-				&Options{Group: "--version"}),
-			Entry("version flag captured another flag",
-				&Options{Version: "--kind"}),
-			Entry("kind flag captured another flag",
-				&Options{Kind: "--group"}),
-			Entry("missing group and domain",
-				&Options{Version: "v1", Kind: "FirstMate"}),
-			Entry("group with uppercase characters",
-				&Options{Group: "Crew", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("group with non-alpha characters",
-				&Options{Group: "crew1*?", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("missing version",
-				&Options{Group: "crew", Domain: "test.io", Kind: "FirstMate"}),
-			Entry("version without v prefix",
-				&Options{Group: "crew", Domain: "test.io", Version: "1", Kind: "FirstMate"}),
-			Entry("unstable version without v prefix",
-				&Options{Group: "crew", Domain: "test.io", Version: "1beta1", Kind: "FirstMate"}),
-			Entry("unstable version with wrong prefix",
-				&Options{Group: "crew", Domain: "test.io", Version: "a1beta1", Kind: "FirstMate"}),
-			Entry("unstable version without alpha/beta number",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1beta", Kind: "FirstMate"}),
-			Entry("multiple unstable version",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1beta1alpha1", Kind: "FirstMate"}),
-			Entry("missing kind",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1"}),
-			Entry("kind is too long",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: strings.Repeat("a", 64)}),
-			Entry("kind with whitespaces",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "First Mate"}),
-			Entry("kind ends with `-`",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate-"}),
-			Entry("kind starts with a decimal character",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "1FirstMate"}),
-			Entry("kind starts with a lowercase character",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "firstMate"}),
-			Entry("Invalid CRD version",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate", CRDVersion: "a"}),
-			Entry("Invalid webhook version",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate", WebhookVersion: "a"}),
+			func(options Options) { Expect(options.Validate()).NotTo(Succeed()) },
+			Entry("group flag captured another flag", Options{Group: "--version"}),
+			Entry("version flag captured another flag", Options{Version: "--kind"}),
+			Entry("kind flag captured another flag", Options{Kind: "--group"}),
+			Entry("missing group and domain", Options{Version: "v1", Kind: "FirstMate"}),
+			Entry("missing version", Options{Group: "crew", Domain: "test.io", Kind: "FirstMate"}),
+			Entry("missing kind", Options{Group: "crew", Domain: "test.io", Version: "v1"}),
 		)
 	})
 
@@ -96,7 +56,7 @@ var _ = Describe("Options", func() {
 		})
 
 		DescribeTable("should succeed if the Resource is valid",
-			func(options *Options) {
+			func(options Options) {
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
@@ -105,6 +65,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Group).To(Equal(options.Group))
 					Expect(resource.Domain).To(Equal(options.Domain))
 					Expect(resource.Version).To(Equal(options.Version))
@@ -127,13 +88,13 @@ var _ = Describe("Options", func() {
 					Expect(resource.ImportAlias()).To(Equal(options.Group + options.Version))
 				}
 			},
-			Entry("basic", &Options{
+			Entry("basic", Options{
 				Group:   "crew",
 				Domain:  "test.io",
 				Version: "v1",
 				Kind:    "FirstMate",
 			}),
-			Entry("API", &Options{
+			Entry("API", Options{
 				Group:      "crew",
 				Domain:     "test.io",
 				Version:    "v1",
@@ -142,28 +103,28 @@ var _ = Describe("Options", func() {
 				CRDVersion: "v1",
 				Namespaced: true,
 			}),
-			Entry("Controller", &Options{
+			Entry("Controller", Options{
 				Group:        "crew",
 				Domain:       "test.io",
 				Version:      "v1",
 				Kind:         "FirstMate",
 				DoController: true,
 			}),
-			Entry("Webhooks", &Options{
+			Entry("Webhooks", Options{
 				Group:          "crew",
 				Domain:         "test.io",
 				Version:        "v1",
 				Kind:           "FirstMate",
+				WebhookVersion: "v1",
 				DoDefaulting:   true,
 				DoValidation:   true,
 				DoConversion:   true,
-				WebhookVersion: "v1",
 			}),
 		)
 
 		DescribeTable("should default the Plural by pluralizing the Kind",
 			func(kind, plural string) {
-				options := &Options{Group: "crew", Version: "v1", Kind: kind}
+				options := Options{Group: "crew", Version: "v1", Kind: kind}
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
@@ -172,6 +133,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Plural).To(Equal(plural))
 				}
 			},
@@ -182,7 +144,7 @@ var _ = Describe("Options", func() {
 
 		DescribeTable("should keep the Plural if specified",
 			func(kind, plural string) {
-				options := &Options{Group: "crew", Version: "v1", Kind: kind, Plural: plural}
+				options := Options{Group: "crew", Version: "v1", Kind: kind, Plural: plural}
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
@@ -191,6 +153,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Plural).To(Equal(plural))
 				}
 			},
@@ -200,7 +163,7 @@ var _ = Describe("Options", func() {
 
 		DescribeTable("should allow hyphens and dots in group names",
 			func(group, safeGroup string) {
-				options := &Options{
+				options := Options{
 					Group:   group,
 					Domain:  "test.io",
 					Version: "v1",
@@ -214,6 +177,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Group).To(Equal(options.Group))
 					if multiGroup {
 						Expect(resource.Path).To(Equal(
@@ -231,7 +195,7 @@ var _ = Describe("Options", func() {
 		)
 
 		It("should not append '.' if provided an empty domain", func() {
-			options := &Options{Group: "crew", Version: "v1", Kind: "FirstMate"}
+			options := Options{Group: "crew", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
 			for _, multiGroup := range []bool{false, true} {
@@ -240,13 +204,14 @@ var _ = Describe("Options", func() {
 				}
 
 				resource := options.NewResource(cfg)
+				Expect(resource.Validate()).To(Succeed())
 				Expect(resource.QualifiedGroup()).To(Equal(options.Group))
 			}
 		})
 
 		DescribeTable("should use core apis",
 			func(group, qualified string) {
-				options := &Options{
+				options := Options{
 					Group:   group,
 					Domain:  "test.io",
 					Version: "v1",
@@ -260,6 +225,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Path).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
 					Expect(resource.API.CRDVersion).To(Equal(""))
 					Expect(resource.QualifiedGroup()).To(Equal(qualified))
@@ -272,7 +238,7 @@ var _ = Describe("Options", func() {
 		It("should use domain if the group is empty", func() {
 			safeDomain := "testio"
 
-			options := &Options{
+			options := Options{
 				Domain:  "test.io",
 				Version: "v1",
 				Kind:    "FirstMate",
@@ -285,6 +251,7 @@ var _ = Describe("Options", func() {
 				}
 
 				resource := options.NewResource(cfg)
+				Expect(resource.Validate()).To(Succeed())
 				Expect(resource.Group).To(Equal(""))
 				if multiGroup {
 					Expect(resource.Path).To(Equal(path.Join(cfg.GetRepository(), "apis", options.Version)))

--- a/pkg/plugins/golang/v2/options_test.go
+++ b/pkg/plugins/golang/v2/options_test.go
@@ -18,7 +18,6 @@ package v2
 
 import (
 	"path"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -31,57 +30,19 @@ import (
 var _ = Describe("Options", func() {
 	Context("Validate", func() {
 		DescribeTable("should succeed for valid options",
-			func(options *Options) { Expect(options.Validate()).To(Succeed()) },
-			Entry("full GVK",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("missing domain",
-				&Options{Group: "crew", Version: "v1", Kind: "FirstMate"}),
-			Entry("kind with multiple initial uppercase characters",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FIRSTMate"}),
+			func(options Options) { Expect(options.Validate()).To(Succeed()) },
+			Entry("full GVK", Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
+			Entry("missing domain", Options{Group: "crew", Version: "v1", Kind: "FirstMate"}),
 		)
 
 		DescribeTable("should fail for invalid options",
-			func(options *Options) { Expect(options.Validate()).NotTo(Succeed()) },
-			Entry("group flag captured another flag",
-				&Options{Group: "--version"}),
-			Entry("version flag captured another flag",
-				&Options{Version: "--kind"}),
-			Entry("kind flag captured another flag",
-				&Options{Kind: "--group"}),
-			Entry("missing group",
-				&Options{Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("group with uppercase characters",
-				&Options{Group: "Crew", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("group with non-alpha characters",
-				&Options{Group: "crew1*?", Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
-			Entry("missing version",
-				&Options{Group: "crew", Domain: "test.io", Kind: "FirstMate"}),
-			Entry("version without v prefix",
-				&Options{Group: "crew", Domain: "test.io", Version: "1", Kind: "FirstMate"}),
-			Entry("unstable version without v prefix",
-				&Options{Group: "crew", Domain: "test.io", Version: "1beta1", Kind: "FirstMate"}),
-			Entry("unstable version with wrong prefix",
-				&Options{Group: "crew", Domain: "test.io", Version: "a1beta1", Kind: "FirstMate"}),
-			Entry("unstable version without alpha/beta number",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1beta", Kind: "FirstMate"}),
-			Entry("multiple unstable version",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1beta1alpha1", Kind: "FirstMate"}),
-			Entry("missing kind",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1"}),
-			Entry("kind is too long",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: strings.Repeat("a", 64)}),
-			Entry("kind with whitespaces",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "First Mate"}),
-			Entry("kind ends with `-`",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate-"}),
-			Entry("kind starts with a decimal character",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "1FirstMate"}),
-			Entry("kind starts with a lowercase character",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "firstMate"}),
-			Entry("Invalid CRD version",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate", CRDVersion: "a"}),
-			Entry("Invalid webhook version",
-				&Options{Group: "crew", Domain: "test.io", Version: "v1", Kind: "FirstMate", WebhookVersion: "a"}),
+			func(options Options) { Expect(options.Validate()).NotTo(Succeed()) },
+			Entry("group flag captured another flag", Options{Group: "--version"}),
+			Entry("version flag captured another flag", Options{Version: "--kind"}),
+			Entry("kind flag captured another flag", Options{Kind: "--group"}),
+			Entry("missing group", Options{Domain: "test.io", Version: "v1", Kind: "FirstMate"}),
+			Entry("missing version", Options{Group: "crew", Domain: "test.io", Kind: "FirstMate"}),
+			Entry("missing kind", Options{Group: "crew", Domain: "test.io", Version: "v1"}),
 		)
 	})
 
@@ -94,7 +55,7 @@ var _ = Describe("Options", func() {
 		})
 
 		DescribeTable("should succeed if the Resource is valid",
-			func(options *Options) {
+			func(options Options) {
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
@@ -103,6 +64,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Group).To(Equal(options.Group))
 					Expect(resource.Domain).To(Equal(options.Domain))
 					Expect(resource.Version).To(Equal(options.Version))
@@ -125,29 +87,29 @@ var _ = Describe("Options", func() {
 					Expect(resource.ImportAlias()).To(Equal(options.Group + options.Version))
 				}
 			},
-			Entry("basic", &Options{
+			Entry("basic", Options{
 				Group:   "crew",
 				Domain:  "test.io",
 				Version: "v1",
 				Kind:    "FirstMate",
 			}),
-			Entry("API", &Options{
+			Entry("API", Options{
 				Group:      "crew",
 				Domain:     "test.io",
 				Version:    "v1",
 				Kind:       "FirstMate",
 				DoAPI:      true,
-				CRDVersion: v1beta1,
+				CRDVersion: "v1beta1",
 				Namespaced: true,
 			}),
-			Entry("Controller", &Options{
+			Entry("Controller", Options{
 				Group:        "crew",
 				Domain:       "test.io",
 				Version:      "v1",
 				Kind:         "FirstMate",
 				DoController: true,
 			}),
-			Entry("Webhooks", &Options{
+			Entry("Webhooks", Options{
 				Group:          "crew",
 				Domain:         "test.io",
 				Version:        "v1",
@@ -155,13 +117,13 @@ var _ = Describe("Options", func() {
 				DoDefaulting:   true,
 				DoValidation:   true,
 				DoConversion:   true,
-				WebhookVersion: v1beta1,
+				WebhookVersion: "v1beta1",
 			}),
 		)
 
 		DescribeTable("should default the Plural by pluralizing the Kind",
 			func(kind, plural string) {
-				options := &Options{Group: "crew", Version: "v1", Kind: kind}
+				options := Options{Group: "crew", Version: "v1", Kind: kind}
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
@@ -170,6 +132,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Plural).To(Equal(plural))
 				}
 			},
@@ -180,7 +143,7 @@ var _ = Describe("Options", func() {
 
 		DescribeTable("should keep the Plural if specified",
 			func(kind, plural string) {
-				options := &Options{Group: "crew", Version: "v1", Kind: kind, Plural: plural}
+				options := Options{Group: "crew", Version: "v1", Kind: kind, Plural: plural}
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
@@ -189,6 +152,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Plural).To(Equal(plural))
 				}
 			},
@@ -198,7 +162,7 @@ var _ = Describe("Options", func() {
 
 		DescribeTable("should allow hyphens and dots in group names",
 			func(group, safeGroup string) {
-				options := &Options{
+				options := Options{
 					Group:   group,
 					Domain:  "test.io",
 					Version: "v1",
@@ -212,6 +176,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Group).To(Equal(options.Group))
 					if multiGroup {
 						Expect(resource.Path).To(Equal(
@@ -229,7 +194,7 @@ var _ = Describe("Options", func() {
 		)
 
 		It("should not append '.' if provided an empty domain", func() {
-			options := &Options{Group: "crew", Version: "v1", Kind: "FirstMate"}
+			options := Options{Group: "crew", Version: "v1", Kind: "FirstMate"}
 			Expect(options.Validate()).To(Succeed())
 
 			for _, multiGroup := range []bool{false, true} {
@@ -238,13 +203,14 @@ var _ = Describe("Options", func() {
 				}
 
 				resource := options.NewResource(cfg)
+				Expect(resource.Validate()).To(Succeed())
 				Expect(resource.QualifiedGroup()).To(Equal(options.Group))
 			}
 		})
 
 		DescribeTable("should use core apis",
 			func(group, qualified string) {
-				options := &Options{
+				options := Options{
 					Group:   group,
 					Domain:  "test.io",
 					Version: "v1",
@@ -258,6 +224,7 @@ var _ = Describe("Options", func() {
 					}
 
 					resource := options.NewResource(cfg)
+					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Path).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
 					Expect(resource.API.CRDVersion).To(Equal(""))
 					Expect(resource.QualifiedGroup()).To(Equal(qualified))

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	goPlugin "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds"
@@ -41,6 +42,8 @@ type createWebhookSubcommand struct {
 	commandName string
 
 	options *goPlugin.Options
+
+	resource resource.Resource
 
 	// force indicates that the resource should be created even if it already exists
 	force bool
@@ -97,6 +100,9 @@ func (p *createWebhookSubcommand) InjectConfig(c config.Config) {
 }
 
 func (p *createWebhookSubcommand) Run() error {
+	// Create the resource from the options
+	p.resource = p.options.NewResource(p.config)
+
 	return cmdutil.Run(p)
 }
 
@@ -105,22 +111,25 @@ func (p *createWebhookSubcommand) Validate() error {
 		return err
 	}
 
-	if !p.options.DoDefaulting && !p.options.DoValidation && !p.options.DoConversion {
+	if err := p.resource.Validate(); err != nil {
+		return err
+	}
+
+	if !p.resource.HasDefaultingWebhook() && !p.resource.HasValidationWebhook() && !p.resource.HasConversionWebhook() {
 		return fmt.Errorf("%s create webhook requires at least one of --defaulting,"+
 			" --programmatic-validation and --conversion to be true", p.commandName)
 	}
 
 	// check if resource exist to create webhook
-	if r, err := p.config.GetResource(p.options.GVK()); err != nil {
-		return fmt.Errorf("%s create webhook requires an api with the group,"+
-			" kind and version provided", p.commandName)
+	if r, err := p.config.GetResource(p.resource.GVK); err != nil {
+		return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
 	} else if r.Webhooks != nil && !r.Webhooks.IsEmpty() && !p.force {
 		return errors.New("webhook resource already exists")
 	}
 
-	if !p.config.IsWebhookVersionCompatible(p.options.WebhookVersion) {
+	if !p.config.IsWebhookVersionCompatible(p.resource.Webhooks.WebhookVersion) {
 		return fmt.Errorf("only one webhook version can be used for all resources, cannot add %q",
-			p.options.WebhookVersion)
+			p.resource.Webhooks.WebhookVersion)
 	}
 
 	return nil
@@ -133,9 +142,7 @@ func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
 	}
 
-	// Create the resource from the options
-	res := p.options.NewResource(p.config)
-	return scaffolds.NewWebhookScaffolder(p.config, string(bp), res, p.force), nil
+	return scaffolds.NewWebhookScaffolder(p.config, string(bp), p.resource, p.force), nil
 }
 
 func (p *createWebhookSubcommand) PostScaffold() error {


### PR DESCRIPTION
Split resource validation between Options and Resource objects so that Resources built in different ways can still be validated.

Fixes: #1973
