### PR TITLE
:bug: remove duplicate words and fix spelling mistakes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -36,7 +36,7 @@ body:
       <summary>Code & details examples</summary>
       
       `````markdown
-      Some code code written in Go:
+      Some code written in Go:
 
       ```go
       type Manager struct {

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -36,7 +36,7 @@ body:
       <summary>Code & details examples</summary>
 
       `````markdown
-      Some code code written in Go:
+      Some code written in Go:
 
       ```go
       type Manager struct {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ to create a new branch. Instead, you will just need to ensure that all major fix
 `release-MAJOR.MINOR` branch. To know more about versioning check https://semver.org/.
 
 **Note:** Before `3.5.*` release this project was released based on `MAJOR`. A change to the
-the process was done to ensure that we have an aligned process under the org (similar to `controller-runtime` and
+process was done to ensure that we have an aligned process under the org (similar to `controller-runtime` and
 `controller-tools`) and to make it easier to produce patch releases.
 
 ## How to do a release

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
@@ -4223,7 +4223,7 @@ spec:
                                   of an init container are taken into account during
                                   scheduling by finding the highest request/limit
                                   for each resource type, and then using the max of
-                                  of that value or the sum of the normal containers.
+                                  that value or the sum of the normal containers.
                                   Limits are applied to init containers in a similar
                                   fashion. Init containers cannot currently be added
                                   or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'

--- a/docs/book/src/plugins/creating-plugins.md
+++ b/docs/book/src/plugins/creating-plugins.md
@@ -16,7 +16,7 @@ In this way, currently, you can [Extend the CLI][extending-cli] and use the `Bun
 
 ```go
   mylanguagev1Bundle, _ := plugin.NewBundle(language.DefaultNameQualifier, plugin.Version{Number: 1},
-		kustomizecommonv1.Plugin{}, // extend the common base from Kuebebuilder
+		kustomizecommonv1.Plugin{}, // extend the common base from Kubebuilder
 		mylanguagev1.Plugin{}, // your plugin language which will do the scaffolds for the specific language on top of the common base
 	)
 ```

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/certificate.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/certificate.go
@@ -51,7 +51,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: {{ .ProjectName }}

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/service_account.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/rbac/service_account.go
@@ -46,7 +46,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ .ProjectName }}
     app.kubernetes.io/part-of: {{ .ProjectName }}

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -58,7 +58,7 @@ metadata:
     app.kubernetes.io/name: {{ lower .Resource.Kind }}
     app.kubernetes.io/instance: {{ lower .Resource.Kind }}-sample
     app.kubernetes.io/part-of: {{ .ProjectName }}
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: {{ .ProjectName }}
   name: {{ lower .Resource.Kind }}-sample
 spec:

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -58,7 +58,7 @@ metadata:
     app.kubernetes.io/name: {{ lower .Resource.Kind }}
     app.kubernetes.io/instance: {{ lower .Resource.Kind }}-sample
     app.kubernetes.io/part-of: {{ .ProjectName }}
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: {{ .ProjectName }}
   name: {{ lower .Resource.Kind }}-sample
 spec:

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -200,7 +200,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 			}
 
 			// Perform all operations required before remove the finalizer and allow
-			// the Kubernetes API to remove the custom custom resource.
+			// the Kubernetes API to remove the custom resource.
 			r.doFinalizerOperationsFor{{ .Resource.Kind }}({{ lower .Resource.Kind }})
 
 			// TODO(user): If you add operations to the doFinalizerOperationsFor{{ .Resource.Kind }} method 

--- a/testdata/project-v3-addon-and-grafana/config/rbac/service_account.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
     app.kubernetes.io/part-of: project-v3-addon-and-grafana

--- a/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v3-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
   name: admiral-sample
 spec:

--- a/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
   name: captain-sample
 spec:

--- a/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v3-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-addon-and-grafana
   name: firstmate-sample
 spec:

--- a/testdata/project-v3-config/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-config/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3-config

--- a/testdata/project-v3-config/config/rbac/service_account.yaml
+++ b/testdata/project-v3-config/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-config
     app.kubernetes.io/part-of: project-v3-config

--- a/testdata/project-v3-config/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v3-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-config
   name: admiral-sample
 spec:

--- a/testdata/project-v3-config/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-config
   name: captain-sample
 spec:

--- a/testdata/project-v3-config/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3-config/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v3-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-config
   name: firstmate-sample
 spec:

--- a/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-multigroup/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3-multigroup

--- a/testdata/project-v3-multigroup/config/rbac/service_account.yaml
+++ b/testdata/project-v3-multigroup/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-multigroup
     app.kubernetes.io/part-of: project-v3-multigroup

--- a/testdata/project-v3-multigroup/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v3-multigroup/config/samples/_v1_lakers.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: lakers
     app.kubernetes.io/instance: lakers-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: lakers-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3-multigroup/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: captain-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/fiz_v1_bar.yaml
+++ b/testdata/project-v3-multigroup/config/samples/fiz_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v3-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: healthcheckpolicy
     app.kubernetes.io/instance: healthcheckpolicy-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: healthcheckpolicy-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/foo_v1_bar.yaml
+++ b/testdata/project-v3-multigroup/config/samples/foo_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: kraken
     app.kubernetes.io/instance: kraken-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: kraken-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v3-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: leviathan
     app.kubernetes.io/instance: leviathan-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: leviathan-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: destroyer
     app.kubernetes.io/instance: destroyer-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: destroyer-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: frigate
     app.kubernetes.io/instance: frigate-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: frigate-sample
 spec:

--- a/testdata/project-v3-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v3-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: cruiser
     app.kubernetes.io/instance: cruiser-sample
     app.kubernetes.io/part-of: project-v3-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3-multigroup
   name: cruiser-sample
 spec:

--- a/testdata/project-v3-with-deploy-image/config/certmanager/certificate.yaml
+++ b/testdata/project-v3-with-deploy-image/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3-with-deploy-image

--- a/testdata/project-v3-with-deploy-image/config/rbac/service_account.yaml
+++ b/testdata/project-v3-with-deploy-image/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3-with-deploy-image
     app.kubernetes.io/part-of: project-v3-with-deploy-image

--- a/testdata/project-v3-with-deploy-image/controllers/busybox_controller.go
+++ b/testdata/project-v3-with-deploy-image/controllers/busybox_controller.go
@@ -152,7 +152,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			// Perform all operations required before remove the finalizer and allow
-			// the Kubernetes API to remove the custom custom resource.
+			// the Kubernetes API to remove the custom resource.
 			r.doFinalizerOperationsForBusybox(busybox)
 
 			// TODO(user): If you add operations to the doFinalizerOperationsForBusybox method

--- a/testdata/project-v3-with-deploy-image/controllers/memcached_controller.go
+++ b/testdata/project-v3-with-deploy-image/controllers/memcached_controller.go
@@ -152,7 +152,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			// Perform all operations required before remove the finalizer and allow
-			// the Kubernetes API to remove the custom custom resource.
+			// the Kubernetes API to remove the custom resource.
 			r.doFinalizerOperationsForMemcached(memcached)
 
 			// TODO(user): If you add operations to the doFinalizerOperationsForMemcached method

--- a/testdata/project-v3/config/certmanager/certificate.yaml
+++ b/testdata/project-v3/config/certmanager/certificate.yaml
@@ -5,7 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   labels:
-    app.kuberentes.io/name: issuer
+    app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: selfsigned-issuer
     app.kubernetes.io/component: certificate
     app.kubernetes.io/created-by: project-v3

--- a/testdata/project-v3/config/rbac/service_account.yaml
+++ b/testdata/project-v3/config/rbac/service_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kuberentes.io/instance: controller-manager
+    app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v3
     app.kubernetes.io/part-of: project-v3

--- a/testdata/project-v3/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v3
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3
   name: admiral-sample
 spec:

--- a/testdata/project-v3/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v3
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3
   name: captain-sample
 spec:

--- a/testdata/project-v3/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v3/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v3
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v3
   name: firstmate-sample
 spec:

--- a/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
   name: admiral-sample
 spec:

--- a/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
   name: captain-sample
 spec:

--- a/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
   name: firstmate-sample
 spec:

--- a/testdata/project-v4-config/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4-config/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v4-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-config
   name: admiral-sample
 spec:

--- a/testdata/project-v4-config/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-config/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-config
   name: captain-sample
 spec:

--- a/testdata/project-v4-config/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4-config/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v4-config
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-config
   name: firstmate-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v4-multigroup/config/samples/_v1_lakers.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: lakers
     app.kubernetes.io/instance: lakers-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: lakers-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-multigroup/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: captain-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/fiz_v1_bar.yaml
+++ b/testdata/project-v4-multigroup/config/samples/fiz_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v4-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: healthcheckpolicy
     app.kubernetes.io/instance: healthcheckpolicy-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: healthcheckpolicy-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/foo_v1_bar.yaml
+++ b/testdata/project-v4-multigroup/config/samples/foo_v1_bar.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: bar
     app.kubernetes.io/instance: bar-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: bar-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: kraken
     app.kubernetes.io/instance: kraken-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: kraken-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: leviathan
     app.kubernetes.io/instance: leviathan-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: leviathan-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: destroyer
     app.kubernetes.io/instance: destroyer-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: destroyer-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: frigate
     app.kubernetes.io/instance: frigate-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: frigate-sample
 spec:

--- a/testdata/project-v4-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: cruiser
     app.kubernetes.io/instance: cruiser-sample
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4-multigroup
   name: cruiser-sample
 spec:

--- a/testdata/project-v4-with-deploy-image/controllers/busybox_controller.go
+++ b/testdata/project-v4-with-deploy-image/controllers/busybox_controller.go
@@ -152,7 +152,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			// Perform all operations required before remove the finalizer and allow
-			// the Kubernetes API to remove the custom custom resource.
+			// the Kubernetes API to remove the custom resource.
 			r.doFinalizerOperationsForBusybox(busybox)
 
 			// TODO(user): If you add operations to the doFinalizerOperationsForBusybox method

--- a/testdata/project-v4-with-deploy-image/controllers/memcached_controller.go
+++ b/testdata/project-v4-with-deploy-image/controllers/memcached_controller.go
@@ -152,7 +152,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			// Perform all operations required before remove the finalizer and allow
-			// the Kubernetes API to remove the custom custom resource.
+			// the Kubernetes API to remove the custom resource.
 			r.doFinalizerOperationsForMemcached(memcached)
 
 			// TODO(user): If you add operations to the doFinalizerOperationsForMemcached method

--- a/testdata/project-v4/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_admiral.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: admiral
     app.kubernetes.io/instance: admiral-sample
     app.kubernetes.io/part-of: project-v4
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4
   name: admiral-sample
 spec:

--- a/testdata/project-v4/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_captain.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: captain
     app.kubernetes.io/instance: captain-sample
     app.kubernetes.io/part-of: project-v4
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4
   name: captain-sample
 spec:

--- a/testdata/project-v4/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_firstmate.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: firstmate
     app.kubernetes.io/instance: firstmate-sample
     app.kubernetes.io/part-of: project-v4
-    app.kuberentes.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: project-v4
   name: firstmate-sample
 spec:


### PR DESCRIPTION
A minor cleanup that fixes:

* Duplicate words `code code`, `of of`, `the the` etc. 
* Spelling `Kuebebuilder` -> `Kubebuilder` and `kuberentes` -> `kubernetes`

Since one of the spelling mistakes is a label I made this as a :bug: 