### PR TITLE
:seedling: fix release by adding github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch all tags
+        run: git fetch --force --tags
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.19'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: v1.11.2
+          args: release -f ./build/.goreleaser.yml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: kubebuilder
+          path: dist/*
+          if-no-files-found: error

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,8 @@ the process was done to ensure that we have an aligned process under the org (si
 ### Draft a new release from GitHub
 
 1. Create a new tag with the correct version from the new `release-<MAJOR.MINOR>` branch
-2. Add the changelog on it and publish. Now, the code source is released !
+2. Verify the Release Github Action. It should build the assets and publish in the draft release 
+3. You also need to manually add the changelog generated above on the release page and publish it. Now, the code source is released !
 
 ### Update the website docs (https://book.kubebuilder.io/quick-start.html)
 
@@ -38,7 +39,7 @@ the process was done to ensure that we have an aligned process under the org (si
 
 ### When the release be done and the website update: Announce the new release:
 
-1. Publish the new release on the Slack channel, i.e:
+1. Announce the new release on the Slack channel, i.e:
 
 ````
 :announce: Kubebuilder v3.5.0 has been released!
@@ -47,11 +48,13 @@ For more info, see the release page: https://github.com/kubernetes-sigs/kubebuil
  :tada:  Thanks to all our contributors!
 ````
 
-2. An announcement email is sent to `kubebuilder@googlegroups.com` with the subject `[ANNOUNCE] Kubebuilder $VERSION is released`
+2. Announce the new release via email is sent to `kubebuilder@googlegroups.com` with the subject `[ANNOUNCE] Kubebuilder $VERSION is released`
 
 ## What to do if things goes wrong? How to release from my local env as a workaround?
 
-As a workaround we can release from locally by:
+As a workaround we can release from locally by: 
+
+PS.: _This workaround uses the google cloud. Note that we move the binary CLI release from google cloud to use Github Actions instead_
 
 1. Download google container builder: https://github.com/GoogleCloudPlatform/cloud-build-local
 2. Verify that you can use the cloud-build-local CLI tool


### PR DESCRIPTION
## Description

Currently, we have been doing the releases manually because the token added to allow us to update the release draft with the manifests when it is done via the google cloud no longer works.

Therefore, this PR sort it out by moving to GitHub actions as discussed in the past

## Test performed to check that is working
See: the built is working just the publish fails because it was done from the fork: https://github.com/camilamacedo86/kubebuilder/actions/runs/3043272293/jobs/4902353947#step:7:88

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2413
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2667
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2768