### PR TITLE
🌱 bump kube-rbac-proxy version version v0.11.0

### DIFF
--- a/build/cloudbuild_kube-rbac-proxy.yaml
+++ b/build/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.10.0
+  _KUBE_RBAC_PROXY_VERSION: v0.11.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   env:


### PR DESCRIPTION
**Description**
Bump : [0.11.0](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.11.0) to generate this image