### PR TITLE
📖 : delete cronjob tutorial Incorrect kustomization.yaml

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/kustomization.yaml
@@ -1,10 +1,3 @@
 resources:
 - manager.yaml
 
-generatorOptions:
-  disableNameSuffixHash: true
-
-configMapGenerator:
-- name: manager-config
-  files:
-  - controller_manager_config.yaml


### PR DESCRIPTION
#3249 
Delete cronjob tutorial Incorrect code in kustomization.yaml, that will lead to `make deploy` error
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
