### PR TITLE
:seedling: chore(test): bump k8s tools version to 1.22

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -43,7 +43,7 @@ builds:
       - linux_ppc64le
       - darwin_amd64
     env:
-      - KUBERNETES_VERSION=1.21.1
+      - KUBERNETES_VERSION=1.22.1
       - CGO_ENABLED=0
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.

--- a/docs/book/src/component-config-tutorial/testdata/project/Makefile
+++ b/docs/book/src/component-config-tutorial/testdata/project/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.22
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.22
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/docs/book/src/migration/manually_migration_guide_v2_v3.md
+++ b/docs/book/src/migration/manually_migration_guide_v2_v3.md
@@ -425,7 +425,7 @@ test: manifests generate fmt vet ## Run tests.
 <aside class="note">
 <h1>Envtest binaries</h1>
 
-The Kubernetes binaries that are required for the Envtest were upgraded from `1.16.4` to `1.21.1`.
+The Kubernetes binaries that are required for the Envtest were upgraded from `1.16.4` to `1.22.1`.
 You can still install them globally by following [these installation instructions][doc-envtest].
 
 </aside>

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.21
+ENVTEST_K8S_VERSION = 1.22
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -39,6 +39,15 @@ Or configure the existing target to skip the download and point to a [custom loc
 make test SKIP_FETCH_TOOLS=1 KUBEBUILDER_ASSETS=/opt/kubebuilder/testbin
 ```
 
+### Kubernetes 1.20 and 1.21 binary issues
+
+There have been many reports of the `kube-apiserver` or `etcd` binary [hanging during cleanup][cr-1571]
+or misbehaving in other ways. We recommend using the 1.19.2 tools version to circumvent such issues,
+which do not seem to arise in 1.22+. This is likely NOT the cause of a `fork/exec: permission denied`
+or `fork/exec: not found` error, which is caused by improper tools installation.
+
+[cr-1571]:https://github.com/kubernetes-sigs/controller-runtime/issues/1571
+
 ## Writing tests
 
 Using `envtest` in integration tests follows the general flow of:

--- a/test/e2e/local.sh
+++ b/test/e2e/local.sh
@@ -18,7 +18,7 @@ source "$(dirname "$0")/../common.sh"
 source "$(dirname "$0")/setup.sh"
 
 export KIND_CLUSTER="local-kubebuilder-e2e"
-create_cluster ${KIND_K8S_VERSION:-v1.22.1}
+create_cluster ${KIND_K8S_VERSION}
 if [ -z "${SKIP_KIND_CLEANUP:-}" ]; then
   trap delete_cluster EXIT
 fi

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -28,6 +28,7 @@ install_kind
 #   create_cluster <k8s version>
 function create_cluster {
   : ${KIND_CLUSTER:?"KIND_CLUSTER must be set"}
+  : ${1:?"k8s version must be set as arg 1"}
   if ! kind get clusters | grep -q $KIND_CLUSTER ; then
     kind create cluster -v 4 --name $KIND_CLUSTER --retain --wait=1m --config $(dirname "$0")/kind-config.yaml --image=kindest/node:$1
   fi

--- a/test/testdata/test.sh
+++ b/test/testdata/test.sh
@@ -29,15 +29,16 @@ function test_project {
 }
 
 build_kb
-fetch_tools
-
-# Test project v2
-test_project project-v2
-test_project project-v2-multigroup
-test_project project-v2-addon
 
 # Test project v3
 test_project project-v3
 test_project project-v3-multigroup
 test_project project-v3-addon
 test_project project-v3-config
+
+# Test project v2, which relies on pre-installed envtest tools to run 'make test'.
+tools_k8s_version="1.19.2"
+fetch_tools
+test_project project-v2
+test_project project-v2-multigroup
+test_project project-v2-addon


### PR DESCRIPTION
Trying out the bump to 1.22. https://github.com/kubernetes-sigs/controller-runtime/issues/1571 is fixed by using a context instead of a signal handler.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>

