### PR TITLE
:book: Fix markdown format in VERSIONING.md

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -57,7 +57,7 @@ the desired next version.  Once the PR is merged, Google Cloud Build will
 take care of building and publishing the artifacts.
 
 [envtest-ref]: https://book.kubebuilder.io/reference/artifacts.html
-[tools-branch]: https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases)
+[tools-branch]: https://github.com/kubernetes-sigs/kubebuilder/tree/tools-releases
 
 ## Versioning
 


### PR DESCRIPTION
**Description**
- This PR fixes markdown format in `VERSIONING.md` about refering to tools-branch link.
Before this PR, tools-branch link [is not expand the link](https://github.com/kubernetes-sigs/kubebuilder/blob/master/VERSIONING.md#tools-releases) on `VERSIONING.md`.
It looks like `[tools-releases branch][tools-branch]` in plain text.

/kind documentation

