### PR TITLE
🌱Removed constant addschemeCodeFragment in pkg\plugins\golang\v3\scaffolds\internal\templates\api\webhook_suitetest.go since it is unused

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -94,10 +94,6 @@ func (f *WebhookSuite) GetMarkers() []machinery.Marker {
 const (
 	apiImportCodeFragment = `%s "%s"
 `
-	addschemeCodeFragment = `err = %s.AddToScheme(scheme	)
-Expect(err).NotTo(HaveOccurred())
-
-`
 	addWebhookManagerCodeFragment = `err = (&%s{}).SetupWebhookWithManager(mgr)
 Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION


<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
Job `golanci-lint` is failing https://github.com/kubernetes-sigs/kubebuilder/runs/6232355086?check_suite_focus=true

### Motivation
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2658