### PR TITLE
🌱 Enable cross-package coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test-unit: ## Run the unit tests
 .PHONY: test-coverage
 test-coverage: ## Run unit tests creating the output to report coverage
 	- rm -rf *.out  # Remove all coverage files if exists
-	go test -race -failfast -tags=integration -coverprofile=coverage-all.out ./cmd/... ./pkg/... ./plugins/...
+	go test -race -failfast -tags=integration -coverprofile=coverage-all.out -coverpkg="./pkg/cli/...,./pkg/config/...,./pkg/internal/...,./pkg/model/...,./pkg/plugin/...,./pkg/plugins/golang,./pkg/plugins/internal/..." ./pkg/...
 
 .PHONY: test-integration
 test-integration: ## Run the integration tests


### PR DESCRIPTION
By default coverage only is accounted for LoC in the same package as the tests.
If you provide `-coverpkg` you can specify a list of packages that will be taken into account when creating the coverage report.
This allows tests in a package to be used to provide coverage for other packages in the provided list.

### Impact on covered files
As a side-effect, the list of files that are being covered is slightly different.

The following files were considered previously by coverage and are no longer:
- [ ] `pkg/plugins/golang/v2/api.go`
- [ ] `pkg/plugins/golang/v2/edit.go`
- [ ] `pkg/plugins/golang/v2/init.go`
- [ ] `pkg/plugins/golang/v2/options.go`
- [ ] `pkg/plugins/golang/v2/plugin.go`
- [ ] `pkg/plugins/golang/v2/webhook.go`

All of them, exept for `pkg/plugins/golang/v2/options.go` were not being tested and had a 0% coverage, as this is being tested with integration tests. Loosing coverage on `pkg/plugins/golang/v2/options.go` which is at a 96.5% covered doesn't seem to big of an issue. Additionally, this file is going to disapear in plugin phase 1.5.

On the other hand, files that were not considered previously by coverage are being taken into account now:
- [x] `pkg/internal/validation/dns.go`
- [x] `pkg/model/file/errors.go`
- [x] `pkg/model/file/funcmap.go`
- [x] `pkg/model/file/marker.go`
- [x] `pkg/model/file/mixins.go`
- [x] `pkg/model/plugin.go`
- [x] `pkg/model/universe.go`
- [x] `pkg/plugins/internal/cmdutil/cmdutil.go`

So summing up, we are just removing coverage from a file that is going to disapear and currently has 96.5% to add 8 new files that will stay and were not covered before.