### PR TITLE
:sparkles: Must include Dockerfile in declarative plugin

### DIFF
--- a/pkg/plugins/golang/declarative/v1/init.go
+++ b/pkg/plugins/golang/declarative/v1/init.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/declarative/v1/internal/templates"
+)
+
+var _ plugin.InitSubcommand = &initSubcommand{}
+
+type initSubcommand struct {
+	config config.Config
+}
+
+func (p *initSubcommand) InjectConfig(c config.Config) error {
+	p.config = c
+
+	return nil
+}
+
+func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
+	// Initialize the machinery.Scaffold that will write the files to disk
+	scaffold := machinery.NewScaffold(fs,
+		machinery.WithConfig(p.config),
+	)
+
+	if err := scaffold.Execute(
+		&templates.Dockerfile{},
+	); err != nil {
+		return fmt.Errorf("error updating scaffold: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/plugins/golang/declarative/v1/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/declarative/v1/internal/templates/dockerfile.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Dockerfile{}
+
+// Dockerfile scaffolds a file that defines the containerized build process
+type Dockerfile struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Dockerfile) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = "Dockerfile"
+	}
+
+	f.TemplateBody = dockerfileTemplate
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+const dockerfileTemplate = `# Build the manager binary
+FROM golang:1.16 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+
+# Stage channels and make readable
+COPY channels/ /channels/
+RUN chmod -R a+rx /channels/
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+COPY --from=builder /channels /channels
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+`

--- a/pkg/plugins/golang/declarative/v1/plugin.go
+++ b/pkg/plugins/golang/declarative/v1/plugin.go
@@ -37,6 +37,7 @@ var _ plugin.CreateAPI = Plugin{}
 
 // Plugin implements the plugin.Full interface
 type Plugin struct {
+	initSubcommand
 	createAPISubcommand
 }
 
@@ -48,6 +49,9 @@ func (Plugin) Version() plugin.Version { return pluginVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }
+
+// GetInitSubcommand will return the subcommand which is responsible for initializing and common scaffolding
+func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
 
 // GetCreateAPISubcommand will return the subcommand which is responsible for scaffolding apis
 func (p Plugin) GetCreateAPISubcommand() plugin.CreateAPISubcommand { return &p.createAPISubcommand }

--- a/testdata/project-v2-addon/Dockerfile
+++ b/testdata/project-v2-addon/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,13 +15,19 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+
+# Stage channels and make readable
+COPY channels/ /channels/
+RUN chmod -R a+rx /channels/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+COPY --from=builder /channels /channels
+
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/testdata/project-v3-addon/Dockerfile
+++ b/testdata/project-v3-addon/Dockerfile
@@ -17,11 +17,17 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
+# Stage channels and make readable
+COPY channels/ /channels/
+RUN chmod -R a+rx /channels/
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /channels /channels
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
We need to copy the channels directory in the Dockerfile, particularly now that we're running with non-root permissions and it is no longer a one-liner.
    
Add Dockerfile generation.