### PR TITLE
:book: Update Configuring EnvTest binary directory docs

### DIFF
--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -22,8 +22,8 @@ curl -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools
 Then install them:
 
 ```sh
-mkdir /opt/kubebuilder/testbin
-tar -C /opt/kubebuilder/testbin --strip-components=1 -zvxf envtest-bins.tar.gz
+mkdir /usr/local/kubebuilder
+tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz
 ```
 
 Once these binaries are installed, you can either change the `test` target to:
@@ -36,7 +36,7 @@ test: manifests generate fmt vet
 Or configure the existing target to skip the download and point to a [custom location](#environment-variables):
 
 ```sh
-make test SKIP_FETCH_TOOLS=1 KUBEBUILDER_ASSETS=/opt/kubebuilder/testbin
+make test SKIP_FETCH_TOOLS=1 KUBEBUILDER_ASSETS=/usr/local/kubebuilder
 ```
 
 ## Writing tests


### PR DESCRIPTION
The documentation for [Configuring EnvTest](https://book.kubebuilder.io/reference/envtest.html#installation) results in a non-working configuration unless a `KUBEBUILDER_ASSETS` environment variable is provided. This seems contrary to the documentation indication that the `test` target can be changed to the provided snippet.

This should address #2331.