### PR TITLE
:book: Fix incomplete instruction for validating webhook

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -92,7 +92,8 @@ This marker is responsible for generating a validating webhook manifest.
 //+kubebuilder:webhook:verbs=create;update;delete,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 /*
-To validate our CRD beyond what's possible with declarative validation.
+Now let's see how to validate our CRD beyond what's possible with declarative
+validation.
 Generally, declarative validation should be sufficient, but sometimes more
 advanced use cases call for complex validation.
 


### PR DESCRIPTION
Fix incomplete instruction for validating webhook.
The current instruction about the validating webhook has incomplete
sentence which is confusing. Fixed that.


