### PR TITLE
🐛 Fix the bug where an error was being hidden by a potentially valid flag not being recognized by the root command

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -49,6 +49,10 @@ func (c cli) newRootCmd() *cobra.Command {
 	fs.String(projectVersionFlag, "", "project version")
 	fs.StringSlice(pluginsFlag, nil, "plugin keys of the plugin to initialize the project with")
 
+	// As the root command will be used to shot the help message under some error conditions,
+	// like during plugin resolving, we need to allow unknown flags to prevent parsing errors.
+	cmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
+
 	return cmd
 }
 


### PR DESCRIPTION
By telling the root command that it should not error out if found unknown flags we ensure that the error that made us print the root help message is surfaced instead of being hidden behind the `unknown flag: --flag` bug.

Fixes: #2022
