### PR TITLE
⚠️ Use a single set of default plugins instead of one per project version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,6 @@ import (
 	"log"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/cli"
-	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
 	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
 	pluginv2 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2"
 	pluginv3 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3"
@@ -35,8 +34,7 @@ func main() {
 			&pluginv2.Plugin{},
 			&pluginv3.Plugin{},
 		),
-		cli.WithDefaultPlugins(cfgv2.Version, &pluginv2.Plugin{}),
-		cli.WithDefaultPlugins(cfgv3.Version, &pluginv3.Plugin{}),
+		cli.WithDefaultPlugins(&pluginv3.Plugin{}),
 		cli.WithCompletion(),
 	)
 	if err != nil {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -108,7 +108,7 @@ var _ = Describe("CLI", func() {
 				projectVersion, plugins, err = c.getInfoFromFlags()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(projectVersion).To(Equal("2"))
-				Expect(len(plugins)).To(Equal(0))
+				Expect(plugins).To(Equal([]string{"go.kubebuilder.io/v2"}))
 			})
 		})
 
@@ -197,14 +197,14 @@ var _ = Describe("CLI", func() {
 				projectVersion, plugins, err = getInfoFromConfig(projectConfig)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(projectVersion.Compare(projectConfig.GetVersion())).To(Equal(0))
-				Expect(len(plugins)).To(Equal(0))
+				Expect(plugins).To(Equal([]string{"go.kubebuilder.io/v2"}))
 			})
 		})
 
 		When("having layout field", func() {
 			It("should succeed", func() {
 				projectConfig = cfgv3.New()
-				Expect(projectConfig.SetLayout("go.kubebuilder.io/v2")).To(Succeed())
+				Expect(projectConfig.SetLayout("go.kubebuilder.io/v3")).To(Succeed())
 				projectVersion, plugins, err = getInfoFromConfig(projectConfig)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(projectVersion.Compare(projectConfig.GetVersion())).To(Equal(0))
@@ -411,10 +411,7 @@ var _ = Describe("CLI", func() {
 				It("should succeed", func() {
 					c = &cli{
 						defaultProjectVersion: projectVersion1,
-						defaultPlugins: map[config.Version][]string{
-							projectVersion1: {pluginKey1},
-							projectVersion2: {pluginKey2},
-						},
+						defaultPlugins:        []string{pluginKey1},
 					}
 					_, plugins, err = c.resolveFlagsAndConfigFileConflicts(
 						"",
@@ -463,9 +460,7 @@ var _ = Describe("CLI", func() {
 			When("having default plugin keys set and from flags", func() {
 				It("should succeed", func() {
 					c = &cli{
-						defaultPlugins: map[config.Version][]string{
-							{}: {pluginKey1},
-						},
+						defaultPlugins: []string{pluginKey1},
 					}
 					_, plugins, err = c.resolveFlagsAndConfigFileConflicts(
 						"",
@@ -482,9 +477,7 @@ var _ = Describe("CLI", func() {
 			When("having default plugin keys set and from config file", func() {
 				It("should succeed", func() {
 					c = &cli{
-						defaultPlugins: map[config.Version][]string{
-							{}: {pluginKey1},
-						},
+						defaultPlugins: []string{pluginKey1},
 					}
 					_, plugins, err = c.resolveFlagsAndConfigFileConflicts(
 						"",
@@ -528,9 +521,7 @@ var _ = Describe("CLI", func() {
 		When("having three plugin keys sources", func() {
 			It("should succeed if plugin keys from flags and config file are the same", func() {
 				c = &cli{
-					defaultPlugins: map[config.Version][]string{
-						{}: {pluginKey1},
-					},
+					defaultPlugins: []string{pluginKey1},
 				}
 				_, plugins, err = c.resolveFlagsAndConfigFileConflicts(
 					"",
@@ -545,9 +536,7 @@ var _ = Describe("CLI", func() {
 
 			It("should fail if plugin keys from flags and config file are different", func() {
 				c = &cli{
-					defaultPlugins: map[config.Version][]string{
-						{}: {pluginKey1},
-					},
+					defaultPlugins: []string{pluginKey1},
 				}
 				_, _, err = c.resolveFlagsAndConfigFileConflicts(
 					"",
@@ -582,9 +571,7 @@ var _ = Describe("CLI", func() {
 			pluginKeys := []string{"go.kubebuilder.io/v2"}
 			c := &cli{
 				defaultProjectVersion: projectVersion,
-				defaultPlugins: map[config.Version][]string{
-					projectVersion: pluginKeys,
-				},
+				defaultPlugins:        pluginKeys,
 			}
 			c.cmd = c.newRootCmd()
 			Expect(c.getInfo()).To(Succeed())
@@ -745,7 +732,7 @@ var _ = Describe("CLI", func() {
 
 				c, err = New(
 					WithDefaultProjectVersion(projectVersion),
-					WithDefaultPlugins(projectVersion, deprecatedPlugin),
+					WithDefaultPlugins(deprecatedPlugin),
 					WithPlugins(deprecatedPlugin),
 				)
 				_ = w.Close()

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -57,22 +57,16 @@ func WithDefaultProjectVersion(version config.Version) Option {
 }
 
 // WithDefaultPlugins is an Option that sets the cli's default plugins.
-func WithDefaultPlugins(projectVersion config.Version, plugins ...plugin.Plugin) Option {
+func WithDefaultPlugins(plugins ...plugin.Plugin) Option {
 	return func(c *cli) error {
-		if err := projectVersion.Validate(); err != nil {
-			return fmt.Errorf("broken pre-set project version %q for default plugins: %v", projectVersion, err)
-		}
 		if len(plugins) == 0 {
-			return fmt.Errorf("empty set of plugins provided for project version %q", projectVersion)
+			return fmt.Errorf("empty set of plugins provided")
 		}
 		for _, p := range plugins {
 			if err := plugin.Validate(p); err != nil {
 				return fmt.Errorf("broken pre-set default plugin %q: %v", plugin.KeyFor(p), err)
 			}
-			if !plugin.SupportsVersion(p, projectVersion) {
-				return fmt.Errorf("default plugin %q doesn't support version %q", plugin.KeyFor(p), projectVersion)
-			}
-			c.defaultPlugins[projectVersion] = append(c.defaultPlugins[projectVersion], plugin.KeyFor(p))
+			c.defaultPlugins = append(c.defaultPlugins, plugin.KeyFor(p))
 		}
 		return nil
 	}

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -99,57 +99,43 @@ var _ = Describe("CLI options", func() {
 
 	Context("WithDefaultPlugins", func() {
 		It("should return a valid CLI", func() {
-			c, err = newCLI(WithDefaultPlugins(projectVersion, p))
+			c, err = newCLI(WithDefaultPlugins(p))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c).NotTo(BeNil())
-			Expect(c.defaultPlugins).To(Equal(map[config.Version][]string{projectVersion: {plugin.KeyFor(p)}}))
-		})
-
-		When("providing an invalid project version", func() {
-			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(config.Version{}, p))
-				Expect(err).To(HaveOccurred())
-			})
+			Expect(c.defaultPlugins).To(Equal([]string{plugin.KeyFor(p)}))
 		})
 
 		When("providing an empty set of plugins", func() {
 			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(projectVersion))
+				_, err = newCLI(WithDefaultPlugins())
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		When("providing a plugin with an invalid name", func() {
 			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(projectVersion, np1))
+				_, err = newCLI(WithDefaultPlugins(np1))
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		When("providing a plugin with an invalid version", func() {
 			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(projectVersion, np2))
+				_, err = newCLI(WithDefaultPlugins(np2))
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		When("providing a plugin with an empty list of supported versions", func() {
 			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(projectVersion, np3))
+				_, err = newCLI(WithDefaultPlugins(np3))
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		When("providing a plugin with an invalid list of supported versions", func() {
 			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(projectVersion, np4))
-				Expect(err).To(HaveOccurred())
-			})
-		})
-
-		When("providing a default plugin for an unsupported project version", func() {
-			It("should return an error", func() {
-				_, err = newCLI(WithDefaultPlugins(config.Version{Number: 2}, p))
+				_, err = newCLI(WithDefaultPlugins(np4))
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -74,8 +74,8 @@ configuration please run:
 
 	str += fmt.Sprintf("\nDefault project version: %s\n", c.defaultProjectVersion)
 
-	if defaultPlugins, hasDefaultPlugins := c.defaultPlugins[c.defaultProjectVersion]; hasDefaultPlugins {
-		str += fmt.Sprintf("Default plugin keys: %q\n", strings.Join(defaultPlugins, ","))
+	if len(c.defaultPlugins) != 0 {
+		str += fmt.Sprintf("Default plugin keys: %q\n", strings.Join(c.defaultPlugins, ","))
 	}
 
 	str += fmt.Sprintf(`

--- a/test/e2e/v2/plugin_cluster_test.go
+++ b/test/e2e/v2/plugin_cluster_test.go
@@ -67,6 +67,7 @@ var _ = Describe("kubebuilder", func() {
 			By("init v2 project")
 			err := kbc.Init(
 				"--project-version", "2",
+				"--plugins", "go/v2",
 				"--domain", kbc.Domain,
 				"--fetch-deps=false")
 			Expect(err).Should(Succeed())

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -113,10 +113,10 @@ function scaffold_test_project {
 
 build_kb
 
-# Project version 2 uses plugin go/v2 (default).
-scaffold_test_project project-v2 --project-version=2
-scaffold_test_project project-v2-multigroup --project-version=2
-scaffold_test_project project-v2-addon --project-version=2
+# Project version 2 uses plugin go/v2.
+scaffold_test_project project-v2 --plugins=go/v2 --project-version=2
+scaffold_test_project project-v2-multigroup --plugins=go/v2 --project-version=2
+scaffold_test_project project-v2-addon --plugins=go/v2 --project-version=2
 # Project version 3 (default) uses plugin go/v3 (default).
 scaffold_test_project project-v3
 scaffold_test_project project-v3-multigroup


### PR DESCRIPTION
This PR is the breaking change needed for #1941 and #1942 so that we #2019 no longer blocks v3.0.0 as it will no longer be a breaking change.

The exact same behavior has been maintained for all `kubebuilder init --plugins <PLUGINS> --project-version <PROJECT VERSION>` combination, including the absence of any of these flags.

- Follow up: #2019