### PR TITLE
🐛 Fix go/v2 with config/v3 resources in config file to store webhook information

### DIFF
--- a/pkg/plugins/golang/v2/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v2/scaffolds/webhook.go
@@ -64,6 +64,10 @@ func (s *webhookScaffolder) newUniverse() *model.Universe {
 }
 
 func (s *webhookScaffolder) scaffold() error {
+	if err := s.config.UpdateResource(s.resource); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
+
 	if err := machinery.NewScaffold().Execute(
 		s.newUniverse(),
 		&api.Webhook{},


### PR DESCRIPTION
Fix go/v2 with config/v3 resources in config file to store webhook information

Fixes: #1996