### PR TITLE
📖 Update static book examples to Kubebuilder v3.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/emptyapi.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptyapi.go
@@ -68,8 +68,9 @@ a Kind.  Then, the `object` generator generates an implementation of the
 interface that all types representing Kinds must implement.
 */
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -79,7 +80,7 @@ type CronJob struct {
 	Status CronJobStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // CronJobList contains a list of CronJob
 type CronJobList struct {

--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -77,8 +77,7 @@ logging works by attaching key-value pairs to a static message.  We can pre-assi
 some pairs at the top of our reconcile method to have those attached to all log
 lines in this reconciler.
 */
-func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
+func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("cronjob", req.NamespacedName)
 
 	// your logic here

--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -34,11 +34,18 @@ import (
 // +kubebuilder:docs-gen:collapse=Imports
 
 /*
+By default, kubebuilder will include the RBAC rules necessary to update finalizers for CronJobs.
+*/
+
+//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
+
+/*
 The code snippet below shows skeleton code for implementing a finalizer.
 */
 
-func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	ctx := context.Background()
+func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("cronjob", req.NamespacedName)
 
 	var cronJob *batchv1.CronJob
@@ -60,7 +67,7 @@ func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// registering our finalizer.
 		if !containsString(cronJob.GetFinalizers(), myFinalizerName) {
 			cronJob.SetFinalizers(append(cronJob.GetFinalizers(), myFinalizerName))
-			if err := r.Update(context.Background(), cronJob); err != nil {
+			if err := r.Update(ctx, cronJob); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -76,7 +83,7 @@ func (r *CronJobReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 			// remove our finalizer from the list and update it.
 			cronJob.SetFinalizers(removeString(cronJob.GetFinalizers(), myFinalizerName))
-			if err := r.Update(context.Background(), cronJob); err != nil {
+			if err := r.Update(ctx, cronJob); err != nil {
 				return ctrl.Result{}, err
 			}
 		}


### PR DESCRIPTION
While working on the "Watching" documentation, I noticed that there were other examples in the book that had not yet been updated from v2 to v3.

This PR is pretty simple, and just updating the code differences with starting an empty project using v3.

For the finalizers, I added the RBAC finalizer permission as well, since that is available in v3.

The biggest difference is in `emptymain.go`, since there is a lot more generated code in v3 than in v2. I can scale the changes back for that file, but it now represents what a user would see when creating a new v3 project.