### PR TITLE
✨ Include additional info in error messages.

### DIFF
--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -148,18 +148,19 @@ func (r *Resource) Update(other Resource) error {
 
 	// Make sure we are not merging resources for different GVKs.
 	if !r.GVK.IsEqualTo(other.GVK) {
-		return fmt.Errorf("unable to update a Resource with another with non-matching GVK")
+		return fmt.Errorf("unable to update a Resource (GVK %+v) with another with non-matching GVK %+v", r.GVK, other.GVK)
 	}
 
 	if r.Plural != other.Plural {
-		return fmt.Errorf("unable to update Resource with another with non-matching Plural")
+		return fmt.Errorf("unable to update Resource (Plural %q) with another with non-matching Plural %q",
+			r.Plural, other.Plural)
 	}
 
 	if other.Path != "" && r.Path != other.Path {
 		if r.Path == "" {
 			r.Path = other.Path
 		} else {
-			return fmt.Errorf("unable to update Resource with another with non-matching Path")
+			return fmt.Errorf("unable to update Resource (Path %q) with another with non-matching Path %q", r.Path, other.Path)
 		}
 	}
 


### PR DESCRIPTION
This makes it easier to figure out what the actual values should be.

When using from within `operator-sdk` I faced an error such as the following when scaffolding a webhook on a project when some directories were moved around:

```
FATA[0000] failed to create webhook: unable to scaffold with "kustomize.common.kubebuilder.io/v1": error updating resource: unable to update Resource with another with non-matching Path 
```
