### PR TITLE
:warning: (go/v3) deprecate go/v3 in favor of go/v4

### DIFF
--- a/docs/book/src/plugins/go-v3-plugin.md
+++ b/docs/book/src/plugins/go-v3-plugin.md
@@ -1,4 +1,16 @@
-# go/v3 (go.kubebuilder.io/v3)
+# [Deprecated] go/v3 (go.kubebuilder.io/v3)
+
+<aside class="note warning">
+<h1>Deprecated</h1>
+
+The `go/v3` cannot fully support Kubernetes 1.25+ and work with Kustomize versions > v3.
+
+The recommended way to migrate a `v3` project is to create a new `v4` project and copy over the API
+and the reconciliation code. The conversion will end up with a project that looks like a native `v4` project.
+For further information check the [Migration guide](../migration/migration_guide_gov3_to_gov4.md)
+
+</aside>
+
 
 Kubebuilder tool will scaffold the go/v3 plugin by default. This plugin is a composition of the plugins ` kustomize.common.kubebuilder.io/v1` and `base.go.kubebuilder.io/v3`. By using you can scaffold the default project which is a helper to construct sets of [controllers][controller-runtime]. 
 
@@ -23,8 +35,9 @@ As `go/v3` is the default plugin there is no need to explicitly mention to Kubeb
 To create a new project with the `go/v3` plugin the following command can be used:
 
 ```sh
-kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io/project
+kubebuilder init --plugins=`go/v3` --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io/project
 ```
+
 All the other subcommands supported by the go/v3 plugin can be executed similarly.
 
 <aside class="note">

--- a/pkg/plugins/golang/v4/plugin.go
+++ b/pkg/plugins/golang/v4/plugin.go
@@ -63,3 +63,10 @@ func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
 
 // GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
 func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
+
+func (p Plugin) DeprecationWarning() string {
+	return "This version is deprecated." +
+		"The `go/v3` cannot scaffold projects using kustomize versions v4x+ and cannot be fulled support on Kubernetes 1.25+." +
+		"It is recommended to upgrade your project to the latest versions available (go/v4)." +
+		"Please, check the migration guide to learn how to upgrade your project"
+}

--- a/pkg/plugins/golang/v4/plugin.go
+++ b/pkg/plugins/golang/v4/plugin.go
@@ -67,7 +67,7 @@ func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcom
 func (p Plugin) DeprecationWarning() string {
 	return "This version is deprecated." +
 		"The `go/v3` cannot scaffold projects using kustomize versions v4x+" +
-		" and cannot be whole support on Kubernetes 1.25+." +
+		" and cannot fully support Kubernetes 1.25+." +
 		"It is recommended to upgrade your project to the latest versions available (go/v4)." +
 		"Please, check the migration guide to learn how to upgrade your project"
 }

--- a/pkg/plugins/golang/v4/plugin.go
+++ b/pkg/plugins/golang/v4/plugin.go
@@ -66,7 +66,8 @@ func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcom
 
 func (p Plugin) DeprecationWarning() string {
 	return "This version is deprecated." +
-		"The `go/v3` cannot scaffold projects using kustomize versions v4x+ and cannot be fulled support on Kubernetes 1.25+." +
+		"The `go/v3` cannot scaffold projects using kustomize versions v4x+" +
+		" and cannot be whole support on Kubernetes 1.25+." +
 		"It is recommended to upgrade your project to the latest versions available (go/v4)." +
 		"Please, check the migration guide to learn how to upgrade your project"
 }


### PR DESCRIPTION
## Description 

deprecated go/v3 plugin


Motivation: https://github.com/kubernetes-sigs/kubebuilder/issues/3117