### PR TITLE
✨ fix(scaffolds): better defaults

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -63,6 +63,7 @@ spec:
         - "--v=10"
         ports:
         - containerPort: 8443
+          protocol: TCP
           name: https
 {{- if not .ComponentConfig }}
       - name: manager

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
@@ -95,8 +95,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/auth_proxy_service.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/auth_proxy_service.go
@@ -51,6 +51,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/webhook/service.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/webhook/service.go
@@ -52,6 +52,7 @@ metadata:
 spec:
   ports:
     - port: 443
+      protocol: TCP
       targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
@@ -18,6 +18,7 @@ spec:
         - "--v=10"
         ports:
         - containerPort: 8443
+          protocol: TCP
           name: https
       - name: manager
         args:

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -47,8 +47,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/testdata/project-v3-addon/config/rbac/auth_proxy_service.yaml
+++ b/testdata/project-v3-addon/config/rbac/auth_proxy_service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
@@ -18,4 +18,5 @@ spec:
         - "--v=10"
         ports:
         - containerPort: 8443
+          protocol: TCP
           name: https

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -45,8 +45,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/testdata/project-v3-config/config/rbac/auth_proxy_service.yaml
+++ b/testdata/project-v3-config/config/rbac/auth_proxy_service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3-config/config/webhook/service.yaml
+++ b/testdata/project-v3-config/config/webhook/service.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   ports:
     - port: 443
+      protocol: TCP
       targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -18,6 +18,7 @@ spec:
         - "--v=10"
         ports:
         - containerPort: 8443
+          protocol: TCP
           name: https
       - name: manager
         args:

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -47,8 +47,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/testdata/project-v3-multigroup/config/rbac/auth_proxy_service.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/auth_proxy_service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3-multigroup/config/webhook/service.yaml
+++ b/testdata/project-v3-multigroup/config/webhook/service.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   ports:
     - port: 443
+      protocol: TCP
       targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -18,6 +18,7 @@ spec:
         - "--v=10"
         ports:
         - containerPort: 8443
+          protocol: TCP
           name: https
       - name: manager
         args:

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -47,8 +47,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/testdata/project-v3/config/rbac/auth_proxy_service.yaml
+++ b/testdata/project-v3/config/rbac/auth_proxy_service.yaml
@@ -9,6 +9,7 @@ spec:
   ports:
   - name: https
     port: 8443
+    protocol: TCP
     targetPort: https
   selector:
     control-plane: controller-manager

--- a/testdata/project-v3/config/webhook/service.yaml
+++ b/testdata/project-v3/config/webhook/service.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   ports:
     - port: 443
+      protocol: TCP
       targetPort: 9443
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
- explicitly specify port protocol where missing
- larger resource limit for controller manager

With the original default manifest, the server-side-apply would fail since the required `protocol` field is missing.

This is actually a k8s [bug](https://github.com/kubernetes-sigs/structured-merge-diff/issues/130) and should not be omitted before 1.20.

The default controller manager resource limit is too low for downloading small amount (~30kb) of http resource. It results a OOMKilled Pod status and no logs could be found.

Sometimes you got the CrashLoopBackOff status but no logs found, which took me sometime to figure it out.

We can watch the status transition via `kubectl get po -w`:

```sh
bootstrap-controller-manager-8f88c7b5b-gplpg   2/2     Running            4          3m59s
bootstrap-controller-manager-8f88c7b5b-gplpg   1/2     OOMKilled          4          4m5s
bootstrap-controller-manager-8f88c7b5b-gplpg   1/2     CrashLoopBackOff   4          4m10s
bootstrap-controller-manager-8f88c7b5b-gplpg   1/2     Running            5          5m27s
bootstrap-controller-manager-8f88c7b5b-gplpg   2/2     Running            5          5m39s
bootstrap-controller-manager-8f88c7b5b-gplpg   1/2     OOMKilled          5          6m4s
bootstrap-controller-manager-8f88c7b5b-gplpg   1/2     CrashLoopBackOff   5          6m9s
```

I suppose this default improves the user experience especially for beginners.