### PR TITLE
:bug: regression - extracommands require a valid PROJECT file again

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -158,6 +158,9 @@ func (c *CLI) buildCmd() error {
 		if config.IsRegistered(stableVersion) {
 			// Use the stableVersion
 			c.projectVersion = stableVersion
+		} else {
+			// stable version not registered, let's bail out
+			return err
 		}
 	default:
 		return err

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -93,8 +93,10 @@ var _ = Describe("CLI", func() {
 	})
 
 	Context("buildCmd", func() {
+		var projectFile string
+
 		BeforeEach(func() {
-			projectFile := `domain: zeusville.com
+			projectFile = `domain: zeusville.com
 layout: go.kubebuilder.io/v3
 projectName: demo-zeus-operator
 repo: github.com/jmrodri/demo-zeus-operator
@@ -122,6 +124,17 @@ plugins:
 					config.Version{
 						Number: 3,
 						Stage:  stage.Stable})).To(Equal(0))
+			})
+			It("should fail when stable is not registered ", func() {
+				// overwrite project file with fake 4-alpha
+				f, err := c.fs.FS.OpenFile("PROJECT", os.O_WRONLY, 0)
+				Expect(err).To(Not(HaveOccurred()))
+				_, err = f.WriteString(strings.ReplaceAll(projectFile, "3-alpha", "4-alpha"))
+				Expect(err).To(Not(HaveOccurred()))
+
+				// buildCmd should return an error
+				err = c.buildCmd()
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -25,6 +25,12 @@ func Register(version Version, constructor func() Config) {
 	registry[version] = constructor
 }
 
+// IsRegistered returns true if the given version has been registered through Register
+func IsRegistered(version Version) bool {
+	_, ok := registry[version]
+	return ok
+}
+
 // New creates Config instances from the previously registered implementations through Register
 func New(version Version) (Config, error) {
 	if constructor, exists := registry[version]; exists {

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -39,6 +39,16 @@ var _ = Describe("registry", func() {
 		})
 	})
 
+	Context("IsRegistered", func() {
+		It("should return true for registered constructors", func() {
+			Register(version, f)
+			Expect(IsRegistered(version)).To(BeTrue())
+		})
+		It("should fail for unregistered constructors", func() {
+			Expect(IsRegistered(version)).To(BeFalse())
+		})
+	})
+
 	Context("New", func() {
 		It("should use the registered constructors", func() {
 			registry[version] = f


### PR DESCRIPTION
Ignore UnsupportedVersion error to allow extra commands to be able to actually run.

Fixes: #2125 