### PR TITLE
✨ (declarative/v1) : Update the sigs.k8s.io/kubebuilder-declarative-pattern dep used for projects scaffolded with go/v3 plugin from fea7e5cc701290589ec20ef4d9c0629d08b5307d to d0f104b6a96e152043e9c2d76229373a981ac96a

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -476,7 +476,6 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/pkg/plugins/golang/declarative/v1/api.go
+++ b/pkg/plugins/golang/declarative/v1/api.go
@@ -32,7 +32,7 @@ import (
 const (
 	// kbDeclarativePattern is the sigs.k8s.io/kubebuilder-declarative-pattern version
 	kbDeclarativePatternForV2 = "v0.0.0-20200522144838-848d48e5b073"
-	kbDeclarativePatternForV3 = "fea7e5cc701290589ec20ef4d9c0629d08b5307d"
+	kbDeclarativePatternForV3 = "d0f104b6a96e152043e9c2d76229373a981ac96a"
 )
 
 var _ plugin.CreateAPISubcommand = &createAPISubcommand{}

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
 	sigs.k8s.io/controller-runtime v0.11.2
-	sigs.k8s.io/kubebuilder-declarative-pattern v0.0.0-20220110041111-fea7e5cc7012
+	sigs.k8s.io/kubebuilder-declarative-pattern v0.11.20220513-0.20220425225139-d0f104b6a96e
 )
 
 require (


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
Update the sigs.k8s.io/kubebuilder-declarative-pattern dep used for projects scaffolded with go/v3 plugin from [`fea7e5cc701290589ec20ef4d9c0629d08b5307d`](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/commit/fea7e5cc701290589ec20ef4d9c0629d08b5307d) to [`d0f104b6a96e152043e9c2d76229373a981ac96a`](https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/commit/d0f104b6a96e152043e9c2d76229373a981ac96a)

See the comparison between the two versions: https://github.com/kubernetes-sigs/kubebuilder-declarative-pattern/compare/fea7e5cc701290589ec20ef4d9c0629d08b5307d...d0f104b6a96e152043e9c2d76229373a981ac96a