### PR TITLE
✨ Update kustomize version for Macbook M1 support

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -34,7 +34,7 @@ const (
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
 	ControllerToolsVersion = "v0.8.0"
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
-	KustomizeVersion = "v3.8.7"
+	KustomizeVersion = "v4.2.0"
 
 	imageName = "controller:latest"
 )


### PR DESCRIPTION
Currently we set `KustomizeVersion` to 3.8.7 where there are no kustomize arm64 assets available for Macbook M1 machines.

Starting with kustomize **4.2.0** there are darwin_arm64 packages available. We should update the kustomize version so developers with M1 machines can download the kustomize binary with `install_kustomize.sh` in `Makefile`.

