### PR TITLE
:sparkles: Experimental practice to scaffold dashboard manifest for custom metrics

### DIFF
--- a/docs/book/src/plugins/grafana-v1-alpha.md
+++ b/docs/book/src/plugins/grafana-v1-alpha.md
@@ -132,6 +132,48 @@ See an example of how to use the plugin in your project:
   - Per-second rate of retries handled by workqueue
 - Sample: <img width="914" src="https://user-images.githubusercontent.com/18136486/180360101-411c81e9-d54e-4b21-bbb0-e3f94fcf48cb.png">
 
+### Visualize Custom Metrics
+
+The Grafana plugin supports scaffolding manifests for custom metrics.
+
+#### Generate Config Template
+
+When the plugin is triggered for the first time, `grafana/custom-metrics/config.yaml` is generated.
+
+```yaml
+---
+customMetrics:
+#  - metric: # Raw custom metric (required)
+#    type:   # Metric type: counter/gauge/histogram (required)
+#    expr:   # Prom_ql for the metric (optional)
+```
+
+#### Add Custom Metrics to Config
+
+You can enter multiple custom metrics in the file. For each element, you need to specify the `metric` and its `type`.
+The Grafana plugin can automatically generate `expr` for visualization.
+Alternatively, you can provide `expr` and the plugin will use the specified one directly.
+
+```yaml
+---
+customMetrics:
+  - metric: memcached_operator_reconcile_total # Raw custom metric (required)
+    type: counter # Metric type: counter/gauge/histogram (required)
+  - metric: memcached_operator_reconcile_time_seconds_bucket
+    type: histogram
+```
+
+#### Scaffold Manifest
+
+Once `config.yaml` is configured, you can run `kubebuilder edit --plugins grafana.kubebuilder.io/v1-alpha` again.
+This time, the plugin will generate `grafana/custom-metrics/custom-metrics-dashboard.json`, which can be imported to Grafana UI.
+
+#### Show case:
+
+See an example of how to visualize your custom metrics:
+
+![output2](https://user-images.githubusercontent.com/18136486/186933170-d2e0de71-e079-4d1b-906a-99a549d66ebf.gif)
+
 ## Subcommands
 
 The Grafana plugin implements the following subcommands:

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -242,3 +242,14 @@ func ReplaceRegexInFile(path, match, replace string) error {
 	}
 	return nil
 }
+
+// HasFileContentWith check if given `text` can be found in file
+func HasFileContentWith(path, text string) (bool, error) {
+	// nolint:gosec
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	return strings.Contains(string(contents), text), nil
+}

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -18,13 +18,21 @@ package scaffolds
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates"
+
+	"sigs.k8s.io/yaml"
 )
 
 var _ plugins.Scaffolder = &editScaffolder{}
+
+const configFilePath = "grafana/custom-metrics/config.yaml"
 
 type editScaffolder struct {
 	// fs is the filesystem that will be used by the scaffolder
@@ -41,6 +49,100 @@ func (s *editScaffolder) InjectFS(fs machinery.Filesystem) {
 	s.fs = fs
 }
 
+func fileExist(configFilePath string) bool {
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func loadConfig(configPath string) ([]templates.CustomMetricItem, error) {
+	if !fileExist(configPath) {
+		return nil, nil
+	}
+
+	// nolint:gosec
+	f, err := os.Open(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error loading plugin config: %w", err)
+	}
+
+	items, err := configReader(f)
+
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("could not close config.yaml: %w", err)
+	}
+
+	return items, err
+}
+
+func configReader(reader io.Reader) ([]templates.CustomMetricItem, error) {
+	yamlFile, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	config := templates.CustomMetricsConfig{}
+
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	validatedMetricItems := validateCustomMetricItems(config.CustomMetrics)
+
+	return validatedMetricItems, nil
+}
+
+func validateCustomMetricItems(rawItems []templates.CustomMetricItem) []templates.CustomMetricItem {
+	// 1. Filter items of missing `Metric` or `Type`
+	filterResult := []templates.CustomMetricItem{}
+	for _, item := range rawItems {
+		if hasFields(item) {
+			filterResult = append(filterResult, item)
+		}
+	}
+
+	// 2. Fill Expr if missing
+	validatedItems := make([]templates.CustomMetricItem, len(filterResult))
+	for i, item := range filterResult {
+		validatedItems[i] = fillMissingExpr(item)
+	}
+
+	return validatedItems
+}
+
+func hasFields(item templates.CustomMetricItem) bool {
+	// If `Expr` exists, return true
+	if item.Expr != "" {
+		return true
+	}
+
+	// If `Metric` & valid `Type` exists, return true
+	metricType := strings.ToLower(item.Type)
+	if item.Metric != "" && (metricType == "counter" || metricType == "gauge" || metricType == "histogram") {
+		return true
+	}
+
+	return false
+}
+
+// TODO: Prom_ql exprs can improved to be more pratical and applicable
+func fillMissingExpr(item templates.CustomMetricItem) templates.CustomMetricItem {
+	if item.Expr == "" {
+		switch strings.ToLower(item.Type) {
+		case "counter":
+			item.Expr = "sum(rate(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, pod)`
+		case "histogram":
+			// nolint: lll
+			item.Expr = "histogram_quantile(0.90, sum by(instance, le) (rate(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}[5m])))`
+		default: // gauge
+			item.Expr = item.Metric
+		}
+	}
+	return item
+}
+
 // Scaffold implements cmdutil.Scaffolder
 func (s *editScaffolder) Scaffold() error {
 	fmt.Println("Generating Grafana manifests to visualize controller status...")
@@ -48,8 +150,20 @@ func (s *editScaffolder) Scaffold() error {
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs)
 
-	return scaffold.Execute(
+	configPath := string(configFilePath)
+
+	var templatesBuilder = []machinery.Builder{
 		&templates.RuntimeManifest{},
 		&templates.ResourcesManifest{},
-	)
+		&templates.CustomMetricsConfigManifest{ConfigPath: configPath},
+	}
+
+	configItems, err := loadConfig(configPath)
+	if err == nil && len(configItems) > 0 {
+		templatesBuilder = append(templatesBuilder, &templates.CustomMetricsDashManifest{Items: configItems})
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "Error on scaffolding manifest for custom metris:\n%v", err)
+	}
+
+	return scaffold.Execute(templatesBuilder...)
 }

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
@@ -51,5 +51,6 @@ func (s *initScaffolder) Scaffold() error {
 	return scaffold.Execute(
 		&templates.RuntimeManifest{},
 		&templates.ResourcesManifest{},
+		&templates.CustomMetricsConfigManifest{ConfigPath: string(configFilePath)},
 	)
 }

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &CustomMetricsConfigManifest{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type CustomMetricsConfigManifest struct {
+	machinery.TemplateMixin
+	ConfigPath string
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *CustomMetricsConfigManifest) SetTemplateDefaults() error {
+	f.Path = f.ConfigPath
+
+	f.TemplateBody = customMetricsConfigTemplate
+
+	f.IfExistsAction = machinery.SkipFile
+
+	return nil
+}
+
+// nolint: lll
+const customMetricsConfigTemplate = `---
+customMetrics:
+#  - metric: # Raw custom metric (required)
+#    type:   # Metric type: counter/gauge/histogram (required)
+#    expr:   # Prom_ql for the metric (optional)
+#
+#
+# Example:
+# ---
+# customMetrics:
+#   - metric: foo_bar
+#     type: histogram
+#   	expr: histogram_quantile(0.90, sum by(instance, le) (rate(foo_bar{job=\"$job\", namespace=\"$namespace\"}[5m])))
+`

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom_metrics.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom_metrics.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"text/template"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+type CustomMetricsConfig struct {
+	CustomMetrics []CustomMetricItem `json:"customMetrics"`
+}
+
+type CustomMetricItem struct {
+	Metric string `json:"metric"`
+	Type   string `json:"type"`
+	Expr   string `json:"expr,omitempty"`
+}
+
+var _ machinery.Template = &CustomMetricsDashManifest{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type CustomMetricsDashManifest struct {
+	machinery.TemplateMixin
+
+	Items []CustomMetricItem
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *CustomMetricsDashManifest) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("grafana", "custom-metrics", "custom-metrics-dashboard.json")
+	}
+
+	defaultTemplate, err := f.createTemplate()
+	if err != nil {
+		return err
+	}
+
+	f.TemplateBody = defaultTemplate
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+var fns = template.FuncMap{
+	"plus1": func(x int) int {
+		return x + 1
+	},
+}
+
+func (f *CustomMetricsDashManifest) createTemplate() (string, error) {
+	t := template.Must(template.New("customMetricsDashTemplate").Funcs(fns).Parse(customMetricsDashTemplate))
+
+	outputTmpl := &bytes.Buffer{}
+	if err := t.Execute(outputTmpl, f.Items); err != nil {
+		return "", fmt.Errorf("error when generating manifest from config: %w", err)
+	}
+
+	return outputTmpl.String(), nil
+}
+
+// nolint: lll
+const customMetricsDashTemplate = `{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [{{ $n := len . }}{{ range $i, $e := . }}
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 3,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24
+      },
+      "interval": "1m",
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.3",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "exemplar": true,
+          "expr": "{{ .Expr }}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "title": "{{ .Metric }} ({{ .Type }})",
+      "type": "timeseries"
+    }{{ if ne (plus1 $i) $n }},
+		{{end}}{{end}}
+  ],
+  "refresh": "",
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "observability",
+          "value": "observability"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(controller_runtime_reconcile_total, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, pod)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Custom-Metrics",
+  "weekStart": ""
+}
+`

--- a/test/e2e/grafana/e2e_suite_test.go
+++ b/test/e2e/grafana/e2e_suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grafana
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Run e2e tests using the Ginkgo runner.
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	fmt.Fprintf(GinkgoWriter, "Starting grafana plugin kubebuilder suite\n")
+	RunSpecs(t, "Kubebuilder grafana plugin e2e suite")
+}

--- a/test/e2e/grafana/generate_test.go
+++ b/test/e2e/grafana/generate_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grafana
+
+import (
+	"path/filepath"
+
+	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
+
+	//nolint:golint
+	//nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+
+	//nolint:golint
+	//nolint:revive
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"
+)
+
+var _ = Describe("kubebuilder", func() {
+	Context("plugin grafana/v1-alpha", func() {
+		var (
+			kbc *utils.TestContext
+		)
+
+		BeforeEach(func() {
+			var err error
+			kbc, err = utils.NewTestContext(pluginutil.KubebuilderBinName, "GO111MODULE=on")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kbc.Prepare()).To(Succeed())
+		})
+
+		AfterEach(func() {
+			kbc.Destroy()
+		})
+
+		It("should generate a runnable project with grafana plugin", func() {
+			GenerateProject(kbc)
+		})
+
+	})
+})
+
+// GenerateProject implements a grafana/v1(-alpha) plugin project defined by a TestContext.
+func GenerateProject(kbc *utils.TestContext) {
+	var err error
+
+	By("initializing a project")
+	err = kbc.Init(
+		"--plugins", "grafana.kubebuilder.io/v1-alpha",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("verifying the initial template content and updating for real custom metrics")
+	ExpectWithOffset(1, pluginutil.ReplaceInFile(
+		filepath.Join(kbc.Dir, "grafana", "custom-metrics", "config.yaml"),
+		`---
+customMetrics:
+#  - metric: # Raw custom metric (required)
+#    type:   # Metric type: counter/gauge/histogram (required)
+#    expr:   # Prom_ql for the metric (optional)
+`,
+		`---
+customMetrics:
+  - metric: foo_bar
+    type: counter
+  - metric: foo_bar
+    type: histogram
+`)).To(Succeed())
+
+	By("editing a project based on grafana/custom-metrics/config.yaml")
+	err = kbc.Edit(
+		"--plugins", "grafana.kubebuilder.io/v1-alpha",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	fileContainsExpr, err := pluginutil.HasFileContentWith(
+		filepath.Join(kbc.Dir, "grafana", "custom-metrics", "custom-metrics-dashboard.json"),
+		`sum(rate(foo_bar{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, pod)`)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, fileContainsExpr).To(BeTrue())
+
+	fileContainsExpr, err = pluginutil.HasFileContentWith(
+		filepath.Join(kbc.Dir, "grafana", "custom-metrics", "custom-metrics-dashboard.json"),
+		`histogram_quantile(0.90, sum by(instance, le) (rate(foo_bar{job=\"$job\", namespace=\"$namespace\"}[5m])))`)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, fileContainsExpr).To(BeTrue())
+}

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -62,6 +62,7 @@ function test_cluster {
   docker pull busybox:1.28
   kind load docker-image --name $KIND_CLUSTER busybox:1.28
 
+  go test $(dirname "$0")/grafana $flags -timeout 30m
   go test $(dirname "$0")/deployimage $flags -timeout 30m
   go test $(dirname "$0")/v3 $flags -timeout 30m
   go test $(dirname "$0")/v4 $flags -timeout 30m

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -218,6 +218,15 @@ func (t *TestContext) Init(initOptions ...string) error {
 	return err
 }
 
+// Edit is for running `kubebuilder edit`
+func (t *TestContext) Edit(editOptions ...string) error {
+	editOptions = append([]string{"edit"}, editOptions...)
+	//nolint:gosec
+	cmd := exec.Command(t.BinaryName, editOptions...)
+	_, err := t.Run(cmd)
+	return err
+}
+
 // CreateAPI is for running `kubebuilder create api`
 func (t *TestContext) CreateAPI(resourceOptions ...string) error {
 	resourceOptions = append([]string{"create", "api"}, resourceOptions...)

--- a/testdata/project-v3-addon-and-grafana/grafana/custom-metrics/config.yaml
+++ b/testdata/project-v3-addon-and-grafana/grafana/custom-metrics/config.yaml
@@ -1,0 +1,13 @@
+---
+customMetrics:
+#  - metric: # Raw custom metric (required)
+#    type:   # Metric type: counter/gauge/histogram (required)
+#    expr:   # Prom_ql for the metric (optional)
+#
+#
+# Example:
+# ---
+# customMetrics:
+#   - metric: foo_bar
+#     type: histogram
+#   	expr: histogram_quantile(0.90, sum by(instance, le) (rate(foo_bar{job=\"$job\", namespace=\"$namespace\"}[5m])))

--- a/testdata/project-v4-addon-and-grafana/grafana/custom-metrics/config.yaml
+++ b/testdata/project-v4-addon-and-grafana/grafana/custom-metrics/config.yaml
@@ -1,0 +1,13 @@
+---
+customMetrics:
+#  - metric: # Raw custom metric (required)
+#    type:   # Metric type: counter/gauge/histogram (required)
+#    expr:   # Prom_ql for the metric (optional)
+#
+#
+# Example:
+# ---
+# customMetrics:
+#   - metric: foo_bar
+#     type: histogram
+#   	expr: histogram_quantile(0.90, sum by(instance, le) (rate(foo_bar{job=\"$job\", namespace=\"$namespace\"}[5m])))


### PR DESCRIPTION
#### (This PR is experimental and welcome discussion)
### Description
This is the experimental practice to see how possible if we can bring dashboards for custom metrics through the Grafana Plugin.

The user can add the desired metrics in `grafana/custom-metrics/config.yaml`:
```yaml
---
customMetrics: []
  # - metric: Raw custom metric (required)
  #   type:   Metric type: counter/gauge/histogram (required)
  #   expr:   Prom_ql for the metric (optional)

```
(If you execute the plugin for the first time(either by `init` or `edit`), the above config template will be automatically generated.)

 The plugin triggered by `edit` subcommand will read the `config.yaml` and generate `grafana/custom-metrics/custom-metrics-dashboard.json`, which can be directly import in the Grafana Web UI.

#### Story 1
Users get the config entry when initialize the project or introduce the `grafana-plugin` for the first time:
```shell
# Initialize a project with the plugin enabled
kubebuilder init --plugins=grafana.kubebuilder.io/v1-alpha

# Introduce the Grafana Plugin to an existing project
kubebuilder edit --plugins=grafana.kubebuilder.io/v1-alpha
```

A nested `custom-metrics/config.yaml` will be generated under `grafana/`.

#### Story 2
Users configure `grafana/custom-metrics/config.yaml` and run `edit` subcommand to get Grafana manifest:
```shell
kubebuilder edit --plugins=grafana.kubebuilder.io/v1-alpha
```

The `grafana/custom-metrics/config.yaml` will be validated and then the manifest will be generated: `grafana/custom-metrics/custom-metrics-dashboard.json`.


### Sample

1. Specify custom metrics in config.yaml
```yaml
---
customMetrics:
  - metric: memcached_operator_reconcile_total
    type: counter
  - metric: memcached_operator_reconcile_time_seconds_bucket
    type: histogram
```
2. Run `kubebuilder edit --plugins=grafana.kubebuilder.io/v1-alpha1` to generate the manifest
3. Import the manifest into Grafana Web UI:

<img width="1585" src="https://user-images.githubusercontent.com/18136486/184810327-023a9894-e48b-434b-ad47-2c6180d86cb9.png">

![newpre](https://user-images.githubusercontent.com/18136486/186933170-d2e0de71-e079-4d1b-906a-99a549d66ebf.gif)



<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
