### PR TITLE
🌱 : Sync with master to prepare for 3.4.1 patch release

### DIFF
--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -48,4 +48,4 @@ steps:
 secrets:
 - kmsKeyName: projects/kubebuilder/locations/global/keyRings/kubebuilder-gh-tokens/cryptoKeys/gh-release-token
   secretEnv:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_TOKEN: CiQAChsKTruEiSo6yBI+xg75jyr4f8yM93R2e9QbpeRX3jF3VAwSUQDQuYkCiUd+6e/1wKQAyHnf6BYv0GNGMghyNzYbXT0owBzQqmIQJeu/VDGZcEVabIWErNXjbPqPiysIu0uAiKAAUTUK0VYMr9E6GdTJ0+hVmg==

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -94,10 +94,7 @@ func (f *WebhookSuite) GetMarkers() []machinery.Marker {
 const (
 	apiImportCodeFragment = `%s "%s"
 `
-	addschemeCodeFragment = `err = %s.AddToScheme(scheme	)
-Expect(err).NotTo(HaveOccurred())
 
-`
 	addWebhookManagerCodeFragment = `err = (&%s{}).SetupWebhookWithManager(mgr)
 Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**Description**
🌱 : Sync with master to prepare for 3.4.1 patch release

**Motivation**
We checked that the changes made in the cloud build do not workout so we are reverting them prior to the release 3.4.1 . See: https://github.com/kubernetes-sigs/kubebuilder/pull/2663