### PR TITLE
:book: fix component config tutorial instructions for customTypes

### DIFF
--- a/docs/book/src/component-config-tutorial/config-type.md
+++ b/docs/book/src/component-config-tutorial/config-type.md
@@ -21,6 +21,9 @@ This will create a new type file in `api/config/v2/` for the `ProjectConfig`
 kind. We'll need to change this file to embed the 
 [v1alpha1.ControllerManagerConfigurationSpec](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/#ControllerManagerConfigurationSpec)
 
+Note that because you create a new CustomType you will need to update the default
+scaffold to be able ti use the new Kind created instead, see:
+
 {{#literatego ./testdata/projectconfig_types.go}}
 
 Lastly, we'll change the `main.go` to reference this type for parsing the file.

--- a/docs/book/src/component-config-tutorial/testdata/project/config/manager/controller_manager_config.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/manager/controller_manager_config.yaml
@@ -1,5 +1,5 @@
-apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
-kind: ControllerManagerConfig
+apiVersion: config.tutorial.kubebuilder.io/v2
+kind: ProjectConfig
 health:
   healthProbeBindAddress: :8081
 metrics:


### PR DESCRIPTION
## Description

In the tutorial we describe how to create a custom type to inform
However, we are missing letting the users know that they need to change the default scaffold to use it. 