### PR TITLE
🌱 For kubebuilder-tools, upgrade go version from 1.17 to 1.18, alphine image from 3.8 to 3.16 and etcd from v3.5.1 to v3.5.4

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -17,11 +17,11 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.1
+ARG ETCD_VERSION=v3.5.4
 ARG OS=darwin
 ARG ARCH
 
@@ -57,7 +57,7 @@ WORKDIR /usr/local
 RUN tar -czvf /kubebuilder_${OS}_${ARCH}.tar.gz kubebuilder/
 
 # Copy tarball to final image.
-FROM alpine:3.8
+FROM alpine:3.16
 
 # Platform args.
 ARG OS=darwin

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -18,11 +18,11 @@
 # - etcd (fetch)
 
 # no need for anything fancy
-FROM alpine:3.8 as builder
+FROM alpine:3.16 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.1
+ARG ETCD_VERSION=v3.5.4
 ARG OS=linux
 ARG ARCH
 


### PR DESCRIPTION
**Description**
For kubebuilder-tools:
- upgrade the go version from 1.17 to 1.18, 
- alphine image from 3.8 to 3.16 
- etc from v3.5.1 to v3.5.4

**motivation**
solve tech-debts
solve issue to build the kubebuilder tools for k8s 1.24.1, see:


```
Step #0: Step 12/21 : RUN make WHAT=cmd/kube-apiserver &&     cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kube-apiserver $DEST
Step #0:  ---> Running in 9877f1b79125
Step #0: 
Step #0: Detected go version: go version go1.17.11 linux/amd64.
Step #0: Kubernetes requires go1.18.1 or greater.
Step #0: Please install go1.18.1 or later.
Step #0: 
Step #0: !!! [0607 09:16:49] Call tree:
Step #0: !!! [0607 09:16:49]  1: /kubernetes/hack/lib/golang.sh:787 kube::golang::setup_env(...)
Step #0: !!! [0607 09:16:49]  2: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
Step #0: !!! [0607 09:16:49] Call tree:
Step #0: !!! [0607 09:16:49]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
Step #0: Makefile.generated_files:61: .make/go-pkgdeps.mk: No such file or directory
Step #0: make[1]: *** [Makefile.generated_files:73: .make/go-pkgdeps.mk] Error 1
Step #0: make: *** [Makefile:528: generated_files] Error 2
Step #0: The command '/bin/sh -c make WHAT=cmd/kube-apiserver &&     cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kube-apiserver $DEST' returned a non-zero code: 2
Finished Step #0
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 2
Step #0: 
```