### PR TITLE
🌱 Fix coverage report on master

### DIFF
--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -28,8 +28,6 @@ import (
 // Version is the config.Version for project configuration 2
 var Version = config.Version{Number: 2}
 
-const apiVersion = "v1beta1"
-
 type cfg struct {
 	// Version
 	Version config.Version `json:"version"`


### PR DESCRIPTION
Master branch was not properly linted, and therefore the coverage report was not being uploaded.

Setting the emoji as 🌱 as it only affects the CI.