### PR TITLE
🌱  Update joelanford/go-apidiff (v0.4.0 -> v0.5.0)

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version: "1.19"
       - name: Execute go-apidiff
-        uses: joelanford/go-apidiff@v0.4.0
+        uses: joelanford/go-apidiff@v0.5.0
         with:
           compare-imports: true
           print-compatible: true

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ apidiff: go-apidiff ## Run the go-apidiff to verify any API differences compared
 
 .PHONY: go-apidiff
 go-apidiff:
-	go install github.com/joelanford/go-apidiff@v0.4.0
+	go install github.com/joelanford/go-apidiff@v0.5.0
 
 ##@ Tests
 


### PR DESCRIPTION
Minor chore pr to just keep dependencies up to date. Updates joelanford/go-apidiff from v0.4.0 to v0.5.0. 

Release notes seem safe: https://github.com/joelanford/go-apidiff/releases/tag/v0.5.0