### PR TITLE
WIP: :seedling: fix release by adding github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Tag Release
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+}
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: kubebuilder
+          path: dist/*
+
+
+


### PR DESCRIPTION
## Description

Currently, we have been doing the releases manually because the token added to allow us to update the release draft with the manifests when it is done via the google cloud no longer works. 

Therefore, this PR sort it out by moving to GitHub actions as discussed in the past