### PR TITLE
:seedling: allowing run tool with go 1.18 to test against prow

### DIFF
--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -36,7 +36,7 @@ import (
 // Variables and function to check Go version requirements.
 var (
 	goVerMin = golang.MustParse("go1.17")
-	goVerMax = golang.MustParse("go1.18")
+	goVerMax = golang.MustParse("go2.0alpha1")
 )
 
 var _ plugin.InitSubcommand = &initSubcommand{}


### PR DESCRIPTION
**Description**
Allow run tool with go 1.17
We are facing issues in the prow ci because infra was updated and using go 1.18