### PR TITLE
🌱 : increase the timeout for snapshot releases from master

### DIFF
--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -28,7 +28,7 @@ steps:
 - name: "gcr.io/cloud-builders/gsutil"
   args: ["-h", "Content-Type:application/gzip", "cp", "kubebuilder_linux_amd64.tar.gz", "gs://kubebuilder-release/kubebuilder_master_linux_amd64.tar.gz"]
 - name: "ubuntu"
-  args: ["tar", "-zcvf", "kubebuilder_linux_arm4.tar.gz", "-C", "dist/kubebuilder_linux_arm4", "kubebuilder"]
+  args: ["tar", "-zcvf", "kubebuilder_linux_arm64.tar.gz", "-C", "dist/kubebuilder_linux_arm64", "kubebuilder"]
 - name: "gcr.io/cloud-builders/gsutil"
   args: ["-h", "Content-Type:application/gzip", "cp", "kubebuilder_linux_arm64.tar.gz", "gs://kubebuilder-release/kubebuilder_master_linux_arm64.tar.gz"]
 - name: "ubuntu"
@@ -43,3 +43,4 @@ steps:
   args: ["tar", "-zcvf", "kubebuilder_darwin_arm64.tar.gz", "-C", "dist/kubebuilder_darwin_arm64", "kubebuilder"]
 - name: "gcr.io/cloud-builders/gsutil"
   args: ["-h", "Content-Type:application/gzip", "cp", "kubebuilder_darwin_arm64.tar.gz", "gs://kubebuilder-release/kubebuilder_master_darwin_arm64.tar.gz"]
+timeout: '3600s'


### PR DESCRIPTION
**Description**
🌱 : increase the timeout for snapshot releases from master

**Tested locally** (it will fix all current issues)
```
cloud-build-local --config=build/cloudbuild_snapshot.yaml --dryrun=false --write-workspace=./cloudbuild .
2022/05/08 09:50:46 Warning: The server docker version installed (20.10.8) is different from the one used in GCB (19.03.8)
2022/05/08 09:50:46 Warning: The client docker version installed (20.10.8) is different from the one used in GCB (19.03.8)
Using default tag: latest
latest: Pulling from cloud-builders/metadata
Digest: sha256:1637a9488e321e52f86e6dfef1b7f47396c75d439e3c1566a9a85a4ac289e6ee
Status: Image is up to date for gcr.io/cloud-builders/metadata:latest
gcr.io/cloud-builders/metadata:latest
2022/05/08 09:50:56 Started spoofed metadata server
2022/05/08 09:50:56 Build id = localbuild_8b5067c8-1648-4914-82e4-542259929dd4
2022/05/08 09:50:57 status changed to "BUILD"
BUILD
Starting Step #0
Step #0: Already have image (with digest): goreleaser/goreleaser:v1.8.3
Step #0: Running in snapshot mode. Release notes will not be generated from commits.
Step #0:    • releasing...             
Step #0:    • loading config file       file=build/.goreleaser.yml
Step #0:    • loading environment variables
Step #0: 
Step #0:    • getting and validating git state
Step #0:       • building...               commit=7504a409f4e35242bfc36343c9cf0ded644e4ac3 latest tag=v3.0.0-alpha.0
Step #0:       • pipe skipped              error=disabled during snapshot mode
Step #0:    • parsing tag              
Step #0:    • running before hooks     
Step #0:       • running                   hook=go mod download
Step #0:    • setting defaults         
Step #0:    • snapshotting             
Step #0:       • building snapshot...      version=3.0.0-alpha.0-SNAPSHOT-7504a409
Step #0:    • checking distribution directory
Step #0:    • loading go mod information
Step #0:    • build prerequisites      
Step #0:    • writing effective config file
Step #0:       • writing                   config=dist/config.yaml
Step #0:    • building binaries        
Step #0:       • building                  binary=dist/kubebuilder_linux_arm64/kubebuilder
Step #0:       • building                  binary=dist/kubebuilder_darwin_arm64/kubebuilder
Step #0:       • building                  binary=dist/kubebuilder_darwin_amd64_v1/kubebuilder
Step #0:       • building                  binary=dist/kubebuilder_linux_amd64_v1/kubebuilder
Step #0:       • building                  binary=dist/kubebuilder_linux_ppc64le/kubebuilder
Step #0:    • archives                 
Step #0:       • skip archiving           
Step #0:  binary=kubebuilder name=kubebuilder_darwin_arm64
Step #0:       • skip archiving            binary=kubebuilder name=kubebuilder_linux_amd64
Step #0:       • skip archiving            binary=kubebuilder name=kubebuilder_linux_arm64
Step #0:       • skip archiving            binary=kubebuilder name=kubebuilder_linux_ppc64le
Step #0:       • skip archiving            binary=kubebuilder name=kubebuilder_darwin_amd64
Step #0:    • calculating checksums    
Step #0:    • storing release metadata 
Step #0:       • writing                   file=dist/artifacts.json
Step #0:       • writing                   file=dist/metadata.json
Step #0:    • release succeeded after 223.30s
Finished Step #0
2022/05/08 09:54:42 Step Step #0 finished
Starting Step #1
Step #1: Already have image (with digest): ubuntu
Step #1: kubebuilder
Finished Step #1
2022/05/08 09:54:44 Step Step #1 finished
Starting Step #2
Step #2: Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #2: Copying file://kubebuilder_linux_amd64.tar.gz [Content-Type=application/gzip]...
Step #2: / [0 files][    0.0 B/ 14.7 MiB]                                       - [1 files][ 14.7 MiB/ 14.7 MiB]    1.2 MiB/s                                   
Step #2: Operation completed over 1 objects/14.7 MiB.                                     
Finished Step #2
2022/05/08 09:55:01 Step Step #2 finished
Starting Step #3
Step #3: Already have image (with digest): ubuntu
Step #3: kubebuilder
Finished Step #3
2022/05/08 09:55:03 Step Step #3 finished
Starting Step #4
Step #4: Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #4: Copying file://kubebuilder_linux_arm64.tar.gz [Content-Type=application/gzip]...
Step #4: / [0 files][    0.0 B/ 13.7 MiB]                                       / [1 files][ 13.7 MiB/ 13.7 MiB]                                                
Step #4: Operation completed over 1 objects/13.7 MiB.                                     
Finished Step #4
2022/05/08 09:55:17 Step Step #4 finished
Starting Step #5
Step #5: Already have image (with digest): ubuntu
Step #5: kubebuilder
Finished Step #5
2022/05/08 09:55:19 Step Step #5 finished
Starting Step #6
Step #6: Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #6: Copying file://kubebuilder_linux_ppc64le.tar.gz [Content-Type=application/gzip]...
Step #6: / [0 files][    0.0 B/ 13.6 MiB]                                       \ [1 files][ 13.6 MiB/ 13.6 MiB]                                                
Step #6: Operation completed over 1 objects/13.6 MiB.                                     
Finished Step #6
2022/05/08 09:55:32 Step Step #6 finished
Starting Step #7
Step #7: Already have image (with digest): ubuntu
Step #7: kubebuilder
Finished Step #7
2022/05/08 09:55:34 Step Step #7 finished
Starting Step #8
Step #8: Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #8: Copying file://kubebuilder_darwin_amd64.tar.gz [Content-Type=application/gzip]...
Step #8: / [0 files][    0.0 B/ 14.5 MiB]                                       / [1 files][ 14.5 MiB/ 14.5 MiB]                                                
Step #8: Operation completed over 1 objects/14.5 MiB.                                     
Finished Step #8
2022/05/08 09:55:47 Step Step #8 finished
Starting Step #9
Step #9: Already have image (with digest): ubuntu
Step #9: kubebuilder
Finished Step #9
2022/05/08 09:55:50 Step Step #9 finished
Starting Step #10
Step #10: Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #10: Copying file://kubebuilder_darwin_arm64.tar.gz [Content-Type=application/gzip]...
Step #10: / [0 files][    0.0 B/ 14.0 MiB]                                      \ [1 files][ 14.0 MiB/ 14.0 MiB]                                                
Step #10: Operation completed over 1 objects/14.0 MiB.                                     
Finished Step #10
2022/05/08 09:56:02 Step Step #10 finished
2022/05/08 09:56:02 status changed to "DONE"
DONE
```

Note: It has not been running successfully so far. 
The goal with this PR is to fix it. See that it has been trigged and falling since 2020:

<img width="1018" alt="Screenshot 2022-05-08 at 23 10 09" src="https://user-images.githubusercontent.com/7708031/167317847-24e9f8c8-6238-45b9-b721-925e19b1c890.png">

