### PR TITLE
📖 update cronjob to use batchv1 api instead of v1beta1

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -22,7 +22,7 @@ package v1
 /*
  */
 import (
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -88,7 +88,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty"`
 
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate batchv1beta1.JobTemplateSpec `json:"jobTemplate"`
+	JobTemplate batchv1.JobTemplateSpec `json:"jobTemplate"`
 
 	//+kubebuilder:validation:Minimum=0
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller_test.go
@@ -32,7 +32,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,7 +77,7 @@ var _ = Describe("CronJob controller", func() {
 				},
 				Spec: cronjobv1.CronJobSpec{
 					Schedule: "1 * * * *",
-					JobTemplate: batchv1beta1.JobTemplateSpec{
+					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							// For simplicity, we only fill out the required fields.
 							Template: v1.PodTemplateSpec{

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -22,7 +22,7 @@ package v1
 /*
  */
 import (
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -60,7 +60,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty"`
 
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate batchv1beta1.JobTemplateSpec `json:"jobTemplate"`
+	JobTemplate batchv1.JobTemplateSpec `json:"jobTemplate"`
 
 	// +kubebuilder:validation:Minimum=0
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
@@ -25,7 +25,7 @@ package v2
 /*
  */
 import (
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -67,7 +67,7 @@ type CronJobSpec struct {
 	Suspend *bool `json:"suspend,omitempty"`
 
 	// Specifies the job that will be created when executing a CronJob.
-	JobTemplate batchv1beta1.JobTemplateSpec `json:"jobTemplate"`
+	JobTemplate batchv1.JobTemplateSpec `json:"jobTemplate"`
 
 	// +kubebuilder:validation:Minimum=0
 

--- a/pkg/plugin/util/testdata/exampleFile.txt
+++ b/pkg/plugin/util/testdata/exampleFile.txt
@@ -1,1 +1,1 @@
-exampleTarget
+exampleTargetexampleCodeexampleCode


### PR DESCRIPTION
Issue: https://github.com/kubernetes-sigs/kubebuilder/issues/3031

Update tutorial to use the batchv1 API version for cronjob. 