### PR TITLE
🌱 Use same joelanford/go-apidiff version (v0.4.0) in workflow and Makefile

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version: "1.19"
       - name: Execute go-apidiff
-        uses: joelanford/go-apidiff@v0.2.0
+        uses: joelanford/go-apidiff@v0.4.0
         with:
           compare-imports: true
           print-compatible: true


### PR DESCRIPTION
Use the same version of joelanford/go-apidiff in the Makefile and github workflow. 

In the Makefile version 0.4.0 is used:
https://github.com/kubernetes-sigs/kubebuilder/blob/d67473979371c60b213742a9a7f19cf67b6bab43/Makefile#L95