### PR TITLE
🐛 fixes default value for the --ignore-not-found flag in the install and undeploy make targets

### DIFF
--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/makefile.go
@@ -134,7 +134,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
@@ -139,7 +139,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v2-addon/Makefile
+++ b/testdata/project-v2-addon/Makefile
@@ -78,7 +78,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v2-multigroup/Makefile
+++ b/testdata/project-v2-multigroup/Makefile
@@ -78,7 +78,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v2/Makefile
+++ b/testdata/project-v2/Makefile
@@ -78,7 +78,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -80,7 +80,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -80,7 +80,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -80,7 +80,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v3-v1beta1/Makefile
+++ b/testdata/project-v3-v1beta1/Makefile
@@ -81,7 +81,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -80,7 +80,7 @@ docker-push: ## Push docker image with the manager.
 ##@ Deployment
 
 ifndef ignore-not-found
-  ignore-not-found = no
+  ignore-not-found = false
 endif
 
 .PHONY: install


### PR DESCRIPTION
**Description**
PR #2341 aimed to provide users with a flag that can be passed to make uninstall and make undeploy to ignore-not-found errors when executing the underlying `kubectl delete` command. It introduced a bug where the default value for the flag was set to `no`, whereas it should have been set to `false`. This PR addresses this issue.
