### PR TITLE
:book: Link to v2 book as well from intro page

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,8 +1,6 @@
-**Note:** Impatient readers may head straight to [Quick
-Start](quick-start.md).
+**Note:** Impatient readers may head straight to [Quick Start](quick-start.md).
 
-**Using Kubebuilder v1? Check the [legacy
-documentation](https://book-v1.book.kubebuilder.io)**
+**Using Kubebuilder v1 or v2? Check the legacy documentation for [v1](https://book-v1.book.kubebuilder.io) or [v2](https://book-v2.book.kubebuilder.io)** 
 
 ## Who is this for
 


### PR DESCRIPTION
Hi there!

Not sure if this has been brought up before but now that we're on v3 I think it'd be nice to also link to the v2 version of the documentation for those who are temporarily stuck on v2 like me :sweat_smile: 