### PR TITLE
:seedling: generalize tools Dockerfiles for arm64, ppc64le linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ GCP Cloud Build watches this branch.  On every push, it runs the pipeline define
 
 - `_GOARCH=amd64 _GOOS=darwin`
 - `_GOARCH=amd64 _GOOS=linux`
+- `_GOARCH=arm64 _GOOS=linux`
+- `_GOARCH=ppc64le _GOOS=linux`
 
 (we may add more the in the future).
 

--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -12,22 +12,36 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+substitutions:
+  _KUBERNETES_VERSION: v1.19.2
 steps:
 - name: "gcr.io/cloud-builders/docker"
-  args: ["build", "-t", "gcr.io/kubebuilder/thirdparty-${_GOOS}:1.20.2", "./build/thirdparty/${_GOOS}"]
+  args: [
+    "build",
+    "--build-arg", "OS=${_GOOS}",
+    "--build-arg", "ARCH=${_GOARCH}",
+    "--build-arg", "KUBERNETES_VERSION=${_KUBERNETES_VERSION}",
+    "-t", "gcr.io/kubebuilder/thirdparty-${_GOOS}-${_GOARCH}:${_KUBERNETES_VERSION}",
+    "./build/thirdparty/${_GOOS}",
+  ]
   # darwin takes forever
   timeout: 30m
 
-- name: "gcr.io/kubebuilder/thirdparty-${_GOOS}:1.20.2"
-  args: ["cp", "/kubebuilder_${_GOOS}_${_GOARCH}.tar.gz", "/workspace/kubebuilder-1.20.2-${_GOOS}-${_GOARCH}.tar.gz"]
-  env:
-  - 'GOOS=${_GOOS}'
-  - 'GOARCH=${_GOARCH}'
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['-h', 'Content-Type:application/gzip', 'cp', '/workspace/kubebuilder-1.20.2-${_GOOS}-${_GOARCH}.tar.gz', 'gs://kubebuilder-tools/kubebuilder-tools-1.20.2-${_GOOS}-${_GOARCH}.tar.gz']
-  env:
-  - 'GOOS=${_GOOS}'
-  - 'GOARCH=${_GOARCH}'
-images: ["gcr.io/kubebuilder/thirdparty-${_GOOS}:1.20.2"]
+- name: "gcr.io/kubebuilder/thirdparty-${_GOOS}-${_GOARCH}:${_KUBERNETES_VERSION}"
+  args: [
+    "cp",
+    "/kubebuilder_${_GOOS}_${_GOARCH}.tar.gz",
+    "/workspace/kubebuilder-tools-${_KUBERNETES_VERSION}-${_GOOS}-${_GOARCH}.tar.gz",
+  ]
+
+- name: "gcr.io/cloud-builders/gsutil"
+  args: [
+    "-h", "Content-Type:application/gzip",
+    "cp",
+    "/workspace/kubebuilder-tools-${_KUBERNETES_VERSION}-${_GOOS}-${_GOARCH}.tar.gz",
+    "gs://kubebuilder-tools/kubebuilder-tools-${_KUBERNETES_VERSION}-${_GOOS}-${_GOARCH}.tar.gz",
+  ]
+
+images: ["gcr.io/kubebuilder/thirdparty-${_GOOS}-${_GOARCH}:${_KUBERNETES_VERSION}"]
 # darwin takes forever
 timeout: 30m

--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -13,45 +13,54 @@
 #  limitations under the License.
 
 # Build or fetch the following binaries for darwin and then host them in a tar.gz file in an alpine image
-# - apiserver (build)
+# - kube-apiserver (build)
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.15 as darwin
-# Install tools
-ENV CGO 0
-ENV DEST /usr/local/kubebuilder/bin/
+FROM golang:1.15 as builder
 
+# Version and platform args.
+ARG KUBERNETES_VERSION
+ARG ETCD_VERSION=v3.4.9
+ARG OS=darwin
+ARG ARCH
+
+# Tools path.
+ENV DEST=/usr/local/kubebuilder/bin/
+
+# Install dependencies.
 RUN apt update && \
-    apt install rsync -y && \
-    apt-get install unzip && \
-    go get github.com/jteeuwen/go-bindata/go-bindata && \
-    ( mkdir -p $DEST || echo "" )
+    apt install unzip rsync -y && \
+    mkdir -p $DEST
 
-RUN git clone https://github.com/kubernetes/kubernetes $GOPATH/src/k8s.io/kubernetes --depth=1 -b v1.20.2
-
-WORKDIR /go/src/k8s.io/kubernetes
-
-# Build for linux first otherwise it won't work for darwin - :(
-ENV KUBE_BUILD_PLATFORMS linux/amd64
-RUN make WHAT=cmd/kube-apiserver
-ENV KUBE_BUILD_PLATFORMS darwin/amd64
+# kube-apiserver
+WORKDIR /kubernetes
+RUN git clone https://github.com/kubernetes/kubernetes . --depth=1 -b ${KUBERNETES_VERSION}
+ENV CGO_ENABLED=0
+ENV KUBE_BUILD_PLATFORMS=${OS}/${ARCH}
 RUN make WHAT=cmd/kube-apiserver && \
-    cp _output/local/bin/$KUBE_BUILD_PLATFORMS/kube-apiserver $DEST
+    cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kube-apiserver $DEST
 
-RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/darwin/amd64/kubectl && \
+# kubectl
+RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/${OS}/${ARCH}/kubectl && \
     chmod +x kubectl && \
     cp kubectl $DEST
 
-ENV ETCD_VERSION="3.4.9"
-ENV ETCD_DOWNLOAD_FILE="etcd-v${ETCD_VERSION}-darwin-amd64.zip"
-RUN curl -sLO https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-darwin-amd64.zip -o ${ETCD_DOWNLOAD_FILE} && \
-    unzip -o ${ETCD_DOWNLOAD_FILE} && \
-    cp etcd-v${ETCD_VERSION}-darwin-amd64/etcd $DEST
+# etcd
+ENV ETCD_BASE_NAME=etcd-${ETCD_VERSION}-${OS}-${ARCH}
+RUN curl -sLO https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD_BASE_NAME}.zip && \
+    unzip -o ${ETCD_BASE_NAME}.zip && \
+    cp ${ETCD_BASE_NAME}/etcd $DEST
 
+# Package into tarball.
 WORKDIR /usr/local
-RUN tar -czvf /kubebuilder_darwin_amd64.tar.gz kubebuilder/
+RUN tar -czvf /kubebuilder_${OS}_${ARCH}.tar.gz kubebuilder/
 
-# Host the tar.gz file in a thin image
+# Copy tarball to final image.
 FROM alpine:3.8
-COPY --from=darwin /kubebuilder_darwin_amd64.tar.gz /kubebuilder_darwin_amd64.tar.gz
+
+# Platform args.
+ARG OS=darwin
+ARG ARCH
+
+COPY --from=builder /kubebuilder_${OS}_${ARCH}.tar.gz /

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -13,34 +13,52 @@
 #  limitations under the License.
 
 # Fetch the following into binaries for linux and then host them in a tar.gz file in an alpine image
-# - apiserver (fetch)
+# - kube-apiserver (fetch)
 # - kubectl (fetch)
 # - etcd (fetch)
 
 # no need for anything fancy
-FROM alpine:3.8 as linux
-# Install tools
-ENV DEST /usr/local/kubebuilder/bin/
+FROM alpine:3.8 as builder
 
+# Version and platform args.
+ARG KUBERNETES_VERSION
+ARG ETCD_VERSION=v3.4.9
+ARG OS=linux
+ARG ARCH
+
+# Tools path.
+ENV DEST=/usr/local/kubebuilder/bin/
+
+# Install dependencies.
 RUN apk add --no-cache curl && \
-    mkdir -p $DEST || echo ""
+    mkdir -p $DEST
 
-RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl && \
+# kube-apiserver
+ENV K8S_SERVER_BASE_NAME=kubernetes-server-${OS}-${ARCH}
+RUN curl -sLO https://dl.k8s.io/${KUBERNETES_VERSION}/${K8S_SERVER_BASE_NAME}.tar.gz && \
+    tar xzf ${K8S_SERVER_BASE_NAME}.tar.gz && \
+    cp kubernetes/server/bin/kube-apiserver $DEST
+
+# kubectl
+RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/${OS}/${ARCH}/kubectl && \
     chmod +x kubectl && \
     cp kubectl $DEST
 
-RUN curl -sLO https://dl.k8s.io/v1.20.2/kubernetes-server-linux-amd64.tar.gz && \
-    tar xzf kubernetes-server-linux-amd64.tar.gz && \
-    cp kubernetes/server/bin/kube-apiserver $DEST
+# etcd
+ENV ETCD_BASE_NAME=etcd-${ETCD_VERSION}-${OS}-${ARCH}
+RUN curl -sLO https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD_BASE_NAME}.tar.gz && \
+    tar xzf ${ETCD_BASE_NAME}.tar.gz && \
+    cp ${ETCD_BASE_NAME}/etcd $DEST
 
-ENV ETCD_VERSION="3.4.9"
-ENV ETCD_DOWNLOAD_FILE="etcd-v${ETCD_VERSION}-linux-amd64.tar.gz"
-RUN curl -sLO https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz -o ${ETCD_DOWNLOAD_FILE} && \
-    tar xzf ${ETCD_DOWNLOAD_FILE} && \
-    cp etcd-v${ETCD_VERSION}-linux-amd64/etcd $DEST
-
+# Package into tarball.
 WORKDIR /usr/local
-RUN tar -czvf /kubebuilder_linux_amd64.tar.gz kubebuilder/
+RUN tar -czvf /kubebuilder_${OS}_${ARCH}.tar.gz kubebuilder/
 
+# Copy tarball to final image.
 FROM alpine:3.8
-COPY --from=linux /kubebuilder_linux_amd64.tar.gz /kubebuilder_linux_amd64.tar.gz
+
+# Platform args.
+ARG OS=linux
+ARG ARCH
+
+COPY --from=builder /kubebuilder_${OS}_${ARCH}.tar.gz /


### PR DESCRIPTION
- */Dockerfile: generalize for multiple platforms
- build/cloudbuild_tools.yaml: update with new Dockerfile args, prettify
- README.md: add new arches

**Note:** this PR also downgrades k8s version to v1.19.2 so arm64 and ppc64le builds occur for a v1.19 version. I will post a follow-up PR to upgrade the version back to v1.20.2 after this is merged.

Closes #966 

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>