### PR TITLE
:bug: Only enforce lower Go version

### DIFF
--- a/pkg/plugins/golang/go_version.go
+++ b/pkg/plugins/golang/go_version.go
@@ -33,11 +33,6 @@ var (
 		major: 1,
 		minor: 13,
 	}
-	go116alpha1 = goVersion{
-		major:      1,
-		minor:      16,
-		prerelease: "alpha1",
-	}
 
 	goVerRegexp = regexp.MustCompile(goVerPattern)
 )
@@ -149,8 +144,8 @@ func checkGoVersion(verStr string) error {
 		return err
 	}
 
-	if version.compare(go113) < 0 || version.compare(go116alpha1) >= 0 {
-		return fmt.Errorf("requires 1.13 <= version < 1.16")
+	if version.compare(go113) < 0 {
+		return fmt.Errorf("requires Go >= 1.13")
 	}
 
 	return nil

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -174,6 +174,10 @@ var _ = Describe("checkGoVersion", func() {
 		Entry("for go 1.15.6", "go1.15.6"),
 		Entry("for go 1.15.7", "go1.15.7"),
 		Entry("for go 1.15.8", "go1.15.8"),
+		Entry("for go 1.16", "go1.16"),
+		Entry("for go 1.16.1", "go1.16.1"),
+		Entry("for go 1.16.2", "go1.16.2"),
+		Entry("for go 1.16.3", "go1.16.3"),
 	)
 
 	DescribeTable("should return false for non-supported go versions",
@@ -182,8 +186,5 @@ var _ = Describe("checkGoVersion", func() {
 		Entry("for go 1.13beta1", "go1.13beta1"),
 		Entry("for go 1.13rc1", "go1.13rc1"),
 		Entry("for go 1.13rc2", "go1.13rc2"),
-		Entry("for go 1.16beta1", "go1.16beta1"),
-		Entry("for go 1.16rc1", "go1.16rc1"),
-		Entry("for go 1.16", "go1.16"),
 	)
 })


### PR DESCRIPTION
Go versions newer than 1.13 should be supported, including the current stable of 1.16. This brings the implementation inline with the method documentation, which states:

> // checkGoVersion should only ever check if the Go version >= 1.13, since the kubebuilder binary only cares
// that the go binary supports go modules which were stabilized in that version (i.e. in go 1.13) by default

Fixes #2172

