### PR TITLE
🐛 Fixed by prompting the user to perform 'make generate'

### DIFF
--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -161,10 +161,7 @@ func (p *createAPISubcommand) PostScaffold() error {
 	}
 
 	if p.runMake && p.resource.HasAPI() {
-		err = util.RunCmd("Running make", "make", "generate")
-		if err != nil {
-			return err
-		}
+		fmt.Printf("Next: generate targets with:\n$ make generate\n")
 	}
 
 	return nil

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -184,10 +184,7 @@ func (p *createAPISubcommand) PostScaffold() error {
 		return err
 	}
 	if p.runMake && p.resource.HasAPI() {
-		err = util.RunCmd("Running make", "make", "generate")
-		if err != nil {
-			return err
-		}
+		fmt.Printf("Next: generate targets with:\n$ make generate\n")
 	}
 
 	return nil


### PR DESCRIPTION

This PR removes the functionality of generating the samples (CR) by default and give a message to the user to take a special action on generating the target to get the manifests

Changed the golang v2 and v3  by adding relevant statements matching the existing format used by kubebuilder