### PR TITLE
:seedling: upgrade goreleaser to latest version to fix issues

### DIFF
--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
     git checkout $${BRANCH_NAME}
     git branch --set-upstream-to=origin/$${BRANCH_NAME}
     git tag -d ${TAG_NAME}
-- name: "goreleaser/goreleaser:v0.147"
+- name: "goreleaser/goreleaser:v1.8.3"
   entrypoint: "bash"
   args: ["build/build_kubebuilder.sh"]
   secretEnv: ["GITHUB_TOKEN"]

--- a/build/cloudbuild_local.yaml
+++ b/build/cloudbuild_local.yaml
@@ -19,7 +19,7 @@
 # Release tar will be in ./cloudbuild
 
 steps:
-- name: "goreleaser/goreleaser:v0.147"
+- name: "goreleaser/goreleaser:v1.8.3"
   entrypoint: "bash"
   env: ["SNAPSHOT=1"]
   args: ["build/build_kubebuilder.sh"]

--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -19,7 +19,7 @@
 # Release tar will be in ./cloudbuild
 
 steps:
-- name: "goreleaser/goreleaser:v0.147"
+- name: "goreleaser/goreleaser:v1.8.3"
   entrypoint: "bash"
   env: ["SNAPSHOT=1"]
   args: ["build/build_kubebuilder.sh"]


### PR DESCRIPTION
**Description**
upgrade goreleaser to latest version to fix issues

Following the error faced:
```
64le/kubebuilder
:       • building                 
:  binary=/workspace/dist/kubebuilder_darwin_amd64/kubebuilder
:       • building                  binary=/workspace/dist/kubebuilder_linux_amd64/kubebuilder
:    ⨯ release failed after 39.40s error=failed to build for darwin_arm64: pkg/cli/alpha/config-gen/cmd.go:23:2: package embed is not in GOROOT (/usr/local/go/src/embed)
: /go/pkg/mod/sigs.k8s.io/kustomize/kyaml@v0.13.6/fn/framework/parser/parser.go:7:2: package io/fs is not in GOROOT (/usr/local/go/src/io/fs)
: 
2022/04/29 09:43:44 Step  finished
2022/04/29 09:43:45 status changed to "ERROR"
ERROR
ERROR: build step 0 "goreleaser/goreleaser:v0.147" failed: exit status 1
2022/04/29 09:43:57 Build finished with ERROR status
```

The root cause here is the go version used by goreleaser:v0.147. After updating it I could test the cloud built release successfully.  

```
$ cloud-build-local --config=build/cloudbuild_local.yaml --dryrun=false --write-workspace=./cloudbuild .
2022/04/29 09:50:40 Warning: The server docker version installed (20.10.8) is different from the one used in GCB (19.03.8)
2022/04/29 09:50:40 Warning: The client docker version installed (20.10.8) is different from the one used in GCB (19.03.8)
Using default tag: latest
latest: Pulling from cloud-builders/metadata
Digest: sha256:5d4bd374c28f896ea55a50390115d39718910c137f6eb071a3aef010038887b9
Status: Image is up to date for gcr.io/cloud-builders/metadata:latest
gcr.io/cloud-builders/metadata:latest
2022/04/29 09:51:03 Started spoofed metadata server
2022/04/29 09:51:03 Build id = localbuild_ec316d8e-79a2-4218-8ea4-072addc3563c
2022/04/29 09:51:03 status changed to "BUILD"
BUILD
: Pulling image: goreleaser/goreleaser:v1.8.3
: v1.8.3: Pulling from goreleaser/goreleaser
: df9b9388f04a: Already exists
: 52dc419b0ee2: Pulling fs layer
: 25bc292e5bac: Pulling fs layer
: fd90b400223a: Pulling fs layer
: df8967c56364: Pulling fs layer
: ace80ecb1269: Pulling fs layer
: 1e4e51981c46: Pulling fs layer
: 5574e7b80b94: Pulling fs layer
: 7589d221f24d: Pulling fs layer
: 0cdd4672cfa2: Pulling fs layer
: df8967c56364: Waiting
: ace80ecb1269: Waiting
: 1e4e51981c46: Waiting
: 7589d221f24d: Waiting
: 0cdd4672cfa2: Waiting
: 5574e7b80b94: Waiting
: 5765d17b7fa6: Pulling fs layer
: 5765d17b7fa6: Waiting
: 25bc292e5bac: Verifying Checksum
: 25bc292e5bac: Download complete
: 52dc419b0ee2: Verifying Checksum
: 52dc419b0ee2: Pull complete
: 25bc292e5bac: Pull complete
: df8967c56364: Verifying Checksum
: df8967c56364: Download complete
: 1e4e51981c46: Download complete
: 5574e7b80b94: Verifying Checksum
: 5574e7b80b94: Download complete
: fd90b400223a: Download complete
: 7589d221f24d: Verifying Checksum
: 7589d221f24d: Download complete
: 0cdd4672cfa2: Verifying Checksum
: 0cdd4672cfa2: Download complete
: fd90b400223a: Pull complete
: df8967c56364: Pull complete
: 5765d17b7fa6: Verifying Checksum
: 5765d17b7fa6: Download complete
: ace80ecb1269: Verifying Checksum
: ace80ecb1269: Download complete
: ace80ecb1269: Pull complete
: 1e4e51981c46: Pull complete
: 5574e7b80b94: Pull complete
: 7589d221f24d: Pull complete
: 0cdd4672cfa2: Pull complete
: 5765d17b7fa6: Pull complete
: Digest: sha256:06fd8ec7e69a194a1ba2ec3df2f427e03e90fdbced79d979a450a9b753a8d77c
: Status: Downloaded newer image for goreleaser/goreleaser:v1.8.3
: docker.io/goreleaser/goreleaser:v1.8.3
: Running in snapshot mode. Release notes will not be generated from commits.
:    • releasing...             
:    • loading config file       file=build/.goreleaser.yml
:    • loading environment variables
:    • getting and validating git state
:       • building...               commit=c3b398676ead34c84c40a4c90c2827a2e5229eb0 latest tag=v3.0.0-alpha.0
:       • pipe skipped              error=disabled during snapshot mode
:    • parsing tag              
:    • running before hooks     
:       • running                   hook=go mod download
:    • setting defaults         
:    • snapshotting             
:       • building snapshot...      version=3.0.0-alpha.0-SNAPSHOT-c3b39867
:    • checking distribution directory
:    • loading go mod information
:    • build prerequisites      
:    • writing effective config file
:       • writing                   config=dist/config.yaml
:    • building binaries        
:       • building                  binary=dist/kubebuilder_darwin_arm64/kubebuilder
:       • building                  binary=dist/kubebuilder_linux_ppc64le/kubebuilder
:       • building                  binary=dist/kubebuilder_darwin_amd64_v1/kubebuilder
:       • building                  binary=dist/kubebuilder_linux_amd64_v1/kubebuilder
:       • building                  binary=dist/kubebuilder_linux_arm64/kubebuilder
:    • archives                 
:       • skip archiving            binary=kubebuilder name=kubebuilder_linux_amd64
:       • skip archiving            binary=kubebuilder name=kubebuilder_darwin_amd64
:       • skip archiving           
:  binary=kubebuilder name=kubebuilder_linux_arm64
:       • skip archiving            binary=kubebuilder name=kubebuilder_darwin_arm64
:       • skip archiving            binary=kubebuilder name=kubebuilder_linux_ppc64le
:    • calculating checksums    
:    • storing release metadata 
:       • writing                   file=dist/artifacts.json
:       • writing                   file=dist/metadata.json
:    • release succeeded after 243.17s
2022/04/29 09:55:54 Step  finished
2022/04/29 09:55:54 status changed to "DONE"
DONE

```