### PR TITLE
:seedling: improve e2e tests to ensure that pods are restricted

### DIFF
--- a/test/e2e/v3/generate_test.go
+++ b/test/e2e/v3/generate_test.go
@@ -130,7 +130,7 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 }
 
 // GenerateV3 implements a go/v3(-alpha) plugin project defined by a TestContext.
-func GenerateV3(kbc *utils.TestContext, crdAndWebhookVersion string, restrictive bool) {
+func GenerateV3(kbc *utils.TestContext, crdAndWebhookVersion string) {
 	var err error
 
 	By("initializing a project")
@@ -229,7 +229,7 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 		_ = pluginutil.RunCmd("Update dependencies", "go", "mod", "tidy")
 	}
 
-	if restrictive {
+	if kbc.IsRestricted {
 		By("uncomment kustomize files to ensure that pods are restricted")
 		uncommentPodStandards(kbc)
 	}
@@ -252,7 +252,7 @@ func uncommentPodStandards(kbc *utils.TestContext) {
 }
 
 // GenerateV3 implements a go/v3(-alpha) plugin project defined by a TestContext.
-func GenerateV3WithKustomizeV2(kbc *utils.TestContext, crdAndWebhookVersion string, restrictive bool) {
+func GenerateV3WithKustomizeV2(kbc *utils.TestContext, crdAndWebhookVersion string) {
 	var err error
 
 	By("initializing a project")
@@ -418,4 +418,8 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 #          index: 1
 #          create: true`, "#")).To(Succeed())
 
+	if kbc.IsRestricted {
+		By("uncomment kustomize files to ensure that pods are restricted")
+		uncommentPodStandards(kbc)
+	}
 }


### PR DESCRIPTION
**Description**
 improve e2e tests to ensure that pods are restricted

**Motivation**
Ensure that pods are restricted and do not violate : 

```
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "test" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "test" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "test" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "test" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
pod/example created
```