### PR TITLE
:sparkles: Add resource requests and limits to kube-rbac-proxy

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -65,6 +65,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
 {{- if not .ComponentConfig }}
       - name: manager
         args:

--- a/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
@@ -20,3 +20,10 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/testdata/project-v3-v1beta1/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-v1beta1/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,13 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"


### PR DESCRIPTION
Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

**Description**

This change introduces default resource requests and limits for the kube-rbac-proxy container scaffolded by KubeBuilder. It also provides a hint to users that this should get amended to match the specific requirements.

**Motivation**

This is similar to what is already done for the controller-manager.

- Provides information to the scheduler for better pod placement
- Prevents the pod of getting evicted or the container of getting OOM killed as first on the line when there is memory pressure on the node but the pod/container does not consume more than what it is supposed to
- Allows the pod to play well with Quotas and LimitRanges without relying on LimitRange defaults

 Fixes #2428

