### PR TITLE
✨deploy-image/v1alpha: add validation markers for size spec

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -77,6 +77,11 @@ type {{ .Resource.Kind }}Spec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size defines the number of {{ .Resource.Kind }} instances
+	// The following markers will use OpenAPI v3 schema to validate the value
+	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=3
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 ` + "`" + `json:"size,omitempty"` + "`" + `
 
 	{{ if not (isEmptyStr .Port) -}}

--- a/testdata/project-v3-with-deploy-image/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v3-with-deploy-image/api/v1alpha1/busybox_types.go
@@ -29,6 +29,11 @@ type BusyboxSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size defines the number of Busybox instances
+	// The following markers will use OpenAPI v3 schema to validate the value
+	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=3
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 }
 

--- a/testdata/project-v3-with-deploy-image/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v3-with-deploy-image/api/v1alpha1/memcached_types.go
@@ -29,6 +29,11 @@ type MemcachedSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size defines the number of Memcached instances
+	// The following markers will use OpenAPI v3 schema to validate the value
+	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=3
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 
 	// Port defines the port that will be used to init the container with the image

--- a/testdata/project-v3-with-deploy-image/config/crd/bases/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v3-with-deploy-image/config/crd/bases/example.com.testproject.org_busyboxes.yaml
@@ -36,8 +36,12 @@ spec:
             description: BusyboxSpec defines the desired state of Busybox
             properties:
               size:
-                description: Size defines the number of Busybox instances
+                description: 'Size defines the number of Busybox instances The following
+                  markers will use OpenAPI v3 schema to validate the value More info:
+                  https://book.kubebuilder.io/reference/markers/crd-validation.html'
                 format: int32
+                maximum: 3
+                minimum: 1
                 type: integer
             type: object
           status:

--- a/testdata/project-v3-with-deploy-image/config/crd/bases/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v3-with-deploy-image/config/crd/bases/example.com.testproject.org_memcacheds.yaml
@@ -41,8 +41,12 @@ spec:
                 format: int32
                 type: integer
               size:
-                description: Size defines the number of Memcached instances
+                description: 'Size defines the number of Memcached instances The following
+                  markers will use OpenAPI v3 schema to validate the value More info:
+                  https://book.kubebuilder.io/reference/markers/crd-validation.html'
                 format: int32
+                maximum: 3
+                minimum: 1
                 type: integer
             type: object
           status:

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/busybox_types.go
@@ -29,6 +29,11 @@ type BusyboxSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size defines the number of Busybox instances
+	// The following markers will use OpenAPI v3 schema to validate the value
+	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=3
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 }
 

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_types.go
@@ -29,6 +29,11 @@ type MemcachedSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size defines the number of Memcached instances
+	// The following markers will use OpenAPI v3 schema to validate the value
+	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=3
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 
 	// Port defines the port that will be used to init the container with the image

--- a/testdata/project-v4-with-deploy-image/config/crd/bases/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/bases/example.com.testproject.org_busyboxes.yaml
@@ -36,8 +36,12 @@ spec:
             description: BusyboxSpec defines the desired state of Busybox
             properties:
               size:
-                description: Size defines the number of Busybox instances
+                description: 'Size defines the number of Busybox instances The following
+                  markers will use OpenAPI v3 schema to validate the value More info:
+                  https://book.kubebuilder.io/reference/markers/crd-validation.html'
                 format: int32
+                maximum: 3
+                minimum: 1
                 type: integer
             type: object
           status:

--- a/testdata/project-v4-with-deploy-image/config/crd/bases/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/bases/example.com.testproject.org_memcacheds.yaml
@@ -41,8 +41,12 @@ spec:
                 format: int32
                 type: integer
               size:
-                description: Size defines the number of Memcached instances
+                description: 'Size defines the number of Memcached instances The following
+                  markers will use OpenAPI v3 schema to validate the value More info:
+                  https://book.kubebuilder.io/reference/markers/crd-validation.html'
                 format: int32
+                maximum: 3
+                minimum: 1
                 type: integer
             type: object
           status:


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
Adds markers for the size spec for the Custom Resource in the `deploy-image/v1alpha` plugin which will set constraints for its value.

### Motivation
Fixes part of https://github.com/kubernetes-sigs/kubebuilder/issues/2765