### PR TITLE
✨ For kubebuilder-tools : add support to darwin/arm64, and other future OS/Arch asset bundles + etcd

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -42,15 +42,24 @@ RUN make WHAT=cmd/kube-apiserver && \
     cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kube-apiserver $DEST
 
 # kubectl
-RUN curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/${OS}/${ARCH}/kubectl && \
-    chmod +x kubectl && \
-    cp kubectl $DEST
+RUN /bin/bash -x -c ' \
+    { curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/${OS}/${ARCH}/kubectl && \
+      chmod +x kubectl && \
+      cp kubectl $DEST; } || \
+    { make WHAT=cmd/kubectl && \
+      cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kubectl $DEST; }'
 
 # etcd
+WORKDIR /etcd
 ENV ETCD_BASE_NAME=etcd-${ETCD_VERSION}-${OS}-${ARCH}
-RUN curl -sLO https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD_BASE_NAME}.zip && \
-    unzip -o ${ETCD_BASE_NAME}.zip && \
-    cp ${ETCD_BASE_NAME}/etcd $DEST
+RUN /bin/bash -x -c ' \
+    { curl -sLO https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD_BASE_NAME}.zip && \
+      unzip -o ${ETCD_BASE_NAME}.zip && \
+      cp ${ETCD_BASE_NAME}/etcd $DEST; } || \
+    { rm -fr * && \
+      git clone https://github.com/etcd-io/etcd . --depth=1 -b ${ETCD_VERSION} && \
+      GOOS=${OS} GOARCH=${ARCH} ./build.sh && \
+      cp ./bin/etcd $DEST; }'
 
 # Package into tarball.
 WORKDIR /usr/local


### PR DESCRIPTION
This patch updates the Dockerfile used to produce the kubebuilder asset bundle to support darwin/arm64, as well as possible, other, future OS/Architecture combinations, with support for building etcd as well.

This patch will build kubectl and etcd from source in the case either is not found using their prebuilt URL locations.

Testing includes:

1. Building the asset bundle:

    ```shell
    $ docker build --build-arg 'ARCH=arm64' --build-arg 'KUBERNETES_VERSION=v1.24.2' -t envtest-darwin-arm64 .
    [+] Building 148.1s (17/17) FINISHED                                                                                
     => [internal] load build definition from Dockerfile                                                           0.0s
     => => transferring dockerfile: 2.48kB                                                                         0.0s
     => [internal] load .dockerignore                                                                              0.0s
     => => transferring context: 2B                                                                                0.0s
     => [internal] load metadata for docker.io/library/alpine:3.16                                                 0.3s
     => [internal] load metadata for docker.io/library/golang:1.18                                                 0.3s
     => [builder  1/10] FROM docker.io/library/golang:1.18@sha256:1c3d22f95ce57821fff1dcd857c54809ea62f33634e2696  0.0s
     => CACHED [stage-1 1/2] FROM docker.io/library/alpine:3.16@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457  0.0s
     => CACHED [builder  2/10] RUN apt update &&     apt install unzip rsync -y &&     mkdir -p /usr/local/kubebu  0.0s
     => CACHED [builder  3/10] WORKDIR /kubernetes                                                                 0.0s
     => CACHED [builder  4/10] RUN git clone https://github.com/kubernetes/kubernetes . --depth=1 -b v1.24.2       0.0s
     => [builder  5/10] RUN make WHAT=cmd/kube-apiserver &&     cp _output/local/bin/darwin/arm64/kube-apiserve  115.6s
     => [builder  6/10] RUN /bin/bash -o pipefail -c '     { curl -sLO https://storage.googleapis.com/kubernetes-  1.3s
     => [builder  7/10] WORKDIR /etcd                                                                              0.0s 
     => [builder  8/10] RUN /bin/bash -x -c '     { curl -sLO https://github.com/coreos/etcd/releases/download/$  23.1s 
     => [builder  9/10] WORKDIR /usr/local                                                                         0.0s 
     => [builder 10/10] RUN tar -czvf /kubebuilder_darwin_arm64.tar.gz kubebuilder/                                6.4s 
     => [stage-1 2/2] COPY --from=builder /kubebuilder_darwin_arm64.tar.gz /                                       0.1s 
     => exporting to image                                                                                         0.1s 
     => => exporting layers                                                                                        0.1s 
     => => writing image sha256:f1fe3e4bc8d665d35fb05457cfe54d5ce73620eb1196722206772fee176c0a3b                   0.0s 
     => => naming to docker.io/library/envtest-darwin-arm64                                                        0.0s 
    
    Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
    ```

2. Copying the produced asset tarball out of the container image:

    ```shell
    $ docker run envtest-darwin-arm64

    $ docker ps -a
    CONTAINER ID   IMAGE                  COMMAND                  CREATED             STATUS                     PORTS                       NAMES
    66d8420678b6   envtest-darwin-arm64   "/bin/sh"                3 seconds ago       Exited (0) 3 seconds ago                               unruffled_morse

    $ docker cp 66d8420678b6:/kubebuilder_darwin_arm64.tar.gz .
    ```

3. Verifying the contents of the tarball:

    ```shell
    $ tar xzf kubebuilder_darwin_arm64.tar.gz 

    $ ls kubebuilder/bin
    etcd		kube-apiserver	kubectl

    $ file kubebuilder/bin/etcd
    kubebuilder/bin/etcd: Mach-O 64-bit executable arm64

    $ file kubebuilder/bin/kube-apiserver 
    kubebuilder/bin/kube-apiserver: Mach-O 64-bit executable arm64

    $ file kubebuilder/bin/kubectl
    kubebuilder/bin/kubectl: Mach-O 64-bit executable arm64

    $ ./kubebuilder/bin/etcd --version
    etcd Version: 3.5.4
    Git SHA: 08407ff
    Go Version: go1.18.3
    Go OS/Arch: darwin/arm64

    $ ./kubebuilder/bin/kube-apiserver --version
    Kubernetes v1.24.2

    $ ./kubebuilder/bin/kubectl version
    WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
    Client Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.2", GitCommit:"f66044f4361b9f1f96f0053dd46cb7dce5e990a8", GitTreeState:"clean", BuildDate:"2022-06-15T14:22:29Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"darwin/arm64"}
    Kustomize Version: v4.5.4
    Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.0", GitCommit:"4ce5a8954017644c5420bae81d72b09b735c21f0", GitTreeState:"clean", BuildDate:"2022-05-19T15:42:59Z", GoVersion:"go1.18.1", Compiler:"gc", Platform:"linux/arm64"}
    ```

**Update 1**
I decided to validate it again using `--no-cache` when building the image, and it still works as expected:

```shell
$ docker build --no-cache --build-arg 'ARCH=arm64' --build-arg 'KUBERNETES_VERSION=v1.24.2' -t envtest-darwin-arm64 .
[+] Building 164.7s (19/19) FINISHED                                                                                
 => [internal] load build definition from Dockerfile                                                           0.0s
 => => transferring dockerfile: 2.44kB                                                                         0.0s
 => [internal] load .dockerignore                                                                              0.0s
 => => transferring context: 2B                                                                                0.0s
 => [internal] load metadata for docker.io/library/alpine:3.16                                                 0.8s
 => [internal] load metadata for docker.io/library/golang:1.18                                                 0.8s
 => [auth] library/alpine:pull token for registry-1.docker.io                                                  0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                  0.0s
 => CACHED [builder  1/10] FROM docker.io/library/golang:1.18@sha256:1c3d22f95ce57821fff1dcd857c54809ea62f336  0.0s
 => CACHED [stage-1 1/2] FROM docker.io/library/alpine:3.16@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457  0.0s
 => [builder  2/10] RUN apt update &&     apt install unzip rsync -y &&     mkdir -p /usr/local/kubebuilder/b  3.4s
 => [builder  3/10] WORKDIR /kubernetes                                                                        0.0s
 => [builder  4/10] RUN git clone https://github.com/kubernetes/kubernetes . --depth=1 -b v1.24.2             12.8s
 => [builder  5/10] RUN make WHAT=cmd/kube-apiserver &&     cp _output/local/bin/darwin/arm64/kube-apiserve  115.0s 
 => [builder  6/10] RUN /bin/bash -x -c '     { curl -sLO https://storage.googleapis.com/kubernetes-release/r  1.5s 
 => [builder  7/10] WORKDIR /etcd                                                                              0.0s 
 => [builder  8/10] RUN /bin/bash -x -c '     { curl -sLO https://github.com/coreos/etcd/releases/download/$  23.2s 
 => [builder  9/10] WORKDIR /usr/local                                                                         0.0s 
 => [builder 10/10] RUN tar -czvf /kubebuilder_darwin_arm64.tar.gz kubebuilder/                                6.4s 
 => [stage-1 2/2] COPY --from=builder /kubebuilder_darwin_arm64.tar.gz /                                       0.1s 
 => exporting to image                                                                                         0.1s 
 => => exporting layers                                                                                        0.1s 
 => => writing image sha256:4bfb9de03c3f0b58c6611e419cc524804d2d27ec7c82403605a8c14721881246                   0.0s 
 => => naming to docker.io/library/envtest-darwin-arm64                                                        0.0s 

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
```

```shell
$ docker run envtest-darwin-arm64

$ docker ps -a
CONTAINER ID   IMAGE                  COMMAND                  CREATED          STATUS                      PORTS                       NAMES
516bd3122ea7   envtest-darwin-arm64   "/bin/sh"                2 seconds ago    Exited (0) 1 second ago    

$ docker cp 516bd3122ea7:/kubebuilder_darwin_arm64.tar.gz .
```

```shell
$ tar xzf kubebuilder_darwin_arm64.tar.gz

$ file kubebuilder/bin/*
kubebuilder/bin/etcd:           Mach-O 64-bit executable arm64
kubebuilder/bin/kube-apiserver: Mach-O 64-bit executable arm64
kubebuilder/bin/kubectl:        Mach-O 64-bit executable arm64

$ ./kubebuilder/bin/etcd --version
etcd Version: 3.5.4
Git SHA: 08407ff
Go Version: go1.18.3
Go OS/Arch: darwin/arm64
```
