### PR TITLE
📖 improved error log message for creating a controller

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
@@ -260,7 +260,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 {{- end }}
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
+		setupLog.Error(err, "unable to create manager")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Is it better to distinct the creation phase of a controller with the running one?
Starting the controller happens later on with its own step, so it seems more appropriate to use the word `create` instead of `start`