### PR TITLE
:sparkles: (deployimage/v1-alpha): small improvements on the controller scaffold

### DIFF
--- a/testdata/project-v3-with-deploy-image/controllers/busybox_controller.go
+++ b/testdata/project-v3-with-deploy-image/controllers/busybox_controller.go
@@ -17,19 +17,18 @@ limitations under the License.
 package controllers
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +47,7 @@ type BusyboxReconciler struct {
 	Recorder record.EventRecorder
 }
 
-// The following markers are used to generate the rules permissions on config/rbac using controller-gen
+// The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
 // when the command <make manifests> is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
@@ -62,28 +61,27 @@ type BusyboxReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 
-// Note: It is essential for the controller's reconciliation loop to be idempotent. By following the Operator
-// pattern(https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) you will create
-// Controllers(https://kubernetes.io/docs/concepts/architecture/controller/) which provide a reconcile function
-// responsible for synchronizing resources until the desired state is reached on the cluster. Breaking this
-// recommendation goes against the design principles of Controller-runtime(https://github.com/kubernetes-sigs/controller-runtime)
+// It is essential for the controller's reconciliation loop to be idempotent. By following the Operator
+// pattern you will create Controllers which provide a reconcile function
+// responsible for synchronizing resources until the desired state is reached on the cluster.
+// Breaking this recommendation goes against the design principles of controller-runtime.
 // and may lead to unforeseen consequences such as resources becoming stuck and requiring manual intervention.
-//
-// For more details, check Reconcile and its Result here:
+// For further info:
+// - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
+// - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
 	// Fetch the Busybox instance
 	// The purpose is check if the Custom Resource for the Kind Busybox
-	// is applied on the cluster if not we return nill to stop the reconciliation
+	// is applied on the cluster if not we return nil to stop the reconciliation
 	busybox := &examplecomv1alpha1.Busybox{}
 	err := r.Get(ctx, req.NamespacedName, busybox)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
+			// If the custom resource is not found then, it usually means that it was deleted or not created
+			// In this way, we will stop the reconciliation
 			log.Info("busybox resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
@@ -94,15 +92,16 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Let's add a finalizer. Then, we can define some operations which should
 	// occurs before the custom resource to be deleted.
-	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
-	// NOTE: You should not use finalizer to delete the resources that are
-	// created in this reconciliation and have the ownerRef set by ctrl.SetControllerReference
-	// because these will get deleted via k8s api
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers
 	if !controllerutil.ContainsFinalizer(busybox, busyboxFinalizer) {
 		log.Info("Adding Finalizer for Busybox")
-		controllerutil.AddFinalizer(busybox, busyboxFinalizer)
-		err = r.Update(ctx, busybox)
-		if err != nil {
+		if ok := controllerutil.AddFinalizer(busybox, busyboxFinalizer); !ok {
+			log.Error(err, "Failed to add finalizer into the custom resource")
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if err = r.Update(ctx, busybox); err != nil {
+			log.Error(err, "Failed to update custom resource to add finalizer")
 			return ctrl.Result{}, err
 		}
 	}
@@ -112,23 +111,18 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	isBusyboxMarkedToBeDeleted := busybox.GetDeletionTimestamp() != nil
 	if isBusyboxMarkedToBeDeleted {
 		if controllerutil.ContainsFinalizer(busybox, busyboxFinalizer) {
-			// Run finalization logic for memcachedFinalizer. If the
-			// finalization logic fails, don't remove the finalizer so
-			// that we can retry during the next reconciliation.
 			log.Info("Performing Finalizer Operations for Busybox before delete CR")
 			r.doFinalizerOperationsForBusybox(busybox)
 
-			// Remove memcachedFinalizer. Once all finalizers have been
-			// removed, the object will be deleted.
+			log.Info("Removing Finalizer for Busybox after successfully perform the operations")
 			if ok := controllerutil.RemoveFinalizer(busybox, busyboxFinalizer); !ok {
-				if err != nil {
-					log.Error(err, "Failed to remove finalizer for Busybox")
-					return ctrl.Result{}, err
-				}
-			}
-			err := r.Update(ctx, busybox)
-			if err != nil {
 				log.Error(err, "Failed to remove finalizer for Busybox")
+				return ctrl.Result{Requeue: true}, nil
+			}
+
+			if err := r.Update(ctx, busybox); err != nil {
+				log.Error(err, "Failed to remove finalizer for Busybox")
+				return ctrl.Result{}, err
 			}
 		}
 		return ctrl.Result{}, nil
@@ -139,13 +133,20 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	err = r.Get(ctx, types.NamespacedName{Name: busybox.Name, Namespace: busybox.Namespace}, found)
 	if err != nil && apierrors.IsNotFound(err) {
 		// Define a new deployment
-		dep := r.deploymentForBusybox(ctx, busybox)
-		log.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
-		err = r.Create(ctx, dep)
+		dep, err := r.deploymentForBusybox(busybox)
 		if err != nil {
-			log.Error(err, "Failed to create new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+			log.Error(err, "Failed to define new Deployment resource for Busybox")
 			return ctrl.Result{}, err
 		}
+
+		log.Info("Creating a new Deployment",
+			"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+		if err = r.Create(ctx, dep); err != nil {
+			log.Error(err, "Failed to create new Deployment",
+				"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+			return ctrl.Result{}, err
+		}
+
 		// Deployment created successfully
 		// We will requeue the reconciliation so that we can ensure the state
 		// and move forward for the next operations
@@ -156,16 +157,19 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// The API is defining that the Busybox type, have a BusyboxSpec.Size field to set the quantity of Busybox instances (CRs) to be deployed.
-	// The following code ensure the deployment size is the same as the spec
+	// The CRD API is defining that the Busybox type, have a BusyboxSpec.Size field
+	// to set the quantity of Deployment instances is the desired state on the cluster.
+	// Therefore, the following code will ensure the Deployment size is the same as defined
+	// via the Size spec of the Custom Resource which we are reconciling.
 	size := busybox.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		err = r.Update(ctx, found)
-		if err != nil {
-			log.Error(err, "Failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+		if err = r.Update(ctx, found); err != nil {
+			log.Error(err, "Failed to update Deployment",
+				"Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 			return ctrl.Result{}, err
 		}
+
 		// Since it fails we want to re-queue the reconciliation
 		// The reconciliation will only stop when we be able to ensure
 		// the desired state on the cluster
@@ -181,6 +185,13 @@ func (r *BusyboxReconciler) doFinalizerOperationsForBusybox(cr *examplecomv1alph
 	// needs to do before the CR can be deleted. Examples
 	// of finalizers include performing backups and deleting
 	// resources that are not owned by this CR, like a PVC.
+
+	// Note: It is not recommended to use finalizers with the purpose of delete resources which are
+	// created and managed in the reconciliation. These ones, such as the Deployment created on this reconcile,
+	// are defined as depended of the custom resource. See that we use the method ctrl.SetControllerReference.
+	// to set the ownerRef which means that the Deployment will be deleted by the Kubernetes API.
+	// More info: https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/
+
 	// The following implementation will raise an event
 	r.Recorder.Event(cr, "Warning", "Deleting",
 		fmt.Sprintf("Custom Resource %s is being deleted from the namespace %s",
@@ -189,13 +200,15 @@ func (r *BusyboxReconciler) doFinalizerOperationsForBusybox(cr *examplecomv1alph
 }
 
 // deploymentForBusybox returns a Busybox Deployment object
-func (r *BusyboxReconciler) deploymentForBusybox(ctx context.Context, busybox *examplecomv1alpha1.Busybox) *appsv1.Deployment {
+func (r *BusyboxReconciler) deploymentForBusybox(
+	busybox *examplecomv1alpha1.Busybox) (*appsv1.Deployment, error) {
 	ls := labelsForBusybox(busybox.Name)
 	replicas := busybox.Spec.Size
-	log := log.FromContext(ctx)
+
+	// Get the Operand image
 	image, err := imageForBusybox()
 	if err != nil {
-		log.Error(err, "unable to get image for Busybox")
+		return nil, err
 	}
 
 	dep := &appsv1.Deployment{
@@ -242,18 +255,17 @@ func (r *BusyboxReconciler) deploymentForBusybox(ctx context.Context, busybox *e
 			},
 		},
 	}
-	// Set Busybox instance as the owner and controller
-	// You should use the method ctrl.SetControllerReference for all resources
-	// which are created by your controller so that when the Custom Resource be deleted
-	// all resources owned by it (child) will also be deleted.
-	// To know more about it see: https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/
-	ctrl.SetControllerReference(busybox, dep, r.Scheme)
-	return dep
+
+	// Set the ownerRef for the Deployment
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/
+	if err := ctrl.SetControllerReference(busybox, dep, r.Scheme); err != nil {
+		return nil, err
+	}
+	return dep, nil
 }
 
 // labelsForBusybox returns the labels for selecting the resources
-// belonging to the given  Busybox CR name.
-// Note that the labels follows the standards defined in: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 func labelsForBusybox(name string) map[string]string {
 	var imageTag string
 	image, err := imageForBusybox()
@@ -268,22 +280,20 @@ func labelsForBusybox(name string) map[string]string {
 	}
 }
 
-// imageForBusybox gets the image for the resources belonging to the given Busybox CR,
-// from the BUSYBOX_IMAGE ENV VAR defined in the config/manager/manager.yaml
+// imageForBusybox gets the Operand image which is managed by this controller
+// from the BUSYBOX_IMAGE environment variable defined in the config/manager/manager.yaml
 func imageForBusybox() (string, error) {
 	var imageEnvVar = "BUSYBOX_IMAGE"
 	image, found := os.LookupEnv(imageEnvVar)
 	if !found {
-		return "", fmt.Errorf("%s must be set", imageEnvVar)
+		return "", fmt.Errorf("Unable to find %s environment variable with the image", imageEnvVar)
 	}
 	return image, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-// The following code specifies how the controller is built to watch a CR
-// and other resources that are owned and managed by that controller.
-// In this way, the reconciliation can be re-trigged when the CR and/or the Deployment
-// be created/edit/delete.
+// Note that the Deployment will be also watched in order to ensure its
+// desirable state on the cluster
 func (r *BusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&examplecomv1alpha1.Busybox{}).

--- a/testdata/project-v4-with-deploy-image/controllers/busybox_controller.go
+++ b/testdata/project-v4-with-deploy-image/controllers/busybox_controller.go
@@ -17,19 +17,18 @@ limitations under the License.
 package controllers
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +47,7 @@ type BusyboxReconciler struct {
 	Recorder record.EventRecorder
 }
 
-// The following markers are used to generate the rules permissions on config/rbac using controller-gen
+// The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
 // when the command <make manifests> is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
@@ -62,28 +61,27 @@ type BusyboxReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 
-// Note: It is essential for the controller's reconciliation loop to be idempotent. By following the Operator
-// pattern(https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) you will create
-// Controllers(https://kubernetes.io/docs/concepts/architecture/controller/) which provide a reconcile function
-// responsible for synchronizing resources until the desired state is reached on the cluster. Breaking this
-// recommendation goes against the design principles of Controller-runtime(https://github.com/kubernetes-sigs/controller-runtime)
+// It is essential for the controller's reconciliation loop to be idempotent. By following the Operator
+// pattern you will create Controllers which provide a reconcile function
+// responsible for synchronizing resources until the desired state is reached on the cluster.
+// Breaking this recommendation goes against the design principles of controller-runtime.
 // and may lead to unforeseen consequences such as resources becoming stuck and requiring manual intervention.
-//
-// For more details, check Reconcile and its Result here:
+// For further info:
+// - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
+// - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.12.2/pkg/reconcile
 func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
 	// Fetch the Busybox instance
 	// The purpose is check if the Custom Resource for the Kind Busybox
-	// is applied on the cluster if not we return nill to stop the reconciliation
+	// is applied on the cluster if not we return nil to stop the reconciliation
 	busybox := &examplecomv1alpha1.Busybox{}
 	err := r.Get(ctx, req.NamespacedName, busybox)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
+			// If the custom resource is not found then, it usually means that it was deleted or not created
+			// In this way, we will stop the reconciliation
 			log.Info("busybox resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
@@ -94,15 +92,16 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Let's add a finalizer. Then, we can define some operations which should
 	// occurs before the custom resource to be deleted.
-	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/
-	// NOTE: You should not use finalizer to delete the resources that are
-	// created in this reconciliation and have the ownerRef set by ctrl.SetControllerReference
-	// because these will get deleted via k8s api
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers
 	if !controllerutil.ContainsFinalizer(busybox, busyboxFinalizer) {
 		log.Info("Adding Finalizer for Busybox")
-		controllerutil.AddFinalizer(busybox, busyboxFinalizer)
-		err = r.Update(ctx, busybox)
-		if err != nil {
+		if ok := controllerutil.AddFinalizer(busybox, busyboxFinalizer); !ok {
+			log.Error(err, "Failed to add finalizer into the custom resource")
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if err = r.Update(ctx, busybox); err != nil {
+			log.Error(err, "Failed to update custom resource to add finalizer")
 			return ctrl.Result{}, err
 		}
 	}
@@ -112,23 +111,18 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	isBusyboxMarkedToBeDeleted := busybox.GetDeletionTimestamp() != nil
 	if isBusyboxMarkedToBeDeleted {
 		if controllerutil.ContainsFinalizer(busybox, busyboxFinalizer) {
-			// Run finalization logic for memcachedFinalizer. If the
-			// finalization logic fails, don't remove the finalizer so
-			// that we can retry during the next reconciliation.
 			log.Info("Performing Finalizer Operations for Busybox before delete CR")
 			r.doFinalizerOperationsForBusybox(busybox)
 
-			// Remove memcachedFinalizer. Once all finalizers have been
-			// removed, the object will be deleted.
+			log.Info("Removing Finalizer for Busybox after successfully perform the operations")
 			if ok := controllerutil.RemoveFinalizer(busybox, busyboxFinalizer); !ok {
-				if err != nil {
-					log.Error(err, "Failed to remove finalizer for Busybox")
-					return ctrl.Result{}, err
-				}
-			}
-			err := r.Update(ctx, busybox)
-			if err != nil {
 				log.Error(err, "Failed to remove finalizer for Busybox")
+				return ctrl.Result{Requeue: true}, nil
+			}
+
+			if err := r.Update(ctx, busybox); err != nil {
+				log.Error(err, "Failed to remove finalizer for Busybox")
+				return ctrl.Result{}, err
 			}
 		}
 		return ctrl.Result{}, nil
@@ -139,13 +133,20 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	err = r.Get(ctx, types.NamespacedName{Name: busybox.Name, Namespace: busybox.Namespace}, found)
 	if err != nil && apierrors.IsNotFound(err) {
 		// Define a new deployment
-		dep := r.deploymentForBusybox(ctx, busybox)
-		log.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
-		err = r.Create(ctx, dep)
+		dep, err := r.deploymentForBusybox(busybox)
 		if err != nil {
-			log.Error(err, "Failed to create new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+			log.Error(err, "Failed to define new Deployment resource for Busybox")
 			return ctrl.Result{}, err
 		}
+
+		log.Info("Creating a new Deployment",
+			"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+		if err = r.Create(ctx, dep); err != nil {
+			log.Error(err, "Failed to create new Deployment",
+				"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
+			return ctrl.Result{}, err
+		}
+
 		// Deployment created successfully
 		// We will requeue the reconciliation so that we can ensure the state
 		// and move forward for the next operations
@@ -156,16 +157,19 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// The API is defining that the Busybox type, have a BusyboxSpec.Size field to set the quantity of Busybox instances (CRs) to be deployed.
-	// The following code ensure the deployment size is the same as the spec
+	// The CRD API is defining that the Busybox type, have a BusyboxSpec.Size field
+	// to set the quantity of Deployment instances is the desired state on the cluster.
+	// Therefore, the following code will ensure the Deployment size is the same as defined
+	// via the Size spec of the Custom Resource which we are reconciling.
 	size := busybox.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		err = r.Update(ctx, found)
-		if err != nil {
-			log.Error(err, "Failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+		if err = r.Update(ctx, found); err != nil {
+			log.Error(err, "Failed to update Deployment",
+				"Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 			return ctrl.Result{}, err
 		}
+
 		// Since it fails we want to re-queue the reconciliation
 		// The reconciliation will only stop when we be able to ensure
 		// the desired state on the cluster
@@ -181,6 +185,13 @@ func (r *BusyboxReconciler) doFinalizerOperationsForBusybox(cr *examplecomv1alph
 	// needs to do before the CR can be deleted. Examples
 	// of finalizers include performing backups and deleting
 	// resources that are not owned by this CR, like a PVC.
+
+	// Note: It is not recommended to use finalizers with the purpose of delete resources which are
+	// created and managed in the reconciliation. These ones, such as the Deployment created on this reconcile,
+	// are defined as depended of the custom resource. See that we use the method ctrl.SetControllerReference.
+	// to set the ownerRef which means that the Deployment will be deleted by the Kubernetes API.
+	// More info: https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/
+
 	// The following implementation will raise an event
 	r.Recorder.Event(cr, "Warning", "Deleting",
 		fmt.Sprintf("Custom Resource %s is being deleted from the namespace %s",
@@ -189,13 +200,15 @@ func (r *BusyboxReconciler) doFinalizerOperationsForBusybox(cr *examplecomv1alph
 }
 
 // deploymentForBusybox returns a Busybox Deployment object
-func (r *BusyboxReconciler) deploymentForBusybox(ctx context.Context, busybox *examplecomv1alpha1.Busybox) *appsv1.Deployment {
+func (r *BusyboxReconciler) deploymentForBusybox(
+	busybox *examplecomv1alpha1.Busybox) (*appsv1.Deployment, error) {
 	ls := labelsForBusybox(busybox.Name)
 	replicas := busybox.Spec.Size
-	log := log.FromContext(ctx)
+
+	// Get the Operand image
 	image, err := imageForBusybox()
 	if err != nil {
-		log.Error(err, "unable to get image for Busybox")
+		return nil, err
 	}
 
 	dep := &appsv1.Deployment{
@@ -242,18 +255,17 @@ func (r *BusyboxReconciler) deploymentForBusybox(ctx context.Context, busybox *e
 			},
 		},
 	}
-	// Set Busybox instance as the owner and controller
-	// You should use the method ctrl.SetControllerReference for all resources
-	// which are created by your controller so that when the Custom Resource be deleted
-	// all resources owned by it (child) will also be deleted.
-	// To know more about it see: https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/
-	ctrl.SetControllerReference(busybox, dep, r.Scheme)
-	return dep
+
+	// Set the ownerRef for the Deployment
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/
+	if err := ctrl.SetControllerReference(busybox, dep, r.Scheme); err != nil {
+		return nil, err
+	}
+	return dep, nil
 }
 
 // labelsForBusybox returns the labels for selecting the resources
-// belonging to the given  Busybox CR name.
-// Note that the labels follows the standards defined in: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 func labelsForBusybox(name string) map[string]string {
 	var imageTag string
 	image, err := imageForBusybox()
@@ -268,22 +280,20 @@ func labelsForBusybox(name string) map[string]string {
 	}
 }
 
-// imageForBusybox gets the image for the resources belonging to the given Busybox CR,
-// from the BUSYBOX_IMAGE ENV VAR defined in the config/manager/manager.yaml
+// imageForBusybox gets the Operand image which is managed by this controller
+// from the BUSYBOX_IMAGE environment variable defined in the config/manager/manager.yaml
 func imageForBusybox() (string, error) {
 	var imageEnvVar = "BUSYBOX_IMAGE"
 	image, found := os.LookupEnv(imageEnvVar)
 	if !found {
-		return "", fmt.Errorf("%s must be set", imageEnvVar)
+		return "", fmt.Errorf("Unable to find %s environment variable with the image", imageEnvVar)
 	}
 	return image, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-// The following code specifies how the controller is built to watch a CR
-// and other resources that are owned and managed by that controller.
-// In this way, the reconciliation can be re-trigged when the CR and/or the Deployment
-// be created/edit/delete.
+// Note that the Deployment will be also watched in order to ensure its
+// desirable state on the cluster
 func (r *BusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&examplecomv1alpha1.Busybox{}).


### PR DESCRIPTION
## Description
- Improve the logs
- Improve layout to not fail in lll lint checker
- simplify calls with errors ( if err := action; err != nil )
- order the imports
- return an error if be unable to create the deployment to re-queue
- small improvements in the comments
