### PR TITLE
🐛 (deployimage/v1-alpha): fix error to scaffold go/v4-alpha projects

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -29,10 +29,12 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
 	kustomizev1scaffolds "sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v1/scaffolds"
+	kustomizev2scaffolds "sigs.k8s.io/kubebuilder/v3/pkg/plugins/common/kustomize/v2-alpha/scaffolds"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers"
 	golangv3scaffolds "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3/scaffolds"
+	golangv4scaffolds "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds"
 )
 
 var _ plugins.Scaffolder = &apiScaffolder{}
@@ -75,7 +77,15 @@ func (s *apiScaffolder) InjectFS(fs machinery.Filesystem) {
 func (s *apiScaffolder) Scaffold() error {
 	fmt.Println("Writing scaffold for you to edit...")
 
-	if err := s.scaffoldCreateAPIFromPlugins(); err != nil {
+	//nolint:staticcheck
+	isGoV3 := false
+	for _, pluginKey := range s.config.GetPluginChain() {
+		if strings.Contains(pluginKey, "go.kubebuilder.io/v3") {
+			isGoV3 = true
+		}
+	}
+
+	if err := s.scaffoldCreateAPIFromPlugins(isGoV3); err != nil {
 		return err
 	}
 
@@ -157,12 +167,12 @@ func (s *apiScaffolder) addEnvVarIntoManager() error {
 
 // scaffoldCreateAPIFromPlugins will reuse the code from the kustomize and base golang
 // plugins to do the default scaffolds which an API is created
-func (s *apiScaffolder) scaffoldCreateAPIFromPlugins() error {
-	if err := s.scaffoldCreateAPIFromGolang(); err != nil {
+func (s *apiScaffolder) scaffoldCreateAPIFromPlugins(isLegacyLayout bool) error {
+	if err := s.scaffoldCreateAPIFromGolang(isLegacyLayout); err != nil {
 		return fmt.Errorf("error scaffolding golang files for the new API: %v", err)
 	}
 
-	if err := s.scaffoldCreateAPIFromKustomize(); err != nil {
+	if err := s.scaffoldCreateAPIFromKustomize(isLegacyLayout); err != nil {
 		return fmt.Errorf("error scaffolding kustomize manifests for the new API: %v", err)
 	}
 	return nil
@@ -266,32 +276,49 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 	return nil
 }
 
-func (s *apiScaffolder) scaffoldCreateAPIFromKustomize() error {
+func (s *apiScaffolder) scaffoldCreateAPIFromKustomize(isGoV3 bool) error {
 	// Now we need call the kustomize/v1 plugin to do its scaffolds when we create a new API
 	// todo: when we have the go/v4-alpha plugin we will also need to check what is the plugin used
 	// in the Project layout to know if we should use kustomize/v1 OR kustomize/v2-alpha
-	kustomizeV1Scaffolder := kustomizev1scaffolds.NewAPIScaffolder(
-		s.config,
-		s.resource,
-		true,
-	)
-	kustomizeV1Scaffolder.InjectFS(s.fs)
+	var kustomizeScaffolder plugins.Scaffolder
 
-	if err := kustomizeV1Scaffolder.Scaffold(); err != nil {
+	if isGoV3 {
+		kustomizeScaffolder = kustomizev1scaffolds.NewAPIScaffolder(
+			s.config,
+			s.resource,
+			true,
+		)
+	} else {
+		kustomizeScaffolder = kustomizev2scaffolds.NewAPIScaffolder(
+			s.config,
+			s.resource,
+			true,
+		)
+	}
+
+	kustomizeScaffolder.InjectFS(s.fs)
+
+	if err := kustomizeScaffolder.Scaffold(); err != nil {
 		return fmt.Errorf("error scaffolding kustomize files for the APIs: %v", err)
 	}
+
 	return nil
 }
 
-func (s *apiScaffolder) scaffoldCreateAPIFromGolang() error {
+func (s *apiScaffolder) scaffoldCreateAPIFromGolang(isGoV3 bool) error {
 	// Now we need call the kustomize/v1 plugin to do its scaffolds when we create a new API
 	// todo: when we have the go/v4-alpha plugin we will also need to check what is the plugin used
 	// in the Project layout to know if we should use kustomize/v1 OR kustomize/v2-alpha
-
-	golangV3Scaffolder := golangv3scaffolds.NewAPIScaffolder(s.config,
+	if isGoV3 {
+		golangV3Scaffolder := golangv3scaffolds.NewAPIScaffolder(s.config,
+			s.resource, true)
+		golangV3Scaffolder.InjectFS(s.fs)
+		return golangV3Scaffolder.Scaffold()
+	}
+	golangV4Scaffolder := golangv4scaffolds.NewAPIScaffolder(s.config,
 		s.resource, true)
-	golangV3Scaffolder.InjectFS(s.fs)
-	return golangV3Scaffolder.Scaffold()
+	golangV4Scaffolder.InjectFS(s.fs)
+	return golangV4Scaffolder.Scaffold()
 }
 
 const containerTemplate = `Containers: []corev1.Container{{

--- a/testdata/project-v4-with-deploy-image/config/crd/patches/cainjection_in_busyboxes.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/patches/cainjection_in_busyboxes.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: busyboxes.example.com.testproject.org

--- a/testdata/project-v4-with-deploy-image/config/crd/patches/cainjection_in_memcacheds.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/patches/cainjection_in_memcacheds.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: memcacheds.example.com.testproject.org

--- a/testdata/project-v4-with-deploy-image/config/samples/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/kustomization.yaml
@@ -1,0 +1,5 @@
+## Append samples of your project ##
+resources:
+- example.com_v1alpha1_memcached.yaml
+- example.com_v1alpha1_busybox.yaml
+#+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
## Description 
(deployimage/v1-alpha): fix error to scaffold go/v4-alpha projects

Note that the deploy image was not using the kustomize/v2-alpha and go/v4-alpha scaffolds when the project layout was using those versions. 