### PR TITLE
📖 : Add legacy banner to v2 book

### DIFF
--- a/docs/book/theme/header.hbs
+++ b/docs/book/theme/header.hbs
@@ -3,5 +3,7 @@
     <p>We stand in solidarity with the Black community.</p>
     <p>Racism is unacceptable.</p>
     <p>It conflicts with <a href="https://git.k8s.io/community/values.md">the core values of the Kubernetes project</a> and our community does not tolerate it.</p>
+    <hr>
+    <p>Viewing legacy documentation for Kubebuilder, check out the <a href="https://book.kubebuilder.io">latest</a> documentation instead.</p>
     </p>
 </header>


### PR DESCRIPTION
Adds a legacy banner to the top of v2 book.

It is an aid/warning to users visiting the v2 site that they are not on the current version of the book and provides them with a link to the current version if required.

Here is a screenshot of the banner or you can view the docs preview by following the steps in [How to preview the changes performed in the docs](https://github.com/kubernetes-sigs/kubebuilder/blob/master/CONTRIBUTING.md#how-to-preview-the-changes-performed-in-the-docs):

![Screenshot 2021-08-17 at 17 43 58](https://user-images.githubusercontent.com/14892004/129766737-71520a7a-b852-4a1e-8c61-02b23b1a0172.png)

Note: Related to #2289 

