### PR TITLE
📖 Clarify artifacts doc to explicitly mention Kubernetes version

### DIFF
--- a/docs/book/src/reference/artifacts.md
+++ b/docs/book/src/reference/artifacts.md
@@ -12,5 +12,5 @@ You can find a test binary tarball for a particular Kubernetes version and host 
 
 You can find all container image versions for a particular platform at `https://go.kubebuilder.io/images/${os}/${arch}`
 or at `gcr.io/kubebuilder/thirdparty-${os}-${arch}`.
-You can find the container image for a particular version and platform at `https://go.kubebuilder.io/images/${os}/${arch}/${version}`
+You can find the container image for a particular Kubernetes version and host platform at `https://go.kubebuilder.io/images/${os}/${arch}/${version}`
 or at `gcr.io/kubebuilder/thirdparty-${os}-${arch}:${version}`.


### PR DESCRIPTION
Explicitly mention "Kubernetes version" in artifacts documentation so users don't get confused with Kubebuilder version.

Fixes #2244

Signed-off-by: Rashmi Gottipati <chowdary.grashmi@gmail.com>
