### PR TITLE
🐛  (kustomize/v2-alpha): use marker to track samples and do not create tracks for core types

### DIFF
--- a/testdata/project-v4-config/config/samples/kustomization.yaml
+++ b/testdata/project-v4-config/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
----
+## Append samples of your project ##
 resources:
-  - crew_v1_captain.yaml
-  - crew_v1_firstmate.yaml
-  - crew_v1_admiral.yaml
+- crew_v1_captain.yaml
+- crew_v1_firstmate.yaml
+- crew_v1_admiral.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4-declarative-v1/config/samples/kustomization.yaml
+++ b/testdata/project-v4-declarative-v1/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
----
+## Append samples of your project ##
 resources:
-  - crew_v1_captain.yaml
-  - crew_v1_firstmate.yaml
-  - crew_v1_admiral.yaml
+- crew_v1_captain.yaml
+- crew_v1_firstmate.yaml
+- crew_v1_admiral.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4-multigroup/config/samples/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/samples/kustomization.yaml
@@ -1,13 +1,13 @@
----
+## Append samples of your project ##
 resources:
-  - crew_v1_captain.yaml
-  - ship_v1beta1_frigate.yaml
-  - ship_v1_destroyer.yaml
-  - ship_v2alpha1_cruiser.yaml
-  - sea-creatures_v1beta1_kraken.yaml
-  - sea-creatures_v1beta2_leviathan.yaml
-  - foo.policy_v1_healthcheckpolicy.yaml
-  - apps_v1_deployment.yaml
-  - foo_v1_bar.yaml
-  - fiz_v1_bar.yaml
-  - _v1_lakers.yaml
+- crew_v1_captain.yaml
+- ship_v1beta1_frigate.yaml
+- ship_v1_destroyer.yaml
+- ship_v2alpha1_cruiser.yaml
+- sea-creatures_v1beta1_kraken.yaml
+- sea-creatures_v1beta2_leviathan.yaml
+- foo.policy_v1_healthcheckpolicy.yaml
+- foo_v1_bar.yaml
+- fiz_v1_bar.yaml
+- _v1_lakers.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4/config/samples/kustomization.yaml
+++ b/testdata/project-v4/config/samples/kustomization.yaml
@@ -1,5 +1,6 @@
----
+## Append samples of your project ##
 resources:
-  - crew_v1_captain.yaml
-  - crew_v1_firstmate.yaml
-  - crew_v1_admiral.yaml
+- crew_v1_captain.yaml
+- crew_v1_firstmate.yaml
+- crew_v1_admiral.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
## Description

Instead of overwriting the file, we can use a marker so we will just append new values instead. 

## Motivations
- allow manual changes
- fix: does not track values for core types (such as deployment)
- fix layout of the scaffold 


