### PR TITLE
:book: fix typo in DESIGN.md doc

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -99,7 +99,7 @@ project and its various components.
 
 * **Well-commented code**: Code should be commented and given Godocs, even
   private methods and functions. It may *seem* obvious what they do at the
-  time and why, but you might forget, and other will certainly come along.
+  time and why, but you might forget, and others will certainly come along.
 
 * **Test Behaviors**: Test cases should be comprehensible as sets of
   expected behaviors.  Test cases read without code (e.g. just using `It`,


### PR DESCRIPTION
Spotted a small typo in the DESIGN.md document. Wasn't sure if `others` or `other people` sounded better. Went with `others`.

The reason I'm making this change is that it's a simple fix in a document that many newcomers to the project are directed to. 