### PR TITLE
🌱 Bump the linter version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,28 +7,35 @@ issues:
   exclude-rules:
     - linters: [gosec]
       path: "test/e2e/*"
+
+linters-settings:
+  govet:
+    enable=fieldalignment: true
+  revive:
+    rules:
+    - name: if-return
+      disabled: true
+
 linters:
   disable-all: true
   enable:
     - deadcode
     - dupl
     - errcheck
+    - exportloopref
     - goconst
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - prealloc
-    - scopelint
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.37.1 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.41.1 ;\
 	}
 
 .PHONY: apidiff


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

**Description**

Update the version of golangci-lint to the latest version.

This change updates both the version that is downloaded, the config file to account for deprecated linters in 1.41, and fixes some issues found by `revive` (which replaces `golint`.)

`make lint` and `make test` both pass with no issues.

 
**Motivation**

Although the version in current use isn't "old", there are some linters that aren't maintained anymore, or have been supersededded by other linters.

The thought is that the latest version will be more likely to catch more "issues" - before they make it into a release.


**Fixes**

Fixes #2274 