### PR TITLE
✨ Add default-container annotation

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
@@ -65,6 +65,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/testdata/project-v3-addon/config/manager/manager.yaml
+++ b/testdata/project-v3-addon/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/testdata/project-v3-v1beta1/config/manager/manager.yaml
+++ b/testdata/project-v3-v1beta1/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
Previously, if the kube-rbac-proxy or another container were added to
the pod, the user would be required to specify a container when running
those commands. With this annotation and kubectl v1.21+, that is no
longer required, and it will default to the manager container.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

For https://github.com/kubernetes-sigs/kubebuilder/issues/2372