### PR TITLE
🌱 Update old TODOs that are no longer valid

### DIFF
--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -499,8 +499,7 @@ var _ = Describe("cfg", func() {
 					},
 				},
 			}
-			// TODO: include cases with Plural, Path, API.namespaced, Controller, Webhooks.Defaulting,
-			//       Webhooks.Validation and Webhooks.Conversion when added
+			// TODO: include cases with Path when added
 			s1 = `domain: my.domain
 layout: go.kubebuilder.io/v2
 projectName: ProjectName

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/main.go
@@ -92,9 +92,6 @@ const (
 `
 	controllerImportCodeFragment = `"%s/controllers"
 `
-	// TODO(v3): `&%scontrollers` should be used instead of `&%scontroller` as there may be multiple
-	//  controller for different Kinds in the same group. However, this is a backwards incompatible
-	//  change, and thus should be done for next project version.
 	multiGroupControllerImportCodeFragment = `%scontroller "%s/controllers/%s"
 `
 	addschemeCodeFragment = `utilruntime.Must(%s.AddToScheme(scheme))
@@ -108,9 +105,6 @@ const (
 		os.Exit(1)
 	}
 `
-	// TODO(v3): loggers for the same Kind controllers from different groups use the same logger.
-	//  `.WithName("controllers").WithName(GROUP).WithName(KIND)` should be used instead. However,
-	//  this is a backwards incompatible change, and thus should be done for next project version.
 	multiGroupReconcilerSetupCodeFragment = `if err = (&%scontroller.%sReconciler{
 		Client: mgr.GetClient(),
 		Log: ctrl.Log.WithName("controllers").WithName("%s"),


### PR DESCRIPTION
The TODOs about v3 were already applied, removed them.
The TODO about the resource fields stored in the config file is out of date, updated it.