### PR TITLE
📖 docs: fix abbreviation style in quickstart

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -93,7 +93,7 @@ and the `controllers/guestbook_controller.go` where the reconciliation business 
 logic. For more info see [Designing an API](/cronjob-tutorial/api-design.md) and [What's in
 a Controller](cronjob-tutorial/controller-overview.md).
 
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using
+If you are editing the API definitions, generate the manifests such as Custom Ressources (CRs) or Custom Ressource Defintions (CRDs) using
 ```bash
 make manifests
 ```
@@ -178,7 +178,7 @@ make run
 
 ## Install Instances of Custom Resources
 
-If you pressed `y` for Create Resource [y/n] then you created an (CR)Custom Resource for your (CRD)Custom Resource Definition in your samples (make sure to edit them first if you've changed the
+If you pressed `y` for Create Resource [y/n] then you created a CR for your CRD in your samples (make sure to edit them first if you've changed the
 API definition):
 
 ```bash

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -93,7 +93,7 @@ and the `controllers/guestbook_controller.go` where the reconciliation business 
 logic. For more info see [Designing an API](/cronjob-tutorial/api-design.md) and [What's in
 a Controller](cronjob-tutorial/controller-overview.md).
 
-If you are editing the API definitions, generate the manifests such as Custom Ressources (CRs) or Custom Ressource Defintions (CRDs) using
+If you are editing the API definitions, generate the manifests such as Custom Resources (CRs) or Custom Resource Defintions (CRDs) using
 ```bash
 make manifests
 ```


### PR DESCRIPTION
I want to make a small improvement to the quickstart docs.

The abbreviations `CR` and `CRD` should be written out the first time they are mentioned, while atm they are written out in the middle of the document. I also think that the current writing of (CR)Custom Ressource seemed odd. Wiriting it out first followed by the abbreviation in parentheses seems to be more common and is also described as the correct way [here](https://ell.stackexchange.com/questions/18197/which-goes-in-parentheses-an-abbreviation-or-a-full-form).

Closes #2539.