### PR TITLE
:seedling: use github token to build assets on release

### DIFF
--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -48,4 +48,4 @@ steps:
 secrets:
 - kmsKeyName: projects/kubebuilder/locations/global/keyRings/kubebuilder-gh-tokens/cryptoKeys/gh-release-token
   secretEnv:
-    GITHUB_TOKEN: CiQAChsKTruEiSo6yBI+xg75jyr4f8yM93R2e9QbpeRX3jF3VAwSUQDQuYkCiUd+6e/1wKQAyHnf6BYv0GNGMghyNzYbXT0owBzQqmIQJeu/VDGZcEVabIWErNXjbPqPiysIu0uAiKAAUTUK0VYMr9E6GdTJ0+hVmg==
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**
:seedling: use github token to build assets on release

**Motivation**
Try to fix the release issue where the assets have not been uploaded to the release draft. 