### PR TITLE
:seedling: GIT-2731: enable TokenRequest for ServiceAccount token generation

### DIFF
--- a/test/e2e/kind-config-v1.18.yaml
+++ b/test/e2e/kind-config-v1.18.yaml
@@ -1,0 +1,30 @@
+#  Copyright 2022 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  apiServer:
+    extraArgs:
+      "service-account-signing-key-file": /etc/kubernetes/pki/sa.key
+      "service-account-key-file": /etc/kubernetes/pki/sa.pub
+      "service-account-issuer": api
+      "service-account-api-audiences": api,vault,factors
+  

--- a/test/e2e/kind-config-v1.19.yaml
+++ b/test/e2e/kind-config-v1.19.yaml
@@ -1,0 +1,1 @@
+kind-config-v1.18.yaml

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -27,10 +27,16 @@ install_kind
 #   export KIND_CLUSTER=<kind cluster name>
 #   create_cluster <k8s version>
 function create_cluster {
+  KIND_VERSION=$1
   : ${KIND_CLUSTER:?"KIND_CLUSTER must be set"}
   : ${1:?"k8s version must be set as arg 1"}
   if ! kind get clusters | grep -q $KIND_CLUSTER ; then
-    kind create cluster -v 4 --name $KIND_CLUSTER --retain --wait=1m --config $(dirname "$0")/kind-config.yaml --image=kindest/node:$1
+    version_prefix="${KIND_VERSION%.*}"
+    kind_config=$(dirname "$0")/kind-config.yaml
+    if test -f $(dirname "$0")/kind-config-${version_prefix}.yaml; then
+      kind_config=$(dirname "$0")/kind-config-${version_prefix}.yaml
+    fi
+    kind create cluster -v 4 --name $KIND_CLUSTER --retain --wait=1m --config ${kind_config} --image=kindest/node:$1
   fi
 }
 


### PR DESCRIPTION
Closes #2731 

This addresses https://github.com/kubernetes-sigs/kubebuilder/pull/2723#discussion_r898208391

Move to using an explicit Token generated for the SA by invoking the `kubectl create token` command. 