### PR TITLE
(:bug:) Remove deprecated io/ioutil and use os, io instead

### DIFF
--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"go/scanner"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -61,7 +60,7 @@ func (l Literate) Process(input *plugin.Input) error {
 		path := pathInfo.FullPath()
 
 		// TODO(directxman12): don't escape root?
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("unable to import %q: %v", path, err)
 		}

--- a/docs/book/utils/plugin/plugin.go
+++ b/docs/book/utils/plugin/plugin.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -65,7 +64,7 @@ func Run(plug Plugin, inputRaw io.Reader, outputRaw io.Writer, args ...string) e
 		return fmt.Errorf("unable to write output book object: %v", err)
 	}
 
-	ioutil.WriteFile("/tmp/litout.json", out, os.ModePerm)
+	os.WriteFile("/tmp/litout.json", out, os.ModePerm)
 
 	return nil
 }

--- a/pkg/cli/alpha/config-gen/cmd.go
+++ b/pkg/cli/alpha/config-gen/cmd.go
@@ -19,7 +19,6 @@ package configgen
 import (
 	"embed"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -316,7 +315,7 @@ kubebuilder alpha config-gen install-as-plugin
 			}
 
 			// r-x perms to prevent overwrite vulnerability since the script will be executed out-of-tree.
-			return ioutil.WriteFile(fullScriptPath, []byte(pluginScript), 0o500)
+			return os.WriteFile(fullScriptPath, []byte(pluginScript), 0o500)
 		},
 	}
 	c.AddCommand(install)

--- a/pkg/cli/alpha/config-gen/types.go
+++ b/pkg/cli/alpha/config-gen/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package configgen
 
 import (
-	"io/ioutil"
+	"os"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -210,7 +210,7 @@ func (kp *KubebuilderConfigGen) Default() error {
 	}
 
 	if kp.Spec.ControllerManager.ComponentConfig.ConfigFilepath != "" {
-		b, err := ioutil.ReadFile(kp.Spec.ControllerManager.ComponentConfig.ConfigFilepath)
+		b, err := os.ReadFile(kp.Spec.ControllerManager.ComponentConfig.ConfigFilepath)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -18,7 +18,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -590,7 +590,7 @@ plugins:
 				_ = w.Close()
 
 				Expect(err).NotTo(HaveOccurred())
-				printed, _ := ioutil.ReadAll(r)
+				printed, _ := io.ReadAll(r)
 				Expect(string(printed)).To(Equal(
 					fmt.Sprintf(noticeColor, fmt.Sprintf(deprecationFmt, deprecationWarning))))
 			})

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"regexp"
@@ -67,7 +66,7 @@ func GetNonEmptyLines(output string) []string {
 func InsertCode(filename, target, code string) error {
 	// false positive
 	// nolint:gosec
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func InsertCode(filename, target, code string) error {
 	out := string(contents[:idx+len(target)]) + code + string(contents[idx+len(target):])
 	// false positive
 	// nolint:gosec
-	return ioutil.WriteFile(filename, []byte(out), 0644)
+	return os.WriteFile(filename, []byte(out), 0644)
 }
 
 // UncommentCode searches for target in the file and remove the comment prefix
@@ -86,7 +85,7 @@ func InsertCode(filename, target, code string) error {
 func UncommentCode(filename, target, prefix string) error {
 	// false positive
 	// nolint:gosec
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -127,14 +126,14 @@ func UncommentCode(filename, target, prefix string) error {
 	}
 	// false positive
 	// nolint:gosec
-	return ioutil.WriteFile(filename, out.Bytes(), 0644)
+	return os.WriteFile(filename, out.Bytes(), 0644)
 }
 
 // ImplementWebhooks will mock an webhook data
 func ImplementWebhooks(filename string) error {
 	// false positive
 	// nolint:gosec
-	bs, err := ioutil.ReadFile(filename)
+	bs, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
@@ -181,7 +180,7 @@ func ImplementWebhooks(filename string) error {
 	}
 	// false positive
 	// nolint:gosec
-	return ioutil.WriteFile(filename, []byte(str), 0644)
+	return os.WriteFile(filename, []byte(str), 0644)
 }
 
 // EnsureExistAndReplace check if the content exists and then do the replace
@@ -200,7 +199,7 @@ func ReplaceInFile(path, old, new string) error {
 	}
 	// false positive
 	// nolint:gosec
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -208,7 +207,7 @@ func ReplaceInFile(path, old, new string) error {
 		return errors.New("unable to find the content to be replaced")
 	}
 	s := strings.Replace(string(b), old, new, -1)
-	err = ioutil.WriteFile(path, []byte(s), info.Mode())
+	err = os.WriteFile(path, []byte(s), info.Mode())
 	if err != nil {
 		return err
 	}
@@ -228,7 +227,7 @@ func ReplaceRegexInFile(path, match, replace string) error {
 	}
 	// false positive
 	// nolint:gosec
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -236,7 +235,7 @@ func ReplaceRegexInFile(path, match, replace string) error {
 	if s == string(b) {
 		return errors.New("unable to find the content to be replaced")
 	}
-	err = ioutil.WriteFile(path, []byte(s), info.Mode())
+	err = os.WriteFile(path, []byte(s), info.Mode())
 	if err != nil {
 		return err
 	}
@@ -246,7 +245,7 @@ func ReplaceRegexInFile(path, match, replace string) error {
 // HasFileContentWith check if given `text` can be found in file
 func HasFileContentWith(path, text string) (bool, error) {
 	// nolint:gosec
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/plugins/golang/declarative/v1/init.go
+++ b/pkg/plugins/golang/declarative/v1/init.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -74,7 +74,7 @@ func updateDockerfile() error {
 func insertCodeIfDoesNotExist(filename, target, code string) error {
 	// false positive
 	// nolint:gosec
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/golang/v3/commons.go
+++ b/pkg/plugins/golang/v3/commons.go
@@ -18,7 +18,7 @@ package v3
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -37,7 +37,7 @@ const deprecateMsg = "The v1beta1 API version for CRDs and Webhooks are deprecat
 // nolint:lll,gosec
 func applyScaffoldCustomizationsForVbeta1() error {
 	makefilePath := filepath.Join("Makefile")
-	bs, err := ioutil.ReadFile(makefilePath)
+	bs, err := os.ReadFile(makefilePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -19,7 +19,6 @@ package scaffolds
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -77,7 +76,7 @@ func loadConfig(configPath string) ([]templates.CustomMetricItem, error) {
 }
 
 func configReader(reader io.Reader) ([]templates.CustomMetricItem, error) {
-	yamlFile, err := ioutil.ReadAll(reader)
+	yamlFile, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -19,7 +19,6 @@ package utils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -340,13 +339,13 @@ func (cc *CmdContext) Run(cmd *exec.Cmd) ([]byte, error) {
 func (t *TestContext) AllowProjectBeMultiGroup() error {
 	const multiGroup = `multigroup: true
 `
-	projectBytes, err := ioutil.ReadFile(filepath.Join(t.Dir, "PROJECT"))
+	projectBytes, err := os.ReadFile(filepath.Join(t.Dir, "PROJECT"))
 	if err != nil {
 		return err
 	}
 
 	projectBytes = append([]byte(multiGroup), projectBytes...)
-	err = ioutil.WriteFile(filepath.Join(t.Dir, "PROJECT"), projectBytes, 0o644)
+	err = os.WriteFile(filepath.Join(t.Dir, "PROJECT"), projectBytes, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Summary:**

This PR fixes the following error by removing deprecated io/ioutil and using os, io instead.

```
pkg/cli/alpha/config-gen/cmd.go:22:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
```

**Description of change:**

- Update ioutil.ReadAll => io.ReadAll
- Update ioutil.ReadFile => os.ReadFile
- Update ioutil.WriteFile => os.WriteFile