### PR TITLE
:bug: Add leader election namespace to fix manager start error

### DIFF
--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/main.go
@@ -245,6 +245,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "{{ hashFNV .Repo }}.{{ .Domain }}",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v3-addon-and-grafana/main.go
+++ b/testdata/project-v3-addon-and-grafana/main.go
@@ -72,6 +72,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "5a3ee359.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v3-multigroup/main.go
+++ b/testdata/project-v3-multigroup/main.go
@@ -97,6 +97,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "14be1926.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v3-with-deploy-image/main.go
+++ b/testdata/project-v3-with-deploy-image/main.go
@@ -72,6 +72,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "4d73a076.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v3/main.go
+++ b/testdata/project-v3/main.go
@@ -72,6 +72,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "dd1da13f.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v4-addon-and-grafana/main.go
+++ b/testdata/project-v4-addon-and-grafana/main.go
@@ -72,6 +72,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "52a2c700.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v4-multigroup/main.go
+++ b/testdata/project-v4-multigroup/main.go
@@ -97,6 +97,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "3e9f67a9.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v4-with-deploy-image/main.go
+++ b/testdata/project-v4-with-deploy-image/main.go
@@ -72,6 +72,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "1836d577.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/testdata/project-v4/main.go
+++ b/testdata/project-v4/main.go
@@ -72,6 +72,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "da1d9c86.testproject.org",
+		// If you set "leader-elect = true" then "make run" to test the project outside of
+		// the cluster, should uncomment the following to set the leader-election namespace.
+		// LeaderElectionNamespace: "your-ns",
+		//
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
Fixes #3016
On generated code main.go L57, just set leader-election to `true`:
```
flag.BoolVar(&enableLeaderElection, "leader-elect", true, ...
```
Then `make run` will got error:
```
go run ./main.go
1.665666448465308e+09   ERROR   setup   unable to start manager {"error": "unable to find leader election namespace: not running in-cluster, please specify LeaderElectionNamespace"}
main.main
```

This PR is to add leader election namespace to fix this issue.
Plugins go/v3 and go/v4-alpha are updated.