### PR TITLE
✨deploy-image/v1alpha: add env var for storing the image name

### DIFF
--- a/pkg/machinery/funcmap.go
+++ b/pkg/machinery/funcmap.go
@@ -30,6 +30,7 @@ func DefaultFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"title":      cases.Title,
 		"lower":      strings.ToLower,
+		"upper":      strings.ToUpper,
 		"isEmptyStr": isEmptyString,
 		"hashFNV":    hashFNV,
 	}

--- a/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
@@ -40,6 +40,11 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+        - name: BUSYBOX_IMAGE 
+          value: busybox:1.28
+        - name: MEMCACHED_IMAGE 
+          value: memcached:1.4.36-alpine
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -40,6 +40,11 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        env:
+        - name: BUSYBOX_IMAGE 
+          value: busybox:1.28
+        - name: MEMCACHED_IMAGE 
+          value: memcached:1.4.36-alpine
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
This PR works on scaffolding an env var for storing the image informed while creating the API by `deploy-image/v1alpha` plugin, and that env var can be used to get the image where it is needed.
### Motivation
Fixes part of https://github.com/kubernetes-sigs/kubebuilder/issues/2765