### PR TITLE
📖 Replace restricted-access ComponentConfig design doc link with the public one

### DIFF
--- a/docs/book/src/component-config-tutorial/tutorial.md
+++ b/docs/book/src/component-config-tutorial/tutorial.md
@@ -28,6 +28,6 @@ form a runnable project, and live in the book source directory:
 
 ## Resources
 
-* [Versioned Component Configuration File Design](https://docs.google.com/document/d/1FdaEJUEh091qf5B98HM6_8MS764iXrxxigNIdwHYW9c/)
+* [Versioned Component Configuration File Design](https://github.com/kubernetes/community/blob/master/archive/wg-component-standard/component-config/README.md)
 
 * [Config v1alpha1 Go Docs](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/config/v1alpha1/)


### PR DESCRIPTION
This change replaces the restricted-access `ComponentConfig` design doc [link](https://docs.google.com/document/d/1FdaEJUEh091qf5B98HM6_8MS764iXrxxigNIdwHYW9c/), found in the `ComponentConfig` tutorial of the Kubebuilder book, with the [public](https://github.com/kubernetes/community/blob/master/archive/wg-component-standard/component-config/README.md) one.

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
