### PR TITLE
🐛 For go/v3 plugin: Avoid to add duplicated code fragments

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -57,6 +57,7 @@ func (f *WebhookSuite) SetTemplateDefaults() error {
 
 	f.TemplateBody = fmt.Sprintf(webhookTestSuiteTemplate,
 		machinery.NewMarkerFor(f.Path, importMarker),
+		admissionImportAlias,
 		machinery.NewMarkerFor(f.Path, addSchemeMarker),
 		machinery.NewMarkerFor(f.Path, addWebhookManagerMarker),
 		"%s",
@@ -113,7 +114,6 @@ func (f *WebhookSuite) GetCodeFragments() machinery.CodeFragmentsMap {
 
 	// Generate add scheme code fragments
 	addScheme := make([]string, 0)
-	addScheme = append(addScheme, fmt.Sprintf(addschemeCodeFragment, admissionImportAlias))
 
 	// Generate add webhookManager code fragments
 	addWebhookManager := make([]string, 0)
@@ -196,6 +196,9 @@ var _ = BeforeSuite(func() {
 
 	scheme := runtime.NewScheme()
 	err = AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = %s.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	%s

--- a/testdata/project-v3-config/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3-config/api/v1/webhook_suite_test.go
@@ -84,9 +84,6 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = admissionv1beta1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -84,12 +84,6 @@ var _ = BeforeSuite(func() {
 	err = admissionv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = admissionv1beta1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = admissionv1beta1.AddToScheme(scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})


### PR DESCRIPTION
Every time we create webhook for existing project, the following duplicated code are injected.
```go
err = admissionv1beta1.AddToScheme(scheme)
Expect(err).NotTo(HaveOccurred())
```
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
