### PR TITLE
📖 feat(docs): golang version minimum is now go1.18

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,7 +9,7 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.17.9+ 
+- [go](https://golang.org/dl/) version v1.18.0+
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -35,7 +35,7 @@ import (
 
 // Variables and function to check Go version requirements.
 var (
-	goVerMin = golang.MustParse("go1.17.9")
+	goVerMin = golang.MustParse("go1.18.0")
 	goVerMax = golang.MustParse("go2.0alpha1")
 )
 


### PR DESCRIPTION
### Summary
This PR will update the documentation to indicate that the latest release of `kubebuilder` requires `Go 1.18+` in order to build the needed manifest files.

Fixes #2902