### PR TITLE
:sparkles: upgrade k8s version from 1.26.0 to 1.26.1 and etcd from v35.6 to v3.5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+bin/
+testdata/

--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: 1.26.0
+  _KUBERNETES_VERSION: 1.26.1
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [

--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.6
+ARG ETCD_VERSION=v3.5.7
 ARG OS=darwin
 ARG ARCH
 

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.17 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.6
+ARG ETCD_VERSION=v3.5.7
 ARG OS=linux
 ARG ARCH
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.6
+ARG ETCD_VERSION=v3.5.7
 ARG OS=windows
 ARG ARCH
 


### PR DESCRIPTION
## Description
- upgrade k8s version from 1.26.0 to 1.26.1
-  etcd from v3.5.6 to v3.5.7