### PR TITLE
:seedling: Ignore release notes in the release to fix it

### DIFF
--- a/build/build_kubebuilder.sh
+++ b/build/build_kubebuilder.sh
@@ -90,7 +90,10 @@ if [ -z "$SNAPSHOT" ]; then
       [[ "${TAG_NAME}" == "v"*"-beta."* ]] && NOTES_FLAGS+=" -r beta"
       [[ "${TAG_NAME}" == "v"*"-rc."* ]] && NOTES_FLAGS+=" -r rc"
   fi
-  notes $NOTES_FLAGS | tee "$tmp_notes"
+  # TODO(cmacedo): figure out how to download the release notes and let it available in the cloud build
+  # Currently it does not work: https://github.com/kubernetes-sigs/kubebuilder/issues/2667
+  # notes $NOTES_FLAGS | tee "$tmp_notes"
+  notes="Mock Release Notes for $(git describe --tags --always --broken)"
   # we need to delete the tag for the release notes script, so restore it when done so that
   # go releaser can find the right tag
   if [[ -n "${TAG_NAME}" ]]; then


### PR DESCRIPTION
**Description**
Ignore release notes in the release to fix it

**Motivation**
See: https://github.com/kubernetes-sigs/kubebuilder/issues/2667

Currently, the releases have been not generated in the Google Cloud build because the script tries to install the go module to generate the release notes and then use it. But it cannot work. See; https://github.com/GoogleCloudPlatform/cloud-builders/blob/master/go/README.md#note-1-workspace-and-go
 
Then, the idea here just stops trying to generate the release notes and update the release page automatically because it can be done easily manually. However, building the assets is more complicated. 

So, let's keep the release building the assets and adding only them to the release page so that we can add the changelog manually for now. 