### PR TITLE
🐛 For go/v3, ensure that the plugin can only be used with its go supported version >= 1.17 and < 1.18

### DIFF
--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -35,8 +35,8 @@ import (
 
 // Variables and function to check Go version requirements.
 var (
-	goVerMin = golang.MustParse("go1.16")
-	goVerMax = golang.MustParse("go2.0alpha1")
+	goVerMin = golang.MustParse("go1.17")
+	goVerMax = golang.MustParse("go1.18")
 )
 
 var _ plugin.InitSubcommand = &initSubcommand{}


### PR DESCRIPTION
Hey @camilamacedo86 🙂 

Here is the new PR. Hope this time it works absolutely fine. 