### PR TITLE
✨deploy-image/v1-alpha: add a todo comment for users stating envtest limitations

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -107,6 +107,8 @@ var _ = Describe("{{ .Resource.Kind }} controller", func() {
 		})
 
 		AfterEach(func() {
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace);
 	

--- a/testdata/project-v3-with-deploy-image/controllers/busybox_controller_test.go
+++ b/testdata/project-v3-with-deploy-image/controllers/busybox_controller_test.go
@@ -60,6 +60,8 @@ var _ = Describe("Busybox controller", func() {
 		})
 
 		AfterEach(func() {
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
 

--- a/testdata/project-v3-with-deploy-image/controllers/memcached_controller_test.go
+++ b/testdata/project-v3-with-deploy-image/controllers/memcached_controller_test.go
@@ -60,6 +60,8 @@ var _ = Describe("Memcached controller", func() {
 		})
 
 		AfterEach(func() {
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
 

--- a/testdata/project-v4-with-deploy-image/controllers/busybox_controller_test.go
+++ b/testdata/project-v4-with-deploy-image/controllers/busybox_controller_test.go
@@ -60,6 +60,8 @@ var _ = Describe("Busybox controller", func() {
 		})
 
 		AfterEach(func() {
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
 

--- a/testdata/project-v4-with-deploy-image/controllers/memcached_controller_test.go
+++ b/testdata/project-v4-with-deploy-image/controllers/memcached_controller_test.go
@@ -60,6 +60,8 @@ var _ = Describe("Memcached controller", func() {
 		})
 
 		AfterEach(func() {
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
 


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
Added a todo comment for users in controller_test.go file for deploy-image/v1-alpha plugin, highlighting the limitations of the envtest.
### Motivation
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2856