### PR TITLE
✨  : make go/v4 to be default Kubebuilder CLI scaffold

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,7 +75,7 @@ func main() {
 		),
 		cli.WithPlugins(externalPlugins...),
 		cli.WithDefaultPlugins(cfgv2.Version, golangv2.Plugin{}),
-		cli.WithDefaultPlugins(cfgv3.Version, gov3Bundle),
+		cli.WithDefaultPlugins(cfgv3.Version, gov4Bundle),
 		cli.WithDefaultProjectVersion(cfgv3.Version),
 		cli.WithCompletion(),
 	)

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -53,19 +53,6 @@ Kubebuilder provides autocompletion support for Bash and Zsh via the command `ku
 
 Create a directory, and then run the init command inside of it to initialize a new project. Follows an example.
 
-<aside class="note warning">
-<h1> Apple Silicon (M1) </h1>
-
-The current scaffold done by the CLI (`go/v3`) uses [kubernetes-sigs/kustomize][kustomize] v3 which does not provide
-a valid binary for Apple Silicon (`darwin/arm64`). Therefore, you can use the `go/v4` plugin
-instead which provides support for this platform:
-
-```bash
-kubebuilder init --domain my.domain --repo my.domain/guestbook --plugins=go/v4
-```
-
-</aside>
-
 ```bash
 mkdir -p ~/projects/guestbook
 cd ~/projects/guestbook

--- a/hack/docs/internal/generate_component_config.go
+++ b/hack/docs/internal/generate_component_config.go
@@ -73,6 +73,7 @@ func (sp *Sample) GenerateSampleProject() {
 		"--license", "apache2",
 		"--owner", "The Kubernetes authors",
 		"--component-config",
+		"--plugins=go/v3",
 	)
 	CheckError("Initializing the project", err)
 


### PR DESCRIPTION
## Description

Make go/v4 layout the default layout of kubebuilder CLI
Now, new projects init without inform plugin will be created using go/v4 by default.

NOTE: It does not break the behaviour for those with a project scaffold with go/v3. It only makes the default scaffold of the the CLI to be go/v4 


## Motivation

https://github.com/kubernetes-sigs/kubebuilder/issues/3117
https://github.com/kubernetes-sigs/kubebuilder/discussions/3217