### PR TITLE
🐛 fix: suite test using global cfg and update docs

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/suite_test.go
@@ -87,7 +87,9 @@ var _ = BeforeSuite(func() {
 	/*
 		Then, we start the envtest cluster.
 	*/
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/controllers/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/controllers/suite_test.go
@@ -58,7 +58,9 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -188,7 +188,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3-config/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3-config/api/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3-multigroup/apis/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/crew/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3-multigroup/apis/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/ship/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3-multigroup/apis/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/ship/v2alpha1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3-multigroup/apis/v1/webhook_suite_test.go
+++ b/testdata/project-v3-multigroup/apis/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3-v1beta1/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3-v1beta1/api/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -71,7 +71,9 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 


### PR DESCRIPTION
According to pr: https://github.com/kubernetes-sigs/kubebuilder/pull/2573, 
It modifies the controller suite test, but not the webhook suite test and documentation, 
so I added the modifications.