### PR TITLE
✨ Update linux and darwin Dockerfile baseimages

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -30,7 +30,7 @@ ARG ARCH
 ENV DEST=/usr/local/kubebuilder/bin/
 
 # Install dependencies.
-RUN apk add --no-cache curl && \
+RUN apk add --no-cache curl=7.83.1-r3 && \
     mkdir -p $DEST
 
 # kube-apiserver
@@ -55,7 +55,7 @@ WORKDIR /usr/local
 RUN tar -czvf /kubebuilder_${OS}_${ARCH}.tar.gz kubebuilder/
 
 # Copy tarball to final image.
-FROM alpine:3.8
+FROM alpine:3.16
 
 # Platform args.
 ARG OS=linux


### PR DESCRIPTION
For darwin update the builder image to `golang:1.19` since it's needed for Kubernetes 1.25
For linux update the final image container to `alpine:3.16` (latest) to be the same as current darwin

No etcd update since it's already latest and greatest: https://github.com/etcd-io/etcd/releases?q=3.5&expanded=true