### PR TITLE
:seedling: revert tools tarball name to old format

### DIFF
--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,14 +13,14 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: v1.19.2
+  _KUBERNETES_VERSION: 1.19.2
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [
     "build",
     "--build-arg", "OS=${_GOOS}",
     "--build-arg", "ARCH=${_GOARCH}",
-    "--build-arg", "KUBERNETES_VERSION=${_KUBERNETES_VERSION}",
+    "--build-arg", "KUBERNETES_VERSION=v${_KUBERNETES_VERSION}",
     "-t", "gcr.io/kubebuilder/thirdparty-${_GOOS}-${_GOARCH}:${_KUBERNETES_VERSION}",
     "./build/thirdparty/${_GOOS}",
   ]


### PR DESCRIPTION
build/cloudbuild_tools.yaml: remove 'v' prefix from _KUBERNETES_VERSION to keep old tarball name format

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>
