### PR TITLE
:seedling: Added the test-coverage for completion.go and version.go inside cli pkg

### DIFF
--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Completion", func() {
+	var (
+		c *CLI
+	)
+
+	BeforeEach(func() {
+		c = &CLI{}
+	})
+
+	When("newBashCmd", func() {
+		It("Testing the BashCompletion", func() {
+			cmd := c.newBashCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Use).To(ContainSubstring("bash"))
+			Expect(cmd.Short).NotTo(Equal(""))
+			Expect(cmd.Short).To(ContainSubstring("Load bash completions"))
+			Expect(cmd.Example).NotTo(Equal(""))
+			Expect(cmd.Example).To(ContainSubstring("# To load completion for this session"))
+		})
+	})
+
+	Context("newZshCmd", func() {
+		It("Testing the ZshCompletion", func() {
+			cmd := c.newZshCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Use).To(ContainSubstring("zsh"))
+			Expect(cmd.Short).NotTo(Equal(""))
+			Expect(cmd.Short).To(ContainSubstring("Load zsh completions"))
+			Expect(cmd.Example).NotTo(Equal(""))
+			Expect(cmd.Example).To(ContainSubstring("# If shell completion is not already enabled in your environment"))
+		})
+	})
+
+	Context("newFishCmd", func() {
+		It("Testing the FishCompletion", func() {
+			cmd := c.newFishCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Use).To(ContainSubstring("fish"))
+			Expect(cmd.Short).NotTo(Equal(""))
+			Expect(cmd.Short).To(ContainSubstring("Load fish completions"))
+			Expect(cmd.Example).NotTo(Equal(""))
+			Expect(cmd.Example).To(ContainSubstring("# To load completion for this session, execute:"))
+		})
+	})
+
+	Context("newPowerShellCmd", func() {
+		It("Testing the PowerShellCompletion", func() {
+			cmd := c.newPowerShellCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Use).To(ContainSubstring("powershell"))
+			Expect(cmd.Short).NotTo(Equal(""))
+			Expect(cmd.Short).To(ContainSubstring("Load powershell completions"))
+		})
+
+	})
+})

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -23,7 +23,7 @@ import (
 )
 
 func (c CLI) newVersionCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "version",
 		Short:   fmt.Sprintf("Print the %s version", c.commandName),
 		Long:    fmt.Sprintf("Print the %s version", c.commandName),
@@ -33,4 +33,5 @@ func (c CLI) newVersionCmd() *cobra.Command {
 			return nil
 		},
 	}
+	return cmd
 }

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Version", func() {
+	var (
+		c *CLI
+	)
+
+	BeforeEach(func() {
+		c = &CLI{}
+	})
+
+	Context("newVersionCmd", func() {
+		It("Test the version", func() {
+			cmd := c.newVersionCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(ContainSubstring("version"))
+			Expect(cmd.Use).NotTo(Equal(""))
+			Expect(cmd.Short).NotTo(Equal(""))
+			Expect(cmd.Short).To(ContainSubstring("Print the"))
+			Expect(cmd.Long).NotTo(Equal(""))
+			Expect(cmd.Long).To(ContainSubstring("Print the"))
+			Expect(cmd.Example).NotTo(Equal(""))
+			Expect(cmd.Example).To(ContainSubstring("version"))
+		})
+	})
+})


### PR DESCRIPTION
This PR introduces the files changes in `completion.go` and `version.go` that will enhance the test coverage.

Fixes: #3211 

Result -
```
> go test pkg/cli/suite_test.go                                                                                                                                   3s
ok      command-line-arguments 

> go test -coverprofile=coverage.out ./...
ok      sigs.k8s.io/kubebuilder/v3/pkg/cli      0.168s  coverage: 84.1% of statements

> go tool cover -func=coverage.out
sigs.k8s.io/kubebuilder/v3/pkg/cli/completion.go:26:    newBashCmd                      100.0%
sigs.k8s.io/kubebuilder/v3/pkg/cli/completion.go:45:    newZshCmd                       100.0%
sigs.k8s.io/kubebuilder/v3/pkg/cli/completion.go:64:    newFishCmd                      100.0%
sigs.k8s.io/kubebuilder/v3/pkg/cli/completion.go:80:    newPowerShellCmd                100.0%
sigs.k8s.io/kubebuilder/v3/pkg/cli/completion.go:90:    newCompletionCmd                100.0%`
sigs.k8s.io/kubebuilder/v3/pkg/cli/version.go:25:       newVersionCmd                   100.0%
```


<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
