### PR TITLE
🐛 Fix wrong plugin key on some OS

### DIFF
--- a/pkg/plugin/helpers.go
+++ b/pkg/plugin/helpers.go
@@ -18,7 +18,6 @@ package plugin
 
 import (
 	"fmt"
-	"path"
 	"sort"
 	"strings"
 
@@ -28,7 +27,7 @@ import (
 
 // KeyFor returns a Plugin's unique identifying string.
 func KeyFor(p Plugin) string {
-	return path.Join(p.Name(), p.Version().String())
+	return fmt.Sprintf("%s/%s", p.Name(), p.Version())
 }
 
 // SplitKey returns a name and version for a plugin key.


### PR DESCRIPTION
Fixes a bug where if a CLI is compiled on an OS that does not use "/" as a path separator, the `cli.WithPlugins` CLI option would generate plugin keys that cannot be parsed.

Other helpers assume "/" is the plugin key separator, for example:

https://github.com/kubernetes-sigs/kubebuilder/blob/a89ce41d8da6f0e86f681fba9475c1875b14e5a3/pkg/plugin/helpers.go#L35-L41

Signed-off-by: Adam Snyder <armsnyder@gmail.com>