### PR TITLE
:bug: (API) remove KustomizeVersion const from golang plugin ( the version is defined in the kustomize plugins which is responsable for )

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -37,16 +37,6 @@ const (
 	ControllerRuntimeVersion = "v0.12.1"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
 	ControllerToolsVersion = "v0.9.0"
-	// KustomizeVersion is the kubernetes-sigs/kustomize version to be used in the project
-	// @Deprecated. This information ought to come from kustomize plugin
-	// Note that by updating the following value nothing will change for the go/3 plugin
-	// it is no longer used and it was not removed only because it would be a breaking
-	// change for the API. (api-diff check)
-	//
-	// NOTE: If you want to update the kustomize version used by this plugin
-	// then you need to update it in pkg/plugins/common/kustomize/v1/plugin.go
-	// Todo: we should remove it for the next go/v4 plugin
-	KustomizeVersion = "v3.8.7"
 
 	imageName = "controller:latest"
 )


### PR DESCRIPTION
## Description

The plugin responsable for define the Kustomize Version is the Kustomize one. 

If you have consumer Kubebuilder as a lib ensure that you properly get the version from the Kustomize Plugin instead of Golang base language. Note that to create helpers and/or plugin versions that are able to deal with more than on version you can, example:

```go
        kustomizeVersion = kustomizecommonv1.KustomizeVersion
	kustomizev2 := kustomizecommonv2alpha.Plugin{}
	pluginKeyForKustomizeV2 := plugin.KeyFor(kustomizev2)

	for _, pluginKey := range s.config.GetPluginChain() {
		if pluginKey == pluginKeyForKustomizeV2 {
			kustomizeVersion = kustomizecommonv2alpha.KustomizeVersion
			break
		}
	}

        ....

        &templates.Makefile{
	      ....
	      KustomizeVersion:         kustomizeVersion,
	      ....
      },

```