### PR TITLE
:sparkles: (kustomize/v2-alpha) bump kustomize version from v4.5.3 to v4.5.5

### DIFF
--- a/pkg/plugins/common/kustomize/v2/plugin.go
+++ b/pkg/plugins/common/kustomize/v2/plugin.go
@@ -25,7 +25,7 @@ import (
 )
 
 // KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
-const KustomizeVersion = "v4.5.3"
+const KustomizeVersion = "v4.5.5"
 
 const pluginName = "kustomize.common." + plugins.DefaultNameQualifier
 

--- a/testdata/project-v3-with-kustomize-v2/Makefile
+++ b/testdata/project-v3-with-kustomize-v2/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.3
+KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"


### PR DESCRIPTION
## Description
:sparkles: (kustomize/v2-alpha) bump kustomize version from v4.5.3 to v4.5.5

## Motivation
We provide it with the latest one available