### PR TITLE
✨ Constructor for Resource

### DIFF
--- a/pkg/model/resource/constructor.go
+++ b/pkg/model/resource/constructor.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"path"
+)
+
+// Option defines the type that .
+type Option func(*Resource) error
+
+// New creates a new Resource.
+func New(gvk GVK, options ...Option) (Resource, error) {
+	resource := Resource{
+		GVK:      gvk,
+		Plural:   RegularPlural(gvk.Kind),
+		API:      &API{},      // Make sure that the pointer is not nil to prevent pointer dereference errors
+		Webhooks: &Webhooks{}, // Make sure that the pointer is not nil to prevent pointer dereference errors
+	}
+
+	for _, option := range options {
+		if err := option(&resource); err != nil {
+			return resource, err
+		}
+	}
+
+	return resource, nil
+}
+
+// WithPlural sets the resource plural form.
+func WithPlural(plural string) Option {
+	return func(resource *Resource) error {
+		resource.Plural = plural
+		return nil
+	}
+}
+
+// WithPath sets the resource path.
+func WithPath(path string) Option {
+	return func(resource *Resource) error {
+		resource.Path = path
+		return nil
+	}
+}
+
+// WithLocalPath sets the resource path to a local location.
+func WithLocalPath(repo string, isMultiGroup bool) Option {
+	return func(resource *Resource) error {
+		resource.Path = APIPackagePath(repo, resource.Group, resource.Version, isMultiGroup)
+		return nil
+	}
+}
+
+// WithBuiltInPath sets the resource path to a core resource location.
+func WithBuiltInPath() Option {
+	return func(resource *Resource) error {
+		resource.Path = path.Join("k8s.io", "api", resource.Group, resource.Version)
+		return nil
+	}
+}
+
+// ScaffoldAPI specifies if a Resource should scaffold the API types.
+func ScaffoldAPI(version string) Option {
+	return func(resource *Resource) error {
+		resource.API.CRDVersion = version
+		return nil
+	}
+}
+
+// WithScope allows to define the scope of the Resource: namespaced or cluster-scoped.
+func WithScope(namespaced bool) Option {
+	return func(resource *Resource) error {
+		resource.API.Namespaced = namespaced
+		return nil
+	}
+}
+
+// ScaffoldController specifies if a Resource should scaffold the controller.
+func ScaffoldController() Option {
+	return func(resource *Resource) error {
+		resource.Controller = true
+		return nil
+	}
+}
+
+var errWebhookVersion = fmt.Errorf("unable to scaffold several webhooks with different versions")
+
+// ScaffoldDefaultingWebhook specifies if a Resource should scaffold a defaulting webhook.
+func ScaffoldDefaultingWebhook(version string) Option {
+	return func(resource *Resource) error {
+		if resource.Webhooks.WebhookVersion == "" {
+			resource.Webhooks.WebhookVersion = version
+		} else if resource.Webhooks.WebhookVersion != version {
+			return errWebhookVersion
+		}
+
+		resource.Webhooks.Defaulting = true
+		return nil
+	}
+}
+
+// ScaffoldValidationWebhook specifies if a Resource should scaffold a validation webhook.
+func ScaffoldValidationWebhook(version string) Option {
+	return func(resource *Resource) error {
+		if resource.Webhooks.WebhookVersion == "" {
+			resource.Webhooks.WebhookVersion = version
+		} else if resource.Webhooks.WebhookVersion != version {
+			return errWebhookVersion
+		}
+
+		resource.Webhooks.Validation = true
+		return nil
+	}
+}
+
+// ScaffoldConversionWebhook specifies if a Resource should scaffold a conversion webhook.
+func ScaffoldConversionWebhook(version string) Option {
+	return func(resource *Resource) error {
+		if resource.Webhooks.WebhookVersion == "" {
+			resource.Webhooks.WebhookVersion = version
+		} else if resource.Webhooks.WebhookVersion != version {
+			return errWebhookVersion
+		}
+
+		resource.Webhooks.Conversion = true
+		return nil
+	}
+}

--- a/pkg/model/resource/constructor_test.go
+++ b/pkg/model/resource/constructor_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("New", func() {
+	var (
+		group   = "group"
+		domain  = "my.domain"
+		version = "v1"
+		kind    = "Kind"
+		plural  = "types"
+		rPath   = "sigs.kubebuilder.io/kubebuilder/test/apis"
+		repo    = "sigs.kubebuilder.io/kubebuilder/test"
+
+		gvk = GVK{
+			Group:   group,
+			Domain:  domain,
+			Version: version,
+			Kind:    kind,
+		}
+	)
+
+	Context("without any options", func() {
+		It("should success", func() {
+			resource, err := New(gvk)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+			Expect(resource.Plural).To(Equal(RegularPlural(gvk.Kind)))
+		})
+	})
+
+	Context("WithPlural", func() {
+		It("should success", func() {
+			resource, err := New(gvk, WithPlural(plural))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+			Expect(resource.Plural).To(Equal(plural))
+		})
+	})
+
+	Context("WithPath", func() {
+		It("should success", func() {
+			resource, err := New(gvk, WithPath(rPath))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+			Expect(resource.Path).To(Equal(rPath))
+		})
+	})
+
+	Context("WithLocalPath", func() {
+		DescribeTable("should success",
+			func(multiGroup bool) {
+				resource, err := New(gvk, WithLocalPath(repo, multiGroup))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+				Expect(resource.Path).To(Equal(APIPackagePath(repo, gvk.Group, gvk.Version, multiGroup)))
+			},
+			Entry("for single-group configuration", false),
+			Entry("for multi-group configuration", true),
+		)
+	})
+
+	Context("WithBuiltInPath", func() {
+		It("should success", func() {
+			resource, err := New(gvk, WithBuiltInPath())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+			Expect(resource.Path).To(Equal(path.Join("k8s.io", "api", resource.Group, resource.Version)))
+		})
+	})
+
+	Context("ScaffoldAPI", func() {
+		It("should success", func() {
+			resource, err := New(gvk, ScaffoldAPI(version))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+			Expect(resource.HasAPI()).To(BeTrue())
+			Expect(resource.API.CRDVersion).To(Equal(version))
+		})
+	})
+
+	Context("WithScope", func() {
+		DescribeTable("should success",
+			func(namespaced bool) {
+				resource, err := New(gvk, WithScope(namespaced))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+				Expect(resource.API.Namespaced).To(Equal(namespaced))
+			},
+			Entry("for cluster-scoped resources", false),
+			Entry("for namespaced resources", true),
+		)
+	})
+
+	Context("ScaffoldController", func() {
+		It("should success", func() {
+			resource, err := New(gvk, ScaffoldController())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+			Expect(resource.Controller).To(BeTrue())
+		})
+	})
+
+	Context("Scaffold*Webhook", func() {
+		DescribeTable("should success",
+			func(defaulting, validation, conversion bool) {
+				options := make([]Option, 0, 3)
+				if defaulting {
+					options = append(options, ScaffoldDefaultingWebhook(version))
+				}
+				if validation {
+					options = append(options, ScaffoldValidationWebhook(version))
+				}
+				if conversion {
+					options = append(options, ScaffoldConversionWebhook(version))
+				}
+
+				resource, err := New(gvk, options...)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resource.GVK.IsEqualTo(gvk)).To(BeTrue())
+
+				if defaulting || validation || conversion {
+					Expect(resource.Webhooks.WebhookVersion).To(Equal(version))
+				}
+				Expect(resource.HasDefaultingWebhook()).To(Equal(defaulting))
+				Expect(resource.HasValidationWebhook()).To(Equal(validation))
+				Expect(resource.HasConversionWebhook()).To(Equal(conversion))
+			},
+			Entry("for no webhook", false, false, false),
+			Entry("for defaulting webhook", true, false, false),
+			Entry("for validation webhook", false, true, false),
+			Entry("for conversion webhook", false, false, true),
+			Entry("for defaulting and validation webhooks", true, true, false),
+			Entry("for defaulting and conversion webhooks", true, false, true),
+			Entry("for validation and conversion webhooks", false, true, true),
+			Entry("for defaulting and validation and conversion webhooks", true, true, true),
+		)
+
+		DescribeTable("should fail",
+			func(options ...Option) {
+				_, err := New(gvk, options...)
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("for wrong defaulting version", ScaffoldConversionWebhook(version), ScaffoldDefaultingWebhook("v2")),
+			Entry("for wrong validation version", ScaffoldDefaultingWebhook(version), ScaffoldValidationWebhook("v2")),
+			Entry("for wrong conversion version", ScaffoldValidationWebhook(version), ScaffoldConversionWebhook("v2")),
+		)
+	})
+})

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -114,7 +114,6 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.options.DoAPI, "resource", true,
 		"if set, generate the resource without prompting the user")
 	p.resourceFlag = fs.Lookup("resource")
-	p.options.CRDVersion = "v1beta1"
 	fs.BoolVar(&p.options.Namespaced, "namespaced", true, "resource is namespaced")
 
 	fs.BoolVar(&p.options.DoController, "controller", true,

--- a/pkg/plugins/golang/v2/options.go
+++ b/pkg/plugins/golang/v2/options.go
@@ -18,7 +18,6 @@ package v2
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	newconfig "sigs.k8s.io/kubebuilder/v3/pkg/config"
@@ -26,6 +25,8 @@ import (
 )
 
 const (
+	v1beta1 = "v1beta1"
+
 	groupPresent    = "group flag present but empty"
 	versionPresent  = "version flag present but empty"
 	kindPresent     = "kind flag present but empty"
@@ -76,11 +77,6 @@ type Options struct {
 	// Plural is the resource's kind plural form.
 	// Optional
 	Plural string
-
-	// CRDVersion is the CustomResourceDefinition API version that will be used for the resource.
-	CRDVersion string
-	// WebhookVersion is the {Validating,Mutating}WebhookConfiguration API version that will be used for the resource.
-	WebhookVersion string
 
 	// Namespaced is true if the resource should be namespaced.
 	Namespaced bool
@@ -135,39 +131,32 @@ func (opts Options) GVK() resource.GVK {
 
 // NewResource creates a new resource from the options
 func (opts Options) NewResource(c newconfig.Config) resource.Resource {
-	res := resource.Resource{
-		GVK:        opts.GVK(),
-		Path:       resource.APIPackagePath(c.GetRepository(), opts.Group, opts.Version, c.IsMultiGroup()),
-		Controller: opts.DoController,
-	}
+	options := make([]resource.Option, 0)
 
 	if opts.Plural != "" {
-		res.Plural = opts.Plural
-	} else {
-		// If not provided, compute a plural for for Kind
-		res.Plural = resource.RegularPlural(opts.Kind)
+		options = append(options, resource.WithPlural(opts.Plural))
 	}
+
+	options = append(options, resource.WithLocalPath(c.GetRepository(), c.IsMultiGroup()))
 
 	if opts.DoAPI {
-		res.API = &resource.API{
-			CRDVersion: opts.CRDVersion,
-			Namespaced: opts.Namespaced,
-		}
-	} else {
-		// Make sure that the pointer is not nil to prevent pointer dereference errors
-		res.API = &resource.API{}
+		options = append(options, resource.ScaffoldAPI(v1beta1), resource.WithScope(opts.Namespaced))
 	}
 
-	if opts.DoDefaulting || opts.DoValidation || opts.DoConversion {
-		res.Webhooks = &resource.Webhooks{
-			WebhookVersion: opts.WebhookVersion,
-			Defaulting:     opts.DoDefaulting,
-			Validation:     opts.DoValidation,
-			Conversion:     opts.DoConversion,
-		}
-	} else {
-		// Make sure that the pointer is not nil to prevent pointer dereference errors
-		res.Webhooks = &resource.Webhooks{}
+	if opts.DoController {
+		options = append(options, resource.ScaffoldController())
+	}
+
+	if opts.DoDefaulting {
+		options = append(options, resource.ScaffoldDefaultingWebhook(v1beta1))
+	}
+
+	if opts.DoValidation {
+		options = append(options, resource.ScaffoldValidationWebhook(v1beta1))
+	}
+
+	if opts.DoConversion {
+		options = append(options, resource.ScaffoldConversionWebhook(v1beta1))
 	}
 
 	// domain and path may need to be changed in case we are referring to a builtin core resource:
@@ -179,11 +168,13 @@ func (opts Options) NewResource(c newconfig.Config) resource.Resource {
 	if !opts.DoAPI {
 		if !c.HasResource(opts.GVK()) {
 			if domain, found := coreGroups[opts.Group]; found {
-				res.Domain = domain
-				res.Path = path.Join("k8s.io", "api", opts.Group, opts.Version)
+				opts.Domain = domain
+				options = append(options, resource.WithBuiltInPath())
 			}
 		}
 	}
+
+	res, _ := resource.New(opts.GVK(), options...)
 
 	return res
 }

--- a/pkg/plugins/golang/v2/options_test.go
+++ b/pkg/plugins/golang/v2/options_test.go
@@ -75,13 +75,17 @@ var _ = Describe("Options", func() {
 					} else {
 						Expect(resource.Path).To(Equal(path.Join(cfg.GetRepository(), "api", options.Version)))
 					}
-					Expect(resource.API.CRDVersion).To(Equal(options.CRDVersion))
-					Expect(resource.API.Namespaced).To(Equal(options.Namespaced))
+					if options.DoAPI {
+						Expect(resource.API.CRDVersion).To(Equal(v1beta1))
+						Expect(resource.API.Namespaced).To(Equal(options.Namespaced))
+					}
 					Expect(resource.Controller).To(Equal(options.DoController))
-					Expect(resource.Webhooks.WebhookVersion).To(Equal(options.WebhookVersion))
-					Expect(resource.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
-					Expect(resource.Webhooks.Validation).To(Equal(options.DoValidation))
-					Expect(resource.Webhooks.Conversion).To(Equal(options.DoConversion))
+					if options.DoDefaulting || options.DoValidation || options.DoConversion {
+						Expect(resource.Webhooks.WebhookVersion).To(Equal(v1beta1))
+						Expect(resource.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
+						Expect(resource.Webhooks.Validation).To(Equal(options.DoValidation))
+						Expect(resource.Webhooks.Conversion).To(Equal(options.DoConversion))
+					}
 					Expect(resource.QualifiedGroup()).To(Equal(options.Group + "." + options.Domain))
 					Expect(resource.PackageName()).To(Equal(options.Group))
 					Expect(resource.ImportAlias()).To(Equal(options.Group + options.Version))
@@ -99,7 +103,6 @@ var _ = Describe("Options", func() {
 				Version:    "v1",
 				Kind:       "FirstMate",
 				DoAPI:      true,
-				CRDVersion: "v1beta1",
 				Namespaced: true,
 			}),
 			Entry("Controller", Options{
@@ -117,7 +120,6 @@ var _ = Describe("Options", func() {
 				DoDefaulting:   true,
 				DoValidation:   true,
 				DoConversion:   true,
-				WebhookVersion: "v1beta1",
 			}),
 		)
 

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -69,7 +69,6 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.options.Kind, "kind", "", "resource Kind")
 	fs.StringVar(&p.options.Plural, "resource", "", "resource irregular plural form")
 
-	p.options.WebhookVersion = "v1beta1"
 	fs.BoolVar(&p.options.DoDefaulting, "defaulting", false,
 		"if set, scaffold the defaulting webhook")
 	fs.BoolVar(&p.options.DoValidation, "programmatic-validation", false,


### PR DESCRIPTION
Provide a constructor for `Resource` in order to better split the model from the command flag options for each plugin so that third-party can consume this API instead of creating an `Options` object.