### PR TITLE
📖  - Update reference links under CronJob tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
+++ b/docs/book/src/cronjob-tutorial/cronjob-tutorial.md
@@ -69,3 +69,6 @@ Otherwise `--repo=<module path>` must be set.
 Read the [Go modules blogpost][go-modules-blogpost] if unfamiliar with the module system.
 
 </aside>
+
+[GOPATH-golang-docs]: https://golang.org/doc/code.html#GOPATH
+[go-modules-blogpost]: https://blog.golang.org/using-go-modules


### PR DESCRIPTION
The reference links for `GOPATH` and `Go modules blogpost` under https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html#scaffolding-out-our-project seems to be missing.

This PR adds these reference links.

Signed-off-by: Burak Sekili <buraksekili@gmail.com>