### PR TITLE
:book: Fix Tutorial Section 1.2 Missing Colon (2/2)

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -141,7 +141,7 @@ func main() {
 
 	var namespaces []string // List of Namespaces
 
-	mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		NewCache:               cache.MultiNamespacedCacheBuilder(namespaces),
 		MetricsBindAddress:     fmt.Sprintf("%s:%d", metricsHost, metricsPort),


### PR DESCRIPTION
This is a simple fix to add another color after err so the short assignment operator (:=) is used.

Fixes: #2337

In the context of the emptymain.go the colon was intentionally left out, but in the context of the tutorial the color was necessary as a replacement for the cluster-scoped and namespaced-scoped manager instantiations