### PR TITLE
:book: Replace "Help" field in EP doc with "Metadata" field

### DIFF
--- a/designs/extensible-cli-and-scaffolding-plugins-phase-2.md
+++ b/designs/extensible-cli-and-scaffolding-plugins-phase-2.md
@@ -177,7 +177,7 @@ The following scenarios shows what `kubebuilder` will send/receive to the extern
 * External plugin to `kubebuilder`:
   * The plugin reads the `PluginRequest` through its `stdin` and processes the request based on the `Command` that was sent. If the `Command` doesn't match what the plugin supports, it writes back an error immediately without any further processing. If the `Command` matches what the plugin supports, it constructs a `PluginResponse` containing the `Command` that was executed by the plugin, and modified `Universe` based on the new files that were scaffolded by the external plugin, `Error` and `ErrorMsg` that add any error information, and writes the `PluginResponse` back to `kubebuilder` through `stdout`.
 
-* Note: If `--help` flag is being passed from `kubebuilder` to the external plugin through `PluginRequest`, the plugin attaches its help text information in the `Help` field of the `PluginResponse`. Both `PluginRequest` and `PluginResponse` also contain `APIVersion` field to have compatible versioned schemas.
+* Note: If `--help` flag is being passed from `kubebuilder` to the external plugin through `PluginRequest`, the plugin attaches its help text information in the `Metadata` field of the `PluginResponse`. Both `PluginRequest` and `PluginResponse` also contain `APIVersion` field to have compatible versioned schemas.
 
 * Handling plugin failures across the chain:
 
@@ -212,9 +212,9 @@ type PluginResponse struct {
   // Command holds the command that gets executed by the plugin such as init, create api, etc.
   Command       string                   `json:"command"`
 
-  // Help contains the plugin specific help text that the plugin returns to kubebuilder when it receives
+  // Metadata contains the plugin specific help text that the plugin returns to Kubebuilder when it receives
   // `--help` flag from Kubebuilder.
-  Help          string                   `json:"help,omitempty"`
+  Metadata plugin.SubcommandMetadata `json:"metadata"`
 
   // APIVersion defines the versioned schema of the PluginResponse that will be written back to kubebuilder.
   // Initially, this will be marked as alpha (v1alpha1).

--- a/pkg/plugin/external/types.go
+++ b/pkg/plugin/external/types.go
@@ -47,7 +47,7 @@ type PluginResponse struct {
 	// Command holds the command that gets executed by the plugin such as init, create api, etc.
 	Command string `json:"command"`
 
-	// Help contains the plugin specific help text that the plugin returns to Kubebuilder when it receives
+	// Metadata contains the plugin specific help text that the plugin returns to Kubebuilder when it receives
 	// `--help` flag from Kubebuilder.
 	Metadata plugin.SubcommandMetadata `json:"metadata"`
 


### PR DESCRIPTION
The `Help` field in `PluginResponse` was replaced with `Metadata` on fc97428.
But `Help` is used in the design document and the comment on the code still now.

This PR updates the external plugin v2 design doc and comment to use the `Metadata` field in `PluginResponse` instead `Help` field.
