### PR TITLE
:seedling: increase goreleaser for snapshot timeout in 30 min

### DIFF
--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -23,6 +23,7 @@ steps:
   entrypoint: "bash"
   env: ["SNAPSHOT=1"]
   args: ["build/build_kubebuilder.sh"]
+  timeout: 30m
 - name: "ubuntu"
   args: ["tar", "-zcvf", "kubebuilder_linux_amd64.tar.gz", "-C", "dist/kubebuilder_linux_amd64_v1", "kubebuilder"]
 - name: "gcr.io/cloud-builders/gsutil"
@@ -43,4 +44,5 @@ steps:
   args: ["tar", "-zcvf", "kubebuilder_darwin_arm64.tar.gz", "-C", "dist/kubebuilder_darwin_arm64", "kubebuilder"]
 - name: "gcr.io/cloud-builders/gsutil"
   args: ["-h", "Content-Type:application/gzip", "cp", "kubebuilder_darwin_arm64.tar.gz", "gs://kubebuilder-release/kubebuilder_master_darwin_arm64.tar.gz"]
-timeout: '3600s'
+
+


### PR DESCRIPTION
**Description**
increase goreleaser for snapshot timeout in 30 min 

**Motivation**
Ensure that snapshot releases can run succeffuly on google cloud