### PR TITLE
:sparkles: external plugins(plugin phase 2): add support to pass CLI flags

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -155,8 +155,18 @@ func WithCompletion() Option {
 
 // parseExternalPluginArgs returns the program arguments.
 func parseExternalPluginArgs() (args []string) {
-	args = make([]string, len(os.Args)-1)
-	copy(args, os.Args[1:])
+	// Loop through os.Args and only get flags and their values that should be passed to the plugins
+	// this also removes the --plugins flag and its values from the list passed to the external plugin
+	for i := range os.Args {
+		if strings.Contains(os.Args[i], "--") && !strings.Contains(os.Args[i], "--plugins") {
+			args = append(args, os.Args[i])
+
+			// Don't go out of bounds and don't append the next value if it is a flag
+			if i+1 < len(os.Args) && !strings.Contains(os.Args[i+1], "--") {
+				args = append(args, os.Args[i+1])
+			}
+		}
+	}
 
 	return args
 }

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -283,6 +283,43 @@ var _ = Describe("Discover external plugins", func() {
 
 		})
 	})
+
+	Context("parsing flags for external plugins", func() {
+		It("should only parse flags excluding the `--plugins` flag", func() {
+			// change the os.Args for this test and set them back after
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"kubebuilder",
+				"init",
+				"--plugins",
+				"myexternalplugin/v1",
+				"--domain",
+				"example.com",
+				"--binary-flag",
+				"--license",
+				"apache2",
+				"--another-binary",
+			}
+
+			args := parseExternalPluginArgs()
+			Expect(args).Should(ContainElements(
+				"--domain",
+				"example.com",
+				"--binary-flag",
+				"--license",
+				"apache2",
+				"--another-binary",
+			))
+
+			Expect(args).ShouldNot(ContainElements(
+				"kubebuilder",
+				"init",
+				"--plugins",
+				"myexternalplugin/v1",
+			))
+		})
+	})
 })
 
 var _ = Describe("CLI options", func() {

--- a/pkg/plugin/external/types.go
+++ b/pkg/plugin/external/types.go
@@ -57,4 +57,29 @@ type PluginResponse struct {
 
 	// ErrorMsgs contains the specific error messages of the plugin failures.
 	ErrorMsgs []string `json:"errorMsgs,omitempty"`
+
+	// Flags contains the plugin specific flags that the plugin returns to Kubebuilder when it receives
+	// a request for a list of supported flags from Kubebuilder
+	Flags []Flag `json:"flags,omitempty"`
+}
+
+// Flag is meant to represent a CLI flag that is used by Kubebuilder to define flags that are parsed
+// for use with an external plugin
+type Flag struct {
+	// Name is the name that should be used when creating the flag.
+	// i.e a name of "domain" would become the CLI flag "--domain"
+	Name string
+
+	// Type is the type of flag that should be created. The types that
+	// Kubebuilder supports are: string, bool, int, and float.
+	// any value other than the supported will be defaulted to be a string
+	Type string
+
+	// Default is the default value that should be used for a flag.
+	// Kubebuilder will attempt to convert this value to the defined
+	// type for this flag.
+	Default string
+
+	// Usage is a description of the flag and when/why/what it is used for.
+	Usage string
 }

--- a/pkg/plugins/external/api.go
+++ b/pkg/plugins/external/api.go
@@ -17,6 +17,8 @@ limitations under the License.
 package external
 
 import (
+	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
@@ -37,6 +39,10 @@ type createAPISubcommand struct {
 func (p *createAPISubcommand) InjectResource(*resource.Resource) error {
 	// Do nothing since resource flags are passed to the external plugin directly.
 	return nil
+}
+
+func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
+	bindExternalPluginFlags(fs, "api", p.Path, p.Args)
 }
 
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {

--- a/pkg/plugins/external/edit.go
+++ b/pkg/plugins/external/edit.go
@@ -17,6 +17,8 @@ limitations under the License.
 package external
 
 import (
+	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/external"
@@ -27,6 +29,10 @@ var _ plugin.EditSubcommand = &editSubcommand{}
 type editSubcommand struct {
 	Path string
 	Args []string
+}
+
+func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
+	bindExternalPluginFlags(fs, "edit", p.Path, p.Args)
 }
 
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {

--- a/pkg/plugins/external/init.go
+++ b/pkg/plugins/external/init.go
@@ -17,6 +17,8 @@ limitations under the License.
 package external
 
 import (
+	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/external"
@@ -27,6 +29,10 @@ var _ plugin.InitSubcommand = &initSubcommand{}
 type initSubcommand struct {
 	Path string
 	Args []string
+}
+
+func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
+	bindExternalPluginFlags(fs, "init", p.Path, p.Args)
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {

--- a/pkg/plugins/external/webhook.go
+++ b/pkg/plugins/external/webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package external
 
 import (
+	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
@@ -33,6 +35,10 @@ type createWebhookSubcommand struct {
 func (p *createWebhookSubcommand) InjectResource(*resource.Resource) error {
 	// Do nothing since resource flags are passed to the external plugin directly.
 	return nil
+}
+
+func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
+	bindExternalPluginFlags(fs, "webhook", p.Path, p.Args)
 }
 
 func (p *createWebhookSubcommand) Scaffold(fs machinery.Filesystem) error {


### PR DESCRIPTION
## Description of Change
This change implements the `BindFlags()` method for the external plugin `init`, `create api`, `create webhook`, and `edit` subcommands.

It has 2 methods in which flags can be bound:
1. An external plugin defines a `flags` subcommand that accepts boolean flags to represent which subcommand to return flags to Kubebuilder for. (ex: `flags --init`)
2. All flags passed by a user are bound when an external plugin is used. This method also adds a default usage message to the flags stating that Kubebuilder was unable to verify the flags passed by a user and suggests that the user consult the external plugin documentation for more information.

The logic flow that is taken is:
```mermaid
flowchart TD
    A[BindFlags] --> B[Request Flags from External Plugin];
    B ----> C{Error?};
    C -- Yes --> D[Parse all flags and provide general message to consult documentation];
    C -- No --> E[Parse only flags specified by External Plugin response];
    D ----> F[Call External Plugin with flags];
    E ----> F;
```

## Motivation for the change
With the current Phase 2 Plugins implementation, the user passed CLI flags are not properly bound. This results in an error stating that a flag passed by a user is an unknown flag even if the external plugin defines the flag.

For example:
If `myexternalplugin/v1` defines the `--captain` flag and a user runs `kubebuilder init --plugins myexternalplugin/v1 --captain kube` the output would be:
```
INFO[0000] Adding external plugin: myexternalplugin     
Error: unknown flag: --captain
Usage:
  kubebuilder init [flags]

Examples:
  # Help for initializing a project with version "2"
  kubebuilder init --project-version="2" -h

  # Help for initializing a project with version "3"
  kubebuilder init --project-version="3" -h

Flags:
  -h, --help                     help for init
      --project-version string   project version (default "3")

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution

2022/05/16 09:38:53 unknown flag: --captain
```

For details on the motivation see issue #2689 

## Additional Context
resolves #2689 

