### PR TITLE
🐛 fix: use user/group from Dockerfile also in manager deployment's `securityContext` instead of running as root

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
@@ -93,6 +93,10 @@ spec:
           capabilities:
             drop:
               - "ALL"
+
+          # Match user/group specified in Dockerfile, do not run as root
+          runAsUser: 65532
+          runAsGroup: 65532
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
@@ -93,6 +93,10 @@ spec:
           capabilities:
             drop:
               - "ALL"
+
+          # Match user/group specified in Dockerfile, do not run as root
+          runAsUser: 65532
+          runAsGroup: 65532
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This matches the top-level security context which has `runAsNonRoot: true`, and therefore avoids errors like `container has runAsNonRoot and image will run as root`. I ran into those when starting a cluster-api (CAPI) infrastructure provider following the [implementer's guide](https://cluster-api.sigs.k8s.io/developer/providers/implementers-guide/overview.html) (which uses kubebuilder).