### PR TITLE
📖 Add the --repo flag to init example of the cronjob tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
@@ -44,9 +44,12 @@ Kubebuilder](../quick-start.md#installation), then scaffold out a new
 project:
 
 ```bash
+# create a project directory, and then run the init command.
+mkdir project
+cd project
 # we'll use a domain of tutorial.kubebuilder.io,
 # so all API groups will be <group>.tutorial.kubebuilder.io.
-kubebuilder init --domain tutorial.kubebuilder.io
+kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io/project
 ```
 
 <aside class="note">


### PR DESCRIPTION
Add the `--repo` flag to init command of the cronjob tutorial.

https://github.com/kubernetes-sigs/kubebuilder/blob/e8715b32a41b7465e9c8cd1d36c25f27453d412f/docs/book/src/cronjob-tutorial/cronjob-tutorial.md#L46-L52

which is the same as the create a project example in quick start.

https://github.com/kubernetes-sigs/kubebuilder/blob/4b171da5846bc40772c0025c1033427dde536115/docs/book/src/quick-start.md#L56-L60
