### PR TITLE
- Docs: 📖 (`:book:`) add info in docs: go version v1.18+ has not been supported yet

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -11,7 +11,7 @@ This Quick Start guide will cover:
 
 - [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0 < v3.1).
 - [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1 < v3.3).
-- [go](https://golang.org/dl/) version v1.17+ (kubebuilder v3.3+).
+- [go](https://golang.org/dl/) version v1.17+, v1.18+ has not been supported yet (kubebuilder v3.3+).
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.


### PR DESCRIPTION
go version not supprot 1.18, but docs does not say it.
when i tried to use go v1.18.1 and kubebuilder v3.30， it has errors.
so need to add it in docs so that user can know it.

Fixes: https://github.com/kubernetes-sigs/kubebuilder/issues/2623

📖 (📖): documentation