### PR TITLE
feat: Add windows support to tools-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ GCP Cloud Build watches this branch.  On every push, it runs the pipeline define
 - `_GOARCH=arm64 _GOOS=linux`
 - `_GOARCH=arm64 _GOOS=darwin`
 - `_GOARCH=ppc64le _GOOS=linux`
+- `_GOARCH=amd64 _GOOS=windows`
 
 (we may add more the in the future).
 
@@ -28,7 +29,7 @@ Each platform has a Dockerfile in [build/thirdparty](build/thirdparty) to assist
 - For Linux, this involves simply downloading the canonical releases from the
   offically Kubernetes and etcd releases & taring them up.
 
-- For Darwin, since the official Kubernetes releases don't build the control
+- For Darwin/Windows, since the official Kubernetes releases don't build the control
   plane, we instead build kube-apiserver ourselves, but use etcd & kubectl from
   official releases.
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -1,0 +1,75 @@
+#  Copyright 2018 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Build or fetch the following binaries for windows and then host them in a tar.gz file in an alpine image
+# - kube-apiserver (build)
+# - kubectl (fetch)
+# - etcd (fetch)
+
+FROM golang:1.19 as builder
+
+# Version and platform args.
+ARG KUBERNETES_VERSION
+ARG ETCD_VERSION=v3.5.5
+ARG OS=windows
+ARG ARCH
+
+# Tools path.
+ENV DEST=/usr/local/kubebuilder/bin/
+
+# Install dependencies.
+RUN apt update && \
+    apt install unzip rsync -y && \
+    mkdir -p $DEST
+
+# kube-apiserver
+WORKDIR /kubernetes
+RUN git clone https://github.com/kubernetes/kubernetes . --depth=1 -b ${KUBERNETES_VERSION}
+ENV CGO_ENABLED=0
+ENV KUBE_BUILD_PLATFORMS=${OS}/${ARCH}
+RUN make WHAT=cmd/kube-apiserver && \
+    cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kube-apiserver.exe $DEST
+
+# kubectl
+RUN /bin/bash -x -c ' \
+    { curl -sLO https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/${OS}/${ARCH}/kubectl.exe && \
+      chmod +x kubectl.exe &&  \
+      cp kubectl.exe $DEST; } || \
+    { make WHAT=cmd/kubectl && \
+      cp _output/local/bin/${KUBE_BUILD_PLATFORMS}/kubectl.exe $DEST; }'
+
+# etcd
+WORKDIR /etcd
+ENV ETCD_BASE_NAME=etcd-${ETCD_VERSION}-${OS}-${ARCH}
+RUN /bin/bash -x -c ' \
+    { curl -sLO https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${ETCD_BASE_NAME}.zip && \
+      unzip -o ${ETCD_BASE_NAME}.zip && \
+      cp ${ETCD_BASE_NAME}/etcd.exe $DEST; } || \
+    { rm -fr * && \
+      git clone https://github.com/etcd-io/etcd . --depth=1 -b ${ETCD_VERSION} && \
+      GOOS=${OS} GOARCH=${ARCH} ./build.sh && \
+      cp ./bin/etcd.exe $DEST; }'
+
+# Package into tarball.
+WORKDIR /usr/local
+RUN tar -czvf /kubebuilder_${OS}_${ARCH}.tar.gz kubebuilder/
+
+# Copy tarball to final image.
+FROM alpine:3.16
+
+# Platform args.
+ARG OS=windows
+ARG ARCH
+
+COPY --from=builder /kubebuilder_${OS}_${ARCH}.tar.gz /


### PR DESCRIPTION
This PR adds support for Windows builds in tools-releases, so that these can be used via setup-envtest. If this is merged, it will require enabling it in the GCP Cloud Build (I have no experience with that part).

I'm currently using the branch behind this PR in https://github.com/kluctl/kubebuilder-tools-releases-windows, which simply clones my kubebuilder fork, checks out the tools-releases-windows branch and manually runs the Docker build for the Windows release. I do this to trick setup-envtest into accepting the downloaded binaries when invoking it with `-i`, which will then later allow me to simply drop the manual downloading. You can find all this here: https://github.com/kluctl/kluctl/blob/main/Makefile#L60.

When this PR gets merged and GCP Cloud Build is updated as well, I will then be able to remove the manual downloading and simply rely on setup-envtest.