### PR TITLE
:seedling: add GitHub Action to lint yaml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,3 +50,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: kind/bug
           body: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: testdata
+          config_data: "{extends: relaxed, rules: {line-length: {max: 120}}}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,10 +50,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: kind/bug
           body: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run yamllint make target
-        run: make yamllint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,3 +50,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: kind/bug
           body: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run yamllint make target
+        run: make yamllint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,8 +55,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          file_or_dir: testdata
-          config_data: "{extends: relaxed, rules: {line-length: {max: 120}}}"
+      - name: Run yamllint make target
+        run: make yamllint

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ generate-testdata: ## Update/generate the testdata in $GOPATH/src/sigs.k8s.io/ku
 	./test/testdata/generate.sh
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint yamllint ## Run golangci-lint linter & yamllint
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+.PHONY: yamllint
+yamllint:
+	@docker run --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest testdata -d "{extends: relaxed, rules: {line-length: {max: 120}}}" --no-warnings
+
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
@@ -44,7 +44,7 @@ func (f *KustomizeConfig) SetTemplateDefaults() error {
 }
 
 //nolint:lll
-const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
+const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v1/scaffolds/internal/templates/config/manager/config.go
@@ -84,7 +84,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
@@ -44,7 +44,7 @@ func (f *KustomizeConfig) SetTemplateDefaults() error {
 }
 
 //nolint:lll
-const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref substitution 
+const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2-alpha/scaffolds/internal/templates/config/manager/config.go
@@ -84,7 +84,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -327,5 +327,5 @@ const recorderTemplate = `
 		Recorder: mgr.GetEventRecorderFor("%s-controller"),`
 
 const envVarTemplate = `
-        - name: %s_IMAGE 
+        - name: %s_IMAGE
           value: %s`

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -49,12 +49,11 @@ kind: {{ .Resource.Kind }}
 metadata:
   name: {{ lower .Resource.Kind }}-sample
 spec:
-  # TODO(user): edit the following value to ensure the number 
-  # of Pods/Instances your Operand must have on cluster        
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
   size: 1
-
-  {{ if not (isEmptyStr .Port) -}}
+{{ if not (isEmptyStr .Port) -}}
   # TODO(user): edit the following value to ensure the container has the right port to be initialized
-  containerPort: {{ .Port }}	
-  {{- end }}
+  containerPort: {{ .Port }}
+{{- end }}
 `

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager/certificate.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager/certificate.go
@@ -42,7 +42,7 @@ func (f *Certificate) SetTemplateDefaults() error {
 
 const certManagerTemplate = `# The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
+# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for
 # breaking changes
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
@@ -41,7 +41,7 @@ func (f *KustomizeConfig) SetTemplateDefaults() error {
 }
 
 //nolint:lll
-const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution 
+const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -42,7 +42,7 @@ func (f *ManagerAuthProxyPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the 
+const kustomizeAuthProxyPatchTemplate = `# This patch inject a sidecar container which is a HTTP proxy for the
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment

--- a/testdata/project-v2/config/certmanager/certificate.yaml
+++ b/testdata/project-v2/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
+# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for
 # breaking changes
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer

--- a/testdata/project-v2/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v2/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v2/config/default/manager_auth_proxy_patch.yaml
@@ -1,4 +1,4 @@
-# This patch inject a sidecar container which is a HTTP proxy for the 
+# This patch inject a sidecar container which is a HTTP proxy for the
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment

--- a/testdata/project-v3-config/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v3-config/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v3-config/config/manager/manager.yaml
+++ b/testdata/project-v3-config/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v3-declarative-v1/config/manager/manager.yaml
+++ b/testdata/project-v3-declarative-v1/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v3-multigroup/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v3-multigroup/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v3-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v3-multigroup/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v3-with-deploy-image/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v3-with-deploy-image/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v3-with-deploy-image/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:
@@ -73,9 +73,9 @@ spec:
         image: controller:latest
         name: manager
         env:
-        - name: BUSYBOX_IMAGE 
+        - name: BUSYBOX_IMAGE
           value: busybox:1.28
-        - name: MEMCACHED_IMAGE 
+        - name: MEMCACHED_IMAGE
           value: memcached:1.4.36-alpine
         securityContext:
           allowPrivilegeEscalation: false

--- a/testdata/project-v3-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
+++ b/testdata/project-v3-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
@@ -3,8 +3,7 @@ kind: Busybox
 metadata:
   name: busybox-sample
 spec:
-  # TODO(user): edit the following value to ensure the number 
-  # of Pods/Instances your Operand must have on cluster        
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
   size: 1
 
-  

--- a/testdata/project-v3-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
+++ b/testdata/project-v3-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
@@ -3,9 +3,8 @@ kind: Memcached
 metadata:
   name: memcached-sample
 spec:
-  # TODO(user): edit the following value to ensure the number 
-  # of Pods/Instances your Operand must have on cluster        
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
   size: 1
-
-  # TODO(user): edit the following value to ensure the container has the right port to be initialized
+# TODO(user): edit the following value to ensure the container has the right port to be initialized
   containerPort: 11211

--- a/testdata/project-v3-with-metrics/config/manager/manager.yaml
+++ b/testdata/project-v3-with-metrics/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v3/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v3/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v3/config/manager/manager.yaml
+++ b/testdata/project-v3/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v4-config/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v4-config/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref substitution 
+# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v4-config/config/manager/manager.yaml
+++ b/testdata/project-v4-config/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v4-declarative-v1/config/manager/manager.yaml
+++ b/testdata/project-v4-declarative-v1/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v4-multigroup/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v4-multigroup/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref substitution 
+# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v4-with-deploy-image/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v4-with-deploy-image/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref substitution 
+# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:
@@ -73,9 +73,9 @@ spec:
         image: controller:latest
         name: manager
         env:
-        - name: BUSYBOX_IMAGE 
+        - name: BUSYBOX_IMAGE
           value: busybox:1.28
-        - name: MEMCACHED_IMAGE 
+        - name: MEMCACHED_IMAGE
           value: memcached:1.4.36-alpine
         securityContext:
           allowPrivilegeEscalation: false

--- a/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
@@ -3,8 +3,7 @@ kind: Busybox
 metadata:
   name: busybox-sample
 spec:
-  # TODO(user): edit the following value to ensure the number 
-  # of Pods/Instances your Operand must have on cluster        
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
   size: 1
 
-  

--- a/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
@@ -3,9 +3,8 @@ kind: Memcached
 metadata:
   name: memcached-sample
 spec:
-  # TODO(user): edit the following value to ensure the number 
-  # of Pods/Instances your Operand must have on cluster        
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
   size: 1
-
-  # TODO(user): edit the following value to ensure the container has the right port to be initialized
+# TODO(user): edit the following value to ensure the container has the right port to be initialized
   containerPort: 11211

--- a/testdata/project-v4-with-metrics/config/manager/manager.yaml
+++ b/testdata/project-v4-with-metrics/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:

--- a/testdata/project-v4/config/certmanager/kustomizeconfig.yaml
+++ b/testdata/project-v4/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref substitution 
+# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -37,7 +37,7 @@ spec:
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution. 
+      # according to the platforms which are supported by your solution.
       # It is considered best practice to support multiple architectures. You can
       # build your manager image using the makefile target docker-buildx.
       # affinity:


### PR DESCRIPTION
## Description
- Add a GitHub Action job to run `yamllint` on the testdata directory. 
    - I used the same `yamllint` configuration that is used in the Operator-SDK ansible operator e2e tests: https://github.com/operator-framework/operator-sdk/blob/f298f7c92ee154a0e8123fb13398a7f21720cf0e/testdata/ansible/memcached-operator/molecule/default/molecule.yml#L8
- Fix any existing errors from running `yamllint -f parsable testdata --no-warnings -d "{extends: relaxed, rules: {line-length: {max: 120}}}"`

## Motivation
- Fixes #3019 