### PR TITLE
⚠️ : (go/v3) upgrade controller-gen from 0.8.0 to 0.9.0

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -36,7 +36,7 @@ const (
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
 	ControllerRuntimeVersion = "v0.12.1"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
-	ControllerToolsVersion = "v0.8.0"
+	ControllerToolsVersion = "v0.9.0"
 	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
 	// @Deprecated. This information ought to come from kustomize plugin
 	// Note that by updating the following value nothing will change for the go/3 plugin

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -114,7 +114,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:
@@ -67,9 +67,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_captains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:
@@ -67,9 +67,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3-addon/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:
@@ -67,9 +67,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -114,7 +114,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/testdata/project-v3-config/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3-config/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-config/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-config/config/crd/bases/crew.testproject.org_captains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-config/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3-config/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -114,7 +114,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/testdata/project-v3-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/fiz.testproject.org_bars.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/fiz.testproject.org_bars.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: bars.fiz.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: healthcheckpolicies.foo.policy.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/foo.testproject.org_bars.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/foo.testproject.org_bars.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: bars.foo.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: krakens.sea-creatures.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: leviathans.sea-creatures.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: cruisers.ship.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: destroyers.ship.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: frigates.ship.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-multigroup/config/crd/bases/testproject.org_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/crd/bases/testproject.org_lakers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: lakers.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-with-kustomize-v2/Makefile
+++ b/testdata/project-v3-with-kustomize-v2/Makefile
@@ -114,7 +114,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v4.5.3
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/testdata/project-v3-with-kustomize-v2/config/crd/bases/crew.testproject.org_admirals.yaml
+++ b/testdata/project-v3-with-kustomize-v2/config/crd/bases/crew.testproject.org_admirals.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: admirals.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-with-kustomize-v2/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3-with-kustomize-v2/config/crd/bases/crew.testproject.org_captains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3-with-kustomize-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3-with-kustomize-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -114,7 +114,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_admirales.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_admirales.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: admirales.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_captains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: captains.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/project-v3/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v3/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: firstmates.crew.testproject.org
 spec:
@@ -48,9 +48,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
**description**
:sparkles: (go/v3) upgrade controller-gen from 0.8.0 to 0.9.0

Follow up of: https://github.com/kubernetes-sigs/kubebuilder/pull/2679
Motivates by: https://github.com/kubernetes-sigs/kubebuilder/issues/2559