### PR TITLE
:book:Update the example to enable webhook and cert manager

### DIFF
--- a/docs/book/src/cronjob-tutorial/running-webhook.md
+++ b/docs/book/src/cronjob-tutorial/running-webhook.md
@@ -38,6 +38,12 @@ You need to enable the webhook and cert manager configuration through kustomize.
 {{#include ./testdata/project/config/default/kustomization.yaml}}
 ```
 
+And `config/crd/kustomization.yaml` should now look like the following:
+
+```yaml
+{{#include ./testdata/project/config/crd/kustomization.yaml}}
+```
+
 Now you can deploy it to your cluster by
 
 ```bash

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -8,12 +8,12 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_cronjobs.yaml
+- patches/webhook_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_cronjobs.yaml
+- patches/cainjection_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -18,9 +18,9 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -36,12 +36,12 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:


### PR DESCRIPTION
Description:
Update the config to make the example work.

Motivation:
The current [Deploy Webhooks](https://book.kubebuilder.io/cronjob-tutorial/running-webhook.html#deploy-webhooks) section is not working when I try to follow the book. 

Return the following error:

```
Error: var '{CERTIFICATE_NAME cert-manager.io_v1_Certificate {metadata.name}}' cannot be mapped to a field in the set of known resources
error: no objects passed to apply
make: *** [deploy] Error 1
```

What issue it fixes:

- Fixes https://github.com/kubernetes-sigs/kubebuilder/issues/2357


