### PR TITLE
🐛 fix: ignore non-go files during Docker build

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/component-config-tutorial/testdata/project/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/

--- a/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/

--- a/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerignore.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerignore.go
@@ -39,8 +39,7 @@ func (f *DockerIgnore) SetTemplateDefaults() error {
 }
 
 const dockerignorefileTemplate = `# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/
 `

--- a/testdata/project-v3-addon/.dockerignore
+++ b/testdata/project-v3-addon/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/

--- a/testdata/project-v3-config/.dockerignore
+++ b/testdata/project-v3-config/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/

--- a/testdata/project-v3-multigroup/.dockerignore
+++ b/testdata/project-v3-multigroup/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/

--- a/testdata/project-v3/.dockerignore
+++ b/testdata/project-v3/.dockerignore
@@ -1,5 +1,4 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore build and test binaries.
+bin/
+testbin/


### PR DESCRIPTION
This change ensures that the scaffolded `.dockerignore` file makes Docker ignore non-Go files.

This avoids large files like test binaries being unnecessarily included in Docker's build context.

Fixes #2073.