### PR TITLE
:bug: "Application Support" whitespace for mac plugins

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -176,7 +176,7 @@ func getPluginsRoot(host string) (pluginsRoot string, err error) {
 	switch host {
 	case "darwin":
 		logrus.Debugf("Detected host is macOS.")
-		pluginsRoot = filepath.Join("Library", "ApplicationSupport", "kubebuilder", "plugins")
+		pluginsRoot = filepath.Join("Library", "Application Support", "kubebuilder", "plugins")
 	case "linux":
 		logrus.Debugf("Detected host is Linux.")
 		pluginsRoot = filepath.Join(".config", "kubebuilder", "plugins")


### PR DESCRIPTION
This mini-PR simply fixes the Plugins Root Directory for darwin hosts for external Plugins.

Without this change the Plugin Discovery will always look in a non-existing Library Directory, causing the Lookup to permanently fail. A suggestion here would be to introduce the "Lookup Plugins" command that was discussed previously in the Discussion around https://github.com/kubernetes-sigs/kubebuilder/issues/2600 to also make this debuggable without having to change log messages or introducing a cli debug flag