### PR TITLE
:seedling: Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-about: Problems and issues with code or docs
+description: Problems and issues with code or docs
 labels:
 - kind/bug
 body: 
@@ -126,7 +126,7 @@ body:
 
 - type: dropdown
   attributes: 
-    label: " "
+    label: "Extra Labels"
     description: |
       If this is *also* a documentation request, etc, please select that below.
     multiple: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 # allow free form issues as an escape hatch.  This can be taken away if people abuse it ;-)
-blank_issues_enabled: true 
+blank_issues_enabled: true
 
 # link to CR and CT for easier access
 contact_links:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -81,7 +81,7 @@ body:
 
 - type: dropdown
   attributes: 
-    label: " "
+    label: "Extra Labels"
     description: |
       If this is *also* a documentation request, etc, please select that below.
     multiple: true


### PR DESCRIPTION
Validation appears to have increased slightly, and some deprecated
fields were switch up.  This made it impossible to file issues in
KubeBuilder, which is... suboptimal.

This fixes that, so we can once again open the receive bugs :-)