### PR TITLE
🌱  golangci-lint: add recommended revive checks to linter-settings but d…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  deadline: 5m
+  allow-parallel-runners: true
+
 issues:
   # don't skip warning about doc comments
   # don't exclude the default set of lint
@@ -13,8 +17,42 @@ linters-settings:
     enable=fieldalignment: true
   revive:
     rules:
-    - name: if-return
-      disabled: true
+      # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+        disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
+      - name: if-return
+        disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
+      - name: increment-decrement
+      - name: var-naming
+        disabled: true   # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
+      - name: var-declaration
+      - name: package-comments
+        disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+        disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
+      - name: superfluous-else
+      - name: unused-parameter
+        disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      #
+      # Rules in addition to the recommended configuration above.
+      #
+      - name: bool-literal-in-expr
+      - name: constant-logical-expr
 
 linters:
   disable-all: true
@@ -40,6 +78,3 @@ linters:
     - unconvert
     - unparam
     - unused
-
-run:
-  deadline: 5m

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.49.0 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.51.1 ;\
 	}
 
 .PHONY: apidiff

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -270,14 +270,14 @@ func (t *TestContext) LoadImageToKindCluster() error {
 }
 
 // LoadImageToKindClusterWithName loads a local docker image with the name informed to the kind cluster
-func (tc TestContext) LoadImageToKindClusterWithName(image string) error {
+func (t TestContext) LoadImageToKindClusterWithName(image string) error {
 	cluster := "kind"
 	if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
 		cluster = v
 	}
 	kindOptions := []string{"load", "docker-image", "--name", cluster, image}
 	cmd := exec.Command("kind", kindOptions...)
-	_, err := tc.Run(cmd)
+	_, err := t.Run(cmd)
 	return err
 }
 


### PR DESCRIPTION
* Updates golangci-lint version from 1.49.0 -> 1.50.1
* Adds [all recommended revive checks](https://github.com/mgechev/revive#recommended-configuration) to the config file. However to keep this pr simpler some new checks where disabled. But at least it's explicit now there are recommended checks that aren't enabled. I would gladly look into each of the disabled checks in follow up prs. 
* Fixes the finding:
   ```
   test/e2e/utils/test_context.go:273:1: receiver-naming: receiver name tc should be consistent with previous receiver name t for TestContext (revive)

   func (tc TestContext) LoadImageToKindClusterWithName(image string) error {
        cluster := "kind"
        if v, ok := os.LookupEnv("KIND_CLUSTER"); ok {
                cluster = v
        }
        kindOptions := []string{"load", "docker-image", "--name", cluster, image}
        cmd := exec.Command("kind", kindOptions...)
        _, err := tc.Run(cmd)
        return err
   }
   ```
