### PR TITLE
🌱 Remove deprecated linters: deadcode, varcheck, structcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - dupl
     - errcheck
     - exportloopref
@@ -37,12 +36,10 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
 
 run:
   deadline: 5m


### PR DESCRIPTION
There are 3 linters that are enabled in golangci-lint today which causes warnings when running the linter. 

```
make lint
(...)
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```

This pr removes the deprecated linters. Since `unused` is enabled no additional linters are enabled.

https://golangci-lint.run/usage/linters/