### PR TITLE
:sparkles: Add RBAC permissions to allow Prometheus to access metrics

### DIFF
--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -51,12 +51,23 @@ Follow the steps below to export the metrics using the Prometheus Operator:
    We recommend using [kube-prometheus](https://github.com/coreos/kube-prometheus#installing)
    in production if you don't have your own monitoring system.
    If you are just experimenting, you can only install Prometheus and Prometheus Operator.
+
 2. Uncomment the line `- ../prometheus` in the `config/default/kustomization.yaml`.
    It creates the `ServiceMonitor` resource which enables exporting the metrics.
 
 ```yaml
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
+```
+
+3. To apply the necessary RBAC resource for Prometheus operator, uncomment the
+line `- ../prometheus_rbac` in the `config/default/kustomization.yaml`. This
+will create a `Role` and `RoleBinding` resources which enables access to the
+metrics.
+
+```yaml
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+- ../prometheus_rbac
 ```
 
 Note that, when you install your project in the cluster, it will create the

--- a/pkg/plugins/common/kustomize/v1/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/init.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac"
 )
 
@@ -80,5 +81,8 @@ func (s *initScaffolder) Scaffold() error {
 		&kdefault.ManagerConfigPatch{},
 		&prometheus.Kustomization{},
 		&prometheus.Monitor{},
+		&prometheus_rbac.Kustomization{},
+		&prometheus_rbac.Role{},
+		&prometheus_rbac.RoleBinding{},
 	)
 }

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -69,6 +69,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac/kustomization.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac/kustomization.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Kustomization{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type Kustomization struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	return nil
+}
+
+const kustomizationTemplate = `resources:
+- role.yaml
+- role_binding.yaml
+`

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac/role.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac/role.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Role{}
+
+// Role scaffolds a file that defines the Prometheus Role
+type Role struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Role) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "role.yaml")
+	}
+
+	f.TemplateBody = roleTemplate
+
+	return nil
+}
+
+const roleTemplate = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]
+`

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac/role_binding.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/prometheus_rbac/role_binding.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &RoleBinding{}
+
+// RoleBinding scaffolds a file that defines the Prometheus RoleBinding
+type RoleBinding struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *RoleBinding) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "role_binding.yaml")
+	}
+
+	f.TemplateBody = roleBindingTemplate
+
+	return nil
+}
+
+const roleBindingTemplate = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring
+`

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/init.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/kdefault"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/rbac"
 )
 
@@ -80,5 +81,8 @@ func (s *initScaffolder) Scaffold() error {
 		&kdefault.ManagerConfigPatch{},
 		&prometheus.Kustomization{},
 		&prometheus.Monitor{},
+		&prometheus_rbac.Kustomization{},
+		&prometheus_rbac.Role{},
+		&prometheus_rbac.RoleBinding{},
 	)
 }

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -71,6 +71,8 @@ resources:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac/kustomization.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Kustomization{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type Kustomization struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	return nil
+}
+
+const kustomizationTemplate = `resources:
+- role.yaml
+- role_binding.yaml
+`

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac/role.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac/role.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Role{}
+
+// Role scaffolds a file that defines the Prometheus Role
+type Role struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Role) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "role.yaml")
+	}
+
+	f.TemplateBody = roleTemplate
+
+	return nil
+}
+
+const roleTemplate = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]
+`

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac/role_binding.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus_rbac/role_binding.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &RoleBinding{}
+
+// RoleBinding scaffolds a file that defines the Prometheus RoleBinding
+type RoleBinding struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *RoleBinding) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "role_binding.yaml")
+	}
+
+	f.TemplateBody = roleBindingTemplate
+
+	return nil
+}
+
+const roleBindingTemplate = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring
+`

--- a/pkg/plugins/golang/v2/scaffolds/init.go
+++ b/pkg/plugins/golang/v2/scaffolds/init.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/manager"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/rbac"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/config/webhook"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2/scaffolds/internal/templates/hack"
@@ -139,6 +140,9 @@ func (s *initScaffolder) Scaffold() error {
 		&webhook.Service{},
 		&prometheus.Kustomization{},
 		&prometheus.Monitor{},
+		&prometheus_rbac.Kustomization{},
+		&prometheus_rbac.Role{},
+		&prometheus_rbac.RoleBinding{},
 		&certmanager.Certificate{},
 		&certmanager.Kustomization{},
 		&certmanager.KustomizeConfig{},

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -79,6 +79,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac/kustomization.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac/kustomization.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Kustomization{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type Kustomization struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	return nil
+}
+
+const kustomizationTemplate = `resources:
+- role.yaml
+- role_binding.yaml
+`

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac/role.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac/role.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Role{}
+
+// Role scaffolds a file that defines the Prometheus Role
+type Role struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Role) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "role.yaml")
+	}
+
+	f.TemplateBody = roleTemplate
+
+	return nil
+}
+
+const roleTemplate = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]
+`

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac/role_binding.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/prometheus_rbac/role_binding.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus_rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &RoleBinding{}
+
+// RoleBinding scaffolds a file that defines the Prometheus RoleBinding
+type RoleBinding struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *RoleBinding) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "prometheus_rbac", "role_binding.yaml")
+	}
+
+	f.TemplateBody = roleBindingTemplate
+
+	return nil
+}
+
+const roleBindingTemplate = `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring
+`

--- a/testdata/project-v2/config/default/kustomization.yaml
+++ b/testdata/project-v2/config/default/kustomization.yaml
@@ -23,6 +23,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v2/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v2/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v2/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v2/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v2/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v2/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v3-addon-and-grafana/config/default/kustomization.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/default/kustomization.yaml
@@ -23,6 +23,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v3-addon-and-grafana/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v3-addon-and-grafana/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v3-addon-and-grafana/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v3-config/config/default/kustomization.yaml
+++ b/testdata/project-v3-config/config/default/kustomization.yaml
@@ -23,6 +23,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v3-config/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v3-config/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v3-config/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v3-config/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v3-config/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v3-config/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v3-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/default/kustomization.yaml
@@ -23,6 +23,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v3-multigroup/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v3-multigroup/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v3-multigroup/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v3-multigroup/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v3-multigroup/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v3-multigroup/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v3-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v3-with-deploy-image/config/default/kustomization.yaml
@@ -23,6 +23,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v3-with-deploy-image/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v3-with-deploy-image/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v3-with-deploy-image/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v3-with-deploy-image/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v3-with-deploy-image/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v3-with-deploy-image/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v3/config/default/kustomization.yaml
+++ b/testdata/project-v3/config/default/kustomization.yaml
@@ -23,6 +23,8 @@ bases:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v3/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v3/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v3/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v3/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v3/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v3/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v4-addon-and-grafana/config/default/kustomization.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/default/kustomization.yaml
@@ -25,6 +25,8 @@ resources:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v4-addon-and-grafana/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v4-addon-and-grafana/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v4-addon-and-grafana/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v4-config/config/default/kustomization.yaml
+++ b/testdata/project-v4-config/config/default/kustomization.yaml
@@ -25,6 +25,8 @@ resources:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v4-config/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v4-config/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v4-config/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v4-config/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v4-config/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v4-config/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -25,6 +25,8 @@ resources:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v4-multigroup/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v4-multigroup/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v4-multigroup/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
@@ -25,6 +25,8 @@ resources:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v4-with-deploy-image/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v4-with-deploy-image/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v4-with-deploy-image/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v4-with-deploy-image/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v4-with-deploy-image/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -25,6 +25,8 @@ resources:
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
+# [PROMETHEUS RBAC] To give Prometheus service account necessary permissions, uncomment all sections with 'PROMETHEUS RBAC'.
+#- ../prometheus_rbac
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/testdata/project-v4/config/prometheus_rbac/kustomization.yaml
+++ b/testdata/project-v4/config/prometheus_rbac/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- role_binding.yaml

--- a/testdata/project-v4/config/prometheus_rbac/role.yaml
+++ b/testdata/project-v4/config/prometheus_rbac/role.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: controller-manager-cluster-role
+  namespace: system
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list"]

--- a/testdata/project-v4/config/prometheus_rbac/role_binding.yaml
+++ b/testdata/project-v4/config/prometheus_rbac/role_binding.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: controller-manager-cluster-role-binding
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: controller-manager-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

Following https://github.com/kubernetes-sigs/kubebuilder/pull/2827, in which the user must manually create and manage the necessary RBAC resources for Prometheus to be able to access the controller metrics, with this PR kubebuilder will be able to generate the necessary RBAC resources that will be deployed alongside the controller and the Prometheus `ServiceMonitor` if the user chooses to do so.



