### PR TITLE
📖 docs: fix typo in the component config tutorial

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/api/v2/projectconfig_types.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/api/v2/projectconfig_types.go
@@ -50,7 +50,7 @@ type ProjectConfig struct {
 	Spec   ProjectConfigSpec   `json:"spec,omitempty"`
 	Status ProjectConfigStatus `json:"status,omitempty"`
 
-	// ControllerManagerConfigurationSpec returns the contfigurations for controllers
+	// ControllerManagerConfigurationSpec returns the configurations for controllers
 	cfg.ControllerManagerConfigurationSpec `json:",inline"`
 
 	ClusterName string `json:"clusterName,omitempty"`

--- a/docs/book/src/component-config-tutorial/testdata/projectconfig_types.go
+++ b/docs/book/src/component-config-tutorial/testdata/projectconfig_types.go
@@ -38,7 +38,7 @@ we'll embed `cfg.ControllerManagerConfigurationSpec` in `ProjectConfig`.
 type ProjectConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// ControllerManagerConfigurationSpec returns the contfigurations for controllers
+	// ControllerManagerConfigurationSpec returns the configurations for controllers
 	cfg.ControllerManagerConfigurationSpec `json:",inline"`
 
 	ClusterName string `json:"clusterName,omitempty"`


### PR DESCRIPTION
Fixes a typo in the component config tutorial (`contfigurations` -> `configurations`).