### PR TITLE
🐛 (config/v3) Track in the project configuration file resources without API

### DIFF
--- a/generate_testdata.sh
+++ b/generate_testdata.sh
@@ -98,7 +98,7 @@ scaffold_test_project() {
 
     $kb create api --group foo.policy --version v1 --kind HealthCheckPolicy --controller=true --resource=true --make=false
 
-    $kb create api --group apps --version v1 --kind Pod --controller=true --resource=false --make=false
+    $kb create api --group apps --version v1 --kind Deployment --controller=true --resource=false --make=false
 
     if [ $project == "project-v3-multigroup" ]; then
       $kb create api --version v1 --kind Lakers --controller=true --resource=true --make=false

--- a/pkg/model/file/funcmap.go
+++ b/pkg/model/file/funcmap.go
@@ -26,10 +26,16 @@ import (
 // DefaultFuncMap returns the default template.FuncMap for rendering the template.
 func DefaultFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"title":   strings.Title,
-		"lower":   strings.ToLower,
-		"hashFNV": hashFNV,
+		"title":      strings.Title,
+		"lower":      strings.ToLower,
+		"isEmptyStr": isEmptyString,
+		"hashFNV":    hashFNV,
 	}
+}
+
+// isEmptyString returns whether the string is empty
+func isEmptyString(s string) bool {
+	return s == ""
 }
 
 // hashFNV will generate a random string useful for generating a unique string

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -155,8 +155,12 @@ func (r *Resource) Update(other Resource) error {
 		return fmt.Errorf("unable to update Resource with another with non-matching Plural")
 	}
 
-	if r.Path != other.Path {
-		return fmt.Errorf("unable to update Resource with another with non-matching Path")
+	if other.Path != "" && r.Path != other.Path {
+		if r.Path == "" {
+			r.Path = other.Path
+		} else {
+			return fmt.Errorf("unable to update Resource with another with non-matching Path")
+		}
 	}
 
 	// Update API.

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -62,6 +62,8 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -70,19 +72,36 @@ var _ = Describe("Options", func() {
 					Expect(resource.Domain).To(Equal(options.Domain))
 					Expect(resource.Version).To(Equal(options.Version))
 					Expect(resource.Kind).To(Equal(options.Kind))
-					if multiGroup {
-						Expect(resource.Path).To(Equal(
-							path.Join(cfg.GetRepository(), "apis", options.Group, options.Version)))
+					Expect(resource.API).NotTo(BeNil())
+					if options.DoAPI || options.DoDefaulting || options.DoValidation || options.DoConversion {
+						if multiGroup {
+							Expect(resource.Path).To(Equal(
+								path.Join(cfg.GetRepository(), "apis", options.Group, options.Version)))
+						} else {
+							Expect(resource.Path).To(Equal(path.Join(cfg.GetRepository(), "api", options.Version)))
+						}
 					} else {
-						Expect(resource.Path).To(Equal(path.Join(cfg.GetRepository(), "api", options.Version)))
+						// Core-resources have a path despite not having an API/Webhook but they are not tested here
+						Expect(resource.Path).To(Equal(""))
 					}
-					Expect(resource.API.CRDVersion).To(Equal(options.CRDVersion))
-					Expect(resource.API.Namespaced).To(Equal(options.Namespaced))
+					if options.DoAPI {
+						Expect(resource.API.CRDVersion).To(Equal(options.CRDVersion))
+						Expect(resource.API.Namespaced).To(Equal(options.Namespaced))
+						Expect(resource.API.IsEmpty()).To(BeFalse())
+					} else {
+						Expect(resource.API.IsEmpty()).To(BeTrue())
+					}
 					Expect(resource.Controller).To(Equal(options.DoController))
-					Expect(resource.Webhooks.WebhookVersion).To(Equal(options.WebhookVersion))
-					Expect(resource.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
-					Expect(resource.Webhooks.Validation).To(Equal(options.DoValidation))
-					Expect(resource.Webhooks.Conversion).To(Equal(options.DoConversion))
+					Expect(resource.Webhooks).NotTo(BeNil())
+					if options.DoDefaulting || options.DoValidation || options.DoConversion {
+						Expect(resource.Webhooks.WebhookVersion).To(Equal(options.WebhookVersion))
+						Expect(resource.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
+						Expect(resource.Webhooks.Validation).To(Equal(options.DoValidation))
+						Expect(resource.Webhooks.Conversion).To(Equal(options.DoConversion))
+						Expect(resource.Webhooks.IsEmpty()).To(BeFalse())
+					} else {
+						Expect(resource.Webhooks.IsEmpty()).To(BeTrue())
+					}
 					Expect(resource.QualifiedGroup()).To(Equal(options.Group + "." + options.Domain))
 					Expect(resource.PackageName()).To(Equal(options.Group))
 					Expect(resource.ImportAlias()).To(Equal(options.Group + options.Version))
@@ -130,6 +149,8 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -150,6 +171,8 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -168,12 +191,15 @@ var _ = Describe("Options", func() {
 					Domain:  "test.io",
 					Version: "v1",
 					Kind:    "FirstMate",
+					DoAPI:   true, // Scaffold the API so that the path is saved
 				}
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -201,6 +227,8 @@ var _ = Describe("Options", func() {
 			for _, multiGroup := range []bool{false, true} {
 				if multiGroup {
 					Expect(cfg.SetMultiGroup()).To(Succeed())
+				} else {
+					Expect(cfg.ClearMultiGroup()).To(Succeed())
 				}
 
 				resource := options.NewResource(cfg)
@@ -222,12 +250,15 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
 					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Path).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
-					Expect(resource.API.CRDVersion).To(Equal(""))
+					Expect(resource.API).NotTo(BeNil())
+					Expect(resource.API.IsEmpty()).To(BeTrue())
 					Expect(resource.QualifiedGroup()).To(Equal(qualified))
 				}
 			},
@@ -242,12 +273,15 @@ var _ = Describe("Options", func() {
 				Domain:  "test.io",
 				Version: "v1",
 				Kind:    "FirstMate",
+				DoAPI:   true, // Scaffold the API so that the path is saved
 			}
 			Expect(options.Validate()).To(Succeed())
 
 			for _, multiGroup := range []bool{false, true} {
 				if multiGroup {
 					Expect(cfg.SetMultiGroup()).To(Succeed())
+				} else {
+					Expect(cfg.ClearMultiGroup()).To(Succeed())
 				}
 
 				resource := options.NewResource(cfg)

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -154,9 +154,9 @@ func (p *createAPISubcommand) Validate() error {
 	}
 
 	// In case we want to scaffold a resource API we need to do some checks
-	if p.resource.HasAPI() {
-		// Check that resource doesn't exist or flag force was set
-		if !p.force && p.config.HasResource(p.resource.GVK) {
+	if p.options.DoAPI {
+		// Check that resource doesn't have the API scaffolded or flag force was set
+		if res, err := p.config.GetResource(p.resource.GVK); err == nil && res.HasAPI() && !p.force {
 			return errors.New("API resource already exists")
 		}
 

--- a/pkg/plugins/golang/v2/options_test.go
+++ b/pkg/plugins/golang/v2/options_test.go
@@ -61,6 +61,8 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -69,19 +71,36 @@ var _ = Describe("Options", func() {
 					Expect(resource.Domain).To(Equal(options.Domain))
 					Expect(resource.Version).To(Equal(options.Version))
 					Expect(resource.Kind).To(Equal(options.Kind))
-					if multiGroup {
-						Expect(resource.Path).To(Equal(
-							path.Join(cfg.GetRepository(), "apis", options.Group, options.Version)))
+					Expect(resource.API).NotTo(BeNil())
+					if options.DoAPI || options.DoDefaulting || options.DoValidation || options.DoConversion {
+						if multiGroup {
+							Expect(resource.Path).To(Equal(
+								path.Join(cfg.GetRepository(), "apis", options.Group, options.Version)))
+						} else {
+							Expect(resource.Path).To(Equal(path.Join(cfg.GetRepository(), "api", options.Version)))
+						}
 					} else {
-						Expect(resource.Path).To(Equal(path.Join(cfg.GetRepository(), "api", options.Version)))
+						// Core-resources have a path despite not having an API/Webhook but they are not tested here
+						Expect(resource.Path).To(Equal(""))
 					}
-					Expect(resource.API.CRDVersion).To(Equal(options.CRDVersion))
-					Expect(resource.API.Namespaced).To(Equal(options.Namespaced))
+					if options.DoAPI {
+						Expect(resource.API.CRDVersion).To(Equal(options.CRDVersion))
+						Expect(resource.API.Namespaced).To(Equal(options.Namespaced))
+						Expect(resource.API.IsEmpty()).To(BeFalse())
+					} else {
+						Expect(resource.API.IsEmpty()).To(BeTrue())
+					}
 					Expect(resource.Controller).To(Equal(options.DoController))
-					Expect(resource.Webhooks.WebhookVersion).To(Equal(options.WebhookVersion))
-					Expect(resource.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
-					Expect(resource.Webhooks.Validation).To(Equal(options.DoValidation))
-					Expect(resource.Webhooks.Conversion).To(Equal(options.DoConversion))
+					Expect(resource.Webhooks).NotTo(BeNil())
+					if options.DoDefaulting || options.DoValidation || options.DoConversion {
+						Expect(resource.Webhooks.WebhookVersion).To(Equal(options.WebhookVersion))
+						Expect(resource.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
+						Expect(resource.Webhooks.Validation).To(Equal(options.DoValidation))
+						Expect(resource.Webhooks.Conversion).To(Equal(options.DoConversion))
+						Expect(resource.Webhooks.IsEmpty()).To(BeFalse())
+					} else {
+						Expect(resource.Webhooks.IsEmpty()).To(BeTrue())
+					}
 					Expect(resource.QualifiedGroup()).To(Equal(options.Group + "." + options.Domain))
 					Expect(resource.PackageName()).To(Equal(options.Group))
 					Expect(resource.ImportAlias()).To(Equal(options.Group + options.Version))
@@ -129,6 +148,8 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -149,6 +170,8 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -167,12 +190,15 @@ var _ = Describe("Options", func() {
 					Domain:  "test.io",
 					Version: "v1",
 					Kind:    "FirstMate",
+					DoAPI:   true, // Scaffold the API so that the path is saved
 				}
 				Expect(options.Validate()).To(Succeed())
 
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
@@ -200,6 +226,8 @@ var _ = Describe("Options", func() {
 			for _, multiGroup := range []bool{false, true} {
 				if multiGroup {
 					Expect(cfg.SetMultiGroup()).To(Succeed())
+				} else {
+					Expect(cfg.ClearMultiGroup()).To(Succeed())
 				}
 
 				resource := options.NewResource(cfg)
@@ -221,12 +249,15 @@ var _ = Describe("Options", func() {
 				for _, multiGroup := range []bool{false, true} {
 					if multiGroup {
 						Expect(cfg.SetMultiGroup()).To(Succeed())
+					} else {
+						Expect(cfg.ClearMultiGroup()).To(Succeed())
 					}
 
 					resource := options.NewResource(cfg)
 					Expect(resource.Validate()).To(Succeed())
 					Expect(resource.Path).To(Equal(path.Join("k8s.io", "api", options.Group, options.Version)))
-					Expect(resource.API.CRDVersion).To(Equal(""))
+					Expect(resource.API).NotTo(BeNil())
+					Expect(resource.API.IsEmpty()).To(BeTrue())
 					Expect(resource.QualifiedGroup()).To(Equal(qualified))
 				}
 			},

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
@@ -72,7 +72,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	{{ if .Resource.HasAPI -}}
+	{{ if not (isEmptyStr .Resource.Path) -}}
 	{{ .Resource.ImportAlias }} "{{ .Resource.Path }}"
 	{{- end }}
 )
@@ -108,7 +108,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(req ctrl.Request) (ctrl.Resul
 // SetupWithManager sets up the controller with the Manager.
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		{{ if .Resource.HasAPI -}}
+		{{ if not (isEmptyStr .Resource.Path) -}}
 		For(&{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}).
 		{{- else -}}
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -98,13 +98,13 @@ func (f *SuiteTest) GetCodeFragments() file.CodeFragmentsMap {
 
 	// Generate import code fragments
 	imports := make([]string, 0)
-	if f.Resource.HasAPI() {
+	if f.Resource.Path != "" {
 		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias(), f.Resource.Path))
 	}
 
 	// Generate add scheme code fragments
 	addScheme := make([]string, 0)
-	if f.Resource.HasAPI() {
+	if f.Resource.Path != "" {
 		addScheme = append(addScheme, fmt.Sprintf(addschemeCodeFragment, f.Resource.ImportAlias()))
 	}
 

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -176,8 +176,8 @@ func (p *createAPISubcommand) Validate() error {
 	}
 
 	// In case we want to scaffold a resource API we need to do some checks
-	if p.resource.HasAPI() {
-		// Check that resource doesn't exist or flag force was set
+	if p.options.DoAPI {
+		// Check that resource doesn't have the API scaffolded or flag force was set
 		if res, err := p.config.GetResource(p.resource.GVK); err == nil && res.HasAPI() && !p.force {
 			return errors.New("API resource already exists")
 		}

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -86,11 +86,11 @@ func (s *apiScaffolder) scaffold() error {
 	doAPI := s.resource.HasAPI()
 	doController := s.resource.HasController()
 
-	if doAPI {
+	if err := s.config.UpdateResource(s.resource); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
 
-		if err := s.config.UpdateResource(s.resource); err != nil {
-			return fmt.Errorf("error updating resource: %w", err)
-		}
+	if doAPI {
 
 		if err := machinery.NewScaffold(s.plugins...).Execute(
 			s.newUniverse(),

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
@@ -72,7 +72,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	{{ if .Resource.HasAPI -}}
+	{{ if not (isEmptyStr .Resource.Path) -}}
 	{{ .Resource.ImportAlias }} "{{ .Resource.Path }}"
 	{{- end }}
 )
@@ -108,7 +108,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 // SetupWithManager sets up the controller with the Manager.
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		{{ if .Resource.HasAPI -}}
+		{{ if not (isEmptyStr .Resource.Path) -}}
 		For(&{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}).
 		{{- else -}}
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -98,13 +98,13 @@ func (f *SuiteTest) GetCodeFragments() file.CodeFragmentsMap {
 
 	// Generate import code fragments
 	imports := make([]string, 0)
-	if f.Resource.HasAPI() {
+	if f.Resource.Path != "" {
 		imports = append(imports, fmt.Sprintf(apiImportCodeFragment, f.Resource.ImportAlias(), f.Resource.Path))
 	}
 
 	// Generate add scheme code fragments
 	addScheme := make([]string, 0)
-	if f.Resource.HasAPI() {
+	if f.Resource.Path != "" {
 		addScheme = append(addScheme, fmt.Sprintf(addschemeCodeFragment, f.Resource.ImportAlias()))
 	}
 

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v3
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -119,7 +118,7 @@ func (p *createWebhookSubcommand) Validate() error {
 	if r, err := p.config.GetResource(p.resource.GVK); err != nil {
 		return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
 	} else if r.Webhooks != nil && !r.Webhooks.IsEmpty() && !p.force {
-		return errors.New("webhook resource already exists")
+		return fmt.Errorf("webhook resource already exists")
 	}
 
 	if !p.config.IsWebhookVersionCompatible(p.resource.Webhooks.WebhookVersion) {

--- a/testdata/project-v2-multigroup/config/rbac/role.yaml
+++ b/testdata/project-v2-multigroup/config/rbac/role.yaml
@@ -9,7 +9,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - pods
+  - deployments
   verbs:
   - create
   - delete
@@ -21,7 +21,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - pods/status
+  - deployments/status
   verbs:
   - get
   - patch

--- a/testdata/project-v2-multigroup/controllers/apps/deployment_controller.go
+++ b/testdata/project-v2-multigroup/controllers/apps/deployment_controller.go
@@ -14,39 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apps
+package controllers
 
 import (
 	"context"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// PodReconciler reconciles a Pod object
-type PodReconciler struct {
+// DeploymentReconciler reconciles a Deployment object
+type DeploymentReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apps,resources=pods/finalizers,verbs=update
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by
-// the Pod object against the actual cluster state, and then
+// the Deployment object against the actual cluster state, and then
 // perform operations to make the cluster state reflect the state specified by
 // the user.
 //
 // For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
-func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = r.Log.WithValues("pod", req.NamespacedName)
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
+func (r *DeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	_ = context.Background()
+	_ = r.Log.WithValues("deployment", req.NamespacedName)
 
 	// your logic here
 
@@ -54,9 +55,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
-		// For().
+		For(&appsv1.Deployment{}).
 		Complete(r)
 }

--- a/testdata/project-v2-multigroup/controllers/apps/suite_test.go
+++ b/testdata/project-v2-multigroup/controllers/apps/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +60,9 @@ var _ = BeforeSuite(func(done Done) {
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
+
+	err = appsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 

--- a/testdata/project-v2-multigroup/go.mod
+++ b/testdata/project-v2-multigroup/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
+	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	sigs.k8s.io/controller-runtime v0.6.4

--- a/testdata/project-v2-multigroup/main.go
+++ b/testdata/project-v2-multigroup/main.go
@@ -155,12 +155,12 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "HealthCheckPolicy")
 		os.Exit(1)
 	}
-	if err = (&appscontroller.PodReconciler{
+	if err = (&appscontroller.DeploymentReconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Pod"),
+		Log:    ctrl.Log.WithName("controllers").WithName("Deployment"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Pod")
+		setupLog.Error(err, "unable to create controller", "controller", "Deployment")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/testdata/project-v3-config/PROJECT
+++ b/testdata/project-v3-config/PROJECT
@@ -40,4 +40,9 @@ resources:
   webhooks:
     defaulting: true
     webhookVersion: v1
+- controller: true
+  domain: testproject.org
+  group: crew
+  kind: Laker
+  version: v1
 version: "3"

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -78,6 +78,11 @@ resources:
   kind: HealthCheckPolicy
   path: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup/apis/foo.policy/v1
   version: v1
+- controller: true
+  group: apps
+  kind: Deployment
+  path: k8s.io/api/apps/v1
+  version: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/testdata/project-v3-multigroup/config/rbac/role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/role.yaml
@@ -9,7 +9,7 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - pods
+  - deployments
   verbs:
   - create
   - delete
@@ -21,13 +21,13 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - pods/finalizers
+  - deployments/finalizers
   verbs:
   - update
 - apiGroups:
   - apps
   resources:
-  - pods/status
+  - deployments/status
   verbs:
   - get
   - patch

--- a/testdata/project-v3-multigroup/controllers/apps/deployment_controller.go
+++ b/testdata/project-v3-multigroup/controllers/apps/deployment_controller.go
@@ -14,39 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package apps
 
 import (
 	"context"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// PodReconciler reconciles a Pod object
-type PodReconciler struct {
+// DeploymentReconciler reconciles a Deployment object
+type DeploymentReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=apps,resources=pods,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=pods/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // TODO(user): Modify the Reconcile function to compare the state specified by
-// the Pod object against the actual cluster state, and then
+// the Deployment object against the actual cluster state, and then
 // perform operations to make the cluster state reflect the state specified by
 // the user.
 //
 // For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.6.4/pkg/reconcile
-func (r *PodReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.Log.WithValues("pod", req.NamespacedName)
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = r.Log.WithValues("deployment", req.NamespacedName)
 
 	// your logic here
 
@@ -54,9 +55,8 @@ func (r *PodReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
-		// For().
+		For(&appsv1.Deployment{}).
 		Complete(r)
 }

--- a/testdata/project-v3-multigroup/controllers/apps/suite_test.go
+++ b/testdata/project-v3-multigroup/controllers/apps/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +60,9 @@ var _ = BeforeSuite(func() {
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
+
+	err = appsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -169,12 +169,12 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "HealthCheckPolicy")
 		os.Exit(1)
 	}
-	if err = (&appscontrollers.PodReconciler{
+	if err = (&appscontrollers.DeploymentReconciler{
 		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("apps").WithName("Pod"),
+		Log:    ctrl.Log.WithName("controllers").WithName("apps").WithName("Deployment"),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Pod")
+		setupLog.Error(err, "unable to create controller", "controller", "Deployment")
 		os.Exit(1)
 	}
 	if err = (&controllers.LakersReconciler{

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -40,4 +40,9 @@ resources:
   webhooks:
     defaulting: true
     webhookVersion: v1
+- controller: true
+  domain: testproject.org
+  group: crew
+  kind: Laker
+  version: v1
 version: "3"


### PR DESCRIPTION
When an API is not scaffolded (`kubebuilder create api --resource=false --controller ...`) the resources are not being tracked in the config file. Tracking this in `config/v3` is doable as we can still know if the API was scaffolded by some of its fields, but as `config/v2` doesn't have this additional fields, it can't track this resources. The reason for this is that the pressence of a resource in `config/v2` means that the API was scaffolded at webhook validation (they require the API to be scaffolded) and this information won't be obtainable.

This change also detected that we were defining the `Path` field for those resources that do not have an API which was removed, and it allows to be a bit more intelligent when deploying core-resources.

Fixes #2001
Fixes #2002