### PR TITLE
:sparkles: Update Kubernetes version (1.24.2 -> 1.25.0)

### DIFF
--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: 1.24.2
+  _KUBERNETES_VERSION: 1.25.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [


### PR DESCRIPTION
Updates the `tools-releases` branch Kubernetes version to (1.24.2 -> 1.25.0).

Part of #2908

cc @sbueringer @camilamacedo86 