### PR TITLE
📖: Add version dropdown for doc release

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -7,7 +7,7 @@ title = "The Kubebuilder Book"
 [output.html]
 google-analytics = "UA-119864590-1"
 curly-quotes = true
-additional-css = ["theme/css/markers.css", "theme/css/custom.css"]
+additional-css = ["theme/css/markers.css", "theme/css/custom.css", "theme/css/version-dropdown.css"]
 git-repository-url = "https://github.com/kubernetes-sigs/kubebuilder"
 edit-url-template = "https://github.com/kubernetes-sigs/kubebuilder/edit/master/docs/book/{path}"
 

--- a/docs/book/theme/css/version-dropdown.css
+++ b/docs/book/theme/css/version-dropdown.css
@@ -1,0 +1,23 @@
+.version-dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 90px;
+    box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+    z-index: 1;
+  }
+  
+  .version-dropdown-content a {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+  }
+  
+  .version-dropdown-content a:hover {
+    background-color: #f1f1f1;
+  }
+  
+  .version-dropdown:hover .version-dropdown-content {
+    display: block;
+  }

--- a/docs/book/theme/index.hbs
+++ b/docs/book/theme/index.hbs
@@ -126,6 +126,17 @@
                             <i class="fa fa-search"></i>
                         </button>
                         {{/if}}
+                         <!-- custom code for adding release version dropdown menu -->
+                        <div class="version-dropdown">
+                            <button id="release-version" class="icon-button" type="button" title="Release version" aria-label="Release version" aria-haspopup="true" aria-expanded="false" aria-controls="release-versions">
+                            <i class="fa fa-book"></i>
+                            </button>
+                            <div class="version-dropdown-content">
+                                <a href="https://book.kubebuilder.io/"target="_blank" rel="noopener noreferrer">v3-book</a>
+                                <a href="https://book-v2.book.kubebuilder.io/"target="_blank" rel="noopener noreferrer">v2-book</a>
+                                <a href="https://book-v1.book.kubebuilder.io/"target="_blank" rel="noopener noreferrer">v1-book</a>
+                            </div>
+                        </div>     
                     </div>
 
                     <h1 class="menu-title"><img alt="{{ book_title }}" src="{{ path_to_root }}/logos/logo-single-line.png"></h1>


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
Fixes https://github.com/kubernetes-sigs/kubebuilder/issues/3320
Created feature branch from **master branch**:
**Changes:**
UI Change: Adding a dropdown menu for versions of the documentation.
Code change: Added additional dropdown menu html code and it's CSS changes
**Motivation:**
https://github.com/kubernetes-sigs/kubebuilder/issues/3320

Changes will be useful for the community to get easy access to different documentation version
Easy to maintain in the future if documentation versions increased.
![image](https://user-images.githubusercontent.com/5825319/231739303-d7d9388e-5b28-48eb-bb56-5727c10a3e3d.png)

