### PR TITLE
:book: update prerequisites to clarifies go versions which are supported

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,9 +9,9 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0 < v3.1).
-- [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1 < v3.3).
-- [go](https://golang.org/dl/) version v1.17+ (kubebuilder v3.3+).
+- [go](https://golang.org/dl/) version >= v1.15+ < v1.16 (kubebuilder v3.0 < v3.1).
+- [go](https://golang.org/dl/) version >= v1.16+ < v1.17 (kubebuilder v3.1 < v3.3).
+- [go](https://golang.org/dl/) version >= v1.17+ < v1.18 (kubebuilder v3.3+).
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.


### PR DESCRIPTION
**Description**
📖 Update go version information in the QuickStart Prerequisites

**Motivation** 
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2543