### PR TITLE
:seedling: Bump  kube-rbac-proxy from v0.13.0 to v0.13.1

### DIFF
--- a/build/cloudbuild_kube-rbac-proxy.yaml
+++ b/build/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.13.0
+  _KUBE_RBAC_PROXY_VERSION: v0.13.1
 steps:
 - name: "gcr.io/cloud-builders/docker"
   env:


### PR DESCRIPTION
Add v0.13.1 that fixes few CVEs. Details in kube-rbac-proxy releae notes https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.13.1


Fixes: #3094 