### PR TITLE
⚠️ Explicitly define WithCompletion as an Option

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ func main() {
 		),
 		cli.WithDefaultPlugins(cfgv2.Version, &pluginv2.Plugin{}),
 		cli.WithDefaultPlugins(cfgv3.Version, &pluginv3.Plugin{}),
-		cli.WithCompletion,
+		cli.WithCompletion(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -680,7 +680,7 @@ var _ = Describe("CLI", func() {
 
 		When("enabling completion", func() {
 			It("should create a valid CLI", func() {
-				c, err = New(WithCompletion)
+				c, err = New(WithCompletion())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hasSubCommand(c, "completion")).To(BeTrue())
 			})

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -105,7 +105,9 @@ func WithExtraCommands(cmds ...*cobra.Command) Option {
 }
 
 // WithCompletion is an Option that adds the completion subcommand.
-func WithCompletion(c *cli) error {
-	c.completionCommand = true
-	return nil
+func WithCompletion() Option {
+	return func(c *cli) error {
+		c.completionCommand = true
+		return nil
+	}
 }

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -230,7 +230,7 @@ var _ = Describe("CLI options", func() {
 		})
 
 		It("should add the completion command if requested", func() {
-			c, err = newCLI(WithCompletion)
+			c, err = newCLI(WithCompletion())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).NotTo(BeNil())
 			Expect(c.completionCommand).To(BeTrue())


### PR DESCRIPTION
Output of `go doc ./pkg/cli`:

Current state:
```
package cli // import "sigs.k8s.io/kubebuilder/v3/pkg/cli"

func WithCompletion(c *cli) error
type CLI interface{ ... }
    func New(opts ...Option) (CLI, error)
type Option func(*cli) error
    func WithCommandName(name string) Option
    func WithDefaultPlugins(projectVersion config.Version, plugins ...plugin.Plugin) Option
    func WithDefaultProjectVersion(version config.Version) Option
    func WithExtraCommands(cmds ...*cobra.Command) Option
    func WithPlugins(plugins ...plugin.Plugin) Option
    func WithVersion(version string) Option
```

With this PR:
```
package cli // import "sigs.k8s.io/kubebuilder/v3/pkg/cli"

type CLI interface{ ... }
    func New(opts ...Option) (CLI, error)
type Option func(*cli) error
    func WithCommandName(name string) Option
    func WithCompletion() Option
    func WithDefaultPlugins(projectVersion config.Version, plugins ...plugin.Plugin) Option
    func WithDefaultProjectVersion(version config.Version) Option
    func WithExtraCommands(cmds ...*cobra.Command) Option
    func WithPlugins(plugins ...plugin.Plugin) Option
    func WithVersion(version string) Option
```

Closes: #2044