### PR TITLE
🌱  deploy-image/v1-alpha e2e tests: fix the value of label app.kubernetes.io/name e2e tests use the Kind without be in lower case

### DIFF
--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -253,7 +253,7 @@ func Run(kbc *utils.TestContext) {
 	By("validating that pod(s) status.phase=Running")
 	getMemcachedPodStatus := func() error {
 		status, err := kbc.Kubectl.Get(true, "pods", "-l",
-			fmt.Sprintf("app.kubernetes.io/name=%s", strings.ToLower(kbc.Kind)),
+			fmt.Sprintf("app.kubernetes.io/name=%s", kbc.Kind),
 			"-o", "jsonpath={.items[*].status}",
 		)
 		ExpectWithOffset(2, err).NotTo(HaveOccurred())


### PR DESCRIPTION

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Description
In the e2e tests for `deploy-image/v1-alpha`, label `app.kubernetes.io/name` for pod and deployment for the Kind looks for value `string.ToLower(kbc.Kind)` but it should be only `kbc.Kind`. This PR is made to fix that.

See https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v3-with-deploy-image/controllers/memcached_controller.go#L385 for example, we add `Memcached` not `memcached` to label `app.kubernetes.io/name`.