### PR TITLE
📖 Remove unused removeString function from documentation

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -115,13 +115,3 @@ func containsString(slice []string, s string) bool {
 	}
 	return false
 }
-
-func removeString(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
-}


### PR DESCRIPTION
**Description**

This PR removes `removeString()` from the document since it's not being used in the example since e0b66dca3dc2e3c2c33ecda85183cfe6ae498a7d. The function is a leftover from an old version of the document. In current version, `controllerutil.RemoveFinalizer()` is being used for removing the finalizer.