### PR TITLE
:book: Fix doc link for CRD-version-pref

### DIFF
--- a/docs/book/src/multiversion-tutorial/deployment.md
+++ b/docs/book/src/multiversion-tutorial/deployment.md
@@ -119,3 +119,5 @@ resource.version.group` is for everything else.
 [steps for troubleshooting](/TODO.md)
 
 [ref-multiver]: /reference/generating-crd.md#multiple-versions "Generating CRDs: Multiple Versions"
+
+[crd-version-pref]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority "Versions in CustomResourceDefinitions"


### PR DESCRIPTION
Currently, link for [CRD-version-pref](https://book.kubebuilder.io/multiversion-tutorial/deployment.html#kubectl-and-preferred-versions) is not renderd as markdown format.
It's showed ` [CRD docs][CRD-version-pref] ` literaly.
This is because `deployment.md` does not have cite about `CRD-version-pref`.

This PR fixes the link for `CRD-version-pref`.
I referred link URL from [this PR](https://github.com/kubernetes-sigs/kubebuilder/pull/2384/files#diff-5450fdfc6c1e06b3e8f71ecd3b3025734f6098366820c52844672587c9d194abL123).

