### PR TITLE
📖  Update cert-manager install url because it changed

### DIFF
--- a/docs/book/src/cronjob-tutorial/cert-manager.md
+++ b/docs/book/src/cronjob-tutorial/cert-manager.md
@@ -5,7 +5,7 @@ provisioning the certificates for the webhook server. Other solutions should
 also work as long as they put the certificates in the desired location.
 
 You can follow
-[the cert manager documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html)
+[the cert manager documentation](https://cert-manager.io/docs/installation/)
 to install it.
 
 Cert manager also has a component called CA injector, which is responsible for


### PR DESCRIPTION
Pretty much what the title says.
The outdated link has been replaced with an new link.