### PR TITLE
🌱 Bump golangci-lint version (1.48.0 -> 1.49.0)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48 # Always uses the latest patch version.
+          version: v1.49 # Always uses the latest patch version.
           only-new-issues: true # Show only new issues if it's a pull request
       - name: Report failure
         uses: nashmaniac/create-issue-action@v1.1

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.48.0 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.49.0 ;\
 	}
 
 .PHONY: apidiff


### PR DESCRIPTION
Updates the lint Makefile target updating the golangci-lint version from `1.48.0` to `1.49.0`. 

EDIT: First pr failed due to short description. Hopefully better now. Sorry for retrigger.