### PR TITLE
🌱  Update golangci lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Execute golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29        # Always uses the latest patch version.
+          version: v1.37        # Always uses the latest patch version.
           only-new-issues: true # Show only new issues if it's a pull request
 
   testdata:

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.29.0 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.37.1 ;\
 	}
 
 ##@ Tests

--- a/pkg/internal/validation/dns.go
+++ b/pkg/internal/validation/dns.go
@@ -40,10 +40,10 @@ type dnsValidationConfig struct {
 }
 
 var dns1123LabelConfig = dnsValidationConfig{
-	format:   dns1123LabelFmt,
-	maxLen:   56, // = 63 - len("-system")
-	re:       regexp.MustCompile("^" + dns1123LabelFmt + "$"),
-	errMsg:   "a DNS-1123 label must consist of lower case alphanumeric characters or '-', " +
+	format: dns1123LabelFmt,
+	maxLen: 56, // = 63 - len("-system")
+	re:     regexp.MustCompile("^" + dns1123LabelFmt + "$"),
+	errMsg: "a DNS-1123 label must consist of lower case alphanumeric characters or '-', " +
 		"and must start and end with an alphanumeric character",
 	examples: []string{"example.com"},
 }


### PR DESCRIPTION
Currently, we are using older version of golangci-lint. 
To keep ourselves updated with the new changes and to not stumble upon any future surprises, I feel that we should be updating this golangci-lint version to latest.

BTW, this is my first contribution to this repo.