### PR TITLE
🐛 default service monitor configuration to use https

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -12,7 +12,7 @@ can be found at `config/rbac/auth_proxy_client_clusterrole.yaml`.
 You will need to grant permissions to your Prometheus server so that it can
 scrape the protected metrics. To achieve that, you can create a
 `clusterRoleBinding` to bind the `clusterRole` to the service account that your
-Prometheus server uses.
+Prometheus server uses. If you are using `kube-prometheus`, this cluster binding already exists.
 
 You can run the following kubectl command to create it. If using kubebuilder
 `<project-prefix>` is the `namePrefix` field in `config/default/kustomization.yaml`.
@@ -26,7 +26,7 @@ kubectl create clusterrolebinding metrics --clusterrole=<project-prefix>-metrics
 Follow the steps below to export the metrics using the Prometheus Operator:
 
 1. Install Prometheus and Prometheus Operator.
-We recommend using [kube-prometheus](https://github.com/coreos/kube-prometheus#installing) 
+We recommend using [kube-prometheus](https://github.com/coreos/kube-prometheus#installing)
 in production if you don't have your own monitoring system.
 If you are just experimenting, you can only install Prometheus and Prometheus Operator.
 2. Uncomment the line `- ../prometheus` in the `config/default/kustomization.yaml`.
@@ -38,21 +38,21 @@ It creates the `ServiceMonitor` resource which enables exporting the metrics.
 ```
 
 Note that, when you install your project in the cluster, it will create the
-`ServiceMonitor` to export the metrics. To check the ServiceMonitor, 
+`ServiceMonitor` to export the metrics. To check the ServiceMonitor,
 run `kubectl get ServiceMonitor -n <project>-system`. See an example:
 
 ```
-$ kubectl get ServiceMonitor -n monitor-system 
+$ kubectl get ServiceMonitor -n monitor-system
 NAME                                         AGE
 monitor-controller-manager-metrics-monitor   2m8s
 ```
 
 Also, notice that the metrics are exported by default through port `8443`. In this way,
-you are able to check the Prometheus metrics in its dashboard. To verify it, search 
-for the metrics exported from the namespace where the project is running 
-`{namespace="<project>-system"}`. See an example: 
+you are able to check the Prometheus metrics in its dashboard. To verify it, search
+for the metrics exported from the namespace where the project is running
+`{namespace="<project>-system"}`. See an example:
 
-<img width="1680" alt="Screenshot 2019-10-02 at 13 07 13" src="https://user-images.githubusercontent.com/7708031/66042888-a497da80-e515-11e9-9d77-d8a9fc1159a5.png">  
+<img width="1680" alt="Screenshot 2019-10-02 at 13 07 13" src="https://user-images.githubusercontent.com/7708031/66042888-a497da80-e515-11e9-9d77-d8a9fc1159a5.png">
 
 ## Publishing Additional Metrics
 

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -53,6 +53,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -53,6 +53,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v2-addon/config/prometheus/monitor.yaml
+++ b/testdata/project-v2-addon/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v2-multigroup/config/prometheus/monitor.yaml
+++ b/testdata/project-v2-multigroup/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v2/config/prometheus/monitor.yaml
+++ b/testdata/project-v2/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v3-addon/config/prometheus/monitor.yaml
+++ b/testdata/project-v3-addon/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v3-config/config/prometheus/monitor.yaml
+++ b/testdata/project-v3-config/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v3-multigroup/config/prometheus/monitor.yaml
+++ b/testdata/project-v3-multigroup/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/testdata/project-v3/config/prometheus/monitor.yaml
+++ b/testdata/project-v3/config/prometheus/monitor.yaml
@@ -11,6 +11,10 @@ spec:
   endpoints:
     - path: /metrics
       port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
By default the ServiceMonitor scrapes `port: https` https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v2/config/prometheus/monitor.yaml#L13, which is exposed by the auth proxy service https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v2/config/rbac/auth_proxy_service.yaml#L10-L12 and requires an https connection https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml#L15

Change the ServiceMonitor configuration to work with that by default as otherwise the scraping fails with a `400 Bad Request`.

Thanks to https://github.com/kubernetes-sigs/kubebuilder/issues/1253#issuecomment-597640633 for the required flags.