### PR TITLE
:book: : Fix download redirects with functions

### DIFF
--- a/docs/book/functions/handle-version.js
+++ b/docs/book/functions/handle-version.js
@@ -1,0 +1,36 @@
+function notFound(info) {
+    return {
+        statusCode: 404,
+        headers: {'content-type': 'text/html'},
+        body: ("<h1>Not Found</h1>"+
+            "<p>You shouldn't see this page, please file a bug</p>"+
+            `<details><summary>debug details</summary><pre><code>${JSON.stringify(info)}</code></pre></details>`
+        ),
+    };
+}
+
+function redirectToDownload(version, file) {
+    const loc = `https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/${file}`;
+    return {
+        statusCode: 302,
+        headers: {'location': loc},
+    };
+}
+
+
+exports.handler = async function(evt, ctx) {
+    // grab the prefix too to check for coherence
+    const [prefix, version, os, arch] = evt.path.split("/").slice(-4);
+    if (prefix !== 'releases' || !version || !os || !arch) {
+        return notFound({version: version, os: os, arch: arch, prefix: constPrefix, rawPath: evt.path});
+    }
+
+    switch(version[0]) {
+        case '1':
+            // fallthrough
+        case '2':
+            return redirectToDownload(version, `kubebuilder_${version}_${os}_${arch}.tar.gz`);
+        default:
+            return redirectToDownload(version, `kubebuilder_${os}_${arch}`);
+    }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
     command = "./install-and-build.sh"
     publish = "docs/book/book"
 
+# used to handle the split between v2 and v3+ download links
+[functions]
+    directory = "functions"
 
 # Standard Netlify redirects
 [[redirects]]
@@ -63,21 +66,7 @@
     status = 302
     force = true
 
-# v1 redirects.
-[[redirects]]
-    from = "https://go.kubebuilder.io/releases/1.:minorpatch/:os/:arch"
-    to = "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.:minorpatch/kubebuilder_1.:minorpatch_:os_:arch.tar.gz"
-    status = 302
-    force = true
-
-# v2 redirects.
-[[redirects]]
-    from = "https://go.kubebuilder.io/releases/2.:minorpatch/:os/:arch"
-    to = "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.:minorpatch/kubebuilder_2.:minorpatch_:os_:arch.tar.gz"
-    status = 302
-    force = true
-
-# v3+ redirects.
+# general release redirects
 [[redirects]]
     from = "https://go.kubebuilder.io/releases/:version"
     to = "https://github.com/kubernetes-sigs/kubebuilder/releases/v:version"
@@ -90,10 +79,15 @@
     status = 302
     force = true
 
+# release download redirect
 [[redirects]]
     from = "https://go.kubebuilder.io/releases/:version/:os/:arch"
-    to = "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v:version/kubebuilder_:os_:arch"
-    status = 302
+    # I don't quite know why, but netlify (or at least the dev mode) *insists*
+    # on eating every other query parameter, so just use paths instead
+    to = "/.netlify/functions/handle-version/:version/:os/:arch"
+    # 200 --> don't redirect to the the function then to whereever it says,
+    # just pretend like the function is mounted directly here
+    status = 200
     force = true
 
 # Tools redirects.


### PR DESCRIPTION
This resolves an issue introduced in the redirect prep for v3 (#2062) that
broke our download redirects.

The problem is that v3 releases are `kubebuilder_${os}_${arch}`, whereas
v2 & v1 releases are `kubebuilder_${version}_${os}_${arch}.tar.gz`.

Since netlify can't handle wildcards that are part of a path component
(like `/2.:minorversion`) instead of a whole one (`:version`), we can't
select on major version directly in our redirects.

Instead, we introduce a function that handles this logic for us, and
then use netlify 200-pseudo-redirects to "mount the function on the
downloads part of the releases endpoint.
