### PR TITLE
🌱 Bump kube-rbac-proxy version from v0.8.0 to v0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+testdata/
+.idea/
+bin/
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,22 +4,22 @@ aliases:
   # active folks who can be contacted to perform admin-related
   # tasks on the repo, or otherwise approve any PRs.
   kubebuilder-admins:
-    - droot
-    - mengqiy
     - pwittrock
+    - estroz
+    - camilamacedo86
 
   # non-admin folks who can approve any PRs in the repo
   kubebuilder-approvers:
-    - camilamacedo86
-    - estroz
+    - adirio
 
   # folks who can review and LGTM any PRs in the repo (doesn't include
   # approvers & admins -- those count too via the OWNERS file)
   kubebuilder-reviewers:
     - joelanford
-    - adirio
 
   # folks who may have context on ancient history,
   # but are no longer directly involved
   kubebuilder-emeritus-approvers:
   - directxman12
+  - droot
+  - mengqiy

--- a/build/cloudbuild_kube-rbac-proxy.yaml
+++ b/build/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.8.0
+  _KUBE_RBAC_PROXY_VERSION: v0.9.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   env:


### PR DESCRIPTION
**Description**
🌱 Bump kube-rbac-proxy version from v0.8.0 to v0.9.0

**Motivation**
Check if we will be able to use this helper to build/push the kube-rbac-proxy from the latest versions