### PR TITLE
📖 docs: fix tiny English grammar in section "watching resources"

### DIFF
--- a/docs/book/src/reference/watching-resources/externally-managed.md
+++ b/docs/book/src/reference/watching-resources/externally-managed.md
@@ -12,7 +12,7 @@ There are many examples of Resource Specs that allow users to reference external
 - Deployments and Services have references to Pods
 
 This same functionality can be added to CRDs and custom controllers.
-This will allow for resources to be reconciled when another resources it references is changed.
+This will allow for resources to be reconciled when another resource it references is changed.
 
 As an example, we are going to create a `ConfigDeployment` resource.
 The `ConfigDeployment`'s purpose is to manage a `Deployment` whose pods are always using the latest version of a `ConfigMap`.


### PR DESCRIPTION
<!--

Hiya!  Welcome to KubeBuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

# description

"another (singular) is changed"  is grammatically more correct than using the plural form as the subject.