### PR TITLE
🐛 Ignore file zz_generated.deepcopy.go in default scaffold for v3 test coverage

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
@@ -118,6 +118,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-coverage
+test-coverage: ## Run unit tests creating the output to report coverage
+	- rm -rf *.out  # Remove all coverage files if exists
+	go test -race -failfast -tags=integration -coverprofile=cover.out.tmp
+	cat cover.out.tmp | grep -v "zz_generated.deepcopy.go" > cover.out
+	go tool cover -func cover.out
+	rm cover.out.tmp
+	
 ##@ Build
 
 .PHONY: build

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -59,6 +59,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-coverage
+test-coverage: ## Run unit tests creating the output to report coverage
+	- rm -rf *.out  # Remove all coverage files if exists
+	go test -race -failfast -tags=integration -coverprofile=cover.out.tmp
+	cat cover.out.tmp | grep -v "zz_generated.deepcopy.go" > cover.out
+	go tool cover -func cover.out
+	rm cover.out.tmp
+	
 ##@ Build
 
 .PHONY: build

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -59,6 +59,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-coverage
+test-coverage: ## Run unit tests creating the output to report coverage
+	- rm -rf *.out  # Remove all coverage files if exists
+	go test -race -failfast -tags=integration -coverprofile=cover.out.tmp
+	cat cover.out.tmp | grep -v "zz_generated.deepcopy.go" > cover.out
+	go tool cover -func cover.out
+	rm cover.out.tmp
+	
 ##@ Build
 
 .PHONY: build

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -59,6 +59,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-coverage
+test-coverage: ## Run unit tests creating the output to report coverage
+	- rm -rf *.out  # Remove all coverage files if exists
+	go test -race -failfast -tags=integration -coverprofile=cover.out.tmp
+	cat cover.out.tmp | grep -v "zz_generated.deepcopy.go" > cover.out
+	go tool cover -func cover.out
+	rm cover.out.tmp
+	
 ##@ Build
 
 .PHONY: build

--- a/testdata/project-v3-v1beta1/Makefile
+++ b/testdata/project-v3-v1beta1/Makefile
@@ -61,6 +61,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-coverage
+test-coverage: ## Run unit tests creating the output to report coverage
+	- rm -rf *.out  # Remove all coverage files if exists
+	go test -race -failfast -tags=integration -coverprofile=cover.out.tmp
+	cat cover.out.tmp | grep -v "zz_generated.deepcopy.go" > cover.out
+	go tool cover -func cover.out
+	rm cover.out.tmp
+	
 ##@ Build
 
 .PHONY: build

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -59,6 +59,14 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-coverage
+test-coverage: ## Run unit tests creating the output to report coverage
+	- rm -rf *.out  # Remove all coverage files if exists
+	go test -race -failfast -tags=integration -coverprofile=cover.out.tmp
+	cat cover.out.tmp | grep -v "zz_generated.deepcopy.go" > cover.out
+	go tool cover -func cover.out
+	rm cover.out.tmp
+	
 ##@ Build
 
 .PHONY: build


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
File [`zz_generated.deepcopy.go`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v3/api/v1/zz_generated.deepcopy.go) is autogenerated. We should ignore this file from the test coverage for solving the issue. Read [this](https://github.com/kubernetes-sigs/kubebuilder/issues/2645#issue-1218751619) and [follow-up](https://github.com/kubernetes-sigs/kubebuilder/issues/2645#issuecomment-1113963723) comment for more info.

### Motivation
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2645