### PR TITLE
🐛 Improve scaffolding to filter existing multiline code fragments

### DIFF
--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -353,23 +353,94 @@ func getValidCodeFragments(i Inserter) CodeFragmentsMap {
 	return codeFragments
 }
 
-// filterExistingValues removes the single-line values that already exists
-// TODO: Add support for multi-line duplicate values
+// filterExistingValues removes code fragments that already exist in the content.
 func filterExistingValues(content string, codeFragmentsMap CodeFragmentsMap) error {
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	for scanner.Scan() {
-		line := scanner.Text()
-		for marker, codeFragments := range codeFragmentsMap {
-			for i, codeFragment := range codeFragments {
-				if strings.TrimSpace(line) == strings.TrimSpace(codeFragment) {
-					codeFragmentsMap[marker] = append(codeFragments[:i], codeFragments[i+1:]...)
-				}
+	for marker, codeFragments := range codeFragmentsMap {
+		codeFragmentsOut := codeFragments[:0]
+
+		for _, codeFragment := range codeFragments {
+			exists, err := codeFragmentExists(content, codeFragment)
+			if err != nil {
+				return err
 			}
-			if len(codeFragmentsMap[marker]) == 0 {
-				delete(codeFragmentsMap, marker)
+			if !exists {
+				codeFragmentsOut = append(codeFragmentsOut, codeFragment)
 			}
 		}
+
+		if len(codeFragmentsOut) == 0 {
+			delete(codeFragmentsMap, marker)
+		} else {
+			codeFragmentsMap[marker] = codeFragmentsOut
+		}
 	}
+
+	return nil
+}
+
+// codeFragmentExists checks if the codeFragment exists in the content.
+func codeFragmentExists(content, codeFragment string) (exists bool, err error) {
+	// Trim space on each line in order to match different levels of indentation.
+	var sb strings.Builder
+	for _, line := range strings.Split(codeFragment, "\n") {
+		_, _ = sb.WriteString(strings.TrimSpace(line))
+		_ = sb.WriteByte('\n')
+	}
+
+	codeFragmentTrimmed := strings.TrimSpace(sb.String())
+	scanLines := 1 + strings.Count(codeFragmentTrimmed, "\n")
+	scanFunc := func(contentGroup string) bool {
+		if contentGroup == codeFragmentTrimmed {
+			exists = true
+			return false
+		}
+		return true
+	}
+
+	if err := scanMultiline(content, scanLines, scanFunc); err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
+// scanMultiline scans a string while buffering the specified number of scanLines. It calls scanFunc
+// for every group of lines. The content passed to scanFunc will have trimmed whitespace. It
+// continues scanning the content as long as scanFunc returns true.
+func scanMultiline(content string, scanLines int, scanFunc func(contentGroup string) bool) error {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	// Optimized simple case.
+	if scanLines == 1 {
+		for scanner.Scan() {
+			if !scanFunc(strings.TrimSpace(scanner.Text())) {
+				return scanner.Err()
+			}
+		}
+		return scanner.Err()
+	}
+
+	// Complex case.
+	bufferedLines := make([]string, scanLines)
+	bufferedLinesIndex := 0
+	var sb strings.Builder
+
+	for scanner.Scan() {
+		// Trim space on each line in order to match different levels of indentation.
+		bufferedLines[bufferedLinesIndex] = strings.TrimSpace(scanner.Text())
+		bufferedLinesIndex = (bufferedLinesIndex + 1) % scanLines
+
+		sb.Reset()
+		for i := 0; i < scanLines; i++ {
+			_, _ = sb.WriteString(bufferedLines[(bufferedLinesIndex+i)%scanLines])
+			_ = sb.WriteByte('\n')
+		}
+
+		if !scanFunc(strings.TrimSpace(sb.String())) {
+			return scanner.Err()
+		}
+	}
+
 	return scanner.Err()
 }
 

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -347,6 +347,35 @@ var b int
 					},
 				},
 			),
+			Entry("should filter already existing multi-line indented code fragments",
+				pathGo,
+				`package test
+
+func init() {
+	if err := something(); err != nil {
+		return err
+	}
+	
+	//+kubebuilder:scaffold:-
+}
+`,
+				`package test
+
+func init() {
+	if err := something(); err != nil {
+		return err
+	}
+	
+	//+kubebuilder:scaffold:-
+}
+`,
+				fakeInserter{
+					fakeBuilder: fakeBuilder{path: pathGo},
+					codeFragments: CodeFragmentsMap{
+						NewMarkerFor(pathGo, "-"): {"if err := something(); err != nil {\n\treturn err\n}\n\n"},
+					},
+				},
+			),
 			Entry("should not insert anything if no code fragment",
 				pathYaml,
 				`

--- a/testdata/project-v2-addon/controllers/suite_test.go
+++ b/testdata/project-v2-addon/controllers/suite_test.go
@@ -65,12 +65,6 @@ var _ = BeforeSuite(func(done Done) {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/testdata/project-v2/controllers/suite_test.go
+++ b/testdata/project-v2/controllers/suite_test.go
@@ -65,12 +65,6 @@ var _ = BeforeSuite(func(done Done) {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/testdata/project-v3-addon/controllers/suite_test.go
+++ b/testdata/project-v3-addon/controllers/suite_test.go
@@ -65,12 +65,6 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/testdata/project-v3-config/controllers/suite_test.go
+++ b/testdata/project-v3-config/controllers/suite_test.go
@@ -65,12 +65,6 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/testdata/project-v3-config/main.go
+++ b/testdata/project-v3-config/main.go
@@ -85,13 +85,6 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Captain")
 		os.Exit(1)
 	}
-	if err = (&controllers.CaptainReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Captain")
-		os.Exit(1)
-	}
 	if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
 		os.Exit(1)

--- a/testdata/project-v3-v1beta1/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3-v1beta1/api/v1/webhook_suite_test.go
@@ -106,6 +106,7 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:webhook
 
 	go func() {
+		defer GinkgoRecover()
 		err = mgr.Start(ctx)
 		if err != nil {
 			Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -109,9 +109,6 @@ var _ = BeforeSuite(func() {
 	err = (&Captain{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = (&Captain{}).SetupWebhookWithManager(mgr)
-	Expect(err).NotTo(HaveOccurred())
-
 	err = (&Admiral{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/testdata/project-v3/controllers/suite_test.go
+++ b/testdata/project-v3/controllers/suite_test.go
@@ -65,12 +65,6 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = crewv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/testdata/project-v3/main.go
+++ b/testdata/project-v3/main.go
@@ -85,17 +85,6 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Captain")
 		os.Exit(1)
 	}
-	if err = (&controllers.CaptainReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Captain")
-		os.Exit(1)
-	}
-	if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
-		os.Exit(1)
-	}
 	if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Adam Snyder <armsnyder@gmail.com>

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

Scaffolding can only detect existing generated code if the code fragments are single-line. As a result, multi-line scaffolding can be inserted into code more than once. This fix improves the scaffolding to detect multi-line code fragments and not inject them.

Fixes #2326 