### PR TITLE
:book: update docs to fix typo

### DIFF
--- a/pkg/plugins/common/kustomize/v1/init.go
+++ b/pkg/plugins/common/kustomize/v1/init.go
@@ -50,7 +50,7 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a common project with your domain and name in copyright
   %[1]s init --plugins common/v3 --domain example.org
 
-  # Initialize a common project defining an specific project version
+  # Initialize a common project defining a specific project version
   %[1]s init --plugins common/v3 --project-version 3
 `, cliMeta.CommandName)
 }

--- a/pkg/plugins/golang/v2/init.go
+++ b/pkg/plugins/golang/v2/init.go
@@ -75,7 +75,7 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a new project with your domain and name in copyright
   %[1]s init --plugins go/v2 --domain example.org --owner "Your name"
 
-  # Initialize a new project defining an specific project version
+  # Initialize a new project defining a specific project version
   %[1]s init --plugins go/v2 --project-version 2
 `, cliMeta.CommandName)
 }

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -71,7 +71,7 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a new project with your domain and name in copyright
   %[1]s init --plugins go/v3 --domain example.org --owner "Your name"
 
-  # Initialize a new project defining an specific project version
+  # Initialize a new project defining a specific project version
   %[1]s init --plugins go/v3 --project-version 3
 `, cliMeta.CommandName)
 }


### PR DESCRIPTION
Description: 
Fix a small typo in the `kubebuilder init --help` response. 

Closes: #2444 
