### PR TITLE
:book: controllerutil.AddFinalizer already contains code to avoid duplicates

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -66,11 +66,9 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// registering our finalizer.
-		if !containsString(cronJob.GetFinalizers(), myFinalizerName) {
-			controllerutil.AddFinalizer(cronJob, myFinalizerName)
-			if err := r.Update(ctx, cronJob); err != nil {
-				return ctrl.Result{}, err
-			}
+		controllerutil.AddFinalizer(cronJob, myFinalizerName)
+		if err := r.Update(ctx, cronJob); err != nil {
+			return ctrl.Result{}, err
 		}
 	} else {
 		// The object is being deleted


### PR DESCRIPTION
Removed unneeded code and with that simplified it a bit. controllerutil.AddFinalizer already contains code to avoid duplicates

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
