### PR TITLE
:sparkles: (API) deprecate kustomize/v1 and go/v3 packages

### DIFF
--- a/pkg/plugins/common/kustomize/v1/api.go
+++ b/pkg/plugins/common/kustomize/v1/api.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v2
 package v1
 
 import (

--- a/pkg/plugins/common/kustomize/v1/create.go
+++ b/pkg/plugins/common/kustomize/v1/create.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v2
 package v1
 
 import (

--- a/pkg/plugins/common/kustomize/v1/init.go
+++ b/pkg/plugins/common/kustomize/v1/init.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v2
 package v1
 
 import (

--- a/pkg/plugins/common/kustomize/v1/plugin.go
+++ b/pkg/plugins/common/kustomize/v1/plugin.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v2
 package v1
 
 import (

--- a/pkg/plugins/common/kustomize/v1/webhook.go
+++ b/pkg/plugins/common/kustomize/v1/webhook.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v2
 package v1
 
 import (

--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v4
 package v3
 
 import (

--- a/pkg/plugins/golang/v3/commons.go
+++ b/pkg/plugins/golang/v3/commons.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v4
 package v3
 
 import (

--- a/pkg/plugins/golang/v3/edit.go
+++ b/pkg/plugins/golang/v3/edit.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v4
 package v3
 
 import (

--- a/pkg/plugins/golang/v3/init.go
+++ b/pkg/plugins/golang/v3/init.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v4
 package v3
 
 import (

--- a/pkg/plugins/golang/v3/plugin.go
+++ b/pkg/plugins/golang/v3/plugin.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v4
 package v3
 
 import (

--- a/pkg/plugins/golang/v3/webhook.go
+++ b/pkg/plugins/golang/v3/webhook.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:deprecated This package has been deprecated in favor of v4
 package v3
 
 import (


### PR DESCRIPTION
## Description

deprecate kustomize/v1 and go/v3 packages 

## Motivation

https://github.com/kubernetes-sigs/kubebuilder/issues/3117
https://github.com/kubernetes-sigs/kubebuilder/discussions/3217