### PR TITLE
Update go version to 1.16 in Kubebuilder

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/component-config-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docs/book/src/component-config-tutorial/testdata/project/go.mod
+++ b/docs/book/src/component-config-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.2.1

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docs/book/src/cronjob-tutorial/testdata/project/go.mod
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0

--- a/docs/book/src/migration/manually_migration_guide_v2_v3.md
+++ b/docs/book/src/migration/manually_migration_guide_v2_v3.md
@@ -353,7 +353,7 @@ Ensure that your `go.mod` is using Go version `1.15` and the following dependenc
 ```go
 module example
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0
@@ -377,7 +377,7 @@ FROM golang:1.13 as builder
 With:
 ```
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 ```
 
 ####  Update your Makefile

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.mod
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,7 +9,7 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.15+ and < 1.16.
+- [go](https://golang.org/dl/) version v1.15+.
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/utils/go.mod
+++ b/docs/book/utils/go.mod
@@ -1,3 +1,3 @@
 module sigs.k8s.io/kubebuilder/docs/book/utils
 
-go 1.15
+go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/v3
 
-go 1.15
+go 1.16
 
 require (
 	github.com/cloudflare/cfssl v1.5.0 // for `kubebuilder alpha config-gen`

--- a/pkg/plugins/golang/go_version.go
+++ b/pkg/plugins/golang/go_version.go
@@ -33,11 +33,6 @@ var (
 		major: 1,
 		minor: 13,
 	}
-	go116alpha1 = goVersion{
-		major:      1,
-		minor:      16,
-		prerelease: "alpha1",
-	}
 
 	goVerRegexp = regexp.MustCompile(goVerPattern)
 )
@@ -149,8 +144,8 @@ func checkGoVersion(verStr string) error {
 		return err
 	}
 
-	if version.compare(go113) < 0 || version.compare(go116alpha1) >= 0 {
-		return fmt.Errorf("requires 1.13 <= version < 1.16")
+	if version.compare(go113) < 0 {
+		return fmt.Errorf("requires 1.13 <= version")
 	}
 
 	return nil

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -182,8 +182,5 @@ var _ = Describe("checkGoVersion", func() {
 		Entry("for go 1.13beta1", "go1.13beta1"),
 		Entry("for go 1.13rc1", "go1.13rc1"),
 		Entry("for go 1.13rc2", "go1.13rc2"),
-		Entry("for go 1.16beta1", "go1.16beta1"),
-		Entry("for go 1.16rc1", "go1.16rc1"),
-		Entry("for go 1.16", "go1.16"),
 	)
 })

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/gomod.go
@@ -46,7 +46,7 @@ func (f *GoMod) SetTemplateDefaults() error {
 const goModTemplate = `
 module {{ .Repo }}
 
-go 1.15
+go 1.16
 
 require (
 	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}

--- a/testdata/project-v3-addon/Dockerfile
+++ b/testdata/project-v3-addon/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0

--- a/testdata/project-v3-config/Dockerfile
+++ b/testdata/project-v3-config/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-config/go.mod
+++ b/testdata/project-v3-config/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-config
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-multigroup/go.mod
+++ b/testdata/project-v3-multigroup/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0

--- a/testdata/project-v3/Dockerfile
+++ b/testdata/project-v3/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3/go.mod
+++ b/testdata/project-v3/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
- ⚠ (:warning:): breaking


Description

Update go version from 1.15 to 1.16


**Note**
Here's the link to update the infra to run the CI jobs as well: https://github.com/kubernetes/test-infra/pull/22199