### PR TITLE
🌱 Enable revive unused-parameter check and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,6 @@ linters-settings:
         disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
       - name: superfluous-else
       - name: unused-parameter
-        disabled: true  # TODO: Investigate if it should be enabled. Disabled for now due to many findings.
       - name: unreachable-code
       - name: redefines-builtin-id
       #

--- a/pkg/plugins/external/api.go
+++ b/pkg/plugins/external/api.go
@@ -41,7 +41,7 @@ func (p *createAPISubcommand) InjectResource(*resource.Resource) error {
 	return nil
 }
 
-func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+func (p *createAPISubcommand) UpdateMetadata(_ plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	setExternalPluginMetadata("api", p.Path, subcmdMeta)
 }
 

--- a/pkg/plugins/external/edit.go
+++ b/pkg/plugins/external/edit.go
@@ -31,7 +31,7 @@ type editSubcommand struct {
 	Args []string
 }
 
-func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+func (p *editSubcommand) UpdateMetadata(_ plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	setExternalPluginMetadata("edit", p.Path, subcmdMeta)
 }
 

--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -44,7 +44,7 @@ type mockInValidOutputGetter struct{}
 
 var _ ExecOutputGetter = &mockValidOutputGetter{}
 
-func (m *mockValidOutputGetter) GetExecOutput(request []byte, path string) ([]byte, error) {
+func (m *mockValidOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, error) {
 	return []byte(`{
 		"command": "init", 
 		"error": false, 
@@ -55,7 +55,7 @@ func (m *mockValidOutputGetter) GetExecOutput(request []byte, path string) ([]by
 
 var _ ExecOutputGetter = &mockInValidOutputGetter{}
 
-func (m *mockInValidOutputGetter) GetExecOutput(request []byte, path string) ([]byte, error) {
+func (m *mockInValidOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, error) {
 	return nil, fmt.Errorf("error getting exec command output")
 }
 
@@ -77,7 +77,7 @@ func (m *mockInValidOsWdGetter) GetCurrentDir() (string, error) {
 
 type mockValidFlagOutputGetter struct{}
 
-func (m *mockValidFlagOutputGetter) GetExecOutput(req []byte, path string) ([]byte, error) {
+func (m *mockValidFlagOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, error) {
 	response := external.PluginResponse{
 		Command:  "flag",
 		Error:    false,
@@ -89,7 +89,7 @@ func (m *mockValidFlagOutputGetter) GetExecOutput(req []byte, path string) ([]by
 
 type mockValidMEOutputGetter struct{}
 
-func (m *mockValidMEOutputGetter) GetExecOutput(req []byte, path string) ([]byte, error) {
+func (m *mockValidMEOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, error) {
 	response := external.PluginResponse{
 		Command:  "metadata",
 		Error:    false,

--- a/pkg/plugins/external/init.go
+++ b/pkg/plugins/external/init.go
@@ -31,7 +31,7 @@ type initSubcommand struct {
 	Args []string
 }
 
-func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+func (p *initSubcommand) UpdateMetadata(_ plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	setExternalPluginMetadata("init", p.Path, subcmdMeta)
 }
 

--- a/pkg/plugins/external/webhook.go
+++ b/pkg/plugins/external/webhook.go
@@ -37,7 +37,7 @@ func (p *createWebhookSubcommand) InjectResource(*resource.Resource) error {
 	return nil
 }
 
-func (p *createWebhookSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+func (p *createWebhookSubcommand) UpdateMetadata(_ plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	setExternalPluginMetadata("webhook", p.Path, subcmdMeta)
 }
 

--- a/pkg/plugins/golang/declarative/v1/init.go
+++ b/pkg/plugins/golang/declarative/v1/init.go
@@ -40,7 +40,7 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 	return nil
 }
 
-func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
+func (p *initSubcommand) Scaffold(_ machinery.Filesystem) error {
 	err := updateDockerfile()
 	if err != nil {
 		return err


### PR DESCRIPTION
Enables the revive unused-parameter check and fixes all the findings. This is one of the recommended checks to have enabled but wasn't enabled in #3034 due to many findings.