### PR TITLE
🌱 Add Adirio to aprovers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,12 +13,12 @@ aliases:
   kubebuilder-approvers:
     - camilamacedo86
     - estroz
+    - adirio
 
   # folks who can review and LGTM any PRs in the repo (doesn't include
   # approvers & admins -- those count too via the OWNERS file)
   kubebuilder-reviewers:
     - joelanford
-    - adirio
 
   # folks who may have context on ancient history,
   # but are no longer directly involved


### PR DESCRIPTION
As of https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/CONTRIBUTING-ROLES.md#becoming-an-approver
- I've been a reviewer for almost a year, couple of months are required
- I would say I've been the "main" reviewer or contributor of more than 5-10 substantial contributions