### PR TITLE
🌱 Added condition in test.sh and test_e2e.sh so that prow tests are skipped when the changes are only in docs

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -16,4 +16,9 @@
 
 # prow calls this file currently, but we can just use `make test` to test
 # the set of things we want.
-make test
+CHECK_DOCS_ONLY=$("test/check-docs-only.sh")
+if [ -z "$CHECK_DOCS_ONLY" ]; then
+    make test
+    exit 0
+fi
+echo "WARNING: The tests were skipped because only changes on the docs were faced"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -13,5 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-./test/e2e/ci.sh
+CHECK_DOCS_ONLY=$("test/check-docs-only.sh")
+if [ -z "$CHECK_DOCS_ONLY" ]; then
+    ./test/e2e/ci.sh
+    exit 0
+fi
+echo "WARNING: The tests were skipped because only changes on the docs were faced"


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
- This PR is made for skipping prow tests by adding conditions in [test.sh](https://github.com/kubernetes-sigs/kubebuilder/blob/master/test.sh) and [test_e2e.sh](https://github.com/kubernetes-sigs/kubebuilder/blob/master/test_e2e.sh), so that they are not run when the changes are made only in docs.
- This is a follow-up PR for https://github.com/kubernetes-sigs/kubebuilder/pull/2608, which is made for skipping ci jobs. 

### Motivation
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2591

