### PR TITLE
🌱 Update github workflow to use same golangci-lint minor version as Makefile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49 # Always uses the latest patch version.
+          version: v1.50
           only-new-issues: true # Show only new issues if it's a pull request
       - name: Report failure
         uses: nashmaniac/create-issue-action@v1.1

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.51.1 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.50.1 ;\
 	}
 
 .PHONY: apidiff


### PR DESCRIPTION
This pr ensures the GitHub workflow uses the same minor version of golangci-lint as installed by the Makefile as can be seen here: https://github.com/kubernetes-sigs/kubebuilder/blob/523907a7e70a7b3d02c2df91382f6b1ee2ca4c54/Makefile#L86
 