### PR TITLE
Add new book link to legacy docs

### DIFF
--- a/docs/book/getting_started/installation_and_setup.md
+++ b/docs/book/getting_started/installation_and_setup.md
@@ -1,3 +1,5 @@
+**Currently, Kubebuilder is upgraded to v3. [These](https://book-v1.book.kubebuilder.io/getting_started/installation_and_setup.html) are legacy documents. You can download v3 Kubebuilder [here](https://book.kubebuilder.io/).**
+
 # Installation and Setup
 
 Kubebuilder requires multiple binaries to be installed and cannot be installed with `go get`.


### PR DESCRIPTION
Issue: #3152 
When I was a beginner and searched for kubebuilder installation guide. I got v1 page and in that process I wasted two days which ended in frustration and then I took help from kubebuilder slack channel. Any beginner starting their kubernetes operator journey should not face this problem. So I added v3 link in legacy docs.
- 📖 (:book:): documentation




