### PR TITLE
:bug: (go/v3) moved leases.coordination.k8s.io to its own proxy-role rule

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/auth_proxy_client_role.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/auth_proxy_client_role.go
@@ -45,6 +45,8 @@ kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
 `

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/auth_proxy_role.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/auth_proxy_role.go
@@ -45,12 +45,16 @@ kind: ClusterRole
 metadata:
   name: proxy-role
 rules:
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups:
+  - authentication.k8s.io
   resources:
   - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  verbs: ["create"]
+  verbs:
+  - create
 `

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/leader_election_role.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/leader_election_role.go
@@ -48,9 +48,19 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - get

--- a/testdata/project-v3-addon/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3-addon/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -3,5 +3,7 @@ kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/testdata/project-v3-addon/config/rbac/auth_proxy_role.yaml
+++ b/testdata/project-v3-addon/config/rbac/auth_proxy_role.yaml
@@ -3,11 +3,15 @@ kind: ClusterRole
 metadata:
   name: proxy-role
 rules:
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups:
+  - authentication.k8s.io
   resources:
   - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  verbs: ["create"]
+  verbs:
+  - create

--- a/testdata/project-v3-addon/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-addon/config/rbac/leader_election_role.yaml
@@ -6,9 +6,19 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - get

--- a/testdata/project-v3-config/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3-config/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -3,5 +3,7 @@ kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/testdata/project-v3-config/config/rbac/auth_proxy_role.yaml
+++ b/testdata/project-v3-config/config/rbac/auth_proxy_role.yaml
@@ -3,11 +3,15 @@ kind: ClusterRole
 metadata:
   name: proxy-role
 rules:
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups:
+  - authentication.k8s.io
   resources:
   - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  verbs: ["create"]
+  verbs:
+  - create

--- a/testdata/project-v3-config/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-config/config/rbac/leader_election_role.yaml
@@ -6,9 +6,19 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - get

--- a/testdata/project-v3-multigroup/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -3,5 +3,7 @@ kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/testdata/project-v3-multigroup/config/rbac/auth_proxy_role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/auth_proxy_role.yaml
@@ -3,11 +3,15 @@ kind: ClusterRole
 metadata:
   name: proxy-role
 rules:
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups:
+  - authentication.k8s.io
   resources:
   - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  verbs: ["create"]
+  verbs:
+  - create

--- a/testdata/project-v3-multigroup/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/leader_election_role.yaml
@@ -6,9 +6,19 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - get

--- a/testdata/project-v3/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/testdata/project-v3/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -3,5 +3,7 @@ kind: ClusterRole
 metadata:
   name: metrics-reader
 rules:
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get

--- a/testdata/project-v3/config/rbac/auth_proxy_role.yaml
+++ b/testdata/project-v3/config/rbac/auth_proxy_role.yaml
@@ -3,11 +3,15 @@ kind: ClusterRole
 metadata:
   name: proxy-role
 rules:
-- apiGroups: ["authentication.k8s.io"]
+- apiGroups:
+  - authentication.k8s.io
   resources:
   - tokenreviews
-  verbs: ["create"]
-- apiGroups: ["authorization.k8s.io"]
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
   resources:
   - subjectaccessreviews
-  verbs: ["create"]
+  verbs:
+  - create

--- a/testdata/project-v3/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v3/config/rbac/leader_election_role.yaml
@@ -6,9 +6,19 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - coordination.k8s.io
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
   - leases
   verbs:
   - get


### PR DESCRIPTION
From https://github.com/kubernetes-sigs/kubebuilder/pull/1809#issuecomment-822715429:

>Echoing a comment from Slack so it doesn't get lost, we should probably do a follow up to this where we split this object to its own rule chunk in the role so it's not granting the non-existent perms core/leases and leases.coordination.k8s.io/configmap

/kind bug

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>