### PR TITLE
:bug: (go/v2) fix issue introduced by removing the GO111MODULE=on from Dockerfile

### DIFF
--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/dockerfile.go
@@ -55,7 +55,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v2-addon/Dockerfile
+++ b/testdata/project-v2-addon/Dockerfile
@@ -19,7 +19,7 @@ COPY channels/ /channels/
 RUN chmod -R a+rx /channels/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v2-multigroup/Dockerfile
+++ b/testdata/project-v2-multigroup/Dockerfile
@@ -15,7 +15,7 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v2/Dockerfile
+++ b/testdata/project-v2/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
**Description**

The ` GO111MODULE=on ` was removed from go/v2 with the PR: https://github.com/kubernetes-sigs/kubebuilder/pull/2507
However, projects scaffolds with go/v2 are using golang 1.13 which requires this option