### PR TITLE
🐛 Fix sorting issue with plugin versions and their supported project versions

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -89,7 +89,7 @@ func (c cli) getPluginTable() string {
 		maxPluginKeyLength      = len(pluginKeysHeader)
 		pluginKeys              = make([]string, 0, len(c.plugins))
 		maxProjectVersionLength = len(projectVersionsHeader)
-		projectVersions         = make([]string, 0, len(c.plugins))
+		projectVersions         = make(map[string]string, len(c.plugins))
 	)
 
 	for pluginKey, plugin := range c.plugins {
@@ -106,7 +106,7 @@ func (c cli) getPluginTable() string {
 		if len(supportedProjectVersionsStr) > maxProjectVersionLength {
 			maxProjectVersionLength = len(supportedProjectVersionsStr)
 		}
-		projectVersions = append(projectVersions, supportedProjectVersionsStr)
+		projectVersions[pluginKey] = supportedProjectVersionsStr
 	}
 
 	lines := make([]string, 0, len(c.plugins)+2)
@@ -116,8 +116,8 @@ func (c cli) getPluginTable() string {
 		strings.Repeat("-", maxProjectVersionLength+2))
 
 	sort.Strings(pluginKeys)
-	for i, pluginKey := range pluginKeys {
-		supportedProjectVersions := projectVersions[i]
+	for _, pluginKey := range pluginKeys {
+		supportedProjectVersions := projectVersions[pluginKey]
 		lines = append(lines, fmt.Sprintf(" %[1]*[2]s | %[3]*[4]s",
 			maxPluginKeyLength, pluginKey, maxProjectVersionLength, supportedProjectVersions))
 	}


### PR DESCRIPTION
When creating the plugin table with their supported project versions, the supported project versions were being store as a slice in the same order as the plugin keys slice.
When #1984 sorted the plugin keys slice, it didn't modify the other slice accordingly.
