### PR TITLE
📖  Update go Prerequisites for the latest release 

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,7 +9,8 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.15+ and < 1.16.
+- [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0).
+- [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1+).
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.


### PR DESCRIPTION
This PR is a cherry pick of commit #2257 that updated the QuickStart prerequisites. 

As #2182 upgraded the go version to v1.16, the QuickStart documentation needed to be updated too.