### PR TITLE
🐛 Fix Certificate template to have isCA: true

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/certmanager/certificate.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/certmanager/certificate.yaml
@@ -19,6 +19,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/certmanager/certificate.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/certmanager/certificate.yaml
@@ -19,6 +19,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/certmanager/certificate.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/certmanager/certificate.yaml
@@ -19,6 +19,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/pkg/cli/alpha/config-gen/templates/resources/cert-manager.template.yaml
+++ b/pkg/cli/alpha/config-gen/templates/resources/cert-manager.template.yaml
@@ -20,6 +20,7 @@ spec:
   dnsNames:
   - webhook-service.{{ .Namespace }}.svc
   - webhook-service.{{ .Namespace }}.svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/pkg/cli/alpha/config-gen/testdata/enablecertmanager/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/enablecertmanager/expected.yaml
@@ -372,6 +372,7 @@ spec:
   dnsNames:
     - webhook-service.simple-system.svc
     - webhook-service.simple-system.svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/certificate.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/certificate.go
@@ -64,6 +64,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager/certificate.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager/certificate.go
@@ -62,6 +62,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/testdata/project-v2-addon/config/certmanager/certificate.yaml
+++ b/testdata/project-v2-addon/config/certmanager/certificate.yaml
@@ -20,6 +20,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/testdata/project-v2-multigroup/config/certmanager/certificate.yaml
+++ b/testdata/project-v2-multigroup/config/certmanager/certificate.yaml
@@ -20,6 +20,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/testdata/project-v2/config/certmanager/certificate.yaml
+++ b/testdata/project-v2/config/certmanager/certificate.yaml
@@ -20,6 +20,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/testdata/project-v3-config/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-config/config/certmanager/certificate.yaml
@@ -19,6 +19,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
@@ -19,6 +19,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/testdata/project-v3/config/certmanager/certificate.yaml
+++ b/testdata/project-v3/config/certmanager/certificate.yaml
@@ -19,6 +19,7 @@ spec:
   dnsNames:
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  isCA: true
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer


### PR DESCRIPTION
~Self-signed certificates must have `isCA: true`, or else the kube-apiserver may encounter TLS handshake errors connecting to the webhook server.~

EDIT: I've made this PR a draft while I investigate this further. Input/advice is appreciated.

This change adds the field to the plugin templates.

Fixes #2342 

- [x] I did a global find for `issuerRef` in order to make sure I added the `isCA` field everywhere in the book as well.
- [x] I verified that the `isCA` field exists on the v1alpha2 Certificate version used by old plugin versions.

Signed-off-by: Adam Snyder <armsnyder@gmail.com>
