### PR TITLE
✨  Ask user to perform generate target instead of automatically called by create api

### DIFF
--- a/docs/book/src/cronjob-tutorial/running.md
+++ b/docs/book/src/cronjob-tutorial/running.md
@@ -1,5 +1,12 @@
 # Running and deploying the controller
 
+### Optional
+If opting to make any changes to the API definitions, then before proceeding,
+generate the manifests like CRs or CRDs with 
+```bash
+make manifests
+```
+
 To test out the controller, we can run it locally against the cluster.
 Before we do so, though, we'll need to install our CRDs, as per the [quick
 start](/quick-start.md).  This will automatically update the YAML

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -91,6 +91,11 @@ and the `controllers/guestbook_controller.go` where the reconciliation business 
 logic. For more info see [Designing an API](/cronjob-tutorial/api-design.md) and [What's in
 a Controller](cronjob-tutorial/controller-overview.md).
 
+If you are editing the API definitions, generate the manifests such as CRs or CRDs using 
+```bash
+make manifests
+```
+
 <details><summary>Click here to see an example. `(api/v1/guestbook_types.go)` </summary>
 <p>
 

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -56,5 +56,4 @@ metadata:
   name: {{ lower .Resource.Kind }}-sample
 spec:
   # Add fields here
-  foo: bar
 `

--- a/pkg/plugins/golang/declarative/v1/api.go
+++ b/pkg/plugins/golang/declarative/v1/api.go
@@ -64,6 +64,9 @@ make generate will be run.
   # Edit the Controller Test
   nano controllers/frigate/frigate_controller_test.go
 
+  # Generate the manifests
+  make manifests
+
   # Install CRDs into the Kubernetes cluster using kubectl apply
   make install
 

--- a/pkg/plugins/golang/v2/api.go
+++ b/pkg/plugins/golang/v2/api.go
@@ -74,6 +74,9 @@ make generate will be run.
   # Edit the Controller Test
   nano controllers/frigate/frigate_controller_test.go
 
+  # Generate the manifests
+  make manifests
+
   # Install CRDs into the Kubernetes cluster using kubectl apply
   make install
 
@@ -165,6 +168,7 @@ func (p *createAPISubcommand) PostScaffold() error {
 		if err != nil {
 			return err
 		}
+		fmt.Print("Next: implement your new API and generate the manifests (e.g. CRDs,CRs) with:\n$ make manifests \n")
 	}
 
 	return nil

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -56,5 +56,4 @@ metadata:
   name: {{ lower .Resource.Kind }}-sample
 spec:
   # Add fields here
-  foo: bar
 `

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -82,6 +82,9 @@ make generate will be run.
   # Edit the Controller Test
   nano controllers/frigate/frigate_controller_test.go
 
+  # Generate the manifests
+  make manifests
+
   # Install CRDs into the Kubernetes cluster using kubectl apply
   make install
 
@@ -188,6 +191,7 @@ func (p *createAPISubcommand) PostScaffold() error {
 		if err != nil {
 			return err
 		}
+		fmt.Print("Next: implement your new API and generate the manifests (e.g. CRDs,CRs) with:\n$ make manifests\n")
 	}
 
 	return nil

--- a/test/e2e/v2/plugin_cluster_test.go
+++ b/test/e2e/v2/plugin_cluster_test.go
@@ -19,6 +19,7 @@ package v2
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -292,6 +293,21 @@ var _ = Describe("kubebuilder", func() {
 			// we can change it to probe the readiness endpoint after CR supports it.
 			sampleFile := filepath.Join("config", "samples",
 				fmt.Sprintf("%s_%s_%s.yaml", kbc.Group, kbc.Version, strings.ToLower(kbc.Kind)))
+
+			sampleFilePath, err := filepath.Abs(filepath.Join(fmt.Sprintf("e2e-%s", kbc.TestSuffix), sampleFile))
+			Expect(err).To(Not(HaveOccurred()))
+
+			f, err := os.OpenFile(sampleFilePath, os.O_APPEND|os.O_WRONLY, 0644)
+			Expect(err).To(Not(HaveOccurred()))
+
+			defer func() {
+				err = f.Close()
+				Expect(err).To(Not(HaveOccurred()))
+			}()
+
+			_, err = f.WriteString("  foo: bar")
+			Expect(err).To(Not(HaveOccurred()))
+
 			Eventually(func() error {
 				_, err = kbc.Kubectl.Apply(true, "-f", sampleFile)
 				return err

--- a/testdata/project-v2-addon/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v2-addon/config/samples/crew_v1_admiral.yaml
@@ -4,4 +4,3 @@ metadata:
   name: admiral-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-addon/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v2-addon/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-addon/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v2-addon/config/samples/crew_v1_firstmate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: firstmate-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v2-multigroup/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v2-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -4,4 +4,3 @@ metadata:
   name: healthcheckpolicy-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v2-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -4,4 +4,3 @@ metadata:
   name: kraken-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v2-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -4,4 +4,3 @@ metadata:
   name: leviathan-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v2-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -4,4 +4,3 @@ metadata:
   name: destroyer-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v2-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: frigate-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v2-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -4,4 +4,3 @@ metadata:
   name: cruiser-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v2/config/samples/crew_v1_admiral.yaml
@@ -4,4 +4,3 @@ metadata:
   name: admiral-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v2/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v2/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v2/config/samples/crew_v1_firstmate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: firstmate-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-addon/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3-addon/config/samples/crew_v1_admiral.yaml
@@ -4,4 +4,3 @@ metadata:
   name: admiral-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-addon/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-addon/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-addon/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3-addon/config/samples/crew_v1_firstmate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: firstmate-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-config/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_admiral.yaml
@@ -4,4 +4,3 @@ metadata:
   name: admiral-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-config/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-config/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_firstmate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: firstmate-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/samples/_v1_lakers.yaml
@@ -4,4 +4,3 @@ metadata:
   name: lakers-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-multigroup/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v3-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -4,4 +4,3 @@ metadata:
   name: healthcheckpolicy-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -4,4 +4,3 @@ metadata:
   name: kraken-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -4,4 +4,3 @@ metadata:
   name: leviathan-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -4,4 +4,3 @@ metadata:
   name: destroyer-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: frigate-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -4,4 +4,3 @@ metadata:
   name: cruiser-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_admiral.yaml
@@ -4,4 +4,3 @@ metadata:
   name: admiral-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_captain.yaml
@@ -4,4 +4,3 @@ metadata:
   name: captain-sample
 spec:
   # Add fields here
-  foo: bar

--- a/testdata/project-v3/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_firstmate.yaml
@@ -4,4 +4,3 @@ metadata:
   name: firstmate-sample
 spec:
   # Add fields here
-  foo: bar


### PR DESCRIPTION
Removes the functionality of generating the samples (CR) by default and puts a message to the user to take action on generating the target to get the manifests using `make generate` giving more control to the user. 

This action was done automatically by 'create api' earlier

Fixes #2188.