### PR TITLE
🌱: upgrade docker image for darwin to 1.17

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
Blocks #2471 .
The issue is ENVTEST_K8S_VERSION is set to 1.23 in all testdata makefiles, but  darwin binaries are missing for that version.
I think the issue could be that the last cloudbuild pipeline failed because of timeout? I am not sure ...