### PR TITLE
:sparkles: add support to go 1.18 and for (go/v3), update envtest version to use k8s 1.24

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: Execute go-apidiff
         uses: joelanford/go-apidiff@v0.2.0
         with:

--- a/.github/workflows/testdata.yml
+++ b/.github/workflows/testdata.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Remove pre-installed kustomize
         # This step is needed as the following one tries to remove
         # kustomize for each test but has no permission to do so

--- a/.github/workflows/unit-tests-legacy.yml
+++ b/.github/workflows/unit-tests-legacy.yml
@@ -1,0 +1,50 @@
+# todo: remove this file when go/v2 be removed
+name: Unit tests Legacy (go/v2)
+
+# Trigger the workflow on pull requests and direct pushes to any branch
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          # the go/v2 cannot be updated and is scaffold with golang 1.13
+          # (version used by its dep version of the controller-runtime)
+          # however, we are unable to downgrade the version here
+          # because we will face errors
+          # So we are keeping the latest version where it works
+          # and highlighting that must be fixed
+          # Therefore, we probably will deprecate go/v2 soon since we cannot upgrade it
+          # to use the versions of controller-runtime > v0.9
+          # and controller-tools > v0.6 as k8s > 1.21 then it might not be valid we spend effort on this fix
+          go-version: "1.17"
+      # This step is needed as the following one tries to remove
+      # kustomize for each test but has no permission to do so
+      - name: Remove pre-installed kustomize
+        run: sudo rm -f /usr/local/bin/kustomize
+      - name: Perform the test
+        run: make test-legacy
+      - name: Report failure
+        uses: nashmaniac/create-issue-action@v1.1
+        # Only report failures of pushes (PRs have are visible through the Checks section) to the default branch
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          title: 🐛 Unit tests failed on ${{ matrix.os }} for ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: kind/bug
+          body: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       # This step is needed as the following one tries to remove
       # kustomize for each test but has no permission to do so
       - name: Remove pre-installed kustomize
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: Generate the coverage output
         run: make test-coverage
       - name: Send the coverage output

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,12 @@ check-testdata: ## Run the script to ensure that the testdata is updated
 test-testdata: ## Run the tests of the testdata directory
 	./test/testdata/test.sh
 
+#todo(remove the test-legacy whne the go/v2 be removed from kubebuilder)
+
+.PHONY: test-legacy
+test-legacy: ## Run the legacy tests (go/v2) of the testdata directory
+	./test/testdata/test_legacy.sh
+
 .PHONY: test-e2e-local
 test-e2e-local: ## Run the end-to-end tests locally
 	## To keep the same kind cluster between test runs, use `SKIP_KIND_CLEANUP=1 make test-e2e-local`

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -44,7 +44,7 @@ builds:
       - darwin_amd64
       - darwin_arm64
     env:
-      - KUBERNETES_VERSION=1.23.5
+      - KUBERNETES_VERSION=1.24.1
       - CGO_ENABLED=0
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.

--- a/build/cloudbuild.yaml
+++ b/build/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
     git checkout $${BRANCH_NAME}
     git branch --set-upstream-to=origin/$${BRANCH_NAME}
     git tag -d ${TAG_NAME}
-- name: "goreleaser/goreleaser:v1.8.3"
+- name: "goreleaser/goreleaser:v1.9.2"
   entrypoint: "bash"
   args: ["build/build_kubebuilder.sh"]
   secretEnv: ["GITHUB_TOKEN"]

--- a/build/cloudbuild_local.yaml
+++ b/build/cloudbuild_local.yaml
@@ -19,7 +19,7 @@
 # Release tar will be in ./cloudbuild
 
 steps:
-- name: "goreleaser/goreleaser:v1.8.3"
+- name: "goreleaser/goreleaser:v1.9.2"
   entrypoint: "bash"
   env: ["SNAPSHOT=1"]
   args: ["build/build_kubebuilder.sh"]

--- a/build/cloudbuild_snapshot.yaml
+++ b/build/cloudbuild_snapshot.yaml
@@ -19,7 +19,7 @@
 # Release tar will be in ./cloudbuild
 
 steps:
-- name: "goreleaser/goreleaser:v1.8.3"
+- name: "goreleaser/goreleaser:v1.9.2"
   entrypoint: "bash"
   env: ["SNAPSHOT=1"]
   args: ["build/build_kubebuilder.sh"]

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -11,7 +11,8 @@ This Quick Start guide will cover:
 
 - [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0 < v3.1).
 - [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1 < v3.3).
-- [go](https://golang.org/dl/) version v1.17+ < v1.18 (kubebuilder v3.3+).
+- [go](https://golang.org/dl/) version v1.17+ < v1.18 (kubebuilder v3.4.1).
+- [go](https://golang.org/dl/) version v1.17.9+ (kubebuilder v3.5+).
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/pkg/cli/alpha/config-gen/testdata/go.mod
+++ b/pkg/cli/alpha/config-gen/testdata/go.mod
@@ -1,6 +1,6 @@
 module config-gen/testdata
 
-go 1.17
+go 1.18
 
 require (
 	k8s.io/apimachinery v0.23.5

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -195,6 +195,7 @@ var _ = Describe("checkGoVersion", func() {
 		Entry("for go 1.17.3", "go1.17.3"),
 		Entry("for go 1.17.4", "go1.17.4"),
 		Entry("for go 1.17.5", "go1.17.5"),
+		Entry("for go 1.18.1", "go1.18.1"),
 	)
 
 	DescribeTable("should return an error for non-supported go versions",

--- a/pkg/plugins/golang/v3/commons.go
+++ b/pkg/plugins/golang/v3/commons.go
@@ -78,7 +78,7 @@ manifests: controller-gen`
 		}
 
 		if err := util.ReplaceInFile("Makefile",
-			"ENVTEST_K8S_VERSION = 1.23",
+			"ENVTEST_K8S_VERSION = 1.24.1",
 			"ENVTEST_K8S_VERSION = 1.21"); err != nil {
 			log.Warnf("unable to update the Makefile with %s: %s", "ENVTEST_K8S_VERSION = 1.21", err)
 		}

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -35,7 +35,7 @@ import (
 
 // Variables and function to check Go version requirements.
 var (
-	goVerMin = golang.MustParse("go1.17")
+	goVerMin = golang.MustParse("go1.17.9")
 	goVerMax = golang.MustParse("go2.0alpha1")
 )
 

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/gomod.go
@@ -46,7 +46,7 @@ func (f *GoMod) SetTemplateDefaults() error {
 const goModTemplate = `
 module {{ .Repo }}
 
-go 1.17
+go 1.18
 
 require (
 	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}

--- a/test/common.sh
+++ b/test/common.sh
@@ -26,6 +26,7 @@ function convert_to_tools_ver {
   "1.20"|"1.21") echo "1.19.2";;
   "1.22") echo "1.22.1";;
   "1.23") echo "1.23.3";;
+  "1.24") echo "1.24.1";;
   *)
     echo "k8s version $k8s_ver not supported"
     exit 1
@@ -45,7 +46,7 @@ if [ -n "$TRACE" ]; then
   set -x
 fi
 
-export KIND_K8S_VERSION="${KIND_K8S_VERSION:-"v1.23.3"}"
+export KIND_K8S_VERSION="${KIND_K8S_VERSION:-"v1.24.1"}"
 tools_k8s_version=$(convert_to_tools_ver "${KIND_K8S_VERSION#v*}")
 kind_version=0.11.1
 goarch=amd64

--- a/test/testdata/test_legacy.sh
+++ b/test/testdata/test_legacy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# todo: remove this file when go/v2 be removed
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,9 +30,9 @@ function test_project {
 
 build_kb
 
-# Test project v3
-test_project project-v3
-test_project project-v3-multigroup
-test_project project-v3-addon
-test_project project-v3-config
-
+# Test project v2, which relies on pre-installed envtest tools to run 'make test'.
+tools_k8s_version="1.19.2"
+fetch_tools
+test_project project-v2
+test_project project-v2-multigroup
+test_project project-v2-addon

--- a/testdata/project-v3-addon/Dockerfile
+++ b/testdata/project-v3-addon/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-addon/go.mod
+++ b/testdata/project-v3-addon/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-addon
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.0

--- a/testdata/project-v3-config/Dockerfile
+++ b/testdata/project-v3-config/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-config/go.mod
+++ b/testdata/project-v3-config/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-config
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-multigroup/go.mod
+++ b/testdata/project-v3-multigroup/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/testdata/project-v3-v1beta1/Dockerfile
+++ b/testdata/project-v3-v1beta1/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-v1beta1/Makefile
+++ b/testdata/project-v3-v1beta1/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.1
+ENVTEST_K8S_VERSION = 1.21
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/testdata/project-v3-v1beta1/go.mod
+++ b/testdata/project-v3-v1beta1/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-v1beta1
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.4

--- a/testdata/project-v3-with-kustomize-v2/Dockerfile
+++ b/testdata/project-v3-with-kustomize-v2/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3-with-kustomize-v2/go.mod
+++ b/testdata/project-v3-with-kustomize-v2/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3-with-kustomize-v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/testdata/project-v3/Dockerfile
+++ b/testdata/project-v3/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/testdata/project-v3/go.mod
+++ b/testdata/project-v3/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v3
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
**Description**
- add support to go 1.18
- update envtest version for k8s 1.24
- update goreleaser, ci and tests to ensure that works with 1.18.

PS.: Note that we are here only bumping the scaffolds and not the Kubebuilder tool since we do not want for now to impact who consumes the tool. But we are also updating the tests and the versions used to build the tool to ensure that it can work with 1.18

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2559
Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/2561