### PR TITLE
✨Include base.go.kubebuilder.io/v3 plugin in CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,6 +43,7 @@ func main() {
 		cli.WithVersion(versionString()),
 		cli.WithPlugins(
 			golangv2.Plugin{},
+			golangv3.Plugin{},
 			gov3Bundle,
 			&kustomizecommonv1.Plugin{},
 			&declarativev1.Plugin{},


### PR DESCRIPTION
Registers the existing `base.go.kubebuilder.io/v3` plugin so that it is usable in the `kubebuilder` CLI, for users who do not use Kustomize.

Updated supported plugin table:

```
                        Plugin keys | Supported project versions
------------------------------------+----------------------------
          base.go.kubebuilder.io/v3 |                          3
   declarative.go.kubebuilder.io/v1 |                       2, 3
               go.kubebuilder.io/v2 |                       2, 3
               go.kubebuilder.io/v3 |                          3
 kustomize.common.kubebuilder.io/v1 |                          3
```

Closes #2349 

Signed-off-by: Adam Snyder <armsnyder@gmail.com>
