### PR TITLE
:book: add default conversion review versions to kb book

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+        - "v1"

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/webhook_in_cronjobs.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+        - "v1"


### PR DESCRIPTION
Update tutorials in book to scaffold default conversion review version.
follow up: #2176 

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
