### PR TITLE
[Blocked do not merge] :warning: (kustomize/v1,go/v3): upgrade kustomize 3.x to 4.x and add test to ensure backwards compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ check-testdata: ## Run the script to ensure that the testdata is updated
 .PHONY: test-testdata
 test-testdata: ## Run the tests of the testdata directory
 	./test/testdata/test.sh
+	./test/testdata/test_bk_compatibility_with_3x.sh
 
 #todo(remove the test-legacy whne the go/v2 be removed from kubebuilder)
 

--- a/pkg/plugins/common/kustomize/v1/plugin.go
+++ b/pkg/plugins/common/kustomize/v1/plugin.go
@@ -24,7 +24,7 @@ import (
 )
 
 // KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
-const KustomizeVersion = "v3.8.7"
+const KustomizeVersion = "v4.5.5"
 
 const pluginName = "kustomize.common." + plugins.DefaultNameQualifier
 

--- a/test/testdata/test_bk_compatibility_with_3x.sh
+++ b/test/testdata/test_bk_compatibility_with_3x.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The go/v3 stable plugin with kustomize/v1 was upgraded
+# to move forward from its version 3.X to 4.X.
+# However, we need to ensure the backwords compability
+# and we cannot change the scaffolds mainly of create api and
+# webhook commands to use the new features provide with kustomize 4.X
+# in order to not introduce a breaking change for thoso who scaffold
+# the projects with Kubebuilder CLI 3.X when they will use new versions
+# of the tool. So, this test is for we ensure and does not
+# allow maintainers break the stable plugin.
+#
+# Changes on the syntax for kustomize v4 must be addressed
+# ONLY in the new plugin version kustomize/v2 instead.
+#
+# For further information see the doc about Plugin Versioning
+
+source "$(dirname "$0")/../common.sh"
+
+# Executes the test of the testdata directories
+function test_bk_with_projects {
+  rm -f "$(command -v controller-gen)"
+  rm -f "$(command -v kustomize)"
+
+  header_text "Performing tests in dir $1"
+  pushd "$(dirname "$0")/../../testdata/$1"
+
+  make kustomize
+
+  header_text "Remove the kustomize bin if exists"
+  rm -rf "bin/kustomize"
+
+  header_text "Installing kustomize version v3.8.7"
+  curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 3.8.7 "./bin"
+  ./bin/kustomize version
+
+  header_text "Testing kustomize build manifests with 3.x to ensure backwords compability"
+  ./bin/kustomize build "config/crd"
+  ./bin/kustomize build "config/default"
+  ./bin/kustomize build "config/webhook"
+  ./bin/kustomize build "config/certmanager"
+
+  popd
+  header_text "No changes on the scaffold were done that breaks those who scaffold the projects with Kubebuilder 3.x and go/v3"
+}
+
+build_kb
+
+# Test backwards compatibility of the scaffolds done with project v3 and kustomize v3.x
+# IMPORTANT: Do not remove the test if it fails when you do changes in the scaffolds
+# This test was done with the purpose to ensure that we will NOT change
+# the kustomize/v1 scaffolds in a way that it no longer work with 3.x
+test_bk_with_projects project-v3
+test_bk_with_projects project-v3-multigroup

--- a/testdata/project-v3-addon/Makefile
+++ b/testdata/project-v3-addon/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -113,7 +113,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v4.5.5
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"


### PR DESCRIPTION
## Description
- Update kustomize from 3x to 4x
- Add script test to ensure that maintainers do not change the default scaffold of kustomize/v1 and go/v3 which are stable and we MUST ensure the backwards compatibility

**IMPORTANT:** The changes on the scaffolds to comply with the kustomize 4.x and remove what is deprecated must be done in the new kustomze/v2-alpha plugin ([kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)/[pkg](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg)/[plugins](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins)/[common](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/common)/[kustomize](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/common/kustomize)/v2/) (examples as we did [here](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go#L92-L190))which will be used by a new golang plugin as go/v4-alpha. So that, we do not introduce breaking changes and do not affect those who scaffold the projects with Kubebuilder CLI 3.x and are trying to use its new versions. For further understanding of why it is required check the Plugin Versioning doc:  https://book.kubebuilder.io/plugins/plugins-versioning.html 

## Motivation
Allow us to move forward and support Apple Silicon with go/v3 and kustomize/v1 without introducing breaking changes for those who scaffold the projects with old CLI versions. 

## BLOCKED BY

```
/hold

By testing the changes with its big consumer SDK we could find that the make bundle target on their project brokes:

```sh
$ make bundle
/Users/camilamacedo86/go/src/github.com/operator-framework/operator-sdk/testdata/go/v3/memcached-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
operator-sdk generate kustomize manifests --interactive=false -q
cd config/manager && /Users/camilamacedo86/go/src/github.com/operator-framework/operator-sdk/testdata/go/v3/memcached-operator/bin/kustomize edit set image controller=controller:latest
/Users/camilamacedo86/go/src/github.com/operator-framework/operator-sdk/testdata/go/v3/memcached-operator/bin/kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version 0.0.1  
Error: remove operation does not apply: doc is missing path: "/spec/template/spec/containers/1/volumeMounts/0": missing value
```

So,  we cannot move forward with this one for safety and for not to risk introducing breaking changes for the projects which consume Kubebuilder as lib. See that the kustomize documentation about what should no longer work when we move from v3 to v4 is not very clear. 