### PR TITLE
✨ : added init and edit sub command plugin for component manager config file scaffolding

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/deploy-image/v1alpha1"
 	golangv2 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2"
 	golangv3 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3"
+	configv1alpha1 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/config/v1alpha"
 	grafanav1alpha1 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/grafana/v1alpha"
 )
 
@@ -71,6 +72,7 @@ func main() {
 			&declarativev1.Plugin{},
 			&deployimagev1alpha1.Plugin{},
 			&grafanav1alpha1.Plugin{},
+			&configv1alpha1.Plugin{},
 		),
 		cli.WithPlugins(externalPlugins...),
 		cli.WithDefaultPlugins(cfgv2.Version, golangv2.Plugin{}),

--- a/pkg/plugins/optional/config/v1alpha/commons.go
+++ b/pkg/plugins/optional/config/v1alpha/commons.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"errors"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+)
+
+func InsertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
+	err := target.DecodePluginConfig(pluginKey, cfg)
+	if !errors.As(err, &config.UnsupportedFieldError{}) {
+
+		if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
+			return err
+		}
+
+		if err = target.EncodePluginConfig(pluginKey, cfg); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/plugins/optional/config/v1alpha/constants.go
+++ b/pkg/plugins/optional/config/v1alpha/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+// nolint: lll
+const MetadataDescription = `This command will add Controller Manager Config file to the project:
+	('config/manager/controller_manager_config.yaml')
+`

--- a/pkg/plugins/optional/config/v1alpha/edit.go
+++ b/pkg/plugins/optional/config/v1alpha/edit.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/config/v1alpha/scaffolds"
+)
+
+var _ plugin.EditSubcommand = &editSubcommand{}
+
+type editSubcommand struct {
+	config config.Config
+}
+
+func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+	subcmdMeta.Description = MetadataDescription
+
+	subcmdMeta.Examples = fmt.Sprintf(`  # Edit a common project with this plugin
+  %[1]s edit --plugins=config.kubebuilder.io/v1-alpha
+`, cliMeta.CommandName)
+}
+
+func (p *editSubcommand) InjectConfig(c config.Config) error {
+	p.config = c
+	return nil
+}
+
+func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
+	if err := InsertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
+		return err
+	}
+
+	scaffolder := scaffolds.NewEditScaffolder()
+	scaffolder.InjectFS(fs)
+	return scaffolder.Scaffold()
+}

--- a/pkg/plugins/optional/config/v1alpha/init.go
+++ b/pkg/plugins/optional/config/v1alpha/init.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/config/v1alpha/scaffolds"
+)
+
+var _ plugin.InitSubcommand = &initSubcommand{}
+
+type initSubcommand struct {
+	config config.Config
+}
+
+func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+	subcmdMeta.Description = MetadataDescription
+
+	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a common project with this plugin
+  %[1]s init --plugins=config.kubebuilder.io/v1-alpha
+`, cliMeta.CommandName)
+}
+
+func (p *initSubcommand) InjectConfig(c config.Config) error {
+	p.config = c
+	return nil
+}
+
+func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
+	if err := InsertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
+		return err
+	}
+
+	scaffolder := scaffolds.NewInitScaffolder()
+	scaffolder.InjectFS(fs)
+	return scaffolder.Scaffold()
+}

--- a/pkg/plugins/optional/config/v1alpha/plugin.go
+++ b/pkg/plugins/optional/config/v1alpha/plugin.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/stage"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
+)
+
+const pluginName = "config." + plugins.DefaultNameQualifier
+
+var (
+	pluginVersion            = plugin.Version{Number: 1, Stage: stage.Alpha}
+	supportedProjectVersions = []config.Version{cfgv3.Version}
+	pluginKey                = plugin.KeyFor(Plugin{})
+)
+
+// Plugin implements the plugin.Full interface
+type Plugin struct {
+	initSubcommand
+	editSubcommand
+}
+
+var (
+	_ plugin.Init = Plugin{}
+)
+
+// Name returns the name of the plugin
+func (Plugin) Name() string { return pluginName }
+
+// Version returns the version of the grafana plugin
+func (Plugin) Version() plugin.Version { return pluginVersion }
+
+// SupportedProjectVersions returns an array with all project versions supported by the plugin
+func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }
+
+// GetInitSubcommand will return the subcommand which is responsible for initializing and scaffolding grafana manifests
+func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
+
+// GetEditSubcommand will return the subcommand which is responsible for adding grafana manifests
+func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
+
+type pluginConfig struct{}

--- a/pkg/plugins/optional/config/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/config/v1alpha/scaffolds/edit.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/config/v1alpha/scaffolds/internal/templates"
+)
+
+var _ plugins.Scaffolder = &editScaffolder{}
+
+type editScaffolder struct {
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
+}
+
+// NewEditScaffolder returns a new Scaffolder for project edition operations
+func NewEditScaffolder() plugins.Scaffolder {
+	return &editScaffolder{}
+}
+
+// InjectFS implements cmdutil.Scaffolder
+func (s *editScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
+// Scaffold implements cmdutil.Scaffolder
+func (s *editScaffolder) Scaffold() error {
+	fmt.Println("Generating Grafana manifests to visualize controller status...")
+
+	// Initialize the machinery.Scaffold that will write the files to disk
+	scaffold := machinery.NewScaffold(s.fs)
+
+	return scaffold.Execute(
+		&templates.ControllerManagerConfig{},
+	)
+}

--- a/pkg/plugins/optional/config/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/config/v1alpha/scaffolds/init.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/config/v1alpha/scaffolds/internal/templates"
+)
+
+var _ plugins.Scaffolder = &initScaffolder{}
+
+type initScaffolder struct {
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
+}
+
+// NewInitScaffolder returns a new Scaffolder for project initialization operations
+func NewInitScaffolder() plugins.Scaffolder {
+	return &initScaffolder{}
+}
+
+// InjectFS implements cmdutil.Scaffolder
+func (s *initScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
+// Scaffold implements cmdutil.Scaffolder
+func (s *initScaffolder) Scaffold() error {
+	fmt.Println("Generating config/manager/controller_manager_config.yaml file...")
+
+	// Initialize the machinery.Scaffold that will write the files to disk
+	scaffold := machinery.NewScaffold(s.fs)
+
+	return scaffold.Execute(
+		&templates.ControllerManagerConfig{},
+	)
+}

--- a/pkg/plugins/optional/config/v1alpha/scaffolds/internal/templates/config.go
+++ b/pkg/plugins/optional/config/v1alpha/scaffolds/internal/templates/config.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &ControllerManagerConfig{}
+
+// ControllerManagerConfig scaffolds the config file in config/manager folder.
+type ControllerManagerConfig struct {
+	machinery.TemplateMixin
+	machinery.DomainMixin
+	machinery.RepositoryMixin
+	machinery.ProjectNameMixin
+}
+
+// SetTemplateDefaults implements input.Template
+func (f *ControllerManagerConfig) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "manager", "controller_manager_config.yaml")
+	}
+
+	f.TemplateBody = controllerManagerConfigTemplate
+
+	f.IfExistsAction = machinery.Error
+
+	return nil
+}
+
+const controllerManagerConfigTemplate = `apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+kind: ControllerManagerConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: controllermanagerconfig
+    app.kubernetes.io/instance: controller-manager-configuration
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: {{ .ProjectName }}
+    app.kubernetes.io/part-of: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: 127.0.0.1:8080
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: true
+  resourceName: {{ hashFNV .Repo }}.{{ .Domain }}
+# leaderElectionReleaseOnCancel defines if the leader should step down volume
+# when the Manager ends. This requires the binary to immediately end when the
+# Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+# speeds up voluntary leader transitions as the new leader don't have to wait
+# LeaseDuration time first.
+# In the default scaffold provided, the program ends immediately after
+# the manager stops, so would be fine to enable this option. However,
+# if you are doing or is intended to do any operation such as perform cleanups
+# after the manager stops then its usage might be unsafe.
+# leaderElectionReleaseOnCancel: true
+`


### PR DESCRIPTION
Add init and edit sub command plugin for component manager config file scaffolding.

Current output for the command:

```
laxmikantbhaskarpandhare@lpandhar-mac v1alpha1 % kubebuilder init --plugins config.kubebuilder.io/v1-alpha
Generating config/manager/controller_manager_config.yaml file...
laxmikantbhaskarpandhare@lpandhar-mac v1alpha1 % tree
.
├── PROJECT
└── config
    └── manager
        └── controller_manager_config.yaml

2 directories, 2 files
```

Also, edit sub command is working

```
laxmikantbhaskarpandhare@lpandhar-mac test-scaffold-init % tree                                             
.
└── PROJECT

0 directories, 1 file
laxmikantbhaskarpandhare@lpandhar-mac test-scaffold-init % kubebuilder edit --plugins config.kubebuilder.io/v1-alpha
Generating Grafana manifests to visualize controller status...
laxmikantbhaskarpandhare@lpandhar-mac test-scaffold-init % tree
.
├── PROJECT
└── config
    └── manager
        └── controller_manager_config.yaml

2 directories, 2 files
```