### PR TITLE
🐛 Fix config-gen documentation bug

### DIFF
--- a/pkg/cli/alpha/config-gen/cmd.go
+++ b/pkg/cli/alpha/config-gen/cmd.go
@@ -265,7 +265,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 transformers:
 - |-
-  apiVersion: kubebuilder.sigs.k8s.io
+  apiVersion: kubebuilder.sigs.k8s.io/v1alpha1
   kind: KubebuilderConfigGen
   metadata:
     name: my-project


### PR DESCRIPTION
Add v1alpha1 to the apiVersion in the documentation for the config-gen command.

This is necessary because the install-plugin sub-command installation location must match the api group and api version in the plugin configuration.
