### PR TITLE
📖 : Add legacy banner to v1 book

### DIFF
--- a/docs/book/book.json
+++ b/docs/book/book.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["theme-api", "panel", "sequence-diagrams", "ga"],
+  "plugins": ["theme-api", "panel", "sequence-diagrams", "ga", "kubebuilder-legacy-docs@git+https://github.com/hickeyma/gitbook-plugin-kubebuilder-legacy-docs#0.1.1"],
   "pluginsConfig": {
     "theme-api": {
       "split": true


### PR DESCRIPTION
Adds a legacy banner to the top of v1 book.

It is an aid/warning to users visiting the v1 site that they are not on the current version of the book and provides them with a link to the current version if required.

Here is a screenshot of the banner or you can view the docs preview by following the steps in [How to preview the changes performed in the docs](https://github.com/kubernetes-sigs/kubebuilder/blob/master/CONTRIBUTING.md#how-to-preview-the-changes-performed-in-the-docs):

![Screenshot 2021-08-11 at 12 38 31](https://user-images.githubusercontent.com/14892004/129022792-6da4cbcb-8d2b-44fb-b7ca-3404294676d1.png)

Fixes #1963 

**Note to reviewers:** To override GitBook templates/themes requires using a [GitBook plugin](https://snowdreams1006.github.io/gitbook-official/en/plugins/). A GitBook plugin is a node package which can be published on NPM or can be hosted on GitHub. I have hosted it on https://github.com/hickeyma/gitbook-plugin-kubebuilder-legacy-docs rather than using NPM. I am open to using a more appropriate repo is required.