### PR TITLE
🌱 Add script for checking licenses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ go-apidiff:
 ##@ Tests
 
 .PHONY: test
-test: test-unit test-integration test-testdata test-book ## Run the unit and integration tests (used in the CI)
+test: test-unit test-integration test-testdata test-book test-license ## Run the unit and integration tests (used in the CI)
 
 .PHONY: test-unit
 TEST_PKGS := ./pkg/... ./test/e2e/utils/...
@@ -134,3 +134,7 @@ test-e2e-ci: ## Run the end-to-end tests (used in the CI)`
 .PHONY: test-book
 test-book: ## Run the cronjob tutorial's unit tests to make sure we don't break it
 	cd ./docs/book/src/cronjob-tutorial/testdata/project && make test
+
+.PHONY: test-license
+test-license:  ## Run the license check
+	./test/check-license.sh

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller_test.go
@@ -1,9 +1,4 @@
 /*
-Ideally, we should have one `<kind>_controller_test.go` for each controller scaffolded and called in the `suite_test.go`.
-So, let's write our example test for the CronJob controller (`cronjob_controller_test.go.`)
-*/
-
-/*
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 // +kubebuilder:docs-gen:collapse=Apache License
+
+/*
+Ideally, we should have one `<kind>_controller_test.go` for each controller scaffolded and called in the `suite_test.go`.
+So, let's write our example test for the CronJob controller (`cronjob_controller_test.go.`)
+*/
 
 /*
 As usual, we start with the necessary imports. We also define some utility variables.

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
@@ -1,11 +1,4 @@
 /*
-When we created the CronJob API with `kubebuilder create api` in a [previous chapter](/cronjob-tutorial/new-api.md), Kubebuilder already did some test work for you.
-Kubebuilder scaffolded a `controllers/suite_test.go` file that does the bare bones of setting up a test environment.
-
-First, it will contain the necessary imports.
-*/
-
-/*
 Copyright 2022 The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 // +kubebuilder:docs-gen:collapse=Apache License
+
+/*
+When we created the CronJob API with `kubebuilder create api` in a [previous chapter](/cronjob-tutorial/new-api.md), Kubebuilder already did some test work for you.
+Kubebuilder scaffolded a `controllers/suite_test.go` file that does the bare bones of setting up a test environment.
+
+First, it will contain the necessary imports.
+*/
+
 package controllers
 
 import (

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package api
 
 import (

--- a/test/check-license.sh
+++ b/test/check-license.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "$0")/common.sh
+
+echo "Checking for license header..."
+allfiles=$(listFiles|grep -v ./internal/bindata/...)
+licRes=""
+for file in $allfiles; do
+  if ! head -n4 "${file}" | grep -Eq "(Copyright|generated|GENERATED|Licensed)" ; then
+    licRes="${licRes}\n"$(echo -e "  ${file}")
+  fi
+done
+if [ -n "${licRes}" ]; then
+  echo -e "license header checking failed:\n${licRes}"
+  exit 255
+fi

--- a/test/common.sh
+++ b/test/common.sh
@@ -140,3 +140,13 @@ function is_installed {
   fi
   return 1
 }
+
+function listPkgDirs() {
+	go list -f '{{.Dir}}' ./... | grep -v generated
+}
+
+#Lists all go files
+function listFiles() {
+	# pipeline is much faster than for loop
+	listPkgDirs | xargs -I {} find {} \( -name '*.go' -o -name '*.sh' \)  | grep -v generated
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kubebuilder/issues/1891 

Adds a script that iterates through all .go and .sh files and checks if a license exists in the first 4 lines. Similar script to the SDK https://github.com/operator-framework/operator-sdk/blob/master/hack/check-license.sh with some changes. 