### PR TITLE
✨ Provide third-party devs the option to provide their own alpha subcommands

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -75,6 +75,8 @@ type CLI struct { //nolint:maligned
 	plugins map[string]plugin.Plugin
 	// Commands injected by options.
 	extraCommands []*cobra.Command
+	// Alpha commands injected by options.
+	extraAlphaCommands []*cobra.Command
 	// Whether to add a completion command to the CLI.
 	completionCommand bool
 
@@ -118,6 +120,11 @@ func New(options ...Option) (*CLI, error) {
 
 	// Add extra commands injected by options.
 	if err := c.addExtraCommands(); err != nil {
+		return nil, err
+	}
+
+	// Add extra alpha commands injected by options.
+	if err := c.addExtraAlphaCommands(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -112,6 +112,18 @@ func WithExtraCommands(cmds ...*cobra.Command) Option {
 	}
 }
 
+// WithExtraAlphaCommands is an Option that adds extra alpha subcommands to the CLI.
+//
+// Adding extra alpha commands that duplicate existing commands results in an error.
+func WithExtraAlphaCommands(cmds ...*cobra.Command) Option {
+	return func(c *CLI) error {
+		// We don't know the commands defined by the CLI yet so we are not checking if the extra alpha commands
+		// conflict with a pre-existing one yet. We do this after creating the base commands.
+		c.extraAlphaCommands = append(c.extraAlphaCommands, cmds...)
+		return nil
+	}
+}
+
 // WithCompletion is an Option that adds the completion subcommand.
 func WithCompletion() Option {
 	return func(c *CLI) error {

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -221,6 +221,21 @@ var _ = Describe("CLI options", func() {
 		})
 	})
 
+	Context("WithExtraAlphaCommands", func() {
+		It("should return a valid CLI with extra alpha commands", func() {
+			commandTest := &cobra.Command{
+				Use: "example",
+			}
+			c, err = newCLI(WithExtraAlphaCommands(commandTest))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c).NotTo(BeNil())
+			Expect(c.extraAlphaCommands).NotTo(BeNil())
+			Expect(len(c.extraAlphaCommands)).To(Equal(1))
+			Expect(c.extraAlphaCommands[0]).NotTo(BeNil())
+			Expect(c.extraAlphaCommands[0].Use).To(Equal(commandTest.Use))
+		})
+	})
+
 	Context("WithCompletion", func() {
 		It("should not add the completion command by default", func() {
 			c, err = newCLI()


### PR DESCRIPTION
SDK is providing an alpha command, we are doing the same, when we try to align them, they will collide.
This PRs provides a way to set extra alpha commands for third-party developers.