### PR TITLE
fix testenv docs

### DIFF
--- a/docs/book/src/cronjob-tutorial/running.md
+++ b/docs/book/src/cronjob-tutorial/running.md
@@ -72,6 +72,8 @@ make docker-build docker-push IMG=<some-registry>/<project-name>:tag
 make deploy IMG=<some-registry>/<project-name>:tag
 ```
 
+If you are using an Apple Sillicon M1 Mac, you need to follow the instructions [here](/reference/envtest.md#installation).
+
 <aside class="note">
 <h1>registry permission</h1>
 

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -19,6 +19,14 @@ export K8S_VERSION=1.21.2
 curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/$(go env GOOS)/$(go env GOARCH)"
 ```
 
+However, in the case of M1 Mac using AppleSillicon, the arm64 binary is not yet available, so the test in the Makefile must be changed.
+```makefile
+test: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+```
+
+This way, you can use intel binaries. downloaded intel binaries are executed via Rosseta2.
+
 Then install them:
 
 ```sh


### PR DESCRIPTION
## Description:
I was trying kubebuilder the other day in an Apple Sillicon m1 mac arm64 environment and found that it did not work when run as documented.
From the issues and PR it looks like these issues have been resolved.
I think the documentation needs to be meticulous so as not to discourage first-time users from doing the tutorial.
This is my first commit to kubebuilder, so please let me know if there is anything I can do to help.
Also, if there is anything else in the documentation that you would like to see changed, I will help.

tied [issue](https://github.com/kubernetes-sigs/kubebuilder/issues/2389)

## Motivation
https://github.com/kubernetes-sigs/controller-runtime/issues/1657
https://github.com/kubernetes-sigs/kubebuilder/pull/2516