### PR TITLE
🐛  fix kubernetes word spelling error

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/certificate.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/certificate.go
@@ -51,7 +51,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: {{ .ProjectName }}

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/service_account.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/service_account.go
@@ -46,7 +46,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ .ProjectName }}
     app.kubernetes.io/part-of: {{ .ProjectName }}

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -58,7 +58,7 @@ metadata:
     app.kubernetes.io/name: {{ lower .Resource.Kind }}
     app.kubernetes.io/instance: {{ lower .Resource.Kind }}-sample
     app.kubernetes.io/part-of: {{ .ProjectName }}
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: {{ .ProjectName }}
   name: {{ lower .Resource.Kind }}-sample
 spec:

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -58,7 +58,7 @@ metadata:
     app.kubernetes.io/name: {{ lower .Resource.Kind }}
     app.kubernetes.io/instance: {{ lower .Resource.Kind }}-sample
     app.kubernetes.io/part-of: {{ .ProjectName }}
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: {{ .ProjectName }}
   name: {{ lower .Resource.Kind }}-sample
 spec:

--- a/testdata/project-v3-addon-and-grafana/config/rbac/service_account.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
     app.kubernetes.io/part-of: project-v3-addon-and-grafana

--- a/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v3-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
   name: admiral-sample
 spec:

--- a/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
   name: captain-sample
 spec:

--- a/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v3-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
   name: firstmate-sample
 spec:

--- a/testdata/project-v3-config/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-config/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3-config

--- a/testdata/project-v3-config/config/rbac/service_account.yaml
+++ b/testdata/project-v3-config/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-config
     app.kubernetes.io/part-of: project-v3-config

--- a/testdata/project-v3-config/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v3-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-config
   name: admiral-sample
 spec:

--- a/testdata/project-v3-config/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-config
   name: captain-sample
 spec:

--- a/testdata/project-v3-config/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v3-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-config
   name: firstmate-sample
 spec:

--- a/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3-multigroup

--- a/testdata/project-v3-multigroup/config/rbac/service_account.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-multigroup
     app.kubernetes.io/part-of: project-v3-multigroup

--- a/testdata/project-v3-multigroup/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/samples/_v1_lakers.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: lakers
     app.kubernetes.io/instance: lakers-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: lakers-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-multigroup/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: captain-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/fiz_v1_bar.yaml
+++ b/testdata/project-v3-multigroup/config/samples/fiz_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v3-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: healthcheckpolicy
     app.kubernetes.io/instance: healthcheckpolicy-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: healthcheckpolicy-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/foo_v1_bar.yaml
+++ b/testdata/project-v3-multigroup/config/samples/foo_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: kraken
     app.kubernetes.io/instance: kraken-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: kraken-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: leviathan
     app.kubernetes.io/instance: leviathan-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: leviathan-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: destroyer
     app.kubernetes.io/instance: destroyer-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: destroyer-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: frigate
     app.kubernetes.io/instance: frigate-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: frigate-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: cruiser
     app.kubernetes.io/instance: cruiser-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: cruiser-sample
 spec:

--- a/testdata/project-v3-with-deploy-image/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-with-deploy-image/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3-with-deploy-image

--- a/testdata/project-v3-with-deploy-image/config/rbac/service_account.yaml
+++ b/testdata/project-v3-with-deploy-image/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-with-deploy-image
     app.kubernetes.io/part-of: project-v3-with-deploy-image

--- a/testdata/project-v3/config/certmanager/certificate.yaml
+++ b/testdata/project-v3/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3

--- a/testdata/project-v3/config/rbac/service_account.yaml
+++ b/testdata/project-v3/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3
     app.kubernetes.io/part-of: project-v3

--- a/testdata/project-v3/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v3
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3
   name: admiral-sample
 spec:

--- a/testdata/project-v3/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3
   name: captain-sample
 spec:

--- a/testdata/project-v3/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v3
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3
   name: firstmate-sample
 spec:

--- a/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
   name: admiral-sample
 spec:

--- a/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
   name: captain-sample
 spec:

--- a/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
   name: firstmate-sample
 spec:

--- a/testdata/project-v4-config/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4-config/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v4-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-config
   name: admiral-sample
 spec:

--- a/testdata/project-v4-config/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-config/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-config
   name: captain-sample
 spec:

--- a/testdata/project-v4-config/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4-config/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v4-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-config
   name: firstmate-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v4-multigroup/config/samples/_v1_lakers.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: lakers
     app.kubernetes.io/instance: lakers-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: lakers-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-multigroup/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: captain-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/fiz_v1_bar.yaml
+++ b/testdata/project-v4-multigroup/config/samples/fiz_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v4-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: healthcheckpolicy
     app.kubernetes.io/instance: healthcheckpolicy-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: healthcheckpolicy-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/foo_v1_bar.yaml
+++ b/testdata/project-v4-multigroup/config/samples/foo_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: kraken
     app.kubernetes.io/instance: kraken-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: kraken-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: leviathan
     app.kubernetes.io/instance: leviathan-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: leviathan-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: destroyer
     app.kubernetes.io/instance: destroyer-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: destroyer-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: frigate
     app.kubernetes.io/instance: frigate-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: frigate-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: cruiser
     app.kubernetes.io/instance: cruiser-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: cruiser-sample
 spec:

--- a/testdata/project-v4/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v4
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4
   name: admiral-sample
 spec:

--- a/testdata/project-v4/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4
   name: captain-sample
 spec:

--- a/testdata/project-v4/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v4
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4
   name: firstmate-sample
 spec:


### PR DESCRIPTION
 fix kubernetes word spelling error from `app.kuberentes` to `app.kubernetes` in go templates and some test yaml files