### PR TITLE
📖 Fix name: kube-auth-proxy -> kube-rbac-proxy

### DIFF
--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -5,7 +5,7 @@ publishes a collection of performance metrics for each controller.
 
 ## Protecting the Metrics
 
-These metrics are protected by [kube-auth-proxy](https://github.com/brancz/kube-rbac-proxy)
+These metrics are protected by [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy)
 by default if using kubebuilder. Kubebuilder v2.2.0+ scaffold a clusterrole which
 can be found at `config/rbac/auth_proxy_client_clusterrole.yaml`.
 


### PR DESCRIPTION
Hi, I fixed display name of https://github.com/brancz/kube-rbac-proxy(kube-auth-proxy -> kube-rbac-proxy).
This name can be a check on following page: https://book.kubebuilder.io/reference/metrics.html