### PR TITLE
:seedling: update golangci-lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,12 +30,16 @@ jobs:
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && needs.check_docs_only.outputs.skip != 'true'
     steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
       - name: Clone the code
         uses: actions/checkout@v3
       - name: Run linter
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2 # Always uses the latest patch version.
+          version: v1.48 # Always uses the latest patch version.
           only-new-issues: true # Show only new issues if it's a pull request
       - name: Report failure
         uses: nashmaniac/create-issue-action@v1.1

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.45.2 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.48.0 ;\
 	}
 
 .PHONY: apidiff


### PR DESCRIPTION
Signed-off-by: Bryce Palmer <bpalmer@redhat.com>

## Description of change
- Update `golangci/golangci-lint-action` to `v3`
- Update `golangci-lint` version used to `v1.48`
- Add `actions/setup-go@v3` to setup Go for the `golangci/golangci-lint-action` action


