### PR TITLE
📖 Documentation for go/v2 and go/v3 plugin

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -109,6 +109,8 @@
   - [Extending the CLI](./plugins/extending-cli.md)
   - [Creating your own plugins](./plugins/creating-plugins.md)
   - [Available Plugins](./plugins/available-plugins.md)
+    - [go/v3 plugin](./plugins/go-v3-plugin.md)
+    - [go/v2 plugin](./plugins/go-v2-plugin.md)
     - [Declarative V1](./plugins/declarative-v1.md)
 
 ---  

--- a/docs/book/src/plugins/available-plugins.md
+++ b/docs/book/src/plugins/available-plugins.md
@@ -1,5 +1,15 @@
-# Available Plugins
+# Available plugins
 
-This section details how to use the currently available plugins in Kubebuilder. 
+This section describes the plugins supported and shipped in with the Kubebuilder project.
 
-  - [Declarative V1](declarative-v1.md)
+<aside class="note">
+
+<h1>But you can create your own plugins, see:</h1>
+
+- [Creating your own plugins][create-plugins]. 
+- [Plugins Phase 2][plugins-phase-2] - will allow users to use these external options as helpers to perform the scaffolds with the tool.
+
+</aside>
+
+[create-plugins]: creating-plugins.md
+[plugins-phase-2]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-2.md

--- a/docs/book/src/plugins/declarative-v1.md
+++ b/docs/book/src/plugins/declarative-v1.md
@@ -48,7 +48,7 @@ The following scaffolds will be created or updated by this plugin:
 * `channels/stable`
 * `Dockerfile`
 
-## Further ressources
+## Further resources
 
 * Read more about the [declarative pattern][kubebuilder-declarative-pattern]
 * Watch the KubeCon 2018 Video [Managing Addons with Operators][kubecon-video]

--- a/docs/book/src/plugins/go-v2-plugin.md
+++ b/docs/book/src/plugins/go-v2-plugin.md
@@ -1,0 +1,51 @@
+# go/v2 plugin
+
+The `go/v2` plugin has the purpose to scaffold Golang projects to help users to build projects with [controllers][controller-runtime] and keep the backwards compatibility with the default scaffold made using Kubebuilder CLI `2.x.z` releases.   
+
+<node>
+
+You can check samples using this plugin by looking at the `project-v2-<options>` directories under the [testdata][testdata] projects on the root directory of the Kubebuilder project.
+
+</node>  
+
+## When should I use this plugin
+
+Only if you are looking to scaffold a project with the legacy layout. Otherwise, it is recommended you to use the default Golang version plugin. 
+
+<aside class="note warning">
+
+<h1> Note </h1>
+
+Be aware that this plugin version does not provide a scaffold compatible with the latest versions of the dependencies used in order to keep its backwards compatibility. 
+
+</aside>
+
+## How to use it ?
+
+To initialize a Golang project using the legacy layout and with this plugin run, e.g.:
+
+```sh
+kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io/project --plugins=go/v2
+```
+<aside class="note">
+
+<h1> Note </h1>
+
+By creating a project with this plugin, the PROJECT file scaffold will be using the previous schema (_project version 2_).  So that Kubebuilder CLI knows what plugin version was used and will call its subcommands such as `create api` and `create webhooks`.  Note that further Golang plugins versions use the new Project file schema, which tracks the information about what plugins and versions have been used so far. 
+
+</aside>
+
+## Subcommands supported by the plugin
+
+-  Init -  `kubebuilder init [OPTIONS]`
+-  Edit -  `kubebuilder edit [OPTIONS]`
+-  Create API -  `kubebuilder create api [OPTIONS]`
+-  Create Webhook - `kubebuilder create webhook [OPTIONS]`
+
+## Further resources
+
+- Check the code implementation of the [go/v2 plugin][v2-plugin].
+
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
+[testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata
+[v2-plugin]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/golang/v2

--- a/docs/book/src/plugins/go-v3-plugin.md
+++ b/docs/book/src/plugins/go-v3-plugin.md
@@ -1,0 +1,57 @@
+# go/v3
+
+Kubebuilder tool will scaffold the go/v3 plugin by default. This plugin is a composition of the plugins ` kustomize.common.kubebuilder.io/v1` and `base.go.kubebuilder.io/v3`. By using you can scaffold the default project which is a helper to construct sets of [controllers][controller-runtime]. 
+
+It basically scaffolds all the boilerplate code required to create and design controllers. Note that by following the [quickstart][quickstart] you will be using this plugin. 
+
+<aside class="note">
+
+<h1>Examples</h1>
+
+Samples are provided under the [testdata][testdata] directory of the Kubebuilder project. You can check samples using this plugin by looking at the `project-v3-<options>` projects under the [testdata][testdata] directory on the root directory of the Kubebuilder project.
+
+</aside>
+
+## When to use it
+
+- If you are looking to scaffold Golang projects to develop projects using [controllers][controller-runtime]
+
+## How to use it ?
+
+As `go/v3` is the default plugin there is no need to explicitly mention to Kubebuilder to use this plugin. 
+
+To create a new project with the `go/v3` plugin the following command can be used:
+
+```sh
+kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io/project
+```
+All the other subcommands supported by the go/v3 plugin can be executed similarly.
+
+<aside class="note">
+
+<h1>Note</h1>
+
+Also, if you need you can explicitly inform the plugin via the option provided `--plugins=go/v3`.
+
+</aside> 
+
+## Subcommands supported by the plugin
+
+-  Init -  `kubebuilder init [OPTIONS]`
+-  Edit -  `kubebuilder edit [OPTIONS]`
+-  Create API -  `kubebuilder create api [OPTIONS]`
+-  Create Webhook - `kubebuilder create webhook [OPTIONS]`
+
+## Further resources
+
+- To check how plugins are composited by looking at this definition in the [main.go][plugins-main].
+- Check the code implementation of the [base Golang plugin `base.go.kubebuilder.io/v3`][v3-plugin].
+- Check the code implementation of the [Kustomize/v1 plugin][kustomize-plugin].
+- Check [controller-runtime][controller-runtime] to know more about controllers.
+
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
+[quickstart]: ../quick-start.md
+[testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata
+[plugins-main]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/cmd/main.go
+[v3-plugin]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/golang/v3
+[kustomize-plugin]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/common/kustomize/v1


### PR DESCRIPTION
As mentioned in the issue #2542 I have added the documentation for the go/v2, go/v3 and also the available plugins page.
I have tried my best to follow all the checkpoints mentioned in the issue, but please let me know if any changes are required.