### PR TITLE
✨ (kustomize/v2-alpha): remove unnecessary varReference for setup cert-manager

### DIFF
--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
@@ -44,7 +44,7 @@ func (f *KustomizeConfig) SetTemplateDefaults() error {
 }
 
 //nolint:lll
-const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
+const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref substitution 
 nameReference:
 - kind: Issuer
   group: cert-manager.io
@@ -52,12 +52,4 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
 `

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/webhook/kustomizeconfig.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/webhook/kustomizeconfig.go
@@ -44,7 +44,7 @@ func (f *KustomizeConfig) SetTemplateDefaults() error {
 }
 
 //nolint:lll
-const kustomizeConfigWebhookTemplate = `# the following config is for teaching kustomize where to look at when substituting vars.
+const kustomizeConfigWebhookTemplate = `# the following config is for teaching kustomize where to look at when substituting nameReference.
 # It requires kustomize v2.1.0 or newer to work properly.
 nameReference:
 - kind: Service
@@ -66,7 +66,4 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations
 `

--- a/testdata/project-v3-with-kustomize-v2/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v3-with-kustomize-v2/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref substitution 
 nameReference:
 - kind: Issuer
   group: cert-manager.io
@@ -6,11 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames

--- a/testdata/project-v3-with-kustomize-v2/config/webhook/kustomizeconfig.yaml
+++ b/testdata/project-v3-with-kustomize-v2/config/webhook/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# the following config is for teaching kustomize where to look at when substituting vars.
+# the following config is for teaching kustomize where to look at when substituting nameReference.
 # It requires kustomize v2.1.0 or newer to work properly.
 nameReference:
 - kind: Service
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations


### PR DESCRIPTION
## A description of the change

`vars` field will be deprecated in near future and we are planning to use replacements in `v2-alpha` instead of `vars`.

These changes will remove `varReference` field completely. The default config data for vars is located in the `varReference` field. There is no need to include it in `v2-alpha`

## The motivation for the change
it fixes #2789 

## Notes:

Is this in a document that has been referenced by the configurations field because those are [transformer configurations](https://github.com/kubernetes-sigs/kustomize/blob/de5210b43a90e80c2b9511a01ac62efbb193896e/examples/transformerconfigs/README.md#transformer-configurations). **varReference are unused because we have removed all vars from the Kustomizations**. See: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/kdefault/kustomization.go#L94-L192 

However, the nameReference is for identifying additional places that refer to object names and has nothing to do with vars.

## Tests done to ensure the changes: 

By checking the files built with kustomize ( $ kustomize build config/certmanager ) 

From this PR:  
```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: serving-cert
  namespace: system
spec:
  dnsNames:
  - SERVICE_NAME.SERVICE_NAMESPACE.svc
  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
  issuerRef:
    kind: Issuer
    name: selfsigned-issuer
  secretName: webhook-server-cert
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: selfsigned-issuer
  namespace: system
spec:
  selfSigned: {}

```

From project-v3 with the stable kustomze plugin v1 ( without the changes )

```yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: serving-cert
  namespace: system
spec:
  dnsNames:
  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
  issuerRef:
    kind: Issuer
    name: selfsigned-issuer
  secretName: webhook-server-cert
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: selfsigned-issuer
  namespace: system
spec:
  selfSigned: {}
```

Also, note that in the e2e tests we install cert-manager and we check it out. 