### PR TITLE
:sparkles: (go/v3) change 'runAsUser: 65532'  to 'runAsNonRoot: true'

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/config.go
@@ -69,7 +69,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsNonRoot: true
       containers:
       - command:
         - /manager

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsNonRoot: true
       containers:
       - command:
         - /manager

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsNonRoot: true
       containers:
       - command:
         - /manager

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsNonRoot: true
       containers:
       - command:
         - /manager

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsNonRoot: true
       containers:
       - command:
         - /manager


### PR DESCRIPTION
This PR changes the manager pod template's security context `runAsUser: 65532`  to `runAsNonRoot: true`. User 65532 is already specified in a project's [Dockerfile](https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v3/Dockerfile#L25) which the [security context uses](https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext) when `runAsUser` is unset, making the security context's value redundant (and prone to drift if that value is changed in the Dockerfile) in kubebuilder's case.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>
