### PR TITLE
:bug: Fix e2e tests that timeout when run locally

### DIFF
--- a/test/e2e/local.sh
+++ b/test/e2e/local.sh
@@ -18,7 +18,7 @@ source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/setup.sh"
 
 export KIND_CLUSTER="local-kubebuilder-e2e"
-create_cluster ${KIND_K8S_VERSION:-v1.18.0}
+create_cluster ${KIND_K8S_VERSION:-v1.18.15}
 if [ -z "${SKIP_KIND_CLEANUP:-}" ]; then
   trap delete_cluster EXIT
 fi

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -51,5 +51,5 @@ function test_cluster {
   local flags="$@"
 
   go test $(dirname "$0")/v2 $flags
-  go test $(dirname "$0")/v3 $flags -timeout 20m
+  go test $(dirname "$0")/v3 $flags -timeout 30m
 }


### PR DESCRIPTION
Increases the `go test` timeout value by 10 mins so that e2e tests can run locally. 

At present, they are timing out which makes it impossible to run them successfully.
 
Fixes #2355 

Note: Also, updated the default Kubernetes version to the latest patch release of 1.18.