### PR TITLE
✨ Allow to modify the root's command description

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -48,6 +48,8 @@ type CLI struct { //nolint:maligned
 	commandName string
 	// CLI version string.
 	version string
+	// CLI root's command description.
+	description string
 	// Plugins registered in the CLI.
 	plugins map[string]plugin.Plugin
 	// Default plugins in case none is provided and a config file can't be found.
@@ -120,7 +122,9 @@ func New(options ...Option) (*CLI, error) {
 func newCLI(options ...Option) (*CLI, error) {
 	// Default CLI options.
 	c := &CLI{
-		commandName:    "kubebuilder",
+		commandName: "kubebuilder",
+		description: `CLI tool for building Kubernetes extensions and tools.
+`,
 		plugins:        make(map[string]plugin.Plugin),
 		defaultPlugins: make(map[config.Version][]string),
 		fs:             machinery.Filesystem{FS: afero.NewOsFs()},

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -44,6 +44,14 @@ func WithVersion(version string) Option {
 	}
 }
 
+// WithDescription is an Option that sets the CLI's root description.
+func WithDescription(description string) Option {
+	return func(c *CLI) error {
+		c.description = description
+		return nil
+	}
+}
+
 // WithPlugins is an Option that sets the CLI's plugins.
 //
 // Specifying any invalid plugin results in an error.

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -67,6 +67,16 @@ var _ = Describe("CLI options", func() {
 		})
 	})
 
+	Context("WithDescription", func() {
+		It("should use the provided description string", func() {
+			description := "alternative description"
+			c, err = newCLI(WithDescription(description))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c).NotTo(BeNil())
+			Expect(c.description).To(Equal(description))
+		})
+	})
+
 	Context("WithPlugins", func() {
 		It("should return a valid CLI", func() {
 			c, err = newCLI(WithPlugins(p))

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -31,9 +31,8 @@ const (
 
 func (c CLI) newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use: c.commandName,
-		Long: `CLI tool for building Kubernetes extensions and tools.
-`,
+		Use:     c.commandName,
+		Long:    c.description,
 		Example: c.rootExamples(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()


### PR DESCRIPTION
Create an `Option` that allows to modify the root's command description.

Closes: #1830
