### PR TITLE
📖  Fix link for component-config-tutorial

### DIFF
--- a/docs/book/src/component-config-tutorial/api-changes.md
+++ b/docs/book/src/component-config-tutorial/api-changes.md
@@ -3,7 +3,7 @@
 This tutorial will show you how to create a custom configuration file for your
 project by modifying a project generated with the `--component-config` flag
 passed to the `init` command. The full tutorial's source can be found 
-[here][tutorial-source]. Make sure you've gone through the [installation 
+[here](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/component-config-tutorial/testdata/project). Make sure you've gone through the [installation 
 steps](/quick-start.md#installation) before continuing.
 
 ## New project:

--- a/docs/book/src/component-config-tutorial/api-changes.md
+++ b/docs/book/src/component-config-tutorial/api-changes.md
@@ -3,7 +3,7 @@
 This tutorial will show you how to create a custom configuration file for your
 project by modifying a project generated with the `--component-config` flag
 passed to the `init` command. The full tutorial's source can be found 
-[here](https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/component-config-tutorial/testdata/project). Make sure you've gone through the [installation 
+[here][tutorial-source]. Make sure you've gone through the [installation 
 steps](/quick-start.md#installation) before continuing.
 
 ## New project:

--- a/docs/book/src/component-config-tutorial/tutorial.md
+++ b/docs/book/src/component-config-tutorial/tutorial.md
@@ -20,7 +20,7 @@ type so that you can extend this capability.
 
 Note that most of this tutorial is generated from literate Go files that
 form a runnable project, and live in the book source directory:
-[docs/book/src/componentconfig-tutorial/testdata/project][tutorial-source].
+[docs/book/src/component-config-tutorial/testdata/project][tutorial-source].
 
 [tutorial-source]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/docs/book/src/component-config-tutorial/testdata/project
 


### PR DESCRIPTION
component-config-tutorial link on the book is broken :)

It's pointing to componentconfig-tutorial, missing the dash (-).

Also, some links / references are broken, I'm force pointing here to the correct location in GH repo but can investigate further how should this be done


