### PR TITLE
:bug: Fail when creating api webhook for a core type

### DIFF
--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -106,24 +106,21 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 
 	// domain and path may need to be changed in case we are referring to a builtin core resource:
-	//  - Check if we are scaffolding the resource now           => project resource
 	//  - Check if we already scaffolded the resource            => project resource
 	//  - Check if the resource group is a well-known core group => builtin core resource
 	//  - In any other case, default to                          => project resource
 	// TODO: need to support '--resource-pkg-path' flag for specifying resourcePath
-	if !opts.DoAPI {
-		var alreadyHasAPI bool
-		if c.GetVersion().Compare(cfgv2.Version) == 0 {
-			alreadyHasAPI = c.HasResource(res.GVK)
-		} else {
-			loadedRes, err := c.GetResource(res.GVK)
-			alreadyHasAPI = err == nil && loadedRes.HasAPI()
-		}
-		if !alreadyHasAPI {
-			if domain, found := coreGroups[res.Group]; found {
-				res.Domain = domain
-				res.Path = path.Join("k8s.io", "api", res.Group, res.Version)
-			}
+	var alreadyHasAPI bool
+	if c.GetVersion().Compare(cfgv2.Version) == 0 {
+		alreadyHasAPI = c.HasResource(res.GVK)
+	} else {
+		loadedRes, err := c.GetResource(res.GVK)
+		alreadyHasAPI = err == nil && loadedRes.HasAPI()
+	}
+	if !alreadyHasAPI {
+		if domain, found := coreGroups[res.Group]; found {
+			res.Domain = domain
+			res.Path = path.Join("k8s.io", "api", res.Group, res.Version)
 		}
 	}
 }

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -133,6 +134,11 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.options.DoAPI {
+		// Generating the API for a core resource is forbidden.
+		if strings.HasPrefix(p.resource.Path, "k8s.io") {
+			return errors.New("scaffolding API for core resources is not supported")
+		}
+
 		// Check that resource doesn't have the API scaffolded or flag force was set
 		if res, err := p.config.GetResource(p.resource.GVK); err == nil && res.HasAPI() && !p.force {
 			return errors.New("API resource already exists")

--- a/pkg/plugins/golang/v2/webhook.go
+++ b/pkg/plugins/golang/v2/webhook.go
@@ -101,7 +101,7 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 			return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
 		}
 	} else {
-		if r, err := p.config.GetResource(p.resource.GVK); err != nil {
+		if r, err := p.config.GetResource(p.resource.GVK); err != nil || !r.HasAPI() {
 			return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
 		} else if r.Webhooks != nil && !r.Webhooks.IsEmpty() {
 			return fmt.Errorf("webhook resource already exists")

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -142,6 +143,11 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 
 	// In case we want to scaffold a resource API we need to do some checks
 	if p.options.DoAPI {
+		// Generating the API for a core resource is forbidden.
+		if strings.HasPrefix(p.resource.Path, "k8s.io") {
+			return errors.New("scaffolding API for core resources is not supported")
+		}
+
 		// Check that resource doesn't have the API scaffolded or flag force was set
 		if r, err := p.config.GetResource(p.resource.GVK); err == nil && r.HasAPI() && !p.force {
 			return errors.New("API resource already exists")

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -103,7 +103,7 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 	}
 
 	// check if resource exist to create webhook
-	if r, err := p.config.GetResource(p.resource.GVK); err != nil {
+	if r, err := p.config.GetResource(p.resource.GVK); err != nil || !r.HasAPI() {
 		return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
 	} else if r.Webhooks != nil && !r.Webhooks.IsEmpty() && !p.force {
 		return fmt.Errorf("webhook resource already exists")


### PR DESCRIPTION
This change makes:

- `create api` fail when `--resource` is set and the API is not already scaffolded for a core type
- `create webhook` fail for a core type

Fixes https://github.com/kubernetes-sigs/kubebuilder/issues/2141
