### PR TITLE
📖 Fix grammar in comment

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/controllers/cronjob_controller.go
@@ -271,7 +271,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		around.
 	*/
 
-	// NB: deleting these is "best effort" -- if we fail on a particular one,
+	// NB: deleting these are "best effort" -- if we fail on a particular one,
 	// we won't requeue just to finish the deleting.
 	if cronJob.Spec.FailedJobsHistoryLimit != nil {
 		sort.Slice(failedJobs, func(i, j int) bool {


### PR DESCRIPTION
Change `these is` to `these are` in a comment in cronjob_controller.go.

The verb `is` is singular, whereas `are` is plural. The comment is there to document iterating over multiple failed jobs. So, it would be appropriate to use a plural verb.

Here's to comment for context:
>	// NB: deleting these is "best effort" -- if we fail on a particular one,
>	// we won't requeue just to finish the deleting.
