### PR TITLE
🐛 Fix alpha extra commands parent command

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -75,7 +75,7 @@ func (c *CLI) addExtraAlphaCommands() error {
 				return fmt.Errorf("command %q already exists", fmt.Sprintf("%s %s", alphaCommand, cmd.Name()))
 			}
 		}
-		c.cmd.AddCommand(cmd)
+		alpha.AddCommand(cmd)
 	}
 	return nil
 }


### PR DESCRIPTION
#2089 was adding the commands to the root command instead of to the alpha subcommand.
This PRs fixes the bug and adds a test to verify it in the future.