### PR TITLE
:sparkles: Update Makefile for go/v3 to support darwin/arm64

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
@@ -179,7 +179,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -190,4 +196,10 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s
 `

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
@@ -181,7 +181,7 @@ kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
 ifeq "$(uname -s)" "Darwin"
 ifeq "$(uname -m)" "aarch64"
-	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
 endif
 else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
@@ -198,7 +198,7 @@ $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 
-ETCD_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/master/scripts/"
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
 .PHONY: etcd
 etcd: ## build etcd locally
 	curl -s $(ETCD_SCRIPT) | bash -s

--- a/scripts/build-etcd.sh
+++ b/scripts/build-etcd.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+OS=$(uname -s | awk '{ print tolower($0) }')
+ARCH=$(uname -m)
+echo "Building etcd locally for $OS/$ARCH"
+
+TEMP_DIR=$(mktemp -d)
+cd $TEMP_DIR
+git clone https://github.com/etcd-io/etcd.git
+cd etcd
+make build
+if [ -d $HOME/bin ]
+then
+    mv ./bin/etcd $HOME/bin/etcd
+else
+    mkdir $HOME/bin
+    mv ./bin/etcd $HOME/bin/etcd
+fi
+cd ../../
+rm -rf $TEMP_DIR

--- a/scripts/build-kustomize.sh
+++ b/scripts/build-kustomize.sh
@@ -11,7 +11,7 @@ echo "Building kustomize $KUSTOMIZE_VERSION locally for $OS/$ARCH"
 
 TEMP_DIR=$(mktemp -d)
 cd $TEMP_DIR
-git clone --depth 1 --branch $KUSTOMIZE_VERSION https://github.com/kubernetes-sigs/kustomize.git
+git clone --depth 1 --branch kustomize/$KUSTOMIZE_VERSION https://github.com/kubernetes-sigs/kustomize.git
 cd kustomize/kustomize
 GOBIN=$INSTALL_PATH go install .
 cd ../../..

--- a/scripts/build-kustomize.sh
+++ b/scripts/build-kustomize.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+KUSTOMIZE_VERSION=$1
+INSTALL_PATH=$2
+if [ ! -f $INSTALL_PATH/kustomize ] 
+then
+
+OS=$(uname -s | awk '{ print tolower($0) }')
+ARCH=$(uname -m)
+
+echo "Building kustomize $KUSTOMIZE_VERSION locally for $OS/$ARCH"
+
+TEMP_DIR=$(mktemp -d)
+cd $TEMP_DIR
+git clone --depth 1 --branch $KUSTOMIZE_VERSION https://github.com/kubernetes-sigs/kustomize.git
+cd kustomize/kustomize
+GOBIN=$INSTALL_PATH go install .
+cd ../../..
+rm -rf $TEMP_DIR
+fi

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -120,7 +120,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -131,3 +137,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -120,7 +120,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -131,3 +137,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -120,7 +120,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -131,3 +137,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s

--- a/testdata/project-v3-v1beta1/Makefile
+++ b/testdata/project-v3-v1beta1/Makefile
@@ -122,7 +122,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -133,3 +139,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s

--- a/testdata/project-v3-with-kustomize-v2/Makefile
+++ b/testdata/project-v3-with-kustomize-v2/Makefile
@@ -120,7 +120,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -131,3 +137,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -120,7 +120,13 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
+ifeq "$(uname -s)" "Darwin"
+ifeq "$(uname -m)" "aarch64"
+	curl -s "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-kustomize.sh" | bash -s -- $(KUSTOMIZE_VERSION) $(LOCALBIN)
+endif
+else
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+endif
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -131,3 +137,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+
+ETCD_SCRIPT ?= "https://raw.githubusercontent.com/everettraven/kubebuilder/feat/temp-arm-support/scripts/build-etcd.sh"
+.PHONY: etcd
+etcd: ## build etcd locally
+	curl -s $(ETCD_SCRIPT) | bash -s


### PR DESCRIPTION
## Description of Change
- Add Bash scripts for building `kustomize` and `etcd` locally
- Add a Makefile target to build `etcd` locally with `make etcd`
- Modify the `kustomize` Makefile target to build from source locally if running on `darwin/arm64` (`Darwin` as result from `uname -s` and `aarch64` as result from `uname -m`)

## Motivation for Change
There is seemingly more and more issues occurring for users that are using the M1 Macs to build operators with both Kubebuilder and Operator SDK. This change should provide users an easier way to remediate the issues by providing a new Makefile target to build `etcd` from source and modifying the existing Makefile target for installing `kustomize` to build from source if running on `darwin/arm64`.

##  Additional Context
I do not have an M1 Mac and therefore cannot test this change myself to verify it resolves issues for users on the new M1 Macs. I was however able to test that the scripts added work as expected.