### PR TITLE
📖 Remove kubebuilder hardcoded reference in alpha subcommand description

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -36,12 +36,12 @@ func (c *CLI) newAlphaCmd() *cobra.Command {
 	alpha := &cobra.Command{
 		Use:        alphaCommand,
 		SuggestFor: []string{"experimental"},
-		Short:      "Alpha kubebuilder subcommands",
+		Short:      "Alpha-stage subcommands",
 		Long: strings.TrimSpace(`
-Alpha kubebuilder commands are for unstable features.
+Alpha subcommands are for unstable features.
 
-- Alpha commands are exploratory and may be removed without warning.
-- No backwards compatibility is provided for any alpha commands.
+- Alpha subcommands are exploratory and may be removed without warning.
+- No backwards compatibility is provided for any alpha subcommands.
  		`),
 	}
 	for i := range alphaCommands {


### PR DESCRIPTION
Alpha subcommand had a hardcoded reference to kubebuilder.
As kubebuilder may be used as a library by other CLI tools, the description should be more generic.