### PR TITLE
:book: Use an existing marker for the struct value example.

### DIFF
--- a/docs/book/src/reference/markers.md
+++ b/docs/book/src/reference/markers.md
@@ -89,5 +89,5 @@ each key and value is separated by a colon (`:`), and each key-value
 pair is separated by a comma:
 
 ```go
-// +kubebuilder:validation:Default={magic: {numero: 42, stringified: forty-two}}
+// +kubebuilder:default={magic: {numero: 42, stringified: forty-two}}
 ```


### PR DESCRIPTION
The `+kubebuilder:validation:Default` marker does not appear in the output of `controller-gen crd -www` so it was probably just an invented example.

Let's use an actual existing marker here to prevent the non-existing one from being cargo-culted into other projects any more.