### PR TITLE
🐛(Kubebuilder lib) : Function InsertCode should return error when target string is not found in content

### DIFF
--- a/pkg/plugin/util/testdata/exampleFile.txt
+++ b/pkg/plugin/util/testdata/exampleFile.txt
@@ -1,0 +1,1 @@
+exampleTarget

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -72,6 +72,9 @@ func InsertCode(filename, target, code string) error {
 		return err
 	}
 	idx := strings.Index(string(contents), target)
+	if idx == -1 {
+		return fmt.Errorf("string %s not found in %s", target, string(contents))
+	}
 	out := string(contents[:idx+len(target)]) + code + string(contents[idx+len(target):])
 	// false positive
 	// nolint:gosec

--- a/pkg/plugin/util/util_test.go
+++ b/pkg/plugin/util/util_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InsertCode", func() {
+	path := filepath.Join("testdata", "exampleFile.txt")
+	DescribeTable("should not succeed",
+		func(target string) {
+			Expect(InsertCode(path, target, "exampleCode")).ShouldNot(Succeed())
+		},
+		Entry("target given is not present in file", "randomTarget"),
+	)
+
+	DescribeTable("should succeed",
+		func(target string) {
+			Expect(InsertCode(path, target, "exampleCode")).Should(Succeed())
+		},
+		Entry("target given is present in file", "exampleTarget"),
+	)
+})


### PR DESCRIPTION

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
**Description**
Function [`InsertCode`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/util/util.go#L67-L79) should return error when `strings.Index(string(contents), target)` == -1

**Motivation**
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2639