### PR TITLE
:sparkles: implement `kubebuilder init --workspace` flag for go1.18 style go.work support

### DIFF
--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -25,10 +25,11 @@ import (
 const prefix = "+kubebuilder:scaffold:"
 
 var commentsByExt = map[string]string{
-	".go":   "//",
-	".work": "//",
-	".yaml": "#",
-	".yml":  "#",
+	".go":        "//",
+	".work":      "//",
+	".yaml":      "#",
+	".yml":       "#",
+	"Dockerfile": "#",
 	// When adding additional file extensions, update also the NewMarkerFor documentation and error
 }
 
@@ -39,10 +40,13 @@ type Marker struct {
 }
 
 // NewMarkerFor creates a new marker customized for the specific file
-// Supported file extensions: .go, .work, .yaml, .yml
+// Supported file extensions: .go, .work, .yaml, .yml, Dockerfile
 func NewMarkerFor(path string, value string) Marker {
-	ext := filepath.Ext(path)
-	if comment, found := commentsByExt[ext]; found {
+	extOrFilename := filepath.Ext(path)
+	if extOrFilename == "" {
+		_, extOrFilename = filepath.Split(path)
+	}
+	if comment, found := commentsByExt[extOrFilename]; found {
 		return Marker{comment, value}
 	}
 
@@ -50,7 +54,7 @@ func NewMarkerFor(path string, value string) Marker {
 	for extension := range commentsByExt {
 		extensions = append(extensions, fmt.Sprintf("%q", extension))
 	}
-	panic(fmt.Errorf("unknown file extension: '%s', expected one of: %s", ext, strings.Join(extensions, ", ")))
+	panic(fmt.Errorf("unknown file extension: '%s', expected one of: %s", extOrFilename, strings.Join(extensions, ", ")))
 }
 
 // String implements Stringer

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -26,6 +26,8 @@ const prefix = "+kubebuilder:scaffold:"
 
 var commentsByExt = map[string]string{
 	".go":   "//",
+	".mod":  "//",
+	".work": "//",
 	".yaml": "#",
 	".yml":  "#",
 	// When adding additional file extensions, update also the NewMarkerFor documentation and error
@@ -38,7 +40,7 @@ type Marker struct {
 }
 
 // NewMarkerFor creates a new marker customized for the specific file
-// Supported file extensions: .go, .yaml, .yml
+// Supported file extensions: .go, .mod, .work, .yaml, .yml
 func NewMarkerFor(path string, value string) Marker {
 	ext := filepath.Ext(path)
 	if comment, found := commentsByExt[ext]; found {

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -26,7 +26,6 @@ const prefix = "+kubebuilder:scaffold:"
 
 var commentsByExt = map[string]string{
 	".go":   "//",
-	".mod":  "//",
 	".work": "//",
 	".yaml": "#",
 	".yml":  "#",
@@ -40,7 +39,7 @@ type Marker struct {
 }
 
 // NewMarkerFor creates a new marker customized for the specific file
-// Supported file extensions: .go, .mod, .work, .yaml, .yml
+// Supported file extensions: .go, .work, .yaml, .yml
 func NewMarkerFor(path string, value string) Marker {
 	ext := filepath.Ext(path)
 	if comment, found := commentsByExt[ext]; found {

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -289,7 +289,7 @@ func (s *apiScaffolder) scaffoldCreateAPIFromGolang() error {
 	// in the Project layout to know if we should use kustomize/v1 OR kustomize/v2-alpha
 
 	golangV3Scaffolder := golangv3scaffolds.NewAPIScaffolder(s.config,
-		s.resource, true, true)
+		s.resource, true, false)
 	golangV3Scaffolder.InjectFS(s.fs)
 	return golangV3Scaffolder.Scaffold()
 }

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -52,9 +52,10 @@ type apiScaffolder struct {
 }
 
 // NewAPIScaffolder returns a new Scaffolder for declarative
-//nolint: lll
+// nolint: lll
 func NewDeployImageScaffolder(config config.Config, res resource.Resource, image,
-	command, port, runAsUser string) plugins.Scaffolder {
+	command, port, runAsUser string,
+) plugins.Scaffolder {
 	return &apiScaffolder{
 		config:    config,
 		resource:  res,
@@ -288,7 +289,7 @@ func (s *apiScaffolder) scaffoldCreateAPIFromGolang() error {
 	// in the Project layout to know if we should use kustomize/v1 OR kustomize/v2-alpha
 
 	golangV3Scaffolder := golangv3scaffolds.NewAPIScaffolder(s.config,
-		s.resource, true)
+		s.resource, true, true)
 	golangV3Scaffolder.InjectFS(s.fs)
 	return golangV3Scaffolder.Scaffold()
 }

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -288,7 +288,7 @@ func (s *apiScaffolder) scaffoldCreateAPIFromGolang() error {
 	// todo: when we have the go/v4-alpha plugin we will also need to check what is the plugin used
 	// in the Project layout to know if we should use kustomize/v1 OR kustomize/v2-alpha
 
-	golangV3Scaffolder := golangv3scaffolds.NewAPIScaffolder(s.config,
+	golangV3Scaffolder := golangv3scaffolds.NewWorkspaceAPIScaffolder(s.config,
 		s.resource, true, false)
 	golangV3Scaffolder.InjectFS(s.fs)
 	return golangV3Scaffolder.Scaffold()

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -188,7 +188,7 @@ func (p *createAPISubcommand) PreScaffold(fs machinery.Filesystem) error {
 }
 
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewAPIScaffolder(p.config, *p.resource, p.force, p.useWorkspaces)
+	scaffolder := scaffolds.NewWorkspaceAPIScaffolder(p.config, *p.resource, p.force, p.useWorkspaces)
 	scaffolder.InjectFS(fs)
 	return scaffolder.Scaffold()
 }

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -100,7 +100,7 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.runMake, "make", true, "if true, run `make generate` after generating files")
 
 	// TODO Evaluate if we put that in goPlugin
-	fs.BoolVar(&p.useWorkspaces, "workspace", true, "if true, scaffolds apis with `go.work` workspace differentiation, "+
+	fs.BoolVar(&p.useWorkspaces, "workspace", false, "if true, scaffolds apis with `go.work` workspace differentiation, "+
 		"creating a go.mod file for each generated api.")
 
 	fs.BoolVar(&p.force, "force", false,

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -98,6 +98,8 @@ make generate will be run.
 
 func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.runMake, "make", true, "if true, run `make generate` after generating files")
+
+	// TODO Evaluate if we put that in goPlugin
 	fs.BoolVar(&p.useWorkspaces, "workspace", true, "if true, scaffolds apis with `go.work` workspace differentiation, "+
 		"creating a go.mod file for each generated api.")
 
@@ -200,6 +202,8 @@ func (p *createAPISubcommand) PostScaffold() error {
 		}
 	}
 
+	// for workspace support, we use go mod sync to make sure all modules are considered, not just the root.
+	// this automatically also triggers go mod tidy for all modules and creates go.sum files.
 	if p.useWorkspaces {
 		if err := util.RunCmd("Update workspace", "go", "work", "sync"); err != nil {
 			return err

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -125,7 +125,7 @@ func (p *initSubcommand) PreScaffold(machinery.Filesystem) error {
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewInitScaffolder(
+	scaffolder := scaffolds.NewWorkspaceInitScaffolder(
 		p.config, p.license, p.owner, p.useWorkspaces)
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -126,6 +126,7 @@ func (s *apiScaffolder) Scaffold() error {
 	}
 
 	// if we use workspaces, we have to update the central go.work file with all available references
+	// we also have to update the image building process
 	if s.useWorkspaces {
 		fmt.Println("detected go.work, using workspace scaffolding")
 		if err := scaffold.Execute(
@@ -134,6 +135,12 @@ func (s *apiScaffolder) Scaffold() error {
 			},
 		); err != nil {
 			return fmt.Errorf("error updating go.work: %v", err)
+		}
+
+		if err := scaffold.Execute(
+			&templates.DockerfileUpdater{UseWorkspaces: s.useWorkspaces},
+		); err != nil {
+			return fmt.Errorf("error updating Dockerfile: %v", err)
 		}
 	}
 

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -114,10 +114,10 @@ func (s *apiScaffolder) Scaffold() error {
 
 	// if we use workspaces, we have to update the central go.work file with all available references
 	if s.useWorkspaces {
-		fmt.Println("detected go.work in root, using workspace scaffolding...")
+		fmt.Println("detected go.work, using workspace scaffolding")
 		if err := scaffold.Execute(
 			&templates.GoWorkUpdater{
-				WireUses: true,
+				WireUses: doAPI,
 			},
 		); err != nil {
 			return fmt.Errorf("error updating go.work: %v", err)

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -50,7 +50,7 @@ type apiScaffolder struct {
 }
 
 // NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
-func NewAPIScaffolder(config config.Config, res resource.Resource, force, useWorkspaces bool) plugins.Scaffolder {
+func NewAPIScaffolder(config config.Config, res resource.Resource, force bool, useWorkspaces bool) plugins.Scaffolder {
 	return &apiScaffolder{
 		config:        config,
 		resource:      res,
@@ -114,6 +114,7 @@ func (s *apiScaffolder) Scaffold() error {
 
 	// if we use workspaces, we have to update the central go.work file with all available references
 	if s.useWorkspaces {
+		fmt.Println("detected go.work in root, using workspace scaffolding...")
 		if err := scaffold.Execute(
 			&templates.GoWorkUpdater{
 				WireUses: true,

--- a/pkg/plugins/golang/v3/scaffolds/api.go
+++ b/pkg/plugins/golang/v3/scaffolds/api.go
@@ -50,7 +50,20 @@ type apiScaffolder struct {
 }
 
 // NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
-func NewAPIScaffolder(config config.Config, res resource.Resource, force bool, useWorkspaces bool) plugins.Scaffolder {
+// Deprecated: use NewWorkspaceInitScaffolder
+func NewAPIScaffolder(config config.Config, res resource.Resource, force bool) plugins.Scaffolder {
+	return &apiScaffolder{
+		config:   config,
+		resource: res,
+		force:    force,
+	}
+}
+
+// NewWorkspaceAPIScaffolder returns a new Scaffolder for API/controller creation operations.
+// Compared to NewAPIScaffolder it can take an additional flag to use go.work style workspaces.
+func NewWorkspaceAPIScaffolder(
+	config config.Config, res resource.Resource, force bool, useWorkspaces bool,
+) plugins.Scaffolder {
 	return &apiScaffolder{
 		config:        config,
 		resource:      res,

--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -59,7 +59,19 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config config.Config, license, owner string, useWorkspaces bool) plugins.Scaffolder {
+// Deprecated: use NewWorkspaceInitScaffolder
+func NewInitScaffolder(config config.Config, license, owner string) plugins.Scaffolder {
+	return &initScaffolder{
+		config:          config,
+		boilerplatePath: hack.DefaultBoilerplatePath,
+		license:         license,
+		owner:           owner,
+	}
+}
+
+// NewWorkspaceInitScaffolder returns a new Scaffolder for project initialization operations.
+// Compared to NewInitScaffolder it can take an additional flag to use go.work style workspaces.
+func NewWorkspaceInitScaffolder(config config.Config, license, owner string, useWorkspaces bool) plugins.Scaffolder {
 	return &initScaffolder{
 		config:          config,
 		boilerplatePath: hack.DefaultBoilerplatePath,

--- a/pkg/plugins/golang/v3/scaffolds/init.go
+++ b/pkg/plugins/golang/v3/scaffolds/init.go
@@ -145,7 +145,7 @@ func (s *initScaffolder) Scaffold() error {
 			KustomizeVersion:         kustomizeVersion,
 			ControllerRuntimeVersion: ControllerRuntimeVersion,
 		},
-		&templates.Dockerfile{},
+		&templates.Dockerfile{UseWorkspaces: s.useWorkspaces},
 		&templates.DockerIgnore{},
 		&templates.Readme{},
 	}

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/gomod.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/gomod.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &GoMod{}
+
+// GoMod scaffolds a file that defines the project dependencies
+type GoMod struct {
+	machinery.TemplateMixin
+	machinery.MultiGroupMixin
+	machinery.ResourceMixin
+
+	ControllerRuntimeVersion string
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *GoMod) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup {
+			if f.Resource.Group != "" {
+				f.Path = filepath.Join("apis", "%[group]", "%[version]", "go.mod")
+			} else {
+				f.Path = filepath.Join("apis", "%[version]", "go.mod")
+			}
+		} else {
+			f.Path = filepath.Join("api", "%[version]", "go.mod")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = goModTemplate
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+const goModTemplate = `
+module {{ .Resource.Path }}
+
+go 1.18
+
+require (
+	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}
+)
+`

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
@@ -17,23 +17,34 @@ limitations under the License.
 package templates
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 )
+
+const (
+	dockerfileMarker = "module-dependency-layers"
+)
+const defaultDockerfilePath = "Dockerfile"
 
 var _ machinery.Template = &Dockerfile{}
 
 // Dockerfile scaffolds a file that defines the containerized build process
 type Dockerfile struct {
 	machinery.TemplateMixin
+	UseWorkspaces bool
 }
 
 // SetTemplateDefaults implements file.Template
 func (f *Dockerfile) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = "Dockerfile"
+		f.Path = defaultDockerfilePath
 	}
 
-	f.TemplateBody = dockerfileTemplate
+	f.TemplateBody = fmt.Sprintf(dockerfileTemplate,
+		machinery.NewMarkerFor(f.Path, dockerfileMarker),
+	)
 
 	return nil
 }
@@ -45,6 +56,18 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
+{{- if .UseWorkspaces }}
+
+# Copy all Submodules from the workspace
+%s
+
+# Copy the Go Workspace manifests
+COPY go.work go.work
+COPY go.work.sum go.work.sum
+RUN go work sync
+{{- end }}
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
@@ -66,3 +89,73 @@ USER 65532:65532
 
 ENTRYPOINT ["/manager"]
 `
+
+// ########################################################
+// GoWorkUpdater
+// ########################################################
+
+const (
+	dockerfileCodeFragment = `
+COPY %s/go.mod %s/go.mod
+COPY %s/go.sum %s/go.sum
+`
+)
+
+var _ machinery.Inserter = &DockerfileUpdater{}
+
+type DockerfileUpdater struct {
+	machinery.RepositoryMixin
+	machinery.TemplateMixin
+	machinery.ResourceMixin
+	UseWorkspaces bool
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *DockerfileUpdater) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = defaultDockerfilePath
+	}
+
+	f.TemplateBody = fmt.Sprintf(dockerfileTemplate,
+		machinery.NewMarkerFor(f.Path, dockerfileMarker),
+	)
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+// GetMarkers implements file.Inserter
+func (f *DockerfileUpdater) GetMarkers() []machinery.Marker {
+	return []machinery.Marker{
+		machinery.NewMarkerFor(f.Path, dockerfileMarker),
+	}
+}
+
+// GetCodeFragments implements file.Inserter
+func (f *DockerfileUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
+	fragments := make(machinery.CodeFragmentsMap, 1)
+
+	// If resource is not being provided we are creating the file, not updating it
+	if f.Resource == nil {
+		return fragments
+	}
+
+	// Generate require code fragments
+	uses := make([]string, 0)
+
+	moduleRelativePath, err := filepath.Rel(f.Repo, f.Resource.Path)
+	if err != nil {
+		return fragments
+	}
+	dep := fmt.Sprintf(dockerfileCodeFragment,
+		moduleRelativePath, moduleRelativePath, moduleRelativePath, moduleRelativePath)
+	uses = append(uses, dep)
+
+	// Only store code fragments in the map if the slices are non-empty
+	if len(uses) != 0 {
+		fragments[machinery.NewMarkerFor(f.Path, dockerfileMarker)] = uses
+	}
+
+	return fragments
+}

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/gowork.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/gowork.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+const (
+	apiModulesMarker = "apis"
+)
+
+const defaultWorkPath = "go.work"
+
+var _ machinery.Template = &GoWork{}
+
+// GoWork scaffolds a file that defines the project dependencies
+type GoWork struct {
+	machinery.TemplateMixin
+	machinery.RepositoryMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *GoWork) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = defaultWorkPath
+	}
+
+	f.TemplateBody = fmt.Sprintf(goWorkTemplate,
+		machinery.NewMarkerFor(f.Path, apiModulesMarker),
+	)
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+const goWorkTemplate = `
+go 1.18
+
+%s
+
+use .
+`
+
+// ########################################################
+// GoWorkUpdater
+// ########################################################
+
+const (
+	apisUseCodeFragment = `use ./%s
+`
+)
+
+var _ machinery.Inserter = &GoWorkUpdater{}
+
+type GoWorkUpdater struct {
+	machinery.RepositoryMixin
+	machinery.TemplateMixin
+	machinery.ResourceMixin
+
+	WireUses bool
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *GoWorkUpdater) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = defaultWorkPath
+	}
+
+	f.TemplateBody = fmt.Sprintf(goWorkTemplate,
+		machinery.NewMarkerFor(f.Path, apiModulesMarker),
+	)
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+// GetMarkers implements file.Inserter
+func (f *GoWorkUpdater) GetMarkers() []machinery.Marker {
+	return []machinery.Marker{
+		machinery.NewMarkerFor(f.Path, apiModulesMarker),
+	}
+}
+
+// GetCodeFragments implements file.Inserter
+func (f *GoWorkUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
+	fragments := make(machinery.CodeFragmentsMap, 1)
+
+	// If resource is not being provided we are creating the file, not updating it
+	if f.Resource == nil {
+		return fragments
+	}
+
+	// Generate require code fragments
+	uses := make([]string, 0)
+
+	if f.WireUses {
+		moduleRelativePath, err := filepath.Rel(f.Repo, f.Resource.Path)
+		if err != nil {
+			return fragments
+		}
+		dep := fmt.Sprintf(apisUseCodeFragment, moduleRelativePath)
+		uses = append(uses, dep)
+	}
+
+	// Only store code fragments in the map if the slices are non-empty
+	if len(uses) != 0 {
+		fragments[machinery.NewMarkerFor(f.Path, apiModulesMarker)] = uses
+	}
+
+	return fragments
+}

--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -39,9 +39,7 @@ import (
 
 var _ = Describe("kubebuilder", func() {
 	Context("deploy image plugin 3", func() {
-		var (
-			kbc *utils.TestContext
-		)
+		var kbc *utils.TestContext
 
 		BeforeEach(func() {
 			var err error
@@ -173,8 +171,8 @@ func Run(kbc *utils.TestContext) {
 	var controllerPodName string
 	var err error
 
-	By("updating the go.mod")
-	err = kbc.Tidy()
+	By("updating the go.mod or go.work")
+	err = kbc.TidyOrWorkSync()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("run make all")
@@ -278,7 +276,7 @@ func Run(kbc *utils.TestContext) {
 	}
 	Eventually(getStatus, time.Minute, time.Second).Should(Succeed())
 
-	//Testing the finalizer
+	// Testing the finalizer
 	EventuallyWithOffset(1, func() error {
 		_, err = kbc.Kubectl.Delete(true, "-f", sampleFilePath)
 		return err

--- a/test/e2e/v3/plugin_cluster_test.go
+++ b/test/e2e/v3/plugin_cluster_test.go
@@ -55,9 +55,7 @@ var _ = Describe("kubebuilder", func() {
 	// project version 3 means ("--project-version") the schema
 	// version used to track the info in the PROJECT file.
 	Context("project version 3", func() {
-		var (
-			kbc *utils.TestContext
-		)
+		var kbc *utils.TestContext
 
 		BeforeEach(func() {
 			var err error
@@ -202,8 +200,8 @@ func Run(kbc *utils.TestContext) {
 	err = kbc.LabelAllNamespacesToWarnAboutRestricted()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	By("updating the go.mod")
-	err = kbc.Tidy()
+	By("updating the go.mod or go.work")
+	err = kbc.TidyOrWorkSync()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("building the controller image")
@@ -327,7 +325,7 @@ func Run(kbc *utils.TestContext) {
 	sampleFilePath, err := filepath.Abs(filepath.Join(fmt.Sprintf("e2e-%s", kbc.TestSuffix), sampleFile))
 	Expect(err).To(Not(HaveOccurred()))
 
-	f, err := os.OpenFile(sampleFilePath, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(sampleFilePath, os.O_APPEND|os.O_WRONLY, 0o644)
 	Expect(err).To(Not(HaveOccurred()))
 
 	defer func() {
@@ -433,7 +431,7 @@ func ServiceAccountToken(kbc *utils.TestContext) (out string, err error) {
 	By("Creating the ServiceAccount token")
 	secretName := fmt.Sprintf("%s-token-request", kbc.Kubectl.ServiceAccount)
 	tokenRequestFile := filepath.Join(kbc.Dir, secretName)
-	err = os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0755))
+	err = os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o755))
 	if err != nil {
 		return out, err
 	}

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -43,6 +43,7 @@ func GenerateV4(kbc *utils.TestContext) {
 		"--plugins", "go/v4-alpha",
 		"--project-version", "3",
 		"--domain", kbc.Domain,
+		"--workspace",
 	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
@@ -55,7 +56,6 @@ func GenerateV4(kbc *utils.TestContext) {
 		"--resource",
 		"--controller",
 		"--make=false",
-		"--workspace",
 	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -55,6 +55,7 @@ func GenerateV4(kbc *utils.TestContext) {
 		"--resource",
 		"--controller",
 		"--make=false",
+		"--workspace",
 	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -53,9 +53,7 @@ type tokenRequest struct {
 
 var _ = Describe("kubebuilder", func() {
 	Context("plugin go/v4-alpha", func() {
-		var (
-			kbc *utils.TestContext
-		)
+		var kbc *utils.TestContext
 
 		BeforeEach(func() {
 			var err error
@@ -128,8 +126,8 @@ func Run(kbc *utils.TestContext) {
 	err = kbc.LabelAllNamespacesToWarnAboutRestricted()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	By("updating the go.mod")
-	err = kbc.Tidy()
+	By("updating the go.mod or go.work")
+	err = kbc.TidyOrWorkSync()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("building the controller image")
@@ -253,7 +251,7 @@ func Run(kbc *utils.TestContext) {
 	sampleFilePath, err := filepath.Abs(filepath.Join(fmt.Sprintf("e2e-%s", kbc.TestSuffix), sampleFile))
 	Expect(err).To(Not(HaveOccurred()))
 
-	f, err := os.OpenFile(sampleFilePath, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(sampleFilePath, os.O_APPEND|os.O_WRONLY, 0o644)
 	Expect(err).To(Not(HaveOccurred()))
 
 	defer func() {
@@ -359,7 +357,7 @@ func ServiceAccountToken(kbc *utils.TestContext) (out string, err error) {
 	By("Creating the ServiceAccount token")
 	secretName := fmt.Sprintf("%s-token-request", kbc.Kubectl.ServiceAccount)
 	tokenRequestFile := filepath.Join(kbc.Dir, secretName)
-	err = os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0755))
+	err = os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o755))
 	if err != nil {
 		return out, err
 	}

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -52,7 +52,11 @@ function dump_project {
 function test_init_project {
   header_text "Init project"
   go mod init kubebuilder.io/test
-  $kb init --domain example.com <<< "n"
+  if [ "go.work" == "$1" ]; then
+    $kb init --domain example.com --workspace <<< "n"
+  else
+    $kb init --domain example.com <<< "n"
+  fi
 }
 
 function test_make_project {
@@ -84,14 +88,6 @@ n
 EOF
 }
 
-function test_create_api_with_go_work_support_only {
-  header_text "Creating api only"
-  $kb create api --group insect --version v1beta1 --kind Bee --namespaced false --workspace <<EOF
-y
-n
-EOF
-}
-
 function test_create_namespaced_api_only {
   header_text "Creating namespaced api only"
   $kb create api --group insect --version v1beta1 --kind Bee --namespaced true <<EOF
@@ -110,7 +106,7 @@ EOF
 
 
 prepare_test_dir
-test_init_project
+test_init_project "go.mod"
 cache_project "init"
 test_make_project
 
@@ -128,14 +124,35 @@ test_create_api_only
 
 prepare_test_dir
 dump_project "init"
-test_create_api_with_go_work_support_only
-
-prepare_test_dir
-dump_project "init"
 test_create_namespaced_api_only
 
 prepare_test_dir
 dump_project "init"
+test_create_core_type_controller
+
+prepare_test_dir
+test_init_project "go.work"
+cache_project "init-workspace"
+test_make_project
+
+prepare_test_dir
+dump_project "init-workspace"
+test_create_api_controller
+
+prepare_test_dir
+dump_project "init-workspace"
+test_create_namespaced_api_controller
+
+prepare_test_dir
+dump_project "init-workspace"
+test_create_api_only
+
+prepare_test_dir
+dump_project "init-workspace"
+test_create_namespaced_api_only
+
+prepare_test_dir
+dump_project "init-workspace"
 test_create_core_type_controller
 
 popd

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -84,6 +84,14 @@ n
 EOF
 }
 
+function test_create_api_with_go_work_support_only {
+  header_text "Creating api only"
+  $kb create api --group insect --version v1beta1 --kind Bee --namespaced false --workspace <<EOF
+y
+n
+EOF
+}
+
 function test_create_namespaced_api_only {
   header_text "Creating namespaced api only"
   $kb create api --group insect --version v1beta1 --kind Bee --namespaced true <<EOF
@@ -99,6 +107,7 @@ n
 y
 EOF
 }
+
 
 prepare_test_dir
 test_init_project
@@ -116,6 +125,10 @@ test_create_namespaced_api_controller
 prepare_test_dir
 dump_project "init"
 test_create_api_only
+
+prepare_test_dir
+dump_project "init"
+test_create_api_with_go_work_support_only
 
 prepare_test_dir
 dump_project "init"

--- a/testdata/project-v3-addon-and-grafana/Dockerfile
+++ b/testdata/project-v3-addon-and-grafana/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v3-config/Dockerfile
+++ b/testdata/project-v3-config/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v3-with-deploy-image/Dockerfile
+++ b/testdata/project-v3-with-deploy-image/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v3/Dockerfile
+++ b/testdata/project-v3/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v4-addon-and-grafana/Dockerfile
+++ b/testdata/project-v4-addon-and-grafana/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v4-config/Dockerfile
+++ b/testdata/project-v4-config/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v4-with-deploy-image/Dockerfile
+++ b/testdata/project-v4-with-deploy-image/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download


### PR DESCRIPTION
This PR attempts to create a backwards-compatible `go.work` support in go/v3 / go/v4-alpha: Fixes https://github.com/kubernetes-sigs/kubebuilder/issues/2627

The basic implementation uses a flag called `--workspace` that can be used in `kubebuilder init`:
`kubebuilder init --workspace`

The create API then still looks like

`kubebuilder create api --version v1alpha1 --kind TestKind --group group`, which leads to a `go.work` being created (if not present) or overwritten with the following scaffold:

```
go 1.18

use ./api/v1alpha1

//+kubebuilder:scaffold:apis

use .
```

It also changes the PostScaffolding behavior of the `create api` and `init` commands by using `go mod sync` instead of `go mod tidy` to automatically resolve all modules in the workspace. This allows us to not rely on replace statements which would be harder to scaffold and maintain. Obvious downside to this is that it supports go 1.18 and above only.

Last but not least, to fully include the changes into our scaffolding, the Dockerfile Scaffolding is introduced. This ensures proper layering and the same (if not even more optimized speed during dependency resolution as before when building your image:

```Dockerfile
# Build the manager binary
FROM golang:1.18 as builder

WORKDIR /workspace
# Copy the Go Modules manifests
COPY go.mod go.mod
COPY go.sum go.sum

# Copy all Submodules from the workspace

COPY api/v1alpha1/go.mod api/v1alpha1/go.mod
COPY api/v1alpha1/go.sum api/v1alpha1/go.sum
#+kubebuilder:scaffold:module-dependency-layers

# Copy the Go Workspace manifests
COPY go.work go.work
COPY go.work.sum go.work.sum
RUN go work sync

# cache deps before building and copying source so that we don't need to re-download as much
# and so that source changes don't invalidate our downloaded layer
RUN go mod download

# Copy the go source
COPY main.go main.go
COPY api/ api/
COPY controllers/ controllers/

# Build
RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

# Use distroless as minimal base image to package the manager binary
# Refer to https://github.com/GoogleContainerTools/distroless for more details
FROM gcr.io/distroless/static:nonroot
WORKDIR /
COPY --from=builder /workspace/manager .
USER 65532:65532

ENTRYPOINT ["/manager"]
```

I want to use this PR first in a draft state to collect input and feedback before progressing it and writing tests.

All existing Makefile commands as well as the already scaffolded `go.mod` stays compatible, however `go mod tidy` will not work on the core module on its own. (since `go.work` is necessary to resolve the other modules relative to the base module). Notice that for external developers, you will be able to download the module as normal and also depend on the API modules individually without actually having to import the controller.