### PR TITLE
:book: Fix Tutorial Section 1.2 Missing Colon

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -120,7 +120,7 @@ func main() {
 		Note that the Manager can restrict the namespace that all controllers will watch for resources by:
 	*/
 
-	mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Namespace:              namespace,
 		MetricsBindAddress:     metricsAddr,


### PR DESCRIPTION
This is a simple fix to add the color after `err` so the short assignment operator (`:=`) is used. 
 
Fixes: #2337 
