### PR TITLE
✨ deprecate flag component-config

### DIFF
--- a/pkg/plugins/common/kustomize/v1/create.go
+++ b/pkg/plugins/common/kustomize/v1/create.go
@@ -35,7 +35,10 @@ type createSubcommand struct {
 	force bool
 }
 
-func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) { p.flagSet = fs }
+func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) {
+	p.flagSet = fs
+	_ = fs.MarkDeprecated("component-config", "component-config flag will be deprecated in upcoming releases")
+}
 
 func (p *createSubcommand) InjectConfig(c config.Config) error {
 	p.config = c

--- a/pkg/plugins/common/kustomize/v2-alpha/create.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/create.go
@@ -35,7 +35,10 @@ type createSubcommand struct {
 	force bool
 }
 
-func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) { p.flagSet = fs }
+func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) {
+	p.flagSet = fs
+	_ = fs.MarkDeprecated("component-config", "component-config flag will be deprecated in upcoming releases")
+}
 
 func (p *createSubcommand) InjectConfig(c config.Config) error {
 	p.config = c


### PR DESCRIPTION
this will fix one of the requirements from #2782 

This fix will mark the flag `component-config` as deprecated and throw the warning to the user whenever user tries to use it.
