### PR TITLE
📖 Add documentation to v2 controllers

### DIFF
--- a/pkg/plugins/golang/v2/scaffolds/api.go
+++ b/pkg/plugins/golang/v2/scaffolds/api.go
@@ -122,7 +122,7 @@ func (s *apiScaffolder) scaffold() error {
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),
 			&controllers.SuiteTest{Force: s.force},
-			&controllers.Controller{Force: s.force},
+			&controllers.Controller{ControllerRuntimeVersion: ControllerRuntimeVersion, Force: s.force},
 		); err != nil {
 			return fmt.Errorf("error scaffolding controller: %v", err)
 		}

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
@@ -33,6 +33,8 @@ type Controller struct {
 	file.BoilerplateMixin
 	file.ResourceMixin
 
+	ControllerRuntimeVersion string
+
 	Force bool
 }
 
@@ -85,6 +87,15 @@ type {{ .Resource.Kind }}Reconciler struct {
 //+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the {{ .Resource.Kind }} object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@{{ .ControllerRuntimeVersion }}/pkg/reconcile
 func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("{{ .Resource.Kind | lower }}", req.NamespacedName)
@@ -94,6 +105,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		{{ if .Resource.HasAPI -}}

--- a/plugins/addon/controller.go
+++ b/plugins/addon/controller.go
@@ -65,6 +65,7 @@ type {{ .Resource.Kind }}Reconciler struct {
 //+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 

--- a/testdata/project-v2-addon/controllers/admiral_controller.go
+++ b/testdata/project-v2-addon/controllers/admiral_controller.go
@@ -47,6 +47,7 @@ type AdmiralReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *AdmiralReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 

--- a/testdata/project-v2-addon/controllers/captain_controller.go
+++ b/testdata/project-v2-addon/controllers/captain_controller.go
@@ -47,6 +47,7 @@ type CaptainReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *CaptainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 

--- a/testdata/project-v2-addon/controllers/firstmate_controller.go
+++ b/testdata/project-v2-addon/controllers/firstmate_controller.go
@@ -47,6 +47,7 @@ type FirstMateReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *FirstMateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 

--- a/testdata/project-v2-multigroup/controllers/apps/pod_controller.go
+++ b/testdata/project-v2-multigroup/controllers/apps/pod_controller.go
@@ -35,6 +35,15 @@ type PodReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Pod object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *PodReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("pod", req.NamespacedName)
@@ -44,6 +53,7 @@ func (r *PodReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument

--- a/testdata/project-v2-multigroup/controllers/crew/captain_controller.go
+++ b/testdata/project-v2-multigroup/controllers/crew/captain_controller.go
@@ -37,6 +37,15 @@ type CaptainReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Captain object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("captain", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *CaptainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crewv1.Captain{}).

--- a/testdata/project-v2-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v2-multigroup/controllers/foo.policy/healthcheckpolicy_controller.go
@@ -37,6 +37,15 @@ type HealthCheckPolicyReconciler struct {
 //+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the HealthCheckPolicy object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *HealthCheckPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("healthcheckpolicy", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *HealthCheckPolicyReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *HealthCheckPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&foopolicyv1.HealthCheckPolicy{}).

--- a/testdata/project-v2-multigroup/controllers/sea-creatures/kraken_controller.go
+++ b/testdata/project-v2-multigroup/controllers/sea-creatures/kraken_controller.go
@@ -37,6 +37,15 @@ type KrakenReconciler struct {
 //+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Kraken object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *KrakenReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("kraken", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *KrakenReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *KrakenReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&seacreaturesv1beta1.Kraken{}).

--- a/testdata/project-v2-multigroup/controllers/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v2-multigroup/controllers/sea-creatures/leviathan_controller.go
@@ -37,6 +37,15 @@ type LeviathanReconciler struct {
 //+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Leviathan object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *LeviathanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("leviathan", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *LeviathanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *LeviathanReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&seacreaturesv1beta2.Leviathan{}).

--- a/testdata/project-v2-multigroup/controllers/ship/cruiser_controller.go
+++ b/testdata/project-v2-multigroup/controllers/ship/cruiser_controller.go
@@ -37,6 +37,15 @@ type CruiserReconciler struct {
 //+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Cruiser object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *CruiserReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("cruiser", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *CruiserReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *CruiserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&shipv2alpha1.Cruiser{}).

--- a/testdata/project-v2-multigroup/controllers/ship/destroyer_controller.go
+++ b/testdata/project-v2-multigroup/controllers/ship/destroyer_controller.go
@@ -37,6 +37,15 @@ type DestroyerReconciler struct {
 //+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Destroyer object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *DestroyerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("destroyer", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *DestroyerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *DestroyerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&shipv1.Destroyer{}).

--- a/testdata/project-v2-multigroup/controllers/ship/frigate_controller.go
+++ b/testdata/project-v2-multigroup/controllers/ship/frigate_controller.go
@@ -37,6 +37,15 @@ type FrigateReconciler struct {
 //+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Frigate object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *FrigateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("frigate", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *FrigateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *FrigateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&shipv1beta1.Frigate{}).

--- a/testdata/project-v2/controllers/admiral_controller.go
+++ b/testdata/project-v2/controllers/admiral_controller.go
@@ -37,6 +37,15 @@ type AdmiralReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Admiral object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *AdmiralReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("admiral", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *AdmiralReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *AdmiralReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crewv1.Admiral{}).

--- a/testdata/project-v2/controllers/captain_controller.go
+++ b/testdata/project-v2/controllers/captain_controller.go
@@ -37,6 +37,15 @@ type CaptainReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Captain object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("captain", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *CaptainReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *CaptainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crewv1.Captain{}).

--- a/testdata/project-v2/controllers/firstmate_controller.go
+++ b/testdata/project-v2/controllers/firstmate_controller.go
@@ -37,6 +37,15 @@ type FirstMateReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the FirstMate object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *FirstMateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("firstmate", req.NamespacedName)
@@ -46,6 +55,7 @@ func (r *FirstMateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *FirstMateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crewv1.FirstMate{}).

--- a/testdata/project-v2/controllers/laker_controller.go
+++ b/testdata/project-v2/controllers/laker_controller.go
@@ -35,6 +35,15 @@ type LakerReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
 
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Laker object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
 func (r *LakerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	_ = r.Log.WithValues("laker", req.NamespacedName)
@@ -44,6 +53,7 @@ func (r *LakerReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *LakerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument

--- a/testdata/project-v3-addon/controllers/admiral_controller.go
+++ b/testdata/project-v3-addon/controllers/admiral_controller.go
@@ -47,6 +47,7 @@ type AdmiralReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=admirals/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *AdmiralReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 

--- a/testdata/project-v3-addon/controllers/captain_controller.go
+++ b/testdata/project-v3-addon/controllers/captain_controller.go
@@ -47,6 +47,7 @@ type CaptainReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *CaptainReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 

--- a/testdata/project-v3-addon/controllers/firstmate_controller.go
+++ b/testdata/project-v3-addon/controllers/firstmate_controller.go
@@ -47,6 +47,7 @@ type FirstMateReconciler struct {
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
 
+// SetupWithManager sets up the controller with the Manager.
 func (r *FirstMateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	addon.Init()
 


### PR DESCRIPTION
### Description
Add the documentation that was added to v3 plugin's controllers also to v2 plugin as they are only comments. This makes this change non-breaking because controllers scaffolded with v2 before this change will behave exactly the same as after this, but now they will have some extra documentation comments.
