### PR TITLE
:seedling: Fix a gofmt warning

### DIFF
--- a/docs/book/utils/markerdocs/main.go
+++ b/docs/book/utils/markerdocs/main.go
@@ -256,9 +256,9 @@ func main() {
 	if err := plugin.Run(MarkerDocs{
 		Args: map[string][]string{
 			// marker args
-			"": []string{"-wwww", "crd", "webhook", "rbac:roleName=cheddar" /* role name doesn't mean anything here */, "object", "schemapatch:manifests=."},
+			"": {"-wwww", "crd", "webhook", "rbac:roleName=cheddar" /* role name doesn't mean anything here */, "object", "schemapatch:manifests=."},
 			// cli options args
-			"CLI: ": []string{"-hhhh"},
+			"CLI: ": {"-hhhh"},
 		},
 	}, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>

Warning: redundant type from array, slice, or map composite literal

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
