### PR TITLE
📖 Add FAQ documentation section and propose how to about webhook and Kubernetes client

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -103,8 +103,13 @@
   - [Extending the CLI](./plugins/extending-cli.md)
   - [Creating your own plugins](./plugins/creating-plugins.md)
 
+---
+
+- [FAQ][faq]
+
 ---  
 [Appendix: The TODO Landing Page](./TODO.md)
 
 
 [plugins]: ./plugins/plugins.md
+[faq]: ./faq/faq.md

--- a/docs/book/src/faq/faq.md
+++ b/docs/book/src/faq/faq.md
@@ -1,0 +1,43 @@
+# FAQ
+
+Frequently Ask Question
+
+## How to use Kubernetes client in webhook?
+
+You can declare the Kubernetes client in webhook from the controller manager easily.
+
+<details>
+  <summary>Read more</summary>
+
+To begin, you need to import the client and declare the variable:
+
+```go
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	C client.Client
+)
+```
+
+Next, it is very simple to fill the previous client variable from the controller manager.
+
+```go
+func (r *MyAwesomeCRD) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	C = mgr.GetClient()
+
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+```
+
+Finally, you can use the client in your validator for example:
+
+```go
+func (r *MyAwesomeCRD) ValidateDelete() error {
+	return C.Get(// ... //)
+}
+```
+</details>


### PR DESCRIPTION
Hi awesome community! 👋🏻 

I encountered an issue when I wanted to employ the best practice for using the Kubernetes client in a webhook.

Today, I wanted to suggest to the community to create a new FAQ section in the documentation with this interesting tips.
(We use such a section at [Minikube](https://minikube.sigs.k8s.io/docs/faq/))

What do you think?
Is it a good idea?
Is it in Kubebuilder's philosophy?

Happy to read more.
Have a very nice day.