### PR TITLE
🐛 (:bug:): bugfix fixing the kubebuilder install locally curl request

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -31,7 +31,7 @@ Install [kubebuilder](https://sigs.k8s.io/kubebuilder):
 
 ```bash
 # download kubebuilder and install locally.
-curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$\(go env GOOS\)/$\(go env GOARCH\)
 chmod +x kubebuilder && mv kubebuilder /usr/local/bin/
 ```
 


### PR DESCRIPTION

``` curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$\(go env GOOS)/$\(go env GOARCH) ```

Error

syntax error near unexpected token `)'

