### PR TITLE
⚠️ Inject filesystem from CLI instead of creating several per command

### DIFF
--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -76,7 +76,7 @@ func (c CLI) bindCreateAPI(ctx plugin.Context, cmd *cobra.Command) {
 		return
 	}
 
-	cfg, err := config.LoadInitialized()
+	cfg, err := config.LoadInitialized(c.fs)
 	if err != nil {
 		cmdErr(cmd, err)
 		return
@@ -88,6 +88,6 @@ func (c CLI) bindCreateAPI(ctx plugin.Context, cmd *cobra.Command) {
 	subcommand.UpdateContext(&ctx)
 	cmd.Long = ctx.Description
 	cmd.Example = ctx.Examples
-	cmd.RunE = runECmdFunc(cfg, subcommand,
+	cmd.RunE = runECmdFunc(c.fs, cfg, subcommand,
 		fmt.Sprintf("failed to create API with %q", plugin.KeyFor(createAPIPlugin)))
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -23,11 +23,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
 	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 )
 
@@ -585,6 +587,7 @@ var _ = Describe("CLI", func() {
 				defaultPlugins: map[config.Version][]string{
 					projectVersion: pluginKeys,
 				},
+				fs: machinery.Filesystem{FS: afero.NewMemMapFs()},
 			}
 			c.cmd = c.newRootCmd()
 			Expect(c.getInfo()).To(Succeed())

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/cli/internal/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 )
 
@@ -48,12 +49,13 @@ func errCmdFunc(err error) func(*cobra.Command, []string) error {
 // runECmdFunc returns a cobra RunE function that runs subcommand and saves the
 // config, which may have been modified by subcommand.
 func runECmdFunc(
+	fs machinery.Filesystem,
 	c *config.Config,
 	subcommand plugin.Subcommand,
 	msg string,
 ) func(*cobra.Command, []string) error {
 	return func(*cobra.Command, []string) error {
-		if err := subcommand.Run(); err != nil {
+		if err := subcommand.Run(fs); err != nil {
 			return fmt.Errorf("%s: %v", msg, err)
 		}
 		return c.Save()

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -76,7 +76,7 @@ func (c CLI) bindEdit(ctx plugin.Context, cmd *cobra.Command) {
 		return
 	}
 
-	cfg, err := config.LoadInitialized()
+	cfg, err := config.LoadInitialized(c.fs)
 	if err != nil {
 		cmdErr(cmd, err)
 		return
@@ -88,6 +88,6 @@ func (c CLI) bindEdit(ctx plugin.Context, cmd *cobra.Command) {
 	subcommand.UpdateContext(&ctx)
 	cmd.Long = ctx.Description
 	cmd.Example = ctx.Examples
-	cmd.RunE = runECmdFunc(cfg, subcommand,
+	cmd.RunE = runECmdFunc(c.fs, cfg, subcommand,
 		fmt.Sprintf("failed to edit project with %q", plugin.KeyFor(editPlugin)))
 }

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -136,7 +136,7 @@ func (c CLI) bindInit(ctx plugin.Context, cmd *cobra.Command) {
 		return
 	}
 
-	cfg, err := internalconfig.New(c.projectVersion, internalconfig.DefaultPath)
+	cfg, err := internalconfig.New(c.fs, c.projectVersion, internalconfig.DefaultPath)
 	if err != nil {
 		cmdErr(cmd, fmt.Errorf("unable to initialize the project configuration: %w", err))
 		return
@@ -151,11 +151,11 @@ func (c CLI) bindInit(ctx plugin.Context, cmd *cobra.Command) {
 	cmd.RunE = func(*cobra.Command, []string) error {
 		// Check if a config is initialized in the command runner so the check
 		// doesn't erroneously fail other commands used in initialized projects.
-		_, err := internalconfig.Read()
+		_, err := internalconfig.Read(c.fs)
 		if err == nil || os.IsExist(err) {
 			log.Fatal("config already initialized")
 		}
-		if err := subcommand.Run(); err != nil {
+		if err := subcommand.Run(c.fs); err != nil {
 			return fmt.Errorf("failed to initialize project with %q: %v", plugin.KeyFor(initPlugin), err)
 		}
 		return cfg.Save()

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -76,7 +76,7 @@ func (c CLI) bindCreateWebhook(ctx plugin.Context, cmd *cobra.Command) {
 		return
 	}
 
-	cfg, err := config.LoadInitialized()
+	cfg, err := config.LoadInitialized(c.fs)
 	if err != nil {
 		cmdErr(cmd, err)
 		return
@@ -88,6 +88,6 @@ func (c CLI) bindCreateWebhook(ctx plugin.Context, cmd *cobra.Command) {
 	subcommand.UpdateContext(&ctx)
 	cmd.Long = ctx.Description
 	cmd.Example = ctx.Examples
-	cmd.RunE = runECmdFunc(cfg, subcommand,
+	cmd.RunE = runECmdFunc(c.fs, cfg, subcommand,
 		fmt.Sprintf("failed to create webhook with %q", plugin.KeyFor(createWebhookPlugin)))
 }

--- a/pkg/machinery/filesystem.go
+++ b/pkg/machinery/filesystem.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinery
+
+import (
+	"github.com/spf13/afero"
+)
+
+// Filesystem abstracts the underlying disk for scaffolding
+type Filesystem struct {
+	FS afero.Fs
+}

--- a/pkg/plugin/interfaces.go
+++ b/pkg/plugin/interfaces.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 )
 
 // Plugin is an interface that defines the common base for all plugins
@@ -53,7 +54,7 @@ type Subcommand interface {
 	// command line flags.
 	BindFlags(*pflag.FlagSet)
 	// Run runs the subcommand.
-	Run() error
+	Run(fs machinery.Filesystem) error
 	// InjectConfig passes a config to a plugin. The plugin may modify the config.
 	// Initializing, loading, and saving the config is managed by the cli package.
 	InjectConfig(config.Config)

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -20,14 +20,13 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
@@ -126,7 +125,7 @@ func (p *createAPISubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *createAPISubcommand) Run() error {
+func (p *createAPISubcommand) Run(fs machinery.Filesystem) error {
 	// Ask for API and Controller if not specified
 	reader := bufio.NewReader(os.Stdin)
 	if !p.resourceFlag.Changed {
@@ -141,7 +140,7 @@ func (p *createAPISubcommand) Run() error {
 	// Create the resource from the options
 	p.resource = p.options.NewResource(p.config)
 
-	return cmdutil.Run(p)
+	return cmdutil.Run(p, fs)
 }
 
 func (p *createAPISubcommand) Validate() error {
@@ -171,12 +170,6 @@ func (p *createAPISubcommand) Validate() error {
 }
 
 func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
-	// Load the boilerplate
-	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
-	if err != nil {
-		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
-	}
-
 	// Load the requested plugins
 	plugins := make([]model.Plugin, 0)
 	switch strings.ToLower(p.pattern) {
@@ -188,7 +181,7 @@ func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 		return nil, fmt.Errorf("unknown pattern %q", p.pattern)
 	}
 
-	return scaffolds.NewAPIScaffolder(p.config, string(bp), p.resource, p.force, plugins), nil
+	return scaffolds.NewAPIScaffolder(p.config, p.resource, p.force, plugins), nil
 }
 
 func (p *createAPISubcommand) PostScaffold() error {

--- a/pkg/plugins/golang/v2/edit.go
+++ b/pkg/plugins/golang/v2/edit.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
@@ -57,8 +58,8 @@ func (p *editSubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *editSubcommand) Run() error {
-	return cmdutil.Run(p)
+func (p *editSubcommand) Run(fs machinery.Filesystem) error {
+	return cmdutil.Run(p, fs)
 }
 
 func (p *editSubcommand) Validate() error {

--- a/pkg/plugins/golang/v2/init.go
+++ b/pkg/plugins/golang/v2/init.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
 	"sigs.k8s.io/kubebuilder/v3/pkg/internal/validation"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang"
@@ -110,8 +111,8 @@ func (p *initSubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *initSubcommand) Run() error {
-	return cmdutil.Run(p)
+func (p *initSubcommand) Run(fs machinery.Filesystem) error {
+	return cmdutil.Run(p, fs)
 }
 
 func (p *initSubcommand) Validate() error {

--- a/pkg/plugins/golang/v2/scaffolds/init.go
+++ b/pkg/plugins/golang/v2/scaffolds/init.go
@@ -18,10 +18,12 @@ package scaffolds
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 
+	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager"
@@ -32,7 +34,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/webhook"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/hack"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/machinery"
+	internalmachinery "sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/machinery"
 )
 
 const (
@@ -53,6 +55,9 @@ type initScaffolder struct {
 	boilerplatePath string
 	license         string
 	owner           string
+
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
@@ -65,6 +70,11 @@ func NewInitScaffolder(config config.Config, license, owner string) cmdutil.Scaf
 	}
 }
 
+// InjectFS implements cmdutil.Scaffolder
+func (s *initScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
 func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
 	return model.NewUniverse(
 		model.WithConfig(s.config),
@@ -72,30 +82,27 @@ func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
 	)
 }
 
-// Scaffold implements Scaffolder
+// Scaffold implements cmdutil.Scaffolder
 func (s *initScaffolder) Scaffold() error {
 	fmt.Println("Writing scaffold for you to edit...")
-	return s.scaffold()
-}
 
-func (s *initScaffolder) scaffold() error {
 	bpFile := &hack.Boilerplate{}
 	bpFile.Path = s.boilerplatePath
 	bpFile.License = s.license
 	bpFile.Owner = s.owner
-	if err := machinery.NewScaffold().Execute(
+	if err := internalmachinery.NewScaffold(s.fs).Execute(
 		s.newUniverse(""),
 		bpFile,
 	); err != nil {
 		return err
 	}
 
-	boilerplate, err := ioutil.ReadFile(s.boilerplatePath) //nolint:gosec
+	boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
 	if err != nil {
 		return err
 	}
 
-	return machinery.NewScaffold().Execute(
+	return internalmachinery.NewScaffold(s.fs).Execute(
 		s.newUniverse(string(boilerplate)),
 		&templates.GitIgnore{},
 		&rbac.AuthProxyRole{},

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/hack/boilerplate.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/hack/boilerplate.go
@@ -24,6 +24,9 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
+// DefaultBoilerplatePath is the default path to the boilerplate file
+var DefaultBoilerplatePath = filepath.Join("hack", "boilerplate.go.txt")
+
 var _ file.Template = &Boilerplate{}
 
 // Boilerplate scaffolds a file that defines the common header for the rest of the files
@@ -62,7 +65,7 @@ func (f Boilerplate) Validate() error {
 // SetTemplateDefaults implements file.Template
 func (f *Boilerplate) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("hack", "boilerplate.go.txt")
+		f.Path = DefaultBoilerplatePath
 	}
 
 	if f.License == "" {

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -18,13 +18,12 @@ package v2
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 
 	"github.com/spf13/pflag"
 
 	newconfig "sigs.k8s.io/kubebuilder/v3/pkg/config"
 	cfgv2 "sigs.k8s.io/kubebuilder/v3/pkg/config/v2"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds"
@@ -83,11 +82,11 @@ func (p *createWebhookSubcommand) InjectConfig(c newconfig.Config) {
 	p.config = c
 }
 
-func (p *createWebhookSubcommand) Run() error {
+func (p *createWebhookSubcommand) Run(fs machinery.Filesystem) error {
 	// Create the resource from the options
 	p.resource = p.options.NewResource(p.config)
 
-	return cmdutil.Run(p)
+	return cmdutil.Run(p, fs)
 }
 
 func (p *createWebhookSubcommand) Validate() error {
@@ -121,13 +120,7 @@ func (p *createWebhookSubcommand) Validate() error {
 }
 
 func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
-	// Load the boilerplate
-	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
-	if err != nil {
-		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
-	}
-
-	return scaffolds.NewWebhookScaffolder(p.config, string(bp), p.resource), nil
+	return scaffolds.NewWebhookScaffolder(p.config, p.resource), nil
 }
 
 func (p *createWebhookSubcommand) PostScaffold() error {

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -20,14 +20,13 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
@@ -142,7 +141,7 @@ func (p *createAPISubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *createAPISubcommand) Run() error {
+func (p *createAPISubcommand) Run(fs machinery.Filesystem) error {
 	// TODO: re-evaluate whether y/n input still makes sense. We should probably always
 	// scaffold the resource and controller.
 	reader := bufio.NewReader(os.Stdin)
@@ -158,7 +157,7 @@ func (p *createAPISubcommand) Run() error {
 	// Create the resource from the options
 	p.resource = p.options.NewResource(p.config)
 
-	return cmdutil.Run(p)
+	return cmdutil.Run(p, fs)
 }
 
 func (p *createAPISubcommand) Validate() error {
@@ -199,12 +198,6 @@ func (p *createAPISubcommand) Validate() error {
 }
 
 func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
-	// Load the boilerplate
-	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
-	if err != nil {
-		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
-	}
-
 	// Load the requested plugins
 	plugins := make([]model.Plugin, 0)
 	switch strings.ToLower(p.pattern) {
@@ -216,7 +209,7 @@ func (p *createAPISubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
 		return nil, fmt.Errorf("unknown pattern %q", p.pattern)
 	}
 
-	return scaffolds.NewAPIScaffolder(p.config, string(bp), p.resource, p.force, plugins), nil
+	return scaffolds.NewAPIScaffolder(p.config, p.resource, p.force, plugins), nil
 }
 
 func (p *createAPISubcommand) PostScaffold() error {

--- a/pkg/plugins/golang/v3/edit.go
+++ b/pkg/plugins/golang/v3/edit.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
@@ -57,8 +58,8 @@ func (p *editSubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *editSubcommand) Run() error {
-	return cmdutil.Run(p)
+func (p *editSubcommand) Run(fs machinery.Filesystem) error {
+	return cmdutil.Run(p, fs)
 }
 
 func (p *editSubcommand) Validate() error {

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/internal/validation"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang"
@@ -106,8 +107,8 @@ func (p *initSubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *initSubcommand) Run() error {
-	return cmdutil.Run(p)
+func (p *initSubcommand) Run(fs machinery.Filesystem) error {
+	return cmdutil.Run(p, fs)
 }
 
 func (p *initSubcommand) Validate() error {

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -19,7 +19,10 @@ package scaffolds
 import (
 	"fmt"
 
+	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates"
@@ -29,8 +32,9 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/config/samples"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/hack"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/machinery"
+	internalmachinery "sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/machinery"
 )
 
 var _ cmdutil.Scaffolder = &apiScaffolder{}
@@ -42,6 +46,9 @@ type apiScaffolder struct {
 	boilerplate string
 	resource    resource.Resource
 
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
+
 	// plugins is the list of plugins we should allow to transform our generated scaffolding
 	plugins []model.Plugin
 
@@ -52,24 +59,21 @@ type apiScaffolder struct {
 // NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
 func NewAPIScaffolder(
 	config config.Config,
-	boilerplate string,
 	res resource.Resource,
 	force bool,
 	plugins []model.Plugin,
 ) cmdutil.Scaffolder {
 	return &apiScaffolder{
-		config:      config,
-		boilerplate: boilerplate,
-		resource:    res,
-		plugins:     plugins,
-		force:       force,
+		config:   config,
+		resource: res,
+		plugins:  plugins,
+		force:    force,
 	}
 }
 
-// Scaffold implements Scaffolder
-func (s *apiScaffolder) Scaffold() error {
-	fmt.Println("Writing scaffold for you to edit...")
-	return s.scaffold()
+// InjectFS implements cmdutil.Scaffolder
+func (s *apiScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
 }
 
 func (s *apiScaffolder) newUniverse() *model.Universe {
@@ -80,8 +84,17 @@ func (s *apiScaffolder) newUniverse() *model.Universe {
 	)
 }
 
-// TODO: re-use universe created by s.newUniverse() if possible.
-func (s *apiScaffolder) scaffold() error {
+// Scaffold implements cmdutil.Scaffolder
+func (s *apiScaffolder) Scaffold() error {
+	fmt.Println("Writing scaffold for you to edit...")
+
+	// Load the boilerplate
+	bp, err := afero.ReadFile(s.fs.FS, hack.DefaultBoilerplatePath)
+	if err != nil {
+		return fmt.Errorf("error scaffolding API/controller: unable to load boilerplate: %w", err)
+	}
+	s.boilerplate = string(bp)
+
 	// Keep track of these values before the update
 	doAPI := s.resource.HasAPI()
 	doController := s.resource.HasController()
@@ -92,7 +105,7 @@ func (s *apiScaffolder) scaffold() error {
 
 	if doAPI {
 
-		if err := machinery.NewScaffold(s.plugins...).Execute(
+		if err := internalmachinery.NewScaffold(s.fs, s.plugins...).Execute(
 			s.newUniverse(),
 			&api.Types{Force: s.force},
 			&api.Group{},
@@ -105,7 +118,7 @@ func (s *apiScaffolder) scaffold() error {
 			return fmt.Errorf("error scaffolding APIs: %v", err)
 		}
 
-		if err := machinery.NewScaffold().Execute(
+		if err := internalmachinery.NewScaffold(s.fs).Execute(
 			s.newUniverse(),
 			&crd.Kustomization{},
 			&crd.KustomizeConfig{},
@@ -116,7 +129,7 @@ func (s *apiScaffolder) scaffold() error {
 	}
 
 	if doController {
-		if err := machinery.NewScaffold(s.plugins...).Execute(
+		if err := internalmachinery.NewScaffold(s.fs, s.plugins...).Execute(
 			s.newUniverse(),
 			&controllers.SuiteTest{Force: s.force},
 			&controllers.Controller{ControllerRuntimeVersion: ControllerRuntimeVersion, Force: s.force},
@@ -125,7 +138,7 @@ func (s *apiScaffolder) scaffold() error {
 		}
 	}
 
-	if err := machinery.NewScaffold(s.plugins...).Execute(
+	if err := internalmachinery.NewScaffold(s.fs, s.plugins...).Execute(
 		s.newUniverse(),
 		&templates.MainUpdater{WireResource: doAPI, WireController: doController},
 	); err != nil {

--- a/pkg/plugins/golang/v3/scaffolds/edit.go
+++ b/pkg/plugins/golang/v3/scaffolds/edit.go
@@ -18,10 +18,12 @@ package scaffolds
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 
+	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
 )
 
@@ -30,6 +32,9 @@ var _ cmdutil.Scaffolder = &editScaffolder{}
 type editScaffolder struct {
 	config     config.Config
 	multigroup bool
+
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
 }
 
 // NewEditScaffolder returns a new Scaffolder for configuration edit operations
@@ -40,10 +45,15 @@ func NewEditScaffolder(config config.Config, multigroup bool) cmdutil.Scaffolder
 	}
 }
 
-// Scaffold implements Scaffolder
+// InjectFS implements cmdutil.Scaffolder
+func (s *editScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
+// Scaffold implements cmdutil.Scaffolder
 func (s *editScaffolder) Scaffold() error {
 	filename := "Dockerfile"
-	bs, err := ioutil.ReadFile(filename)
+	bs, err := afero.ReadFile(s.fs.FS, filename)
 	if err != nil {
 		return err
 	}
@@ -77,9 +87,8 @@ func (s *editScaffolder) Scaffold() error {
 	// Check if the str is not empty, because when the file is already in desired format it will return empty string
 	// because there is nothing to replace.
 	if str != "" {
-		// false positive
-		// nolint:gosec
-		return ioutil.WriteFile(filename, []byte(str), 0644)
+		// TODO: instead of writing it directly, we should use the scaffolding machinery for consistency
+		return afero.WriteFile(s.fs.FS, filename, []byte(str), 0644)
 	}
 
 	return nil

--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -18,10 +18,12 @@ package scaffolds
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 
+	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/config/certmanager"
@@ -31,7 +33,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/config/rbac"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds/internal/templates/hack"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/cmdutil"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/machinery"
+	internalmachinery "sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/machinery"
 )
 
 const (
@@ -52,6 +54,9 @@ type initScaffolder struct {
 	boilerplatePath string
 	license         string
 	owner           string
+
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
@@ -64,6 +69,11 @@ func NewInitScaffolder(config config.Config, license, owner string) cmdutil.Scaf
 	}
 }
 
+// InjectFS implements cmdutil.Scaffolder
+func (s *initScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
 func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
 	return model.NewUniverse(
 		model.WithConfig(s.config),
@@ -71,31 +81,27 @@ func (s *initScaffolder) newUniverse(boilerplate string) *model.Universe {
 	)
 }
 
-// Scaffold implements Scaffolder
+// Scaffold implements cmdutil.Scaffolder
 func (s *initScaffolder) Scaffold() error {
 	fmt.Println("Writing scaffold for you to edit...")
-	return s.scaffold()
-}
 
-// TODO: re-use universe created by s.newUniverse() if possible.
-func (s *initScaffolder) scaffold() error {
 	bpFile := &hack.Boilerplate{}
 	bpFile.Path = s.boilerplatePath
 	bpFile.License = s.license
 	bpFile.Owner = s.owner
-	if err := machinery.NewScaffold().Execute(
+	if err := internalmachinery.NewScaffold(s.fs).Execute(
 		s.newUniverse(""),
 		bpFile,
 	); err != nil {
 		return err
 	}
 
-	boilerplate, err := ioutil.ReadFile(s.boilerplatePath) //nolint:gosec
+	boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
 	if err != nil {
 		return err
 	}
 
-	return machinery.NewScaffold().Execute(
+	return internalmachinery.NewScaffold(s.fs).Execute(
 		s.newUniverse(string(boilerplate)),
 		&rbac.Kustomization{},
 		&rbac.AuthProxyRole{},

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/hack/boilerplate.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/hack/boilerplate.go
@@ -24,6 +24,9 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 )
 
+// DefaultBoilerplatePath is the default path to the boilerplate file
+var DefaultBoilerplatePath = filepath.Join("hack", "boilerplate.go.txt")
+
 var _ file.Template = &Boilerplate{}
 
 // Boilerplate scaffolds a file that defines the common header for the rest of the files
@@ -62,7 +65,7 @@ func (f Boilerplate) Validate() error {
 // SetTemplateDefaults implements file.Template
 func (f *Boilerplate) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("hack", "boilerplate.go.txt")
+		f.Path = DefaultBoilerplatePath
 	}
 
 	if f.License == "" {

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -18,12 +18,11 @@ package v3
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
@@ -94,11 +93,11 @@ func (p *createWebhookSubcommand) InjectConfig(c config.Config) {
 	p.config = c
 }
 
-func (p *createWebhookSubcommand) Run() error {
+func (p *createWebhookSubcommand) Run(fs machinery.Filesystem) error {
 	// Create the resource from the options
 	p.resource = p.options.NewResource(p.config)
 
-	return cmdutil.Run(p)
+	return cmdutil.Run(p, fs)
 }
 
 func (p *createWebhookSubcommand) Validate() error {
@@ -131,13 +130,7 @@ func (p *createWebhookSubcommand) Validate() error {
 }
 
 func (p *createWebhookSubcommand) GetScaffolder() (cmdutil.Scaffolder, error) {
-	// Load the boilerplate
-	bp, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt")) // nolint:gosec
-	if err != nil {
-		return nil, fmt.Errorf("unable to load boilerplate: %v", err)
-	}
-
-	return scaffolds.NewWebhookScaffolder(p.config, string(bp), p.resource, p.force), nil
+	return scaffolds.NewWebhookScaffolder(p.config, p.resource, p.force), nil
 }
 
 func (p *createWebhookSubcommand) PostScaffold() error {

--- a/pkg/plugins/internal/cmdutil/cmdutil.go
+++ b/pkg/plugins/internal/cmdutil/cmdutil.go
@@ -16,25 +16,31 @@ limitations under the License.
 
 package cmdutil
 
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
 // Scaffolder interface creates files to set up a controller manager
 type Scaffolder interface {
+	InjectFS(filesystem machinery.Filesystem)
 	// Scaffold performs the scaffolding
 	Scaffold() error
 }
 
 // RunOptions represent the types used to implement the different commands
 type RunOptions interface {
-	// - Step 1: verify that the command can be run (e.g., go version, project version, arguments, ...)
+	// - Step 1: verify that the command can be run (e.g., go version, project version, arguments, ...).
 	Validate() error
-	// - Step 2: create the Scaffolder instance
+	// - Step 2: create the Scaffolder instance.
 	GetScaffolder() (Scaffolder, error)
-	// - Step 3: call the Scaffold method of the Scaffolder instance. Doesn't need any method
-	// - Step 4: finish the command execution
+	// - Step 3: inject the filesystem into the Scaffolder instance. Doesn't need any method.
+	// - Step 4: call the Scaffold method of the Scaffolder instance. Doesn't need any method.
+	// - Step 5: finish the command execution.
 	PostScaffold() error
 }
 
 // Run executes a command
-func Run(options RunOptions) error {
+func Run(options RunOptions, fs machinery.Filesystem) error {
 	// Step 1: validate
 	if err := options.Validate(); err != nil {
 		return err
@@ -45,13 +51,15 @@ func Run(options RunOptions) error {
 	if err != nil {
 		return err
 	}
-	// Step 3: scaffold
+	// Step 3: inject filesystem
+	scaffolder.InjectFS(fs)
+	// Step 4: scaffold
 	if scaffolder != nil {
 		if err := scaffolder.Scaffold(); err != nil {
 			return err
 		}
 	}
-	// Step 4: finish
+	// Step 5: finish
 	if err := options.PostScaffold(); err != nil {
 		return err
 	}

--- a/pkg/plugins/internal/filesystem/filesystem.go
+++ b/pkg/plugins/internal/filesystem/filesystem.go
@@ -53,10 +53,10 @@ type fileSystem struct {
 }
 
 // New returns a new FileSystem
-func New(options ...Options) FileSystem {
+func New(underlying afero.Fs, options ...Options) FileSystem {
 	// Default values
 	fs := fileSystem{
-		fs:       afero.NewOsFs(),
+		fs:       underlying,
 		dirPerm:  defaultDirectoryPermission,
 		filePerm: defaultFilePermission,
 		fileMode: createOrUpdate,

--- a/pkg/plugins/internal/filesystem/filesystem_test.go
+++ b/pkg/plugins/internal/filesystem/filesystem_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
 )
 
 var _ = Describe("FileSystem", func() {
@@ -38,7 +39,7 @@ var _ = Describe("FileSystem", func() {
 
 		Context("when using no options", func() {
 			BeforeEach(func() {
-				fsi = New()
+				fsi = New(afero.NewMemMapFs())
 				fs, ok = fsi.(fileSystem)
 			})
 
@@ -65,7 +66,7 @@ var _ = Describe("FileSystem", func() {
 
 		Context("when using directory permission option", func() {
 			BeforeEach(func() {
-				fsi = New(DirectoryPermissions(dirPerm))
+				fsi = New(afero.NewMemMapFs(), DirectoryPermissions(dirPerm))
 				fs, ok = fsi.(fileSystem)
 			})
 
@@ -92,7 +93,7 @@ var _ = Describe("FileSystem", func() {
 
 		Context("when using file permission option", func() {
 			BeforeEach(func() {
-				fsi = New(FilePermissions(filePerm))
+				fsi = New(afero.NewMemMapFs(), FilePermissions(filePerm))
 				fs, ok = fsi.(fileSystem)
 			})
 
@@ -119,7 +120,7 @@ var _ = Describe("FileSystem", func() {
 
 		Context("when using both directory and file permission options", func() {
 			BeforeEach(func() {
-				fsi = New(DirectoryPermissions(dirPerm), FilePermissions(filePerm))
+				fsi = New(afero.NewMemMapFs(), DirectoryPermissions(dirPerm), FilePermissions(filePerm))
 				fs, ok = fsi.(fileSystem)
 			})
 

--- a/pkg/plugins/internal/machinery/scaffold.go
+++ b/pkg/plugins/internal/machinery/scaffold.go
@@ -27,6 +27,7 @@ import (
 
 	"golang.org/x/tools/imports"
 
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/filesystem"
@@ -55,10 +56,10 @@ type scaffold struct {
 }
 
 // NewScaffold returns a new Scaffold with the provided plugins
-func NewScaffold(plugins ...model.Plugin) Scaffold {
+func NewScaffold(fs machinery.Filesystem, plugins ...model.Plugin) Scaffold {
 	return &scaffold{
 		plugins: plugins,
-		fs:      filesystem.New(),
+		fs:      filesystem.New(fs.FS),
 	}
 }
 

--- a/pkg/plugins/internal/machinery/scaffold_test.go
+++ b/pkg/plugins/internal/machinery/scaffold_test.go
@@ -21,7 +21,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
 
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/file"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/internal/filesystem"
@@ -37,7 +39,7 @@ var _ = Describe("Scaffold", func() {
 
 		Context("when using no plugins", func() {
 			BeforeEach(func() {
-				si = NewScaffold()
+				si = NewScaffold(machinery.Filesystem{FS: afero.NewMemMapFs()})
 				s, ok = si.(*scaffold)
 			})
 
@@ -56,7 +58,7 @@ var _ = Describe("Scaffold", func() {
 
 		Context("when using one plugin", func() {
 			BeforeEach(func() {
-				si = NewScaffold(fakePlugin{})
+				si = NewScaffold(machinery.Filesystem{FS: afero.NewMemMapFs()}, fakePlugin{})
 				s, ok = si.(*scaffold)
 			})
 
@@ -75,7 +77,8 @@ var _ = Describe("Scaffold", func() {
 
 		Context("when using several plugins", func() {
 			BeforeEach(func() {
-				si = NewScaffold(fakePlugin{}, fakePlugin{}, fakePlugin{})
+				si = NewScaffold(machinery.Filesystem{FS: afero.NewMemMapFs()},
+					fakePlugin{}, fakePlugin{}, fakePlugin{})
 				s, ok = si.(*scaffold)
 			})
 


### PR DESCRIPTION
A new filesystem abstraction is being created in multiple places. This PRs creates a single filesystem abstraction in the CLI, and passes/injects it to any machinery that requires it.

Technically speaking this is a brekaing change, because it modifies the `Subcommand` interface in `pkg/plugin/interfaces.go`. This, and the corresponding signature update for the plugins, is the only breaking change in this PR. It is required to expose both the scaffolding machinery (#2036) and the config file machinery (#2056).