### PR TITLE
🌱 Bump Kubernetes version (1.24.1 -> 1.25.0)

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -44,7 +44,7 @@ builds:
       - darwin_amd64
       - darwin_arm64
     env:
-      - KUBERNETES_VERSION=1.24.1
+      - KUBERNETES_VERSION=1.25.0
       - CGO_ENABLED=0
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.


### PR DESCRIPTION
Bump Kubernetes version (1.24.1 -> 1.25.0) as part of https://github.com/kubernetes-sigs/cluster-api/issues/6661


cc @sbueringer 