### PR TITLE
📖 Fix link for ControllerManagerConfigurationSpec

### DIFF
--- a/docs/book/src/component-config-tutorial/define-config.md
+++ b/docs/book/src/component-config-tutorial/define-config.md
@@ -7,6 +7,6 @@ values that are passed into the controller, to do this we can take a look at
 {{#literatego ./testdata/controller_manager_config.yaml}}
 
 To see all the available fields you can look at the `v1alpha` Controller
-Runtime config [ControllerManagerConfiguration](configtype)
+Runtime config [ControllerManagerConfiguration][configtype]
 
 [configtype]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1#ControllerManagerConfigurationSpec


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

It seems the link to ControllerManagerConfigurationSpec does not work and we need to use `[]` instead of `()` to navigate to the correct page. Thanks!

https://book.kubebuilder.io/component-config-tutorial/define-config.html