### PR TITLE
📖: notify `controller-gen` installation for building book 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,10 +3,11 @@
 The kubebuilder book is served using [mdBook](https://github.com/rust-lang-nursery/mdBook). If you want to test changes to the book locally, follow these directions:
 
 1. Follow the instructions at [https://github.com/rust-lang-nursery/mdBook#installation](https://github.com/rust-lang-nursery/mdBook#installation) to
-  install mdBook.
-1. cd into the `docs/book` directory
-1. Run `mdbook serve`
-1. Visit [http://localhost:3000](http://localhost:3000)
+   install mdBook.
+2. Make sure [controller-gen](https://pkg.go.dev/sigs.k8s.io/controller-tools/cmd/controller-gen) is install in `$GOPATH`.
+3. cd into the `docs/book` directory
+4. Run `mdbook serve`
+5. Visit [http://localhost:3000](http://localhost:3000)
 
 # Steps to deploy
 


### PR DESCRIPTION
### Description
Notify users to install `controller-gen` for building book locally.

### Motivation
Resolve: https://github.com/kubernetes-sigs/kubebuilder/issues/2955
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
