### PR TITLE
✨ Update Kubernetes version from 1.25.0 to 1.26.0 for kubebuilder artefacts and bump etcd to v3.5.6

### DIFF
--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: 1.25.0
+  _KUBERNETES_VERSION: 1.26.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [

--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.5
+ARG ETCD_VERSION=v3.5.6
 ARG OS=darwin
 ARG ARCH
 

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.17 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.5
+ARG ETCD_VERSION=v3.5.6
 ARG OS=linux
 ARG ARCH
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.5
+ARG ETCD_VERSION=v3.5.6
 ARG OS=windows
 ARG ARCH
 


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

This PR updates the kubernetes version in the `tools-releases` branch to 1.26.0 from 1.25.0.

It also bumps the etcd binary from v3.5.5 to v3.5.6.