### PR TITLE
 📖 docs: add small improvements to docs

### DIFF
--- a/docs/book/src/cronjob-tutorial/gvks.md
+++ b/docs/book/src/cronjob-tutorial/gvks.md
@@ -54,7 +54,7 @@ The goal of this command is to create Custom Resource (CR) and Custom Resource D
 
 ## But, why create APIs at all?
 
-New APIs are how we teach Kubernetes about our custom objects. The Go structs are used to generate a Custom Resource Definition (CRD) which includes the schema for our data as well as tracking data like what our new type is called. We can then create instances of our custom objects which will be managed by our [controllers][controllers].
+New APIs are how we teach Kubernetes about our custom objects. The Go structs are used to generate a CRD which includes the schema for our data as well as tracking data like what our new type is called. We can then create instances of our custom objects which will be managed by our [controllers][controllers].
 
 Our APIs and resources represent our solutions on the clusters. Basically, the CRDs are a definition of our customized Objects, and the CRs are an instance of it.
 
@@ -70,7 +70,7 @@ The `Scheme` we saw before is simply a way to keep track of what Go type
 corresponds to a given GVK (don't be overwhelmed by its
 [godocs](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime?tab=doc#Scheme)).
 
-For instance, suppose we mark that the
+For instance, suppose we mark the
 `"tutorial.kubebuilder.io/api/v1".CronJob{}` type as being in the
 `batch.tutorial.kubebuilder.io/v1` API group (implicitly saying it has the
 Kind `CronJob`).

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -222,7 +222,7 @@ make uninstall
 
 ## Undeploy controller
 
-UnDeploy the controller to the cluster:
+Undeploy the controller to the cluster:
 
 ```bash
 make undeploy


### PR DESCRIPTION
As I keep on going through the kubebuilder book (which is an amazing resource btw, great job) I found some small mistakes that could be improved.

In quickstart
* Fix typo `UnDeploy`

In gvks.md
* Just use the abbreviation of CRD here as it has already been explained (just a few lines above)
* remove an unnecessary word

Since all of these are really small changes, I hope it's okay that I group them in a single PR.