### PR TITLE
:bug:: Fix controller-pod SA `permission denied` error

### DIFF
--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
@@ -105,6 +105,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
+        # if your K8s version <= 1.21, may need to uncomment the follow fsGroup to get SA token file access.
+        # fsGroup: 65532
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4-addon-and-grafana/config/manager/manager.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/manager/manager.yaml
@@ -58,6 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
+        # if your K8s version <= 1.21, may need to uncomment the follow fsGroup to get SA token file access.
+        # fsGroup: 65532
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4-config/config/manager/manager.yaml
+++ b/testdata/project-v4-config/config/manager/manager.yaml
@@ -58,6 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
+        # if your K8s version <= 1.21, may need to uncomment the follow fsGroup to get SA token file access.
+        # fsGroup: 65532
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -58,6 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
+        # if your K8s version <= 1.21, may need to uncomment the follow fsGroup to get SA token file access.
+        # fsGroup: 65532
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -58,6 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
+        # if your K8s version <= 1.21, may need to uncomment the follow fsGroup to get SA token file access.
+        # fsGroup: 65532
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -58,6 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
+        # if your K8s version <= 1.21, may need to uncomment the follow fsGroup to get SA token file access.
+        # fsGroup: 65532
         # TODO(user): For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted


### PR DESCRIPTION
Fixes #3028

Add `fsGroup` based on [dockerfile.go](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/v3/scaffolds/internal/templates/dockerfile.go#L71) to get proper access to open `serviceaccount` token file.
