### PR TITLE
:sparkles: update kubebuilder cli kubernetes version

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -75,7 +75,7 @@ body:
 
       Does it require a particular Kubernetes version?
 
-      Is there currently another isssue associated with this (use github syntax
+      Is there currently another issue associated with this (use github syntax
       like `#xyz` to link to it)?
   validations: {required: true}
 

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -44,7 +44,7 @@ builds:
       - darwin_amd64
       - darwin_arm64
     env:
-      - KUBERNETES_VERSION=1.24.1
+      - KUBERNETES_VERSION=1.25.0
       - CGO_ENABLED=0
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.


### PR DESCRIPTION
Updates the kubernetes version from 1.24.1 -> 1.25.0 in the kubebuilder cli pipeline to align it with the rest of the repo.

I also sneaked in a minor spelling fix that I noticed but felt excessive to give a separate pr.