### PR TITLE
:book: Backport update of go prerequisites for the 3.3 release

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,8 +9,9 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0).
-- [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1+).
+- [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0 < v3.1).
+- [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1 < v3.3).
+- [go](https://golang.org/dl/) version v1.17+ (kubebuilder v3.3+).
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
@@ -92,7 +93,7 @@ and the `controllers/guestbook_controller.go` where the reconciliation business 
 logic. For more info see [Designing an API](/cronjob-tutorial/api-design.md) and [What's in
 a Controller](cronjob-tutorial/controller-overview.md).
 
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using 
+If you are editing the API definitions, generate the manifests such as CRs or CRDs using
 ```bash
 make manifests
 ```
@@ -201,13 +202,13 @@ make deploy IMG=<some-registry>/<project-name>:tag
 <aside class="note">
 <h1>registry permission</h1>
 
-This image ought to be published in the personal registry you specified. And it is required to have access to pull the image from the working environment. 
+This image ought to be published in the personal registry you specified. And it is required to have access to pull the image from the working environment.
 Make sure you have the proper permission to the registry if the above commands don't work.
 
 <h1>RBAC errors</h1>
 
 If you encounter RBAC errors, you may need to grant yourself cluster-admin
-privileges or be logged in as admin. See [Prerequisites for using Kubernetes RBAC on GKE cluster v1.11.x and older][pre-rbc-gke] which may be your case.  
+privileges or be logged in as admin. See [Prerequisites for using Kubernetes RBAC on GKE cluster v1.11.x and older][pre-rbc-gke] which may be your case.
 
 </aside>
 


### PR DESCRIPTION
Backport pull-request #2489 to branch book-v3.

This pull-requests contains improvements to the prerequisites needed to use kubebuilder 3.3 in the book.