### PR TITLE
📖 fix-missing dashes infront of plugins

### DIFF
--- a/docs/book/src/migration/migration_guide_gov3_to_gov4.md
+++ b/docs/book/src/migration/migration_guide_gov3_to_gov4.md
@@ -50,7 +50,7 @@ module tutorial.kubebuilder.io/migration-project
 Now, we can finish initializing the project with kubebuilder.
 
 ```bash
-kubebuilder init --domain tutorial.kubebuilder.io plugins=go/v4-alpha
+kubebuilder init --domain tutorial.kubebuilder.io --plugins=go/v4-alpha
 ```
 
 <aside class="note">


### PR DESCRIPTION
The kubebuilder command was missing the "--" infront of plugins. This meant that it used the go/v3 layout.

