### PR TITLE
📖 Update kind apiVersion

### DIFF
--- a/docs/book/src/reference/kind-config.yaml
+++ b/docs/book/src/reference/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
Update the apiVersion of the [kind-config.yaml](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/src/reference/kind-config.yaml) to match the current kind version's config format.
`v1alpha3` is no longer supported since kind v0.9.0

Fixes error:
`ERROR: failed to create cluster: unknown apiVersion: kind.sigs.k8s.io/v1alpha3`


* https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0