### PR TITLE
:sparkles: [build] Add support for darwin/arm64 arch

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -42,6 +42,7 @@ builds:
       - linux_arm64
       - linux_ppc64le
       - darwin_amd64
+      - darwin_arm64
     env:
       - KUBERNETES_VERSION=1.23.1
       - CGO_ENABLED=0

--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -39,3 +39,7 @@ steps:
   args: ["tar", "-zcvf", "kubebuilder_darwin_amd64.tar.gz", "-C", "dist/kubebuilder_darwin_amd64", "kubebuilder"]
 - name: "gcr.io/cloud-builders/gsutil"
   args: ["-h", "Content-Type:application/gzip", "cp", "kubebuilder_darwin_amd64.tar.gz", "gs://kubebuilder-release/kubebuilder_master_darwin_amd64.tar.gz"]
+- name: "ubuntu"
+  args: ["tar", "-zcvf", "kubebuilder_darwin_arm64.tar.gz", "-C", "dist/kubebuilder_darwin_arm64", "kubebuilder"]
+- name: "gcr.io/cloud-builders/gsutil"
+  args: ["-h", "Content-Type:application/gzip", "cp", "kubebuilder_darwin_arm64.tar.gz", "gs://kubebuilder-release/kubebuilder_master_darwin_arm64.tar.gz"]


### PR DESCRIPTION
### Description
More and more users are now using M1 chips for development so publishing
kubebuilder-tools in darwin/arm64 arch will enable them to use the
project natively on their machines without needing to apply custom ways
of solving missing dependencies.

### Motivation
Have seen many issues on different projects that utilize `kubebuilder` regarding missing
binaries in `darwin/arm64` arch so I thought to push this. Example Project: `operator-sdk`, `cluster-api`, etc.

### Fixes
- https://github.com/kubernetes-sigs/kubebuilder/issues/2505
- https://github.com/kubernetes-sigs/controller-runtime/issues/1657
- https://github.com/kubernetes-sigs/controller-runtime/issues/1809

