### PR TITLE
 📖: fix the missing of ')' in component config

### DIFF
--- a/docs/book/src/component-config-tutorial/api-changes.md
+++ b/docs/book/src/component-config-tutorial/api-changes.md
@@ -27,7 +27,7 @@ var configFile string
 flag.StringVar(&configFile, "config", "",
     "The controller will load its initial configuration from this file. "+
         "Omit this flag to use the default configuration values. "+
-        "Command-line flags override configuration from this file."
+            "Command-line flags override configuration from this file.")
 ```
 
 Now, we can setup the `Options` struct and check if the `configFile` is set,


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
