### PR TITLE
:book: update migration guide

### DIFF
--- a/docs/book/src/migration/manually_migration_guide_v2_v3.md
+++ b/docs/book/src/migration/manually_migration_guide_v2_v3.md
@@ -353,16 +353,17 @@ Ensure that your `go.mod` is using Go version `1.15` and the following dependenc
 ```go
 module example
 
-go 1.16
+go 1.18
 
 require (
-	github.com/go-logr/logr v0.3.0
-	github.com/onsi/ginkgo v1.14.1
-	github.com/onsi/gomega v1.10.2
-	k8s.io/apimachinery v0.20.2
-	k8s.io/client-go v0.20.2
-	sigs.k8s.io/controller-runtime v0.8.3
+    github.com/onsi/ginkgo v1.16.5
+    github.com/onsi/gomega v1.18.1
+    k8s.io/api v0.24.0
+    k8s.io/apimachinery v0.24.0
+    k8s.io/client-go v0.24.0
+    sigs.k8s.io/controller-runtime v0.12.1
 )
+
 ```
 
 #### Update the golang image
@@ -460,27 +461,33 @@ With:
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN): ## Ensure that the directory exists
+$(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE):
+$(KUSTOMIZE): $(LOCALBIN)
 	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN):
+$(CONTROLLER_GEN): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 ```
 
 And then, to make your project use the `kustomize` version defined in the Makefile, replace all usage of `kustomize` with `$(KUSTOMIZE)`

--- a/docs/book/src/migration/migration_guide_v2tov3.md
+++ b/docs/book/src/migration/migration_guide_v2tov3.md
@@ -39,7 +39,10 @@ go mod init tutorial.kubebuilder.io/migration-project
 <aside class="note warning">
 <h1> Migrating to Kubebuilder v3 while staying on the go/v2 plugin </h1>
 
-You can use `--plugins=go/v2` if you wish to continue using "`Kubebuilder 2.x`" layout and avoid dealing with the breaking changes that will be faced because of the default upper versions which will be used now. See that the [controller-tools][controller-tools] `v0.5.0` & [controller-runtime][controller-runtime] `v0.8.3` are just used by default with the `go/v3` plugin layout. 
+You can use `--plugins=go/v2` if you wish to continue using "`Kubebuilder 2.x`" layout.
+However, with the legacy layout you are unable to produce projects supported
+on Kubernetes versions >= `1.22`. Therefore, it is not recommended.
+
 </aside>
 
 <aside class="note">
@@ -87,9 +90,10 @@ kubebuilder create api --group batch --version v1 --kind CronJob
 
 From now on, the CRDs that will be created by controller-gen will be using the Kubernetes API version `apiextensions.k8s.io/v1`  by default, instead of `apiextensions.k8s.io/v1beta1`. 
 
-The `apiextensions.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and will be removed in Kubernetes `1.22`.
+The `apiextensions.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and was removed in Kubernetes `1.22`.
 
 So, if you would like to keep using the previous version use the flag `--crd-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
+However, it is no longer recommended.
 
 </aside>
 

--- a/docs/book/src/migration/v2vsv3.md
+++ b/docs/book/src/migration/v2vsv3.md
@@ -9,7 +9,7 @@ and [kb-releases][kb-releases] release notes.
 
 ## Common changes
 
-v3 projects use Go modules and request Go 1.15+. Dep is no longer supported for dependency management.
+v3 projects use Go modules and request Go 1.18+. Dep is no longer supported for dependency management.
 
 ## Kubebuilder
 
@@ -19,7 +19,7 @@ v3 projects use Go modules and request Go 1.15+. Dep is no longer supported for 
     
     Furthermore, the PROJECT file itself is now versioned: the `version` field corresponds to the version of the PROJECT file itself, while the `layout` field indicates the scaffolding & primary plugin version in use. 
     
-- The version of the image `gcr.io/kubebuilder/kube-rbac-proxy`, which is an optional component enabled by default to secure the request made against the manager, was updated from `0.5.0` to `0.8.0` to address security concerns. The details of all changes can be found in [kube-rbac-proxy][kube-rbac-proxy].
+- The version of the image `gcr.io/kubebuilder/kube-rbac-proxy`, which is an optional component enabled by default to secure the request made against the manager, was updated from `0.5.0` to `0.11.0` to address security concerns. The details of all changes can be found in [kube-rbac-proxy][kube-rbac-proxy].
  
 ## TL;DR of the New `go/v3` Plugin
 
@@ -41,11 +41,11 @@ Projects scaffolded with Kubebuilder v3 will use the `go.kubebuilder.io/v3` plug
   * A new option to create the projects using ComponentConfig is introduced. For more info see its [enhancement proposal][enhancement proposal] and the [Component config tutorial][component-config-tutorial]
   * Manager manifests now use `SecurityContext` to address security concerns. More info: [#1637][issue-1637] 
 - Misc:
-  * Support for [controller-tools][controller-tools] `v0.5.0` (for `go/v2` it is `v0.3.0` and previously it was `v0.2.5`) 
-  * Support for [controller-runtime][controller-runtime] `v0.8.3` (for `go/v2` it is `v0.6.4` and previously it was `v0.5.0`)
+  * Support for [controller-tools][controller-tools] `v0.9.0` (for `go/v2` it is `v0.3.0` and previously it was `v0.2.5`) 
+  * Support for [controller-runtime][controller-runtime] `v0.12.1` (for `go/v2` it is `v0.6.4` and previously it was `v0.5.0`)
   * Support for [kustomize][kustomize] `v3.8.7` (for `go/v2` it is `v3.5.4` and previously it was `v3.1.0`)
   * Required Envtest binaries are automatically downloaded
-  * The minimum Go version is now `1.15` (previously it was `1.13).
+  * The minimum Go version is now `1.18` (previously it was `1.13`).
 
 <aside class="note warning">
 <h1>Project customizations</h1>


### PR DESCRIPTION
**Description**
Upgrade migration guide accordingly with the latest changes

**Motivation**
Solve tech-debt
Warning users to not use v1beta1 or go/v2 plugin