### PR TITLE
:book: Fix links and formatting in the file CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,13 +98,9 @@ separately.
 The docs are published off of three branches:
 
 - `book-v3`: [book.kubebuilder.io](https://book.kubebuilder.io) -- current docs
-- `book-v2`: [book-v2.kubebuilder.io](https://book.kubebuilder.io) -- legacy docs
-- `book-v1`:
-  [book-v1.book.kubebuilder.io](https://book-v1.book.kubebuilder.io) --
-  legacy docs
-- `master`:
-  [master.book.kubebuilder.io](https://master.book.kubebuilder.io) --
-  "nightly" docs
+- `book-v2`: [book-v2.book.kubebuilder.io](https://book-v2.book.kubebuilder.io) -- legacy docs
+- `book-v1`: [book-v1.book.kubebuilder.io](https://book-v1.book.kubebuilder.io) -- legacy docs
+- `master`: [master.book.kubebuilder.io](https://master.book.kubebuilder.io) -- "nightly" docs
 
 See [VERSIONING.md](VERSIONING.md#book-releases) for more information.
 


### PR DESCRIPTION
#### Description

This PR aims to fix broken links on legacy version of the Kubebuilder book in `CONTRIBUTING.md` file. Also a small fix of formatting in the books parts -- made each bullets of the list one line as it is for the version 3 and 2.

#### Motivation

In the kubebuilder Slack channel someone had raised a question regarding the old Kubebuilder book version and Camila M. found out that some links are broken. This might be not that much important, but at some point someone will find this fix useful.

There is no issue opened at the moment apart discussion in the Slack channel.