### PR TITLE
:book: Add go path note to tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
@@ -59,3 +59,13 @@ You can pass `--project-name=<dns1123-label-string>` to set a different project 
 
 Now that we've got a project in place, let's take a look at what
 Kubebuilder has scaffolded for us so far...
+
+<aside class="note">
+<h1>Developing in $GOPATH</h1>
+
+If your project is initialized within [`GOPATH`][GOPATH-golang-docs], the implicitly called `go mod init` will interpolate the module path for you.
+Otherwise `--repo=<module path>` must be set.
+
+Read the [Go modules blogpost][go-modules-blogpost] if unfamiliar with the module system.
+
+</aside>


### PR DESCRIPTION
In the quick start guide it is mentioned that if the init is executed inside the GOPATH the module path will be interpolated, otherwise the --repo parameter is necessary. This is good to highlight in the tutorial as well, otherwise errors appear like:

```
Error: failed to initialize project: unable to inject the configuration to "base.go.kubebuilder.io/v3": error finding current repository: could not determine repository path from module data, package data, or by initializing a module: go: cannot determine module path for source directory ~/cronjob (outside GOPATH, module path must be specified)
```

Example:

See quick start https://book.kubebuilder.io/quick-start.html#create-a-project vs Tutorial https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html#scaffolding-out-our-project

