### PR TITLE
🐛 Clarify deprecate documentation for API methods which are served to work with CRD/WebHook API versions v1beta1

### DIFF
--- a/pkg/plugin/util/helpers.go
+++ b/pkg/plugin/util/helpers.go
@@ -20,19 +20,22 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 )
 
-// Deprecated: go/v4 no longer supports v1beta1 option
 // HasDifferentCRDVersion returns true if any other CRD version is tracked in the project configuration.
+// Deprecated: v1beta1 CRDs and Webhooks are not supported since k8s 1.22.
+// The features that allow users to scaffold projects using these API versions are deprecated and are no longer supported.
 func HasDifferentCRDVersion(config config.Config, crdVersion string) bool {
 	return hasDifferentAPIVersion(config.ListCRDVersions(), crdVersion)
 }
 
-// Deprecated: go/v4 no longer supports v1beta1 option
 // HasDifferentWebhookVersion returns true if any other webhook version is tracked in the project configuration.
+// Deprecated: v1beta1 CRDs and Webhooks are not supported since k8s 1.22.
+// The features that allow users to scaffold projects using these API versions are deprecated and are no longer supported.
 func HasDifferentWebhookVersion(config config.Config, webhookVersion string) bool {
 	return hasDifferentAPIVersion(config.ListWebhookVersions(), webhookVersion)
 }
 
-// Deprecated: go/v4 no longer supports v1beta1 option
+// Deprecated: v1beta1 CRDs and Webhooks are not supported since k8s 1.22.
+// The features that allow users to scaffold projects using these API versions are deprecated and are no longer supported.
 func hasDifferentAPIVersion(versions []string, version string) bool {
 	return !(len(versions) == 0 || (len(versions) == 1 && versions[0] == version))
 }


### PR DESCRIPTION
These deprecation messages will reappear in the next release wherein go/v3 is deprecated in favor of go/v4. Till then these warnings are not necessary.

Please refer here: https://github.com/operator-framework/helm-operator-plugins/actions/runs/4342983995/jobs/7584462203#step:6:52 - for users with KB 3.9.0, these warnings are unnecessary. They should be re-introduced in the KB version which has go/v3 deprecated.

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
