### PR TITLE
✨: Add go mod tidy to be executed after the scaffolding api

### DIFF
--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -207,6 +207,11 @@ func (p *createAPISubcommand) PostScaffold() error {
 		return fmt.Errorf("unknown pattern %q", p.pattern)
 	}
 
+	err := util.RunCmd("Update dependencies", "go", "mod", "tidy")
+	if err != nil {
+		return err
+	}
+
 	if p.runMake { // TODO: check if API was scaffolded
 		return util.RunCmd("Running make", "make", "generate")
 	}

--- a/pkg/plugins/golang/v2/init.go
+++ b/pkg/plugins/golang/v2/init.go
@@ -178,7 +178,7 @@ func (p *initSubcommand) PostScaffold() error {
 		return err
 	}
 
-	err = util.RunCmd("Update go.mod", "go", "mod", "tidy")
+	err = util.RunCmd("Update dependencies", "go", "mod", "tidy")
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -237,6 +237,11 @@ func (p *createAPISubcommand) PostScaffold() error {
 		return fmt.Errorf("unknown pattern %q", p.pattern)
 	}
 
+	err := util.RunCmd("Update dependencies", "go", "mod", "tidy")
+	if err != nil {
+		return err
+	}
+
 	if p.runMake { // TODO: check if API was scaffolded
 		return util.RunCmd("Running make", "make", "generate")
 	}

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -180,7 +180,7 @@ func (p *initSubcommand) PostScaffold() error {
 		return err
 	}
 
-	err = util.RunCmd("Update go.mod", "go", "mod", "tidy")
+	err = util.RunCmd("Update dependencies", "go", "mod", "tidy")
 	if err != nil {
 		return err
 	}

--- a/testdata/project-v2-addon/go.mod
+++ b/testdata/project-v2-addon/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/onsi/ginkgo v1.12.1
+	github.com/onsi/gomega v1.10.1
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	sigs.k8s.io/controller-runtime v0.6.4

--- a/testdata/project-v2-multigroup/go.mod
+++ b/testdata/project-v2-multigroup/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/onsi/ginkgo v1.12.1
+	github.com/onsi/gomega v1.10.1
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6

--- a/testdata/project-v2/go.mod
+++ b/testdata/project-v2/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-logr/logr v0.1.0
+	github.com/onsi/ginkgo v1.12.1
+	github.com/onsi/gomega v1.10.1
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	sigs.k8s.io/controller-runtime v0.6.4

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	sigs.k8s.io/controller-runtime v0.7.0

--- a/testdata/project-v3-config/go.mod
+++ b/testdata/project-v3-config/go.mod
@@ -4,6 +4,9 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
+	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	sigs.k8s.io/controller-runtime v0.7.0

--- a/testdata/project-v3-multigroup/go.mod
+++ b/testdata/project-v3-multigroup/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
 	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2

--- a/testdata/project-v3/go.mod
+++ b/testdata/project-v3/go.mod
@@ -4,6 +4,9 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/gomega v1.10.2
+	k8s.io/api v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	sigs.k8s.io/controller-runtime v0.7.0


### PR DESCRIPTION
This PR adds an extra step in the API creation subcommand to update `go.mod` after scaffolding the API to make sure we have a fresh `go.mod` in cases of new dependencies introduced by the generated controllers.
 
### My setup
* Go: 1.16 darwin/arm64
* Kubebuilder: version.Version{KubeBuilderVersion:"2.3.2", KubernetesVendor:"unknown", GitCommit:"5da27b892ae310e875c8719d94a5a04302c597d0", BuildDate:"2021-02-22T21:16:26-08:00", GoOs:"darwin", GoArch:"arm64"}
* operator-sdk: v1.4.2, commit: "4b083393be65589358b3e0416573df04f4ae8d9b
* Kubernetes: v1.19.4

### What is the issue? 
Initially, I used the `operator-sdk` to create a new operator, but, after creating an API I stumbled upon the following issue:
```
$ operator-sdk init --domain example.com --repo github.com/example/memcached-operator
$ operator-sdk create api --group cache --version v1alpha1 --kind Memcached --resource --controller
Writing scaffold for you to edit...
api/v1alpha1/memcached_types.go
controllers/memcached_controller.go
....
/Users/xxxxxx/memcached-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Error: go [-e -json -compiled=true -test=false -export=false -deps=true -find=false -tags ignore_autogenerated -- ./...]: exit status 1: go: github.com/example/memcached-operator/controllers: package github.com/go-logr/logr imported from implicitly required module; to add missing requirements, run:
        go get github.com/go-logr/logr@v0.3.0
....

FATA[0000] failed to create API with "go.kubebuilder.io/v3": exit status 2
```

Then, after investigating the code, I found that the error was coming from kubebuilder code and consequently, I looked at generating the controller via `kubebuilder` to double-check. After running the basic commands, I got the same error:

```
$ kubebuilder init --domain my.domain
$ kubebuilder create api --group webapp --version v1 --kind Guestbook
...
/Users/xxxxx/go/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Error: go [list -e -json -compiled=true -test=false -export=false -deps=true -find=false -tags ignore_autogenerated -- ./...]: exit status 1: go: example/controllers: package github.com/go-logr/logr imported from implicitly required module; to add missing requirements, run:
        go get github.com/go-logr/logr@v0.1.0
....
run `controller-gen object:headerFile=hack/boilerplate.go.txt paths=./... -w` to see all available markers, or `controller-gen object:headerFile=hack/boilerplate.go.txt paths=./... -h` for usage
make: *** [generate] Error 1
2021/02/24 22:24:31 failed to create API: exit status 2
```

Then, to double-check I executed the tests of a fresh clone of the kubebuilder repo and I received the same error:

```
$ make test
....
Preparing test directory /tmp/kubebuilder/test
Running kubebuilder commands in test directory /tmp/kubebuilder/test
Restoring cached project 'init'
Creating api and controller
Create Resource [y/n]
Create Controller [y/n]
Writing scaffold for you to edit...
api/v1beta1/bee_types.go
controllers/bee_controller.go
Running make:
$ make generate
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
go get: added sigs.k8s.io/controller-tools v0.4.1
/tmp/kubebuilder/test/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Error: go [-e -json -compiled=true -test=false -export=false -deps=true -find=false -tags ignore_autogenerated -- ./...]: exit status 1: go: kubebuilder.io/test/controllers: package github.com/go-logr/logr imported from implicitly required module; to add missing requirements, run:
        go get github.com/go-logr/logr@v0.3.0
....
2021/02/24 22:33:24 failed to create API with "go.kubebuilder.io/v3": exit status 2
make: *** [test-integration] Error 1
```

### How I solved the issue

Instead of introducing `go mod tidy` in the Makefile template, I decided to add it in the `PostScaffolding` func of API creation subcommand for both v2 and v3, since a similar action is done in [init](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/v3/init.go#L183) subcommand as well.

After I made the code changes, the tests in kubebuilder passed successfully. Also, I executed `make generate` to update the mock data for this PR. 

PTAL. I am open to alternative solutions, in case this one is adding extra complexity.
