### PR TITLE
:book: Fix netlify functions configuration

### DIFF
--- a/docs/book/functions/handle-version.js
+++ b/docs/book/functions/handle-version.js
@@ -13,7 +13,8 @@ function redirectToDownload(version, file) {
     const loc = `https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/${file}`;
     return {
         statusCode: 302,
-        headers: {'location': loc},
+        headers: {'location': loc, 'content-type': 'text/plain'},
+        body: `Redirecting to ${loc}`,
     };
 }
 
@@ -22,7 +23,7 @@ exports.handler = async function(evt, ctx) {
     // grab the prefix too to check for coherence
     const [prefix, version, os, arch] = evt.path.split("/").slice(-4);
     if (prefix !== 'releases' || !version || !os || !arch) {
-        return notFound({version: version, os: os, arch: arch, prefix: constPrefix, rawPath: evt.path});
+        return notFound({version: version, os: os, arch: arch, prefix: prefix, rawPath: evt.path});
     }
 
     switch(version[0]) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,15 @@
     base = "docs/book"
     command = "./install-and-build.sh"
     publish = "docs/book/book"
+    functions = "docs/book/functions"
+
+# TODO(directxman12): I don't know why, but this (functions) stanza is in the
+# docs and local `netlify dev`, but the above one (under build) is used by the
+# online version :-/
 
 # used to handle the split between v2 and v3+ download links
 [functions]
+    # relative to base directory
     directory = "functions"
 
 # Standard Netlify redirects


### PR DESCRIPTION
The local `netlify` dev server and documentation expect a top-level
configuration block named functions, but the remote netlify builder
expects a key under the build block instead.  Who knows why.