### PR TITLE
:sparkles: add default conversion review versions

### DIFF
--- a/pkg/cli/alpha/config-gen/cert-generation-filter.go
+++ b/pkg/cli/alpha/config-gen/cert-generation-filter.go
@@ -38,6 +38,7 @@ type CertFilter struct {
 }
 
 // Filter implements kio.Filter
+// TODO: when v1 CRDs are supported, scaffold conversion webhook versions.
 func (c CertFilter) Filter(input []*yaml.RNode) ([]*yaml.RNode, error) {
 
 	if c.Spec.Webhooks.CertificateSource.Type != "dev" {

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
@@ -66,5 +66,7 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - {{ .Resource.API.CRDVersion }}
     {{- end }}
 `

--- a/testdata/project-v3-addon/config/crd/patches/webhook_in_admirals.yaml
+++ b/testdata/project-v3-addon/config/crd/patches/webhook_in_admirals.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-addon/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3-addon/config/crd/patches/webhook_in_captains.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-addon/config/crd/patches/webhook_in_firstmates.yaml
+++ b/testdata/project-v3-addon/config/crd/patches/webhook_in_firstmates.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-config/config/crd/patches/webhook_in_admirals.yaml
+++ b/testdata/project-v3-config/config/crd/patches/webhook_in_admirals.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-config/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3-config/config/crd/patches/webhook_in_captains.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-config/config/crd/patches/webhook_in_firstmates.yaml
+++ b/testdata/project-v3-config/config/crd/patches/webhook_in_firstmates.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_captains.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_cruisers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_cruisers.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_destroyers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_destroyers.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_frigates.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_frigates.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_healthcheckpolicies.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_healthcheckpolicies.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_krakens.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_krakens.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_lakers.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3-multigroup/config/crd/patches/webhook_in_leviathans.yaml
+++ b/testdata/project-v3-multigroup/config/crd/patches/webhook_in_leviathans.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3/config/crd/patches/webhook_in_admirales.yaml
+++ b/testdata/project-v3/config/crd/patches/webhook_in_admirales.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3/config/crd/patches/webhook_in_captains.yaml
+++ b/testdata/project-v3/config/crd/patches/webhook_in_captains.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/testdata/project-v3/config/crd/patches/webhook_in_firstmates.yaml
+++ b/testdata/project-v3/config/crd/patches/webhook_in_firstmates.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1


### PR DESCRIPTION
The conversion webhook client config requires a list
of conversion review versions. This change scaffolds the
conversion webhook patch with default conversion review version
of v1.

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
