### PR TITLE
:sparkles: upgrade gcr.io/kubebuilder/kube-rbac-proxy from v0.11.0 to v0.12.0

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/templates/patches/controller-manager/01-auth-proxy.template.yaml
+++ b/pkg/cli/alpha/config-gen/templates/patches/controller-manager/01-auth-proxy.template.yaml
@@ -4,7 +4,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/testdata/componentconfig/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/componentconfig/expected.yaml
@@ -276,7 +276,7 @@ spec:
           mountPath: /controller_manager_config.yaml
           subPath: controller_manager_config.yaml
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/testdata/default/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/default/expected.yaml
@@ -273,7 +273,7 @@ spec:
             cpu: 100m
             memory: 20Mi
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/testdata/enablecertmanager/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/enablecertmanager/expected.yaml
@@ -295,7 +295,7 @@ spec:
           name: cert
           readOnly: true
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/testdata/enableconversionwebhooks/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/enableconversionwebhooks/expected.yaml
@@ -304,7 +304,7 @@ spec:
           name: cert
           readOnly: true
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/testdata/enableprometheus/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/enableprometheus/expected.yaml
@@ -273,7 +273,7 @@ spec:
             cpu: 100m
             memory: 20Mi
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/cli/alpha/config-gen/testdata/enablewebhooks/expected.yaml
+++ b/pkg/cli/alpha/config-gen/testdata/enablewebhooks/expected.yaml
@@ -295,7 +295,7 @@ spec:
           name: cert
           readOnly: true
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -61,7 +61,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -61,7 +61,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v2-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2-addon/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v2-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-v1beta1/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-v1beta1/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3-with-kustomize-v2/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-with-kustomize-v2/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
**Description**
upgrade gcr.io/kubebuilder/kube-rbac-proxy from v0.11.0 to v0.12.0

**Motivation**
See its changelog: https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.12.0