### PR TITLE
:sparkles: (go/v3) create and bind to a non-default service account

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -105,6 +105,7 @@ func (s *initScaffolder) scaffold() error {
 		&rbac.RoleBinding{},
 		&rbac.LeaderElectionRole{},
 		&rbac.LeaderElectionRoleBinding{},
+		&rbac.ServiceAccount{},
 		&manager.Kustomization{},
 		&manager.Config{Image: imageName},
 		&manager.ControllerManagerConfig{},

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/manager/config.go
@@ -100,5 +100,6 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/kustomization.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/kustomization.go
@@ -43,6 +43,12 @@ func (f *Kustomization) SetTemplateDefaults() error {
 }
 
 const kustomizeRBACTemplate = `resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/leader_election_role_binding.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/leader_election_role_binding.go
@@ -50,6 +50,6 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/role_binding.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/role_binding.go
@@ -50,6 +50,6 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/service_account.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac/service_account.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,34 +22,27 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
-var _ file.Template = &AuthProxyRoleBinding{}
+var _ file.Template = &ServiceAccount{}
 
-// AuthProxyRoleBinding scaffolds a file that defines the role binding for the auth proxy
-type AuthProxyRoleBinding struct {
+// ServiceAccount scaffolds a file that defines the service account the manager is deployed in.
+type ServiceAccount struct {
 	file.TemplateMixin
 }
 
 // SetTemplateDefaults implements file.Template
-func (f *AuthProxyRoleBinding) SetTemplateDefaults() error {
+func (f *ServiceAccount) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("config", "rbac", "auth_proxy_role_binding.yaml")
+		f.Path = filepath.Join("config", "rbac", "service_account.yaml")
 	}
 
-	f.TemplateBody = proxyRoleBindinggTemplate
+	f.TemplateBody = serviceAccountTemplate
 
 	return nil
 }
 
-const proxyRoleBindinggTemplate = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+const serviceAccountTemplate = `apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: proxy-role
-subjects:
-- kind: ServiceAccount
   name: controller-manager
   namespace: system
 `

--- a/test/e2e/utils/kubectl.go
+++ b/test/e2e/utils/kubectl.go
@@ -27,7 +27,8 @@ import (
 // Kubectl contains context to run kubectl commands
 type Kubectl struct {
 	*CmdContext
-	Namespace string
+	Namespace      string
+	ServiceAccount string
 }
 
 // Command is a general func to run kubectl commands

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -56,8 +56,9 @@ func NewTestContext(binaryName string, env ...string) (*TestContext, error) {
 
 	// Use kubectl to get Kubernetes client and cluster version.
 	kubectl := &Kubectl{
-		Namespace:  fmt.Sprintf("e2e-%s-system", testSuffix),
-		CmdContext: cc,
+		Namespace:      fmt.Sprintf("e2e-%s-system", testSuffix),
+		ServiceAccount: fmt.Sprintf("e2e-%s-controller-manager", testSuffix),
+		CmdContext:     cc,
 	}
 	k8sVersion, err := kubectl.Version()
 	if err != nil {

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -52,4 +52,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/testdata/project-v3-addon/config/rbac/auth_proxy_role_binding.yaml
+++ b/testdata/project-v3-addon/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-addon/config/rbac/kustomization.yaml
+++ b/testdata/project-v3-addon/config/rbac/kustomization.yaml
@@ -1,4 +1,10 @@
 resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/testdata/project-v3-addon/config/rbac/leader_election_role_binding.yaml
+++ b/testdata/project-v3-addon/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-addon/config/rbac/role_binding.yaml
+++ b/testdata/project-v3-addon/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-addon/config/rbac/service_account.yaml
+++ b/testdata/project-v3-addon/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -50,4 +50,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/testdata/project-v3-config/config/rbac/auth_proxy_role_binding.yaml
+++ b/testdata/project-v3-config/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-config/config/rbac/kustomization.yaml
+++ b/testdata/project-v3-config/config/rbac/kustomization.yaml
@@ -1,4 +1,10 @@
 resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/testdata/project-v3-config/config/rbac/leader_election_role_binding.yaml
+++ b/testdata/project-v3-config/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-config/config/rbac/role_binding.yaml
+++ b/testdata/project-v3-config/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-config/config/rbac/service_account.yaml
+++ b/testdata/project-v3-config/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -52,4 +52,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/testdata/project-v3-multigroup/config/rbac/auth_proxy_role_binding.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-multigroup/config/rbac/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/kustomization.yaml
@@ -1,4 +1,10 @@
 resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/testdata/project-v3-multigroup/config/rbac/leader_election_role_binding.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-multigroup/config/rbac/role_binding.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3-multigroup/config/rbac/service_account.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -52,4 +52,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/testdata/project-v3/config/rbac/auth_proxy_role_binding.yaml
+++ b/testdata/project-v3/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3/config/rbac/kustomization.yaml
+++ b/testdata/project-v3/config/rbac/kustomization.yaml
@@ -1,4 +1,10 @@
 resources:
+# All RBAC will be applied under this service account in
+# the deployment namespace. You may comment out this resource
+# if your manager will use a service account that exists at
+# runtime. Be sure to update RoleBinding and ClusterRoleBinding
+# subjects if changing service account names.
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/testdata/project-v3/config/rbac/leader_election_role_binding.yaml
+++ b/testdata/project-v3/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3/config/rbac/role_binding.yaml
+++ b/testdata/project-v3/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/testdata/project-v3/config/rbac/service_account.yaml
+++ b/testdata/project-v3/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
As of now, all managers are deployed under the same service account in a namespace. Although this namespace is unique to the manager initially, it is a common admin pattern to deploy multiple managers under the same namespace for security reasons. This pattern becomes insecure given the current one-service-account-for-all approach, since RBAC will conflict.

This PR adds a ServiceAccount (config/rbac/service_account.yaml) and changes the default service account name from default to controller-manager such that a user can specify which service account their manager should be created in. They may change this value by updating files referencing the metadata.name value in service_account.yaml.

pkg/plugins/golang/v3: update all scaffold referencing the default service account with references to the "controller-manager" service account, specified in service_account.yaml.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

/kind feature
