### PR TITLE
:book: fix(netlify): fix broken redirect resource

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -90,7 +90,7 @@
     from = "https://go.kubebuilder.io/releases/:version/:os/:arch"
     # I don't quite know why, but netlify (or at least the dev mode) *insists*
     # on eating every other query parameter, so just use paths instead
-    to = "/.netlify/functions/handle-version/:version/:os/:arch"
+    to = "/.netlify/functions/handle-version/releases/:version/:os/:arch"
     # 200 --> don't redirect to the the function then to whereever it says,
     # just pretend like the function is mounted directly here
     status = 200


### PR DESCRIPTION
The release redirect rule uses a self-defined JS handler function because releases prior to v3 had a different URL structure not handle-able by Netlify's static redirect definitions. The handler checks for a `releases` resource path component in the request URL, which doesn't exist in the event path provided to the handler (the API may have changed, not sure of the cause). This PR explicitly adds this resource path component to the redirect URL.

Closes #2320 
Closes #2311

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>