### PR TITLE
✨  add options and guidance to provide solutions for other platforms and within multiple architecture support

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -92,7 +92,7 @@
   - [controller-gen CLI](./reference/controller-gen.md)
   - [completion](./reference/completion.md)
   - [Artifacts](./reference/artifacts.md)
-
+  - [Platform Support](platform.md)
   - [Configuring EnvTest](./reference/envtest.md)
 
   - [Metrics](./reference/metrics.md)

--- a/docs/book/src/reference/platform.md
+++ b/docs/book/src/reference/platform.md
@@ -1,0 +1,238 @@
+# Platforms Supported
+
+Kubebuilder produces solutions that by default can work on multiple platforms or specific ones, depending on how you 
+build and configure your workloads. This guide aims to help you properly configure your projects according to your needs.
+
+## Overview
+
+To provide support on specific or multiple platforms, you must ensure that all images used in workloads are built to 
+support the desired platforms. Note that may not be the same as the platform where you develop your solutions 
+and use KubeBuilder, but instead the platform(s) where your solution should run and be distributed. 
+It is recommended to build solutions that work on multiple platforms so that your project works
+on any Kubernetes cluster regardless of the underlying operating system and architecture.
+
+## How to define which platforms are supported
+
+The following covers what you need to do to provide the support for one or more platforms or architectures.
+
+### 1) Build workload images to provide the support for other platform(s)
+
+The images used in workloads such as in your Pods/Deployments will need to provide the support for this other platform. 
+You can inspect the images using a ManifestList of supported platforms using the command 
+[docker manifest inspect <image>][docker-manifest], i.e.:
+
+```shell
+$ docker manifest inspect myresgystry/example/myimage:v0.0.1
+{
+   "schemaVersion": 2,
+   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+   "manifests": [
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 739,
+         "digest": "sha256:a274a1a2af811a1daf3fd6b48ff3d08feb757c2c3f3e98c59c7f85e550a99a32",
+         "platform": {
+            "architecture": "arm64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 739,
+         "digest": "sha256:d801c41875f12ffd8211fffef2b3a3d1a301d99f149488d31f245676fa8bc5d9",
+         "platform": {
+            "architecture": "amd64",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 739,
+         "digest": "sha256:f4423c8667edb5372fb0eafb6ec599bae8212e75b87f67da3286f0291b4c8732",
+         "platform": {
+            "architecture": "s390x",
+            "os": "linux"
+         }
+      },
+      {
+         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+         "size": 739,
+         "digest": "sha256:621288f6573c012d7cf6642f6d9ab20dbaa35de3be6ac2c7a718257ec3aff333",
+         "platform": {
+            "architecture": "ppc64le",
+            "os": "linux"
+         }
+      },
+   ]
+}
+```
+
+### 2) (Recommended as a Best Practice) Ensure that node affinity expressions are set to match the supported platforms
+
+Kubernetes provides a mechanism called [nodeAffinity][node-affinity] which can be used to limit the possible node 
+targets where a pod can be scheduled. This is especially important to ensure correct scheduling behavior in clusters 
+with nodes that span across multiple platforms (i.e. heterogeneous clusters).
+
+**Kubernetes manifest example**
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
+          - arm64
+          - ppc64le
+          - s390x
+        - key: kubernetes.io/os
+            operator: In
+            values:
+              - linux
+```
+
+**Golang Example**
+
+```go 
+Template: corev1.PodTemplateSpec{
+    ...
+    Spec: corev1.PodSpec{
+        Affinity: &corev1.Affinity{
+            NodeAffinity: &corev1.NodeAffinity{
+                RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+                    NodeSelectorTerms: []corev1.NodeSelectorTerm{
+                        {
+                            MatchExpressions: []corev1.NodeSelectorRequirement{
+                                {
+                                    Key:      "kubernetes.io/arch",
+                                    Operator: "In",
+                                    Values:   []string{"amd64"},
+                                },
+                                {
+                                    Key:      "kubernetes.io/os",
+                                    Operator: "In",
+                                    Values:   []string{"linux"},
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        SecurityContext: &corev1.PodSecurityContext{
+            ...
+        },
+        Containers: []corev1.Container{{
+            ...
+        }},
+    },
+```
+
+<aside class="note">
+<h1> Example(s) </h1>
+
+You can look for some code examples by checking the code which is generated via the Deploy 
+Image plugin. ([More info](../plugins/deploy-image-plugin-v1-alpha.md))
+
+</aside>
+
+## Producing projects that support multiple platforms
+
+You can use [`docker buildx`][buildx] to cross-compile via emulation ([QEMU](https://www.qemu.org/)) to build the manager image.
+See that projects scaffold with the latest versions of Kubebuilder have the Makefile target `docker-buildx`.
+
+**Example of Usage**
+
+```shell
+$ make docker-buildx IMG=myregistry/myoperator:v0.0.1
+```
+
+Note that you need to ensure that all images and workloads required and used by your project will provide the same 
+support as recommended above, and that you properly configure the [nodeAffinity][node-affinity] for all your workloads.
+Therefore, ensure that you uncomment the following code in the `config/manager/manager.yaml` file
+
+```yaml
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
+```
+
+<aside class="note">
+<h1>Building images for releases</h1>
+
+
+You will probably want to automate the releases of your projects to ensure that the images are always built for the 
+same platforms. Note that Goreleaser also supports [docker buildx][buildx]. See its [documentation][goreleaser-buildx] for more detail.
+
+Also, you may want to configure GitHub Actions, Prow jobs, or any other solution that you use to build images to 
+provide multi-platform support. Note that you can also use other options like `docker manifest create` to customize 
+your solutions to achieve the same goals with other tools.
+
+By using Docker and the target provided by default you should NOT change the Dockerfile to use
+any specific GOOS and GOARCH to build the manager binary. However, if you are looking for to
+customize the default scaffold and create your own implementations you might want to give
+a look in the Golang [doc](https://go.dev/doc/install/source#environment) to knows 
+its available options.
+
+</aside>
+
+## Which (workload) images are created by default?
+
+Projects created with the Kubebuilder CLI have two workloads which are:
+
+### Manager
+
+The container to run the manager implementation is configured in the `config/manager/manager.yaml` file. 
+This image is built with the Dockerfile file scaffolded by default and contains the binary of the project \
+which will be built via the command `go build -a -o manager main.go`.
+
+Note that when you run `make docker-build` OR `make docker-build IMG=myregistry/myprojectname:<tag>` 
+an image will be built from the client host (local environment) and produce an image for 
+the client os/arch, which is commonly linux/amd64 or linux/arm64.
+
+<aside class="note">
+<h1>Mac Os</h1>
+
+If you are running from an Mac Os environment then, Docker also will consider it as linux/$arch. Be aware that
+when, for example, is running Kind on a Mac OS operational system the nodes will
+end up labeled with ` kubernetes.io/os=linux`
+
+</aside>
+
+### Kube RBAC Proxy
+
+A workload will be created to run the image [gcr.io/kubebuilder/kube-rbac-proxy:<tag>][proxy-images] which is 
+configured in the `config/default/manager_auth_proxy_patch.yaml` manifest. It is a side-car proxy whose purpose 
+is to protect the manager from malicious attacks. You can learn more about its motivations by looking at 
+the README of this project [github.com/brancz/kube-rbac-proxy][https://github.com/brancz/kube-rbac-proxy].
+
+Kubebuilder has been building this image with support for multiple architectures by default.( Check it [here][proxy-images] ). 
+If you need to address any edge case scenario where you want to produce a project that 
+only provides support for a specific architecture platform, you can customize your 
+configuration manifests to use the specific architecture types built for this image.
+
+[node-affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+[docker-manifest]: https://docs.docker.com/engine/reference/commandline/manifest/
+[proxy-images]: https://console.cloud.google.com/gcr/images/kubebuilder/GLOBAL/kube-rbac-proxy
+[buildx]: https://docs.docker.com/build/buildx/
+[goreleaser-buildx]: https://goreleaser.com/customization/docker/#use-a-specific-builder-with-docker-buildx

--- a/docs/book/src/reference/reference.md
+++ b/docs/book/src/reference/reference.md
@@ -30,6 +30,7 @@
   - [controller-gen CLI](controller-gen.md)
   - [completion](completion.md)
   - [Artifacts](artifacts.md)
+  - [Platform Support](platform.md)
   - [Writing controller tests](writing-tests.md)
   - [Metrics](metrics.md)
 

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -53,6 +53,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
@@ -83,6 +83,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -53,6 +53,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
@@ -83,6 +83,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -378,6 +378,34 @@ func (r *{{ .Resource.Kind }}Reconciler) deploymentFor{{ .Resource.Kind }}(
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// TODO(user): Uncomment the following code to configure the nodeAffinity expression
+					// according to the platforms which are supported by your solution. It is considered
+					// best practice to support multiple architectures. build your manager image using the
+					// makefile target docker-buildx. Also, you can use docker manifest inspect <image>
+					// to check what are the platforms supported.
+					// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+					//Affinity: &corev1.Affinity{
+					//	NodeAffinity: &corev1.NodeAffinity{
+					//		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					//			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					//				{
+					//					MatchExpressions: []corev1.NodeSelectorRequirement{
+					//						{
+					//							Key:      "kubernetes.io/arch",
+					//							Operator: "In",
+					//							Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
+					//						},
+					//						{
+					//							Key:      "kubernetes.io/os",
+					//							Operator: "In",
+					//							Values:   []string{"linux"},
+					//						},
+					//					},
+					//				},
+					//			},
+					//		},
+					//	},
+					//},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &[]bool{true}[0],
 						// IMPORTANT: seccomProfile was introduced with Kubernetes 1.19

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go
@@ -40,6 +40,8 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 
 const dockerfileTemplate = `# Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -55,7 +57,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/gitignore.go
@@ -47,6 +47,7 @@ const gitignoreTemplate = `
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with ` + "`go test -c`" + `
 *.test

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/makefile.go
@@ -26,6 +26,7 @@ var _ machinery.Template = &Makefile{}
 type Makefile struct {
 	machinery.TemplateMixin
 	machinery.ComponentConfigMixin
+	machinery.ProjectNameMixin
 
 	// Image is controller manager image name
 	Image string
@@ -127,6 +128,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -134,6 +138,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -172,8 +172,7 @@ func Run(kbc *utils.TestContext) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("building the controller image")
-	cmd := exec.Command("docker", "build", "-t", kbc.ImageName, ".")
-	_, err = kbc.Run(cmd)
+	err = kbc.Make("docker-build", "IMG="+kbc.ImageName)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("loading the controller docker image into the kind cluster")
@@ -181,7 +180,7 @@ func Run(kbc *utils.TestContext) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("deploying the controller-manager")
-	cmd = exec.Command("make", "deploy", "IMG="+kbc.ImageName)
+	cmd := exec.Command("make", "deploy", "IMG="+kbc.ImageName)
 	outputMake, err := kbc.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 

--- a/testdata/project-v3-addon-and-grafana/.gitignore
+++ b/testdata/project-v3-addon-and-grafana/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v3-addon-and-grafana/Dockerfile
+++ b/testdata/project-v3-addon-and-grafana/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,7 +21,11 @@ COPY channels/ /channels/
 RUN chmod -R a+rx /channels/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v3-addon-and-grafana/Makefile
+++ b/testdata/project-v3-addon-and-grafana/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v3-addon-and-grafana/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v3-addon-and-grafana/config/manager/manager.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v3-config/.gitignore
+++ b/testdata/project-v3-config/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v3-config/Dockerfile
+++ b/testdata/project-v3-config/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-config/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v3-multigroup/.gitignore
+++ b/testdata/project-v3-multigroup/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v3-multigroup/Dockerfile
+++ b/testdata/project-v3-multigroup/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v3-with-deploy-image/.gitignore
+++ b/testdata/project-v3-with-deploy-image/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v3-with-deploy-image/Dockerfile
+++ b/testdata/project-v3-with-deploy-image/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v3-with-deploy-image/Makefile
+++ b/testdata/project-v3-with-deploy-image/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v3-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v3-with-deploy-image/controllers/busybox_controller.go
+++ b/testdata/project-v3-with-deploy-image/controllers/busybox_controller.go
@@ -330,6 +330,34 @@ func (r *BusyboxReconciler) deploymentForBusybox(
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// TODO(user): Uncomment the following code to configure the nodeAffinity expression
+					// according to the platforms which are supported by your solution. It is considered
+					// best practice to support multiple architectures. build your manager image using the
+					// makefile target docker-buildx. Also, you can use docker manifest inspect <image>
+					// to check what are the platforms supported.
+					// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+					//Affinity: &corev1.Affinity{
+					//	NodeAffinity: &corev1.NodeAffinity{
+					//		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					//			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					//				{
+					//					MatchExpressions: []corev1.NodeSelectorRequirement{
+					//						{
+					//							Key:      "kubernetes.io/arch",
+					//							Operator: "In",
+					//							Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
+					//						},
+					//						{
+					//							Key:      "kubernetes.io/os",
+					//							Operator: "In",
+					//							Values:   []string{"linux"},
+					//						},
+					//					},
+					//				},
+					//			},
+					//		},
+					//	},
+					//},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &[]bool{true}[0],
 						// IMPORTANT: seccomProfile was introduced with Kubernetes 1.19

--- a/testdata/project-v3-with-deploy-image/controllers/memcached_controller.go
+++ b/testdata/project-v3-with-deploy-image/controllers/memcached_controller.go
@@ -330,6 +330,34 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// TODO(user): Uncomment the following code to configure the nodeAffinity expression
+					// according to the platforms which are supported by your solution. It is considered
+					// best practice to support multiple architectures. build your manager image using the
+					// makefile target docker-buildx. Also, you can use docker manifest inspect <image>
+					// to check what are the platforms supported.
+					// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+					//Affinity: &corev1.Affinity{
+					//	NodeAffinity: &corev1.NodeAffinity{
+					//		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					//			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					//				{
+					//					MatchExpressions: []corev1.NodeSelectorRequirement{
+					//						{
+					//							Key:      "kubernetes.io/arch",
+					//							Operator: "In",
+					//							Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
+					//						},
+					//						{
+					//							Key:      "kubernetes.io/os",
+					//							Operator: "In",
+					//							Values:   []string{"linux"},
+					//						},
+					//					},
+					//				},
+					//			},
+					//		},
+					//	},
+					//},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &[]bool{true}[0],
 						// IMPORTANT: seccomProfile was introduced with Kubernetes 1.19

--- a/testdata/project-v3/.gitignore
+++ b/testdata/project-v3/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v3/Dockerfile
+++ b/testdata/project-v3/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v3/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v4-addon-and-grafana/.gitignore
+++ b/testdata/project-v4-addon-and-grafana/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v4-addon-and-grafana/Dockerfile
+++ b/testdata/project-v4-addon-and-grafana/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,7 +21,11 @@ COPY channels/ /channels/
 RUN chmod -R a+rx /channels/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v4-addon-and-grafana/Makefile
+++ b/testdata/project-v4-addon-and-grafana/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v4-addon-and-grafana/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v4-addon-and-grafana/config/manager/manager.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v4-config/.gitignore
+++ b/testdata/project-v4-config/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v4-config/Dockerfile
+++ b/testdata/project-v4-config/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v4-config/Makefile
+++ b/testdata/project-v4-config/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v4-config/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-config/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v4-config/config/manager/manager.yaml
+++ b/testdata/project-v4-config/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v4-multigroup/.gitignore
+++ b/testdata/project-v4-multigroup/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v4-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v4-with-deploy-image/.gitignore
+++ b/testdata/project-v4-with-deploy-image/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v4-with-deploy-image/Dockerfile
+++ b/testdata/project-v4-with-deploy-image/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v4-with-deploy-image/Makefile
+++ b/testdata/project-v4-with-deploy-image/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v4-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges

--- a/testdata/project-v4-with-deploy-image/controllers/busybox_controller.go
+++ b/testdata/project-v4-with-deploy-image/controllers/busybox_controller.go
@@ -330,6 +330,34 @@ func (r *BusyboxReconciler) deploymentForBusybox(
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// TODO(user): Uncomment the following code to configure the nodeAffinity expression
+					// according to the platforms which are supported by your solution. It is considered
+					// best practice to support multiple architectures. build your manager image using the
+					// makefile target docker-buildx. Also, you can use docker manifest inspect <image>
+					// to check what are the platforms supported.
+					// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+					//Affinity: &corev1.Affinity{
+					//	NodeAffinity: &corev1.NodeAffinity{
+					//		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					//			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					//				{
+					//					MatchExpressions: []corev1.NodeSelectorRequirement{
+					//						{
+					//							Key:      "kubernetes.io/arch",
+					//							Operator: "In",
+					//							Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
+					//						},
+					//						{
+					//							Key:      "kubernetes.io/os",
+					//							Operator: "In",
+					//							Values:   []string{"linux"},
+					//						},
+					//					},
+					//				},
+					//			},
+					//		},
+					//	},
+					//},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &[]bool{true}[0],
 						// IMPORTANT: seccomProfile was introduced with Kubernetes 1.19

--- a/testdata/project-v4-with-deploy-image/controllers/memcached_controller.go
+++ b/testdata/project-v4-with-deploy-image/controllers/memcached_controller.go
@@ -330,6 +330,34 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					// TODO(user): Uncomment the following code to configure the nodeAffinity expression
+					// according to the platforms which are supported by your solution. It is considered
+					// best practice to support multiple architectures. build your manager image using the
+					// makefile target docker-buildx. Also, you can use docker manifest inspect <image>
+					// to check what are the platforms supported.
+					// More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+					//Affinity: &corev1.Affinity{
+					//	NodeAffinity: &corev1.NodeAffinity{
+					//		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					//			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					//				{
+					//					MatchExpressions: []corev1.NodeSelectorRequirement{
+					//						{
+					//							Key:      "kubernetes.io/arch",
+					//							Operator: "In",
+					//							Values:   []string{"amd64", "arm64", "ppc64le", "s390x"},
+					//						},
+					//						{
+					//							Key:      "kubernetes.io/os",
+					//							Operator: "In",
+					//							Values:   []string{"linux"},
+					//						},
+					//					},
+					//				},
+					//			},
+					//		},
+					//	},
+					//},
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsNonRoot: &[]bool{true}[0],
 						// IMPORTANT: seccomProfile was introduced with Kubernetes 1.19

--- a/testdata/project-v4/.gitignore
+++ b/testdata/project-v4/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+Dockerfile.cross
 
 # Test binary, build with `go test -c`
 *.test

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -68,6 +68,9 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+# If you wish built the manager image targeting other platforms you can use the --platform flag.
+# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
+# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
 	docker build -t ${IMG} .
@@ -75,6 +78,23 @@ docker-build: test ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> than the export will fail)
+# To properly provided solutions that supports more than one platform you should use this option.
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+.PHONY: docker-buildx
+docker-buildx: test ## Build and push docker image for the manager for cross-platform support
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
+	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+	- docker buildx create --name project-v3-builder
+	docker buildx use project-v3-builder
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx rm project-v3-builder
+	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/testdata/project-v4/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,22 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -36,6 +36,26 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
+      # according to the platforms which are supported by your solution. 
+      # It is considered best practice to support multiple architectures. You can
+      # build your manager image using the makefile target docker-buildx.
+      # affinity:
+      #   nodeAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #       nodeSelectorTerms:
+      #         - matchExpressions:
+      #           - key: kubernetes.io/arch
+      #             operator: In
+      #             values:
+      #               - amd64
+      #               - arm64
+      #               - ppc64le
+      #               - s390x
+      #           - key: kubernetes.io/os
+      #             operator: In
+      #             values:
+      #               - linux
       securityContext:
         runAsNonRoot: true
         # TODO(user): For common cases that do not require escalating privileges


### PR DESCRIPTION
## Description

- Add a new OPTIONAL option to build images with multi-cluster support. (make docker-buildx-push)
> With the new target introduced in this PR is possible to build the manager image by providing support to multi-platforms. Also, the changes made in the Dockerfile allow users to use other options and help them create customizations to achieve this goal indeed with other tools. 

- Add a doc providing the explanations and guiding operator authors
- Change the kustomize scaffolds to use node Affinity by default so that they can also comply with the recommendations
- Change the deploy-image/v1-alpha plugin in order to provide the setup for node affinity in the controller reconciliation to build the Deployment used to run the Operand image
 - Fix the issue to call docker-build from platforms / hosts that will not provide BUILPLATFORM == linux/amd64
 (before this PR we have authors building solutions where the container will have the support for Linux/arm64 and the binary to run the manager was built with linux/amd64 because it was fixed )

## Motivation
- I am an operator author I'd like to build a project that can be distributed and work no matter the platform. 
- I am an operator author I'd like to customize my project to be distributed to another specific platform

Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/2697
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2850

## Local Test with new OPTIONAL target make docker-buildx:

Building the image:

```
$ make docker-buildx IMG=docker.io/cmacedo/testkube:0.0.3
docker buildx create --name project-v3-builder
project-v3-builder
docker buildx use project-v3-builder
docker buildx build --push --platform=linux/arm64,linux/amd64,linux/s390x,linux/ppc64le --tag docker.io/cmacedo/testkube:0.0.3 .
[+] Building 809.2s (44/44) FINISHED                                                                               
 => [internal] booting buildkit                                                                               4.5s
 => => pulling image moby/buildkit:buildx-stable-1                                                            2.1s
 => => creating container buildx_buildkit_project-v3-builder0                                                 2.3s
 => [internal] load .dockerignore                                                                             0.1s
 => => transferring context: 171B                                                                             0.0s
 => [internal] load build definition from Dockerfile                                                          0.1s
 => => transferring dockerfile: 1.35kB                                                                        0.0s
 => [linux/s390x internal] load metadata for gcr.io/distroless/static:nonroot                                 2.0s
 => [linux/amd64 internal] load metadata for docker.io/library/golang:1.18                                    2.1s
 => [linux/amd64 internal] load metadata for gcr.io/distroless/static:nonroot                                 2.0s
 => [linux/arm64 internal] load metadata for gcr.io/distroless/static:nonroot                                 2.0s
 => [linux/ppc64le internal] load metadata for gcr.io/distroless/static:nonroot                               2.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                 0.0s
 => [linux/amd64 builder 1/9] FROM docker.io/library/golang:1.18@sha256:f1741ed3855b1a558f3c057f777667a4b73f  0.0s
 => => resolve docker.io/library/golang:1.18@sha256:f1741ed3855b1a558f3c057f777667a4b73ff250c4f1bee7f0388cc2  0.1s
 => => sha256:06ef4a250537829c59bb616d2c589fde2f8780ba55d21e5684ebd3ce1193ee30 157B / 157B                    0.2s
 => => sha256:95edc8028182acfa80667fa6a3b869f79574821298f786228e873ac10b3dd7bd 141.88MB / 141.88MB           36.1s
 => => sha256:dacb042d4b557bba852cbd15b9e3251e6b11f0b755b89541540c1894b7c4ef2c 85.91MB / 85.91MB             33.9s
 => => sha256:53ad072f9cd16fc8eb93b182b20e758e11acc0ef60babef0bf1043c08de1901a 54.58MB / 54.58MB             17.8s
 => => sha256:3e94d13e55e7a4ef17ff21376f57fb95c7e1706931f8704aa99260968d81f6e4 5.16MB / 5.16MB               12.4s
 => => sha256:fa9c7528c685216129e8e67bf362a7702e7b1daa585ab85546a41508830657d6 10.88MB / 10.88MB              5.1s
 => => sha256:1671565cc8df8c365c9b661d3fbc164e73d01f1b0430c6179588428f99a9da2e 55.01MB / 55.01MB             16.2s
 => => extracting sha256:1671565cc8df8c365c9b661d3fbc164e73d01f1b0430c6179588428f99a9da2e                     5.6s
 => => extracting sha256:3e94d13e55e7a4ef17ff21376f57fb95c7e1706931f8704aa99260968d81f6e4                     0.5s
 => => extracting sha256:fa9c7528c685216129e8e67bf362a7702e7b1daa585ab85546a41508830657d6                     0.5s
 => => extracting sha256:53ad072f9cd16fc8eb93b182b20e758e11acc0ef60babef0bf1043c08de1901a                     4.6s
 => => extracting sha256:dacb042d4b557bba852cbd15b9e3251e6b11f0b755b89541540c1894b7c4ef2c                     4.4s
 => => extracting sha256:95edc8028182acfa80667fa6a3b869f79574821298f786228e873ac10b3dd7bd                    10.9s
 => => extracting sha256:06ef4a250537829c59bb616d2c589fde2f8780ba55d21e5684ebd3ce1193ee30                     0.0s
 => [linux/amd64 stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b2  1.0s
 => => resolve gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7  0.1s
 => => sha256:0a602d5f6ca3de9b0e0d4d64e8857e504ec7a8c47f1ec617d82a81f6c64b0fe8 801.01kB / 801.01kB            0.4s
 => => extracting sha256:0a602d5f6ca3de9b0e0d4d64e8857e504ec7a8c47f1ec617d82a81f6c64b0fe8                     1.0s
 => [internal] load build context                                                                             0.2s
 => => transferring context: 142.22kB                                                                         0.0s
 => [linux/s390x stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b2  1.0s
 => => resolve gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7  0.1s
 => => sha256:e4d4f1812cc432feba11395231ddd13bc5385bf010a4acbe41c62ea81091b656 801.01kB / 801.01kB            1.7s
 => => extracting sha256:e4d4f1812cc432feba11395231ddd13bc5385bf010a4acbe41c62ea81091b656                     1.0s
 => [linux/arm64 stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b2  1.1s
 => => resolve gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7  0.1s
 => => sha256:a6f41b961ab0c6744fe9133b4fc2df373903f18ee5bf90f4ca00ff1a8c989173 801.01kB / 801.01kB            1.6s
 => => extracting sha256:a6f41b961ab0c6744fe9133b4fc2df373903f18ee5bf90f4ca00ff1a8c989173                     1.1s
 => [linux/ppc64le stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747  1.0s
 => => resolve gcr.io/distroless/static:nonroot@sha256:1f580b0a1922c3e54ae15b0758b5747b260bd99d39d40c2edb3e7  0.1s
 => => sha256:d80414a7217c1c756522dad11d0bba172ba8458b4a5ad4debdc0d697fdbd206e 801.01kB / 801.01kB            2.3s
 => => extracting sha256:d80414a7217c1c756522dad11d0bba172ba8458b4a5ad4debdc0d697fdbd206e                     1.0s
 => [linux/amd64 builder 2/9] WORKDIR /workspace                                                              0.8s
 => [linux/amd64 builder 3/9] COPY go.mod go.mod                                                              0.0s
 => [linux/amd64 builder 4/9] COPY go.sum go.sum                                                              0.0s
 => [linux/amd64->s390x builder 5/9] RUN go mod download                                                     33.4s
 => [linux/amd64->ppc64le builder 5/9] RUN go mod download                                                   33.6s
 => [linux/amd64 builder 5/9] RUN go mod download                                                            36.4s
 => [linux/amd64->arm64 builder 5/9] RUN go mod download                                                     37.7s
 => [linux/amd64->s390x builder 6/9] COPY main.go main.go                                                     4.4s
 => [linux/amd64->ppc64le builder 6/9] COPY main.go main.go                                                   4.8s
 => [linux/amd64 builder 6/9] COPY main.go main.go                                                            2.0s
 => [linux/amd64->arm64 builder 6/9] COPY main.go main.go                                                     0.7s
 => [linux/amd64->s390x builder 7/9] COPY api/ api/                                                           0.5s
 => [linux/amd64->ppc64le builder 7/9] COPY api/ api/                                                         0.2s
 => [linux/amd64 builder 7/9] COPY api/ api/                                                                  0.3s
 => [linux/amd64->arm64 builder 7/9] COPY api/ api/                                                           0.2s
 => [linux/amd64->s390x builder 8/9] COPY controllers/ controllers/                                           0.2s
 => [linux/amd64->ppc64le builder 8/9] COPY controllers/ controllers/                                         0.4s
 => [linux/amd64->s390x builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -a -o manager main  640.4s
 => [linux/amd64->arm64 builder 8/9] COPY controllers/ controllers/                                           0.4s
 => [linux/amd64 builder 8/9] COPY controllers/ controllers/                                                  0.4s
 => [linux/amd64->ppc64le builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o manager   652.8s
 => [linux/amd64 builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go      653.2s
 => [linux/amd64->arm64 builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o manager main  655.5s
 => [linux/s390x stage-1 2/3] COPY --from=builder /workspace/manager .                                        2.5s
 => [linux/ppc64le stage-1 2/3] COPY --from=builder /workspace/manager .                                      0.5s
 => [linux/amd64 stage-1 2/3] COPY --from=builder /workspace/manager .                                        0.5s
 => [linux/arm64 stage-1 2/3] COPY --from=builder /workspace/manager .                                        0.3s
 => exporting to image                                                                                       45.4s
 => => exporting layers                                                                                       7.4s
 => => exporting manifest sha256:260ae0740c97da01a0e61f95b4a6767bee20b3af6b0cab7a677ea6349c8f1fab             0.0s
 => => exporting config sha256:0e50ae208b83e668bc229311d024ef95adbf526f0ea252c52ebbf172585f6ed8               0.0s
 => => exporting manifest sha256:fb37eb73270f7d49e9f84278d1db2b1b9e7e1a3ff5786292c446361250fa401b             0.0s
 => => exporting config sha256:0404cdd2cb316cc2fd93e8cb72e9f517dc416d198d179d678bed4896b6566a79               0.0s
 => => exporting manifest sha256:c4ca8824f7039cc9a7c622bbd3a81b3a514ad5f1987b51c437f2fbd7341bb0cf             0.0s
 => => exporting config sha256:351bf89196c4a16581def71d383acf275b08b7650b3bd8d745864fb28166a338               0.0s
 => => exporting manifest sha256:6607f2f60d16a58f2f6117d034abe8d433c0e1ab903a5c211ed09823bd25a96f             0.0s
 => => exporting config sha256:b7fe530b3df3046f01e5bfff0c02da70fc33ecd87e9db961d87b3e598a31adf7               0.0s
 => => exporting manifest list sha256:969a82c605995d551b6791b38efdc716fa2755540be92520c00b9908a4dbd0b3        0.0s
 => => pushing layers                                                                                        35.8s
 => => pushing manifest for docker.io/cmacedo/testkube:0.0.3@sha256:969a82c605995d551b6791b38efdc716fa275554  1.9s
 => [auth] cmacedo/testkube:pull,push token for registry-1.docker.io                                          0.0s
docker buildx rm project-v3-builder
```

Checking the manifest list: 

```
$ docker manifest inspect docker.io/cmacedo/testkube:0.0.3
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:260ae0740c97da01a0e61f95b4a6767bee20b3af6b0cab7a677ea6349c8f1fab",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:fb37eb73270f7d49e9f84278d1db2b1b9e7e1a3ff5786292c446361250fa401b",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:c4ca8824f7039cc9a7c622bbd3a81b3a514ad5f1987b51c437f2fbd7341bb0cf",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 739,
         "digest": "sha256:6607f2f60d16a58f2f6117d034abe8d433c0e1ab903a5c211ed09823bd25a96f",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      }
   ]
}
```