### PR TITLE
✨ Allow bundles to be used as input to other bundles

### DIFF
--- a/pkg/plugin/bundle_test.go
+++ b/pkg/plugin/bundle_test.go
@@ -84,6 +84,26 @@ var _ = Describe("Bundle", func() {
 			}
 		})
 
+		It("should accept bundles as input", func() {
+			var a, b Bundle
+			var err error
+			plugins := []Plugin{p1, p2, p3}
+			a, err = NewBundle("a", version, p1, p2)
+			Expect(err).NotTo(HaveOccurred())
+			b, err = NewBundle("b", version, a, p3)
+			Expect(err).NotTo(HaveOccurred())
+			versions := b.SupportedProjectVersions()
+			sort.Slice(versions, func(i int, j int) bool {
+				return versions[i].Compare(versions[j]) == -1
+			})
+			expectedVersions := CommonSupportedProjectVersions(plugins...)
+			sort.Slice(expectedVersions, func(i int, j int) bool {
+				return expectedVersions[i].Compare(expectedVersions[j]) == -1
+			})
+			Expect(versions).To(Equal(expectedVersions))
+			Expect(b.Plugins()).To(Equal(plugins))
+		})
+
 		It("should fail for plugins with no common supported project version", func() {
 			for _, plugins := range [][]Plugin{
 				{p2, p4},

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 )
 
-// Plugin is an interface that defines the common base for all plugins
+// Plugin is an interface that defines the common base for all plugins.
 type Plugin interface {
 	// Name returns a DNS1123 label string identifying the plugin uniquely. This name should be fully-qualified,
 	// i.e. have a short prefix describing the plugin type (like a language) followed by a domain.
@@ -41,35 +41,35 @@ type Deprecated interface {
 	DeprecationWarning() string
 }
 
-// Init is an interface for plugins that provide an `init` subcommand
+// Init is an interface for plugins that provide an `init` subcommand.
 type Init interface {
 	Plugin
 	// GetInitSubcommand returns the underlying InitSubcommand interface.
 	GetInitSubcommand() InitSubcommand
 }
 
-// CreateAPI is an interface for plugins that provide a `create api` subcommand
+// CreateAPI is an interface for plugins that provide a `create api` subcommand.
 type CreateAPI interface {
 	Plugin
 	// GetCreateAPISubcommand returns the underlying CreateAPISubcommand interface.
 	GetCreateAPISubcommand() CreateAPISubcommand
 }
 
-// CreateWebhook is an interface for plugins that provide a `create webhook` subcommand
+// CreateWebhook is an interface for plugins that provide a `create webhook` subcommand.
 type CreateWebhook interface {
 	Plugin
 	// GetCreateWebhookSubcommand returns the underlying CreateWebhookSubcommand interface.
 	GetCreateWebhookSubcommand() CreateWebhookSubcommand
 }
 
-// Edit is an interface for plugins that provide a `edit` subcommand
+// Edit is an interface for plugins that provide a `edit` subcommand.
 type Edit interface {
 	Plugin
 	// GetEditSubcommand returns the underlying EditSubcommand interface.
 	GetEditSubcommand() EditSubcommand
 }
 
-// Full is an interface for plugins that provide `init`, `create api`, `create webhook` and `edit` subcommands
+// Full is an interface for plugins that provide `init`, `create api`, `create webhook` and `edit` subcommands.
 type Full interface {
 	Init
 	CreateAPI
@@ -77,9 +77,10 @@ type Full interface {
 	Edit
 }
 
-// Bundle allows to group plugins under a single key
+// Bundle allows to group plugins under a single key.
 type Bundle interface {
 	Plugin
-	// Plugins returns a list of the bundled plugins
+	// Plugins returns a list of the bundled plugins.
+	// The returned list should be flattened, i.e., no plugin bundles should be part of this list.
 	Plugins() []Plugin
 }


### PR DESCRIPTION
A `Bundle` is also a `Plugin`, but as unbundling is not done recursively, when using a `Bundle` as the input of other `Bundle`, it is not properly unbundled.
This PRs solves this by unbundling Bundles at Bundle creation time to avoid having to use recursive unbundling.