### PR TITLE
✨ (WIP) feat: initialize kube-state-metrics plugin

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	golangv3 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3"
 	golangv4 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4"
 	grafanav1alpha1 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/grafana/v1alpha"
+	kubestatemetricsv1alpha1 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/kube-state-metrics/v1alpha"
 )
 
 func main() {
@@ -73,6 +74,7 @@ func main() {
 			&declarativev1.Plugin{},
 			&deployimagev1alpha1.Plugin{},
 			&grafanav1alpha1.Plugin{},
+			&kubestatemetricsv1alpha1.Plugin{},
 		),
 		cli.WithPlugins(externalPlugins...),
 		cli.WithDefaultPlugins(cfgv2.Version, golangv2.Plugin{}),

--- a/pkg/plugins/optional/kube-state-metrics/v1alpha/commons.go
+++ b/pkg/plugins/optional/kube-state-metrics/v1alpha/commons.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"errors"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+)
+
+func InsertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
+	err := target.DecodePluginConfig(pluginKey, cfg)
+	if !errors.As(err, &config.UnsupportedFieldError{}) {
+
+		if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
+			return err
+		}
+
+		if err = target.EncodePluginConfig(pluginKey, cfg); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/plugins/optional/kube-state-metrics/v1alpha/constants.go
+++ b/pkg/plugins/optional/kube-state-metrics/v1alpha/constants.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+// nolint: lll
+const MetaDataDescription = `This command will provide kube-state-metrics custom resource config to the project:
+  - A yaml file enables ksm to populate state metrics for your CR.
+	('kube-state-metrics/cr-config.yaml')
+
+NOTE: This plugin requires:
+- kube-state-metrics to be installed in your cluster
+- rbac of ksm to access your CRs' status
+`

--- a/pkg/plugins/optional/kube-state-metrics/v1alpha/edit.go
+++ b/pkg/plugins/optional/kube-state-metrics/v1alpha/edit.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/kube-state-metrics/v1alpha/scaffolds"
+)
+
+var _ plugin.EditSubcommand = &editSubcommand{}
+
+type editSubcommand struct {
+	config config.Config
+}
+
+func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+	subcmdMeta.Description = MetaDataDescription
+	subcmdMeta.Examples = fmt.Sprintf(`  # Edit a common project with this plugin
+  %[1]s edit --plugins=kube-state-metrics.kubebuilder.io/v1-alpha
+`, cliMeta.CommandName)
+}
+
+func (p *editSubcommand) InjectConfig(c config.Config) error {
+	p.config = c
+	return nil
+}
+
+func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
+	if err := InsertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
+		return err
+	}
+
+	scaffolder := scaffolds.NewEditScaffolder(p.config)
+
+	scaffolder.InjectFS(fs)
+
+	return scaffolder.Scaffold()
+}

--- a/pkg/plugins/optional/kube-state-metrics/v1alpha/plugin.go
+++ b/pkg/plugins/optional/kube-state-metrics/v1alpha/plugin.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	cfgv3 "sigs.k8s.io/kubebuilder/v3/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/stage"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
+)
+
+const pluginName = "kube-state-metrics." + plugins.DefaultNameQualifier
+
+var (
+	pluginVersion            = plugin.Version{Number: 1, Stage: stage.Alpha}
+	supportedProjectVersions = []config.Version{cfgv3.Version}
+	pluginKey                = plugin.KeyFor(Plugin{})
+)
+
+type Plugin struct {
+	editSubcommand
+}
+
+var (
+	_ plugin.Edit = Plugin{}
+)
+
+// Name returns the name of the plugin
+func (Plugin) Name() string { return pluginName }
+
+// Version returns the version of the kube-state-metrics plugin
+func (Plugin) Version() plugin.Version { return pluginVersion }
+
+// SupportedProjectVersions returns an array of all project versions supported by the plugin
+func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }
+
+// GetEditSubcommand returns the subcommand which provides ksm CR config
+func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
+
+type pluginConfig struct{}

--- a/pkg/plugins/optional/kube-state-metrics/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/kube-state-metrics/v1alpha/scaffolds/edit.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"sigs.k8s.io/kubebuilder/v3/pkg/config"
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/optional/kube-state-metrics/v1alpha/scaffolds/internal/templates"
+)
+
+var _ plugins.Scaffolder = &editScaffolder{}
+
+type editScaffolder struct {
+	fs     machinery.Filesystem
+	config config.Config
+}
+
+func NewEditScaffolder(config config.Config) plugins.Scaffolder {
+	return &editScaffolder{
+		config: config,
+	}
+}
+
+func (s *editScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
+func (s *editScaffolder) Scaffold() error {
+	rs, err := s.config.GetResources()
+	if err != nil {
+		return err
+	}
+
+	gvks := []resource.GVK{}
+	for _, r := range rs {
+		gvks = append(gvks, r.Copy().GVK)
+	}
+
+	scaffold := machinery.NewScaffold(s.fs)
+
+	return scaffold.Execute(
+		&templates.ConfigManifest{GVKs: gvks},
+	)
+}

--- a/pkg/plugins/optional/kube-state-metrics/v1alpha/scaffolds/internal/templates/config.go
+++ b/pkg/plugins/optional/kube-state-metrics/v1alpha/scaffolds/internal/templates/config.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"text/template"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
+)
+
+var _ machinery.Template = &ConfigManifest{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type ConfigManifest struct {
+	machinery.TemplateMixin
+
+	// Custom Resource to be instrumented
+	GVKs []resource.GVK
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *ConfigManifest) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("kube-state-metrics", "cr-config.yaml")
+	}
+
+	defaultTemplate, err := f.createTemplate()
+	if err != nil {
+		return err
+	}
+
+	f.TemplateBody = defaultTemplate
+
+	f.IfExistsAction = machinery.OverwriteFile
+
+	return nil
+}
+
+func (f *ConfigManifest) createTemplate() (string, error) {
+	t := template.Must(template.New("customResourcesConfig").Parse(customResourcesConfigTemplate))
+
+	outputTmpl := &bytes.Buffer{}
+	if err := t.Execute(outputTmpl, f.GVKs); err != nil {
+		return "", fmt.Errorf("error when generating kube-state-metrics config: %w", err)
+	}
+
+	return outputTmpl.String(), nil
+}
+
+// nolint: lll
+const customResourcesConfigTemplate = `---
+kind: CustomResourceStateMetrics
+spec:
+  resources:{{ range $i, $e := . }}
+    - groupVersionKind:
+        group: "{{.Group}}.{{.Domain}}"
+        kind: "{{.Kind}}"
+        version: "{{.Version}}"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version{{ end }}
+`

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -118,6 +118,11 @@ function scaffold_test_project {
       $kb edit --plugins=grafana.kubebuilder.io/v1-alpha
   fi
 
+  if [[ $project == "project-v3" || $project == "project-v4" || $project =~ multigroup ]]; then
+     header_text 'Editing project with kube-state-metrics plugin ...'
+     $kb edit --plugins=kube-state-metrics.kubebuilder.io/v1-alpha
+  fi
+
   make generate manifests
   rm -f go.sum
 

--- a/testdata/project-v3-multigroup/PROJECT
+++ b/testdata/project-v3-multigroup/PROJECT
@@ -6,6 +6,8 @@ domain: testproject.org
 layout:
 - go.kubebuilder.io/v3
 multigroup: true
+plugins:
+  kube-state-metrics.kubebuilder.io/v1-alpha: {}
 projectName: project-v3-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3-multigroup
 resources:

--- a/testdata/project-v3-multigroup/kube-state-metrics/cr-config.yaml
+++ b/testdata/project-v3-multigroup/kube-state-metrics/cr-config.yaml
@@ -1,0 +1,257 @@
+---
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Captain"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "ship.testproject.org"
+        kind: "Frigate"
+        version: "v1beta1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "ship.testproject.org"
+        kind: "Destroyer"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "ship.testproject.org"
+        kind: "Cruiser"
+        version: "v2alpha1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "sea-creatures.testproject.org"
+        kind: "Kraken"
+        version: "v1beta1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "sea-creatures.testproject.org"
+        kind: "Leviathan"
+        version: "v1beta2"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "foo.policy.testproject.org"
+        kind: "HealthCheckPolicy"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "apps."
+        kind: "Deployment"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "foo.testproject.org"
+        kind: "Bar"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "fiz.testproject.org"
+        kind: "Bar"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: ".testproject.org"
+        kind: "Lakers"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version

--- a/testdata/project-v3/PROJECT
+++ b/testdata/project-v3/PROJECT
@@ -5,6 +5,8 @@
 domain: testproject.org
 layout:
 - go.kubebuilder.io/v3
+plugins:
+  kube-state-metrics.kubebuilder.io/v1-alpha: {}
 projectName: project-v3
 repo: sigs.k8s.io/kubebuilder/testdata/project-v3
 resources:

--- a/testdata/project-v3/kube-state-metrics/cr-config.yaml
+++ b/testdata/project-v3/kube-state-metrics/cr-config.yaml
@@ -1,0 +1,96 @@
+---
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Captain"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "FirstMate"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Admiral"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Laker"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version

--- a/testdata/project-v4-multigroup/PROJECT
+++ b/testdata/project-v4-multigroup/PROJECT
@@ -6,6 +6,8 @@ domain: testproject.org
 layout:
 - go.kubebuilder.io/v4-alpha
 multigroup: true
+plugins:
+  kube-state-metrics.kubebuilder.io/v1-alpha: {}
 projectName: project-v4-multigroup
 repo: sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup
 resources:

--- a/testdata/project-v4-multigroup/kube-state-metrics/cr-config.yaml
+++ b/testdata/project-v4-multigroup/kube-state-metrics/cr-config.yaml
@@ -1,0 +1,257 @@
+---
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Captain"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "ship.testproject.org"
+        kind: "Frigate"
+        version: "v1beta1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "ship.testproject.org"
+        kind: "Destroyer"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "ship.testproject.org"
+        kind: "Cruiser"
+        version: "v2alpha1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "sea-creatures.testproject.org"
+        kind: "Kraken"
+        version: "v1beta1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "sea-creatures.testproject.org"
+        kind: "Leviathan"
+        version: "v1beta2"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "foo.policy.testproject.org"
+        kind: "HealthCheckPolicy"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "apps."
+        kind: "Deployment"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "foo.testproject.org"
+        kind: "Bar"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "fiz.testproject.org"
+        kind: "Bar"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: ".testproject.org"
+        kind: "Lakers"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version

--- a/testdata/project-v4/PROJECT
+++ b/testdata/project-v4/PROJECT
@@ -5,6 +5,8 @@
 domain: testproject.org
 layout:
 - go.kubebuilder.io/v4-alpha
+plugins:
+  kube-state-metrics.kubebuilder.io/v1-alpha: {}
 projectName: project-v4
 repo: sigs.k8s.io/kubebuilder/testdata/project-v4
 resources:

--- a/testdata/project-v4/kube-state-metrics/cr-config.yaml
+++ b/testdata/project-v4/kube-state-metrics/cr-config.yaml
@@ -1,0 +1,96 @@
+---
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Captain"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "FirstMate"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Admiral"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version
+    - groupVersionKind:
+        group: "crew.testproject.org"
+        kind: "Laker"
+        version: "v1"
+      labelsFromPath:
+        name:
+          - metadata
+          - name
+        namespace:
+          - metadata
+          - namespace
+        uid:
+          - metadata
+          - uid
+      metrics:
+        - name: "info"
+          each:
+            type: Info
+            info:
+              labelsFromPath:
+                version:
+                  - spec
+                  - version


### PR DESCRIPTION
### 2022-11-17 Updates
Hold, we may consider [the monitoring plugin](https://github.com/kubernetes-sigs/kubebuilder/issues/3078) for integrating this feature, OR [phase 2 approach](https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/extensible-cli-and-scaffolding-plugins-phase-2.md) as making this an external plugin.

# Motivation
This is a starting PR to resolve https://github.com/kubernetes-sigs/kubebuilder/issues/2286

# Description
Introduce a new optional plugin `kube-state-metrics`.
This metrics aims to provide configuration file loaded by KSM to populate state metrics of custom resources.
The state metrics should be generated based on user-defined subresource `status`.

This PR initializes the plugin to provide the very basic `_info` metric of the CRs.
A common usage:
_"count custom resources by namespace, cluster, etc"_

## Usage
The plugin is temporary designed to be triggered by `edit` subcommand:
```shell
# Execute the command after APIs are generated
kubebuilder edit --plugins=kube-state-metrics.kubebuilder.io/v1-alpha
```
Once executed, the plugin will look for the apis recorded in `PROJECT`. Then, it will generate a config yaml at:
`kube-state-metrics/cr-config.yaml`

The file can be loaded by `kube-state-metrics` through `--custom-resource-state-config-file /path/to/kube-state-metrics/cr-config.yaml`.
The content refers to https://github.com/kubernetes/kube-state-metrics/blob/v2.6.0/docs/customresourcestate-metrics.md

## TODO:
- [x] initialize the plugin
- [ ] documentation
- [x] testdata
- [ ] e2e tests

## Example
Below is a practice over[ memcached-operator](https://github.com/operator-framework/operator-sdk/tree/v1.25.2/testdata/go/v3/memcached-operator):

![case-1](https://user-images.githubusercontent.com/18136486/202128353-e1a26043-cfdc-408a-8f33-c5ccbdc076f4.png)

![case-2](https://user-images.githubusercontent.com/18136486/202128453-4f042aa6-a762-45db-b973-08aeb2370ce8.png)



<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
