### PR TITLE
:seedling: fix run unit test locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,12 @@ test: test-unit test-integration test-testdata test-book test-license ## Run the
 .PHONY: test-unit
 TEST_PKGS := ./pkg/... ./test/e2e/utils/...
 test-unit: ## Run the unit tests
-	go test -race $(TEST_PKGS)
+	go test $(TEST_PKGS)
 
 .PHONY: test-coverage
 test-coverage: ## Run unit tests creating the output to report coverage
 	- rm -rf *.out  # Remove all coverage files if exists
-	go test -race -failfast -tags=integration -coverprofile=coverage-all.out -coverpkg="./pkg/cli/...,./pkg/config/...,./pkg/internal/...,./pkg/machinery/...,./pkg/model/...,./pkg/plugin/...,./pkg/plugins/golang" $(TEST_PKGS)
+	go test -failfast -tags=integration -coverprofile=coverage-all.out -coverpkg="./pkg/cli/...,./pkg/config/...,./pkg/internal/...,./pkg/machinery/...,./pkg/model/...,./pkg/plugin/...,./pkg/plugins/golang" $(TEST_PKGS)
 
 .PHONY: test-integration
 test-integration: ## Run the integration tests


### PR DESCRIPTION
**Description**
:seedling: fix run unit test and coverage test by removing the race flag

**Why?**
The tests implemented for the config-gen alpha command are not working locally with this option:

```
--- FAIL: TestNewCommand (0.02s)
    --- FAIL: TestNewCommand/testdata/componentconfig (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4e2e04a]
```
E.g the above was using (mac os/amd64) besides working on the ci.

We might need to look for how to come back to the -race option in the future. (I'd suggest seeing if we can migrate alpha-gen to the plugin first)
This pr unblocks contributors that want to run the tests locally.

Closes; https://github.com/kubernetes-sigs/kubebuilder/issues/2567