### PR TITLE
🐛 (Kubebuilder External Plugins API): fix populate PluginRequest.Universe which is empty

### DIFF
--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -710,15 +710,22 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 
 			// create files in Filesystem
 			for _, file := range files {
-				fs.FS.MkdirAll(file.path, 0o700)
-				f, _ := fs.FS.Create(filepath.Join(file.path, file.name))
-				f.Write([]byte(file.content))
-				f.Close()
+				err := fs.FS.MkdirAll(file.path, 0o700)
+				Expect(err).ToNot(HaveOccurred())
+
+				f, err := fs.FS.Create(filepath.Join(file.path, file.name))
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = f.Write([]byte(file.content))
+				Expect(err).ToNot(HaveOccurred())
+
+				err = f.Close()
+				Expect(err).ToNot(HaveOccurred())
 			}
 
 			universe, err := getUniverseMap(fs)
 
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(universe)).To(Equal(len(files)))
 
 			for _, file := range files {

--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -679,6 +679,54 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			checkMetadata()
 		})
 	})
+
+	Context("Helper functions for Sending request to external plugin and parsing response", func() {
+		It("getUniverseMap should return path to content mapping of all files in Filesystem", func() {
+			fs := machinery.Filesystem{
+				FS: afero.NewMemMapFs(),
+			}
+
+			files := []struct {
+				path    string
+				name    string
+				content string
+			}{
+				{
+					path:    "./",
+					name:    "file",
+					content: "level 0 file",
+				},
+				{
+					path:    "dir/",
+					name:    "file",
+					content: "level 1 file",
+				},
+				{
+					path:    "dir/subdir",
+					name:    "file",
+					content: "level 2 file",
+				},
+			}
+
+			// create files in Filesystem
+			for _, file := range files {
+				fs.FS.MkdirAll(file.path, 0o700)
+				f, _ := fs.FS.Create(filepath.Join(file.path, file.name))
+				f.Write([]byte(file.content))
+				f.Close()
+			}
+
+			universe, err := getUniverseMap(fs)
+
+			Expect(err).To(BeNil())
+			Expect(len(universe)).To(Equal(len(files)))
+
+			for _, file := range files {
+				content := universe[filepath.Join(file.path, file.name)]
+				Expect(content).To(Equal(file.content))
+			}
+		})
+	})
 })
 
 func getFlags() []external.Flag {

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -108,7 +108,7 @@ func makePluginRequest(req external.PluginRequest, path string) (*external.Plugi
 // getUniverseMap is a helper function that is used to read the current directory to build
 // the universe map.
 // It will return a map[string]string where the keys are relative paths to files in the directory
-// and values are the contents, or an error if an issue occured while reading one of the files.
+// and values are the contents, or an error if an issue occurred while reading one of the files.
 func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 	universe := map[string]string{}
 
@@ -125,7 +125,12 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 		if err != nil {
 			return err
 		}
-		defer file.Close()
+
+		defer func() {
+			if err := file.Close(); err != nil {
+				return
+			}
+		}()
 
 		content, err := io.ReadAll(file)
 		if err != nil {

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -20,12 +20,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	iofs "io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin"
@@ -102,8 +105,52 @@ func makePluginRequest(req external.PluginRequest, path string) (*external.Plugi
 	return &res, nil
 }
 
+// getUniverseMap is a helper function that is used to read the current directory to build
+// the universe map.
+// It will return a map[string]string where the keys are relative paths to files in the directory
+// and values are the contents, or an error if an issue occured while reading one of the files.
+func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
+	universe := map[string]string{}
+
+	err := afero.Walk(fs.FS, ".", func(path string, info iofs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := fs.FS.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		content, err := io.ReadAll(file)
+		if err != nil {
+			return err
+		}
+
+		universe[path] = string(content)
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return universe, nil
+}
+
 func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, path string) error {
-	req.Universe = map[string]string{}
+	var err error
+
+	req.Universe, err = getUniverseMap(fs)
+	if err != nil {
+		return err
+	}
 
 	res, err := makePluginRequest(req, path)
 	if err != nil {


### PR DESCRIPTION
This PR aims to fix an issue that is causing the `PluginRequest.Universe` not to be populated before Kubebuilder serializes `PluginRequest` and sends it to external plugins through STDIN.

To construct `PluginRequest.Universe`, the fix will scan the root directory of the project, read every file, and then add an entry to the `PluginRequest.Universe` map, where the key will be the relative path to the file, and the value the content of the file.

fixes: #3214

