### PR TITLE
:seedling: Add KB project git-repo and edit icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ WORKSPACE
 # don't check in the build output of the book
 docs/book/book/
 
+# ignore auto-generated dir by `mdbook serve`
+docs/book/src/docs
+
 # Editor temp files
 *~
 \#*#

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -8,6 +8,8 @@ title = "The Kubebuilder Book"
 google-analytics = "UA-119864590-1"
 curly-quotes = true
 additional-css = ["theme/css/markers.css", "theme/css/custom.css"]
+git-repository-url = "https://github.com/kubernetes-sigs/kubebuilder"
+edit-url-template = "https://github.com/kubernetes-sigs/kubebuilder/edit/master/docs/book/{path}"
 
 [preprocessor.literatego]
 command = "./litgo.sh"

--- a/docs/book/theme/index.hbs
+++ b/docs/book/theme/index.hbs
@@ -139,6 +139,11 @@
                             <i id="git-repository-button" class="fa {{git_repository_icon}}"></i>
                         </a>
                         {{/if}}
+                        {{#if git_repository_edit_url}}
+                            <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit">
+                                <i id="git-edit-button" class="fa fa-edit"></i>
+                            </a>
+                        {{/if}}
                     </div>
                 </div>
 


### PR DESCRIPTION
Add `git-repo` and `git-edit` icons on the top-right page, to let other users to go to KB project quickly, and
go to the edit page easily if want to modify the doc.

Tested with `mdbook serve` locally, works fine.