### PR TITLE
:book: simplify quick-start by keeping just the latest go version supported

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,10 +9,7 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.15+ (kubebuilder v3.0 < v3.1).
-- [go](https://golang.org/dl/) version v1.16+ (kubebuilder v3.1 < v3.3).
-- [go](https://golang.org/dl/) version v1.17+ < v1.18 (kubebuilder v3.4.1).
-- [go](https://golang.org/dl/) version v1.17.9+ (kubebuilder v3.5+).
+- [go](https://golang.org/dl/) version v1.17.9+ 
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.


### PR DESCRIPTION
**Description**
simplify quick-start by keeping just the latest go version supported
We do not need add the go version used all previous releases