### PR TITLE
 ✨ Allow template to change parser delimiters

### DIFF
--- a/pkg/machinery/interfaces.go
+++ b/pkg/machinery/interfaces.go
@@ -44,6 +44,10 @@ type Template interface {
 	GetBody() string
 	// SetTemplateDefaults sets the default values for templates
 	SetTemplateDefaults() error
+	// SetDelim sets an action delimiters to replace default delimiters: {{ }}
+	SetDelim(left, right string)
+	// GetDelim returns the alternative delimiters
+	GetDelim() (string, string)
 }
 
 // Inserter is a file builder that inserts code fragments in marked positions

--- a/pkg/machinery/mixins.go
+++ b/pkg/machinery/mixins.go
@@ -48,12 +48,25 @@ type TemplateMixin struct {
 	IfExistsActionMixin
 
 	// TemplateBody is the template body to execute
-	TemplateBody string
+	TemplateBody    string
+	parseDelimLeft  string
+	parseDelimRight string
 }
 
 // GetBody implements Template
 func (t *TemplateMixin) GetBody() string {
 	return t.TemplateBody
+}
+
+// SetDelim implements Template
+func (t *TemplateMixin) SetDelim(left, right string) {
+	t.parseDelimLeft = left
+	t.parseDelimRight = right
+}
+
+// GetDelim implements Template
+func (t *TemplateMixin) GetDelim() (string, string) {
+	return t.parseDelimLeft, t.parseDelimRight
 }
 
 // InserterMixin is the mixin that should be embedded in Inserter builders

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -196,6 +196,10 @@ func (Scaffold) buildFileModel(t Template, models map[string]*File) error {
 func doTemplate(t Template) ([]byte, error) {
 	// Create a new template.Template using the type of the Template as the name
 	temp := template.New(fmt.Sprintf("%T", t))
+	leftDelim, rightDelim := t.GetDelim()
+	if leftDelim != "" && rightDelim != "" {
+		temp.Delims(leftDelim, rightDelim)
+	}
 
 	// Set the function map to be used
 	fm := DefaultFuncMap()

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/resources.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/resources.go
@@ -35,6 +35,9 @@ func (f *ResourcesManifest) SetTemplateDefaults() error {
 		f.Path = filepath.Join("grafana", "controller-resources-metrics.json")
 	}
 
+	// Grafana syntax use {{ }} quite often, which is collided with default delimiter for go template parsing.
+	// Provide an alternative delimiter here to avoid overlaps.
+	f.SetDelim("[[", "]]")
 	f.TemplateBody = controllerResourcesTemplate
 
 	f.IfExistsAction = machinery.OverwriteFile
@@ -169,7 +172,7 @@ const controllerResourcesTemplate = `{
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-					"legendFormat": "Pod: {{"{{pod}}"}} | Container: {{"{{container}}"}}",
+          "legendFormat": "Pod: {{pod}} | Container: {{container}}",
           "refId": "A",
           "step": 10
         }
@@ -259,7 +262,7 @@ const controllerResourcesTemplate = `{
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-					"legendFormat": "Pod: {{"{{pod}}"}} | Container: {{"{{container}}"}}",
+          "legendFormat": "Pod: {{pod}} | Container: {{container}}",
           "refId": "A",
           "step": 10
         }

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/runtime.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/runtime.go
@@ -35,8 +35,10 @@ func (f *RuntimeManifest) SetTemplateDefaults() error {
 		f.Path = filepath.Join("grafana", "controller-runtime-metrics.json")
 	}
 
+	// Grafana syntax use {{ }} quite often, which is collided with default delimiter for go template parsing.
+	// Provide an alternative delimiter here to avoid overlaps.
+	f.SetDelim("[[", "]]")
 	f.TemplateBody = controllerRuntimeTemplate
-
 	f.IfExistsAction = machinery.OverwriteFile
 
 	return nil
@@ -182,7 +184,7 @@ const controllerRuntimeTemplate = `{
           "exemplar": true,
           "expr": "sum(rate(controller_runtime_reconcile_total{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, pod)",
           "interval": "",
-          "legendFormat": "{{"{{instance}}"}} {{"{{pod}}"}}",
+          "legendFormat": "{{instance}} {{pod}}",
           "range": true,
           "refId": "A"
         }
@@ -269,7 +271,7 @@ const controllerRuntimeTemplate = `{
           "exemplar": true,
           "expr": "sum(rate(controller_runtime_reconcile_errors_total{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, pod)",
           "interval": "",
-          "legendFormat": "{{"{{instance}}"}} {{"{{pod}}"}}",
+          "legendFormat": "{{instance}} {{pod}}",
           "range": true,
           "refId": "A"
         }
@@ -371,7 +373,7 @@ const controllerRuntimeTemplate = `{
           "exemplar": true,
           "expr": "histogram_quantile(0.50, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name, le))",
           "interval": "",
-          "legendFormat": "P50 {{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "P50 {{name}} {{instance}} ",
           "refId": "A"
         },
         {
@@ -380,7 +382,7 @@ const controllerRuntimeTemplate = `{
           "expr": "histogram_quantile(0.90, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name, le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "P90 {{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "P90 {{name}} {{instance}} ",
           "refId": "B"
         },
         {
@@ -389,7 +391,7 @@ const controllerRuntimeTemplate = `{
           "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name, le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "P99 {{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "P99 {{name}} {{instance}} ",
           "refId": "C"
         }
       ],
@@ -474,7 +476,7 @@ const controllerRuntimeTemplate = `{
           "exemplar": true,
           "expr": "sum(rate(workqueue_adds_total{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name)",
           "interval": "",
-          "legendFormat": "{{"{{name}}"}} {{"{{instance}}"}}",
+          "legendFormat": "{{name}} {{instance}}",
           "refId": "A"
         }
       ],
@@ -562,7 +564,7 @@ const controllerRuntimeTemplate = `{
           "exemplar": true,
           "expr": "histogram_quantile(0.50, sum(rate(workqueue_work_duration_seconds_bucket{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name, le))",
           "interval": "",
-          "legendFormat": "P50 {{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "P50 {{name}} {{instance}} ",
           "refId": "A"
         },
         {
@@ -571,7 +573,7 @@ const controllerRuntimeTemplate = `{
           "expr": "histogram_quantile(0.90, sum(rate(workqueue_work_duration_seconds_bucket{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name, le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "P90 {{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "P90 {{name}} {{instance}} ",
           "refId": "B"
         },
         {
@@ -580,7 +582,7 @@ const controllerRuntimeTemplate = `{
           "expr": "histogram_quantile(0.99, sum(rate(workqueue_work_duration_seconds_bucket{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name, le))",
           "hide": false,
           "interval": "",
-          "legendFormat": "P99 {{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "P99 {{name}} {{instance}} ",
           "refId": "C"
         }
       ],
@@ -665,7 +667,7 @@ const controllerRuntimeTemplate = `{
           "exemplar": true,
           "expr": "sum(rate(workqueue_retries_total{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, name)",
           "interval": "",
-          "legendFormat": "{{"{{name}}"}} {{"{{instance}}"}} ",
+          "legendFormat": "{{name}} {{instance}} ",
           "refId": "A"
         }
       ],

--- a/testdata/project-v3-addon-and-grafana/grafana/controller-resources-metrics.json
+++ b/testdata/project-v3-addon-and-grafana/grafana/controller-resources-metrics.json
@@ -124,7 +124,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-					"legendFormat": "Pod: {{pod}} | Container: {{container}}",
+          "legendFormat": "Pod: {{pod}} | Container: {{container}}",
           "refId": "A",
           "step": 10
         }
@@ -214,7 +214,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-					"legendFormat": "Pod: {{pod}} | Container: {{container}}",
+          "legendFormat": "Pod: {{pod}} | Container: {{container}}",
           "refId": "A",
           "step": 10
         }

--- a/testdata/project-v4-addon-and-grafana/grafana/controller-resources-metrics.json
+++ b/testdata/project-v4-addon-and-grafana/grafana/controller-resources-metrics.json
@@ -124,7 +124,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-					"legendFormat": "Pod: {{pod}} | Container: {{container}}",
+          "legendFormat": "Pod: {{pod}} | Container: {{container}}",
           "refId": "A",
           "step": 10
         }
@@ -214,7 +214,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
-					"legendFormat": "Pod: {{pod}} | Container: {{container}}",
+          "legendFormat": "Pod: {{pod}} | Container: {{container}}",
           "refId": "A",
           "step": 10
         }


### PR DESCRIPTION
### Description
This change add `SetDelim()` and `GetDelim()` to `Template` interface, give the developer the ability to config an alternative delimiters (by default is `{{` and `}}`) for template parsing.

### Motivation
The current `controllerResourcesTemplate`, `controllerRuntimeTemplate` provided as a grafana dashboard with json format, and it contains some annotations syntax which use `{{ }}` and it's collide with default delimiters for template parsing. 

In order to parse correctly, at the moment, the template data have to write like this:
```
"legendFormat": "P90 {{"{{name}}"}} {{"{{instance}}"}} "
```
It is quite confusing to developers at first glance, and ever harder to do further encoding process like `json.Valid`, `json.Compact`.

By providing an alternative delimiters allow developer write template content in correct format without seeking workaround in order to deal with parse.

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
