### PR TITLE
🐛 (API - External Plugins):  Fix external plugin discovery on Linux

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -171,26 +171,44 @@ func parseExternalPluginArgs() (args []string) {
 	return args
 }
 
+// isHostSupported checks whether the host system is supported or not.
+func isHostSupported(host string) bool {
+	for _, platform := range supportedPlatforms {
+		if host == platform {
+			return true
+		}
+	}
+	return false
+}
+
 // getPluginsRoot detects the host system and gets the plugins root based on the host.
 func getPluginsRoot(host string) (pluginsRoot string, err error) {
+	if !isHostSupported(host) {
+		// freebsd, openbsd, windows...
+		return "", fmt.Errorf("host not supported: %v", host)
+	}
+
+	pluginsRelativePath := filepath.Join("kubebuilder", "plugins")
+	if xdgHome := os.Getenv("XDG_CONFIG_HOME"); xdgHome != "" {
+		return filepath.Join(xdgHome, pluginsRelativePath), nil
+	}
+
 	switch host {
 	case "darwin":
 		logrus.Debugf("Detected host is macOS.")
-		pluginsRoot = filepath.Join("Library", "Application Support", "kubebuilder", "plugins")
+		pluginsRoot = filepath.Join("Library", "Application Support", pluginsRelativePath)
 	case "linux":
 		logrus.Debugf("Detected host is Linux.")
-		pluginsRoot = filepath.Join(".config", "kubebuilder", "plugins")
-	default:
-		// freebsd, openbsd, windows...
-		return "", fmt.Errorf("Host not supported: %v", host)
+		pluginsRoot = filepath.Join(".config", pluginsRelativePath)
 	}
-	userHomeDir, err := getHomeDir()
+
+	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("error retrieving home dir: %v", err)
 	}
 	pluginsRoot = filepath.Join(userHomeDir, pluginsRoot)
 
-	return pluginsRoot, nil
+	return
 }
 
 // DiscoverExternalPlugins discovers the external plugins in the plugins root directory
@@ -285,17 +303,4 @@ func DiscoverExternalPlugins(fs afero.Fs) (ps []plugin.Plugin, err error) {
 // isPluginExectuable checks if a plugin is an executable based on the bitmask and returns true or false.
 func isPluginExectuable(mode fs.FileMode) bool {
 	return mode&0111 != 0
-}
-
-// getHomeDir returns $XDG_CONFIG_HOME if set, otherwise $HOME.
-func getHomeDir() (string, error) {
-	var err error
-	xdgHome := os.Getenv("XDG_CONFIG_HOME")
-	if xdgHome == "" {
-		xdgHome, err = os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-	}
-	return xdgHome, nil
 }

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Discover external plugins", func() {
 
 				_, err = getPluginsRoot("random")
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(ContainSubstring("Host not supported"))
+				Expect(err.Error()).To(ContainSubstring("host not supported"))
 			})
 
 			It("should skip parsing of directories if plugins root is not a directory", func() {
@@ -249,7 +249,17 @@ var _ = Describe("Discover external plugins", func() {
 
 				_, err = getPluginsRoot("random")
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(ContainSubstring("Host not supported"))
+				Expect(err.Error()).To(ContainSubstring("host not supported"))
+			})
+
+			It("should return full path to the external plugins", func() {
+				err = os.Setenv("XDG_CONFIG_HOME", "/some/random/path")
+				Expect(err).To(BeNil())
+
+				pluginsRoot, err := getPluginsRoot(runtime.GOOS)
+				Expect(err).To(BeNil())
+				Expect(pluginsRoot).To(Equal("/some/random/path/kubebuilder/plugins"))
+
 			})
 
 			It("should return error when home directory is set to empty", func() {

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -252,14 +252,32 @@ var _ = Describe("Discover external plugins", func() {
 				Expect(err.Error()).To(ContainSubstring("host not supported"))
 			})
 
-			It("should return full path to the external plugins", func() {
+			It("should return full path to the external plugins without XDG_CONFIG_HOME", func() {
+				if _, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
+					err = os.Setenv("XDG_CONFIG_HOME", "")
+					Expect(err).To(BeNil())
+				}
+
+				home := os.Getenv("HOME")
+
+				pluginsRoot, err := getPluginsRoot("darwin")
+				Expect(err).To(BeNil())
+				expected := filepath.Join(home, "Library", "Application Support", "kubebuilder", "plugins")
+				Expect(pluginsRoot).To(Equal(expected))
+
+				pluginsRoot, err = getPluginsRoot("linux")
+				Expect(err).To(BeNil())
+				expected = filepath.Join(home, ".config", "kubebuilder", "plugins")
+				Expect(pluginsRoot).To(Equal(expected))
+			})
+
+			It("should return full path to the external plugins with XDG_CONFIG_HOME", func() {
 				err = os.Setenv("XDG_CONFIG_HOME", "/some/random/path")
 				Expect(err).To(BeNil())
 
 				pluginsRoot, err := getPluginsRoot(runtime.GOOS)
 				Expect(err).To(BeNil())
 				Expect(pluginsRoot).To(Equal("/some/random/path/kubebuilder/plugins"))
-
 			})
 
 			It("should return error when home directory is set to empty", func() {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	supportedPlatforms = []string{"linux", "darwin"}
+	supportedPlatforms = []string{"darwin", "linux"}
 )
 
 func (c CLI) newRootCmd() *cobra.Command {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -29,6 +29,10 @@ const (
 	projectVersionsHeader = "Supported project versions"
 )
 
+var (
+	supportedPlatforms = []string{"linux", "darwin"}
+)
+
 func (c CLI) newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     c.commandName,


### PR DESCRIPTION
This PR aims to fix a bug that's causing external plugin discovery to fail in Linux systems when `XDG_CONFIG_HOME` environment variable is set.

fixes: #3224 