### PR TITLE
🐛 (kustomize/v2-alpha): Fix typo issue in the labels added to the manifests

### DIFF
--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -48,7 +48,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
+    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: {{ .ProjectName }}

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/rbac/leader_election_role.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/rbac/leader_election_role.go
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ .ProjectName }}
     app.kubernetes.io/part-of: {{ .ProjectName }}
-    app.kubernets.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:

--- a/testdata/project-v3-addon-and-grafana/Makefile
+++ b/testdata/project-v3-addon-and-grafana/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v3-config/Makefile
+++ b/testdata/project-v3-config/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v3-multigroup/Makefile
+++ b/testdata/project-v3-multigroup/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v3-with-deploy-image/Makefile
+++ b/testdata/project-v3-with-deploy-image/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v3/Makefile
+++ b/testdata/project-v3/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v4-addon-and-grafana/Makefile
+++ b/testdata/project-v4-addon-and-grafana/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v4-addon-and-grafana/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
+    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: project-v4-addon-and-grafana

--- a/testdata/project-v4-addon-and-grafana/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v4-addon-and-grafana/config/rbac/leader_election_role.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v4-addon-and-grafana
     app.kubernetes.io/part-of: project-v4-addon-and-grafana
-    app.kubernets.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:

--- a/testdata/project-v4-config/Makefile
+++ b/testdata/project-v4-config/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v4-config/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-config/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
+    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: project-v4-config

--- a/testdata/project-v4-config/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v4-config/config/rbac/leader_election_role.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v4-config
     app.kubernetes.io/part-of: project-v4-config
-    app.kubernets.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v4-multigroup/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
+    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: project-v4-multigroup

--- a/testdata/project-v4-multigroup/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/leader_election_role.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v4-multigroup
     app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernets.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:

--- a/testdata/project-v4-with-deploy-image/Makefile
+++ b/testdata/project-v4-with-deploy-image/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v4-with-deploy-image/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-with-deploy-image/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
+    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: project-v4-with-deploy-image

--- a/testdata/project-v4-with-deploy-image/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v4-with-deploy-image/config/rbac/leader_election_role.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v4-with-deploy-image
     app.kubernetes.io/part-of: project-v4-with-deploy-image
-    app.kubernets.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -92,7 +92,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 

--- a/testdata/project-v4/config/prometheus/monitor.yaml
+++ b/testdata/project-v4/config/prometheus/monitor.yaml
@@ -5,7 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernets.io/name: servicemonitor
+    app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: project-v4

--- a/testdata/project-v4/config/rbac/leader_election_role.yaml
+++ b/testdata/project-v4/config/rbac/leader_election_role.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: project-v4
     app.kubernetes.io/part-of: project-v4
-    app.kubernets.io/managed-by: kustomize
+    app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:
 - apiGroups:


### PR DESCRIPTION
## Description

Fix a typo issue in the labels added to the manifests into the (kustomize/v2-alpha)
The same type of issue is not faced with the kustomize/v1 plugin, see: https://github.com/kubernetes-sigs/kubebuilder/search?q=app.kubernets.io%2Fname

## Motivation

Ensure that the labels added to the manifests scaffolds under the config with the plugin go/v4-alpha are correctly (not missing the `e`):


![Screenshot 2022-10-26 at 16 25 29](https://user-images.githubusercontent.com/7708031/198068405-52b763ee-ef34-452c-988f-55b3059da875.png)

`
