### PR TITLE
🐛  fix: deprecate message should be in go/v3

### DIFF
--- a/pkg/plugins/golang/v3/plugin.go
+++ b/pkg/plugins/golang/v3/plugin.go
@@ -62,3 +62,11 @@ func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
 
 // GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
 func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
+
+func (p Plugin) DeprecationWarning() string {
+	return "This version is deprecated." +
+		"The `go/v3` cannot scaffold projects using kustomize versions v4x+" +
+		" and cannot fully support Kubernetes 1.25+." +
+		"It is recommended to upgrade your project to the latest versions available (go/v4)." +
+		"Please, check the migration guide to learn how to upgrade your project"
+}

--- a/pkg/plugins/golang/v4/plugin.go
+++ b/pkg/plugins/golang/v4/plugin.go
@@ -63,11 +63,3 @@ func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
 
 // GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
 func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
-
-func (p Plugin) DeprecationWarning() string {
-	return "This version is deprecated." +
-		"The `go/v3` cannot scaffold projects using kustomize versions v4x+" +
-		" and cannot fully support Kubernetes 1.25+." +
-		"It is recommended to upgrade your project to the latest versions available (go/v4)." +
-		"Please, check the migration guide to learn how to upgrade your project"
-}


### PR DESCRIPTION
## Description

The message was added to the wrong plugin version
This PR only fix and ensure that the message is the right one. 