### PR TITLE
🐛 For go/v3, ensure that the plugin can only be used with its go supported version >= 1.17 and < 1.18 

### DIFF
--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -35,8 +35,8 @@ import (
 
 // Variables and function to check Go version requirements.
 var (
-	goVerMin = golang.MustParse("go1.16")
-	goVerMax = golang.MustParse("go2.0alpha1")
+	goVerMin = golang.MustParse("go1.17")
+	goVerMax = golang.MustParse("go1.18")
 )
 
 var _ plugin.InitSubcommand = &initSubcommand{}


### PR DESCRIPTION
Hey @camilamacedo86 🙂 
I created a new PR as the previous one just got very messy. 
I am have changed the `plugins/golang/v3/init.go` min and max versions of supported go versions.

[KB is not failing for go versions not supported](https://github.com/kubernetes-sigs/kubebuilder/issues/2530)