### PR TITLE
🐛 fix: incorrect cert-manager kustomize comments

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_projectconfigs.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_cronjobs.yaml
 #- patches/cainjection_in_projectconfigs.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -11,7 +11,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -11,7 +11,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/crd/kustomization.go
@@ -23,8 +23,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 )
 
-var _ machinery.Template = &Kustomization{}
-var _ machinery.Inserter = &Kustomization{}
+var (
+	_ machinery.Template = &Kustomization{}
+	_ machinery.Inserter = &Kustomization{}
+)
 
 // Kustomization scaffolds a file that defines the kustomization scheme for the crd folder
 type Kustomization struct {
@@ -113,7 +115,7 @@ patchesStrategicMerge:
 # patches here are for enabling the conversion webhook for each CRD
 %s
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 %s
 

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -23,8 +23,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 )
 
-var _ machinery.Template = &Kustomization{}
-var _ machinery.Inserter = &Kustomization{}
+var (
+	_ machinery.Template = &Kustomization{}
+	_ machinery.Inserter = &Kustomization{}
+)
 
 // Kustomization scaffolds a file that defines the kustomization scheme for the crd folder
 type Kustomization struct {
@@ -113,7 +115,7 @@ patchesStrategicMerge:
 # patches here are for enabling the conversion webhook for each CRD
 %s
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 %s
 

--- a/testdata/project-v2-addon/config/crd/kustomization.yaml
+++ b/testdata/project-v2-addon/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml

--- a/testdata/project-v2-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v2-multigroup/config/crd/kustomization.yaml
@@ -23,7 +23,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_healthcheckpolicies.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_frigates.yaml

--- a/testdata/project-v2/config/crd/kustomization.yaml
+++ b/testdata/project-v2/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml

--- a/testdata/project-v3-addon/config/crd/kustomization.yaml
+++ b/testdata/project-v3-addon/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml

--- a/testdata/project-v3-config/config/crd/kustomization.yaml
+++ b/testdata/project-v3-config/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml

--- a/testdata/project-v3-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/crd/kustomization.yaml
@@ -25,7 +25,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_lakers.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_frigates.yaml

--- a/testdata/project-v3/config/crd/kustomization.yaml
+++ b/testdata/project-v3/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_admirales.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_captains.yaml
 #- patches/cainjection_in_firstmates.yaml


### PR DESCRIPTION
Several comments for enabling cert-manager in the kustomization config
incorrectly said `[CERTMANAGER] To enable webhook`

This was probably a copy/paste error.
