### PR TITLE
🌱 : update kubernetes-sigs/kubebuilder-release-tools from 0.1.1 to 0.2.0

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
     - name: Verifier action
       id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@v0.1.1
+      uses: kubernetes-sigs/kubebuilder-release-tools@v0.2.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**
update kubernetes-sigs/kubebuilder-release-tools from 0.1.1 to 0.2.0

closes: https://github.com/kubernetes-sigs/kubebuilder/issues/1833