### PR TITLE
📖 Update generating crd link in docs

### DIFF
--- a/docs/book/src/reference/markers/crd.md
+++ b/docs/book/src/reference/markers/crd.md
@@ -4,6 +4,6 @@ These markers describe how to construct a custom resource definition from
 a series of Go types and packages.  Generation of the actual validation
 schema is described by the [validation markers](./crd-validation.md).
 
-See [Generating CRDs](/reference/generating-crd.md) for examples.
+See [Generating CRDs](../generating-crd.md) for examples.
 
 {{#markerdocs CRD}}


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
Fixes: https://github.com/kubernetes-sigs/kubebuilder/issues/2276

The [Generating CRDs](https://github.com/kubernetes-sigs/kubebuilder/blob/cb1b6008f16ad5b4f56b019600f285e902215795/docs/book/src/reference/generating-crd.md) link is broken, a small correction to fix it.