### PR TITLE
🌱 Fix the config registry public API

### DIFF
--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -16,14 +16,12 @@ limitations under the License.
 
 package config
 
-type constructorFunc func() Config
-
 var (
-	registry = make(map[Version]constructorFunc)
+	registry = make(map[Version]func() Config)
 )
 
 // Register allows implementations of Config to register themselves so that they can be created with New
-func Register(version Version, constructor constructorFunc) {
+func Register(version Version, constructor func() Config) {
 	registry[version] = constructor
 }
 

--- a/pkg/config/resgistry_test.go
+++ b/pkg/config/resgistry_test.go
@@ -28,7 +28,7 @@ var _ = Describe("registry", func() {
 	)
 
 	AfterEach(func() {
-		registry = make(map[Version]constructorFunc)
+		registry = make(map[Version]func() Config)
 	})
 
 	Context("Register", func() {


### PR DESCRIPTION
Remove the unexported `contructorFunc` alias to prevent an exported function have a parameter of an unexported type.

This type was being shown in the [public API](https://pkg.go.dev/sigs.k8s.io/kubebuilder/v3/pkg/config#Register) when it was unexported.
