### PR TITLE
:sparkles: Update etcd bin from 3.5.4 to 3.5.5 (envtools)

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.4
+ARG ETCD_VERSION=v3.5.5
 ARG OS=darwin
 ARG ARCH
 

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.16 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.4
+ARG ETCD_VERSION=v3.5.5
 ARG OS=linux
 ARG ARCH
 


### PR DESCRIPTION
## Description

Update etcd bin from 3.5.4 to 3.5.5 (envtools)

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2946