### PR TITLE
🐛: fixed bug for component-config flag

### DIFF
--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
@@ -115,7 +115,7 @@ spec:
       containers:
       - command:
         - /manager
-{{- if not .ComponentConfig }}
+{{- if .ComponentConfig }}
         args:
         - --leader-elect
 {{- end }}

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
@@ -115,7 +115,7 @@ spec:
       containers:
       - command:
         - /manager
-{{- if not .ComponentConfig }}
+{{- if .ComponentConfig }}
         args:
         - --leader-elect
 {{- end }}

--- a/testdata/project-v3-addon-and-grafana/config/manager/manager.yaml
+++ b/testdata/project-v3-addon-and-grafana/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -68,6 +68,8 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         env:

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-addon-and-grafana/config/manager/manager.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-config/config/manager/manager.yaml
+++ b/testdata/project-v4-config/config/manager/manager.yaml
@@ -68,6 +68,8 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         env:

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -68,8 +68,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
There are 2 places where we must revert the sign which we missed as part of old PR https://github.com/kubernetes-sigs/kubebuilder/pull/2826

```
{{- if not .ComponentConfig }}
        args:
        - --leader-elect
{{- end }}
```

it should be now modified to

```
{{- if .ComponentConfig }}
        args:
        - --leader-elect
{{- end }}
```

As of now, we are scaffolding the controller_manager_config.yaml file only when the flag --component-config is passed.

This fixes #3009 