### PR TITLE
🌱 ci: remove check docs only since it is blocking the ci

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -6,29 +6,11 @@ on:
   pull_request:
 
 jobs:
-  check_docs_only:
-    name: check_docs_only
-    runs-on: ubuntu-18.04
-    outputs:
-      skip: ${{ steps.check_docs_only.outputs.skip }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - id: check_docs_only
-        # Since PR's are squashed prior to merging to the branch checked out (default branch),
-        # HEAD^ will resolve to the previous point in history.
-        run: |
-          REF="HEAD^"
-          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(test/check-docs-only.sh $REF)"
-
   go-apidiff:
     name: Verify API differences
     runs-on: ubuntu-latest
-    needs: check_docs_only
     # Pull requests from different repository only trigger this checks
-    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && needs.check_docs_only.outputs.skip != 'true'
+    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Clone the code
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,29 +6,11 @@ on:
   pull_request:
 
 jobs:
-  check_docs_only:
-    name: check_docs_only
-    runs-on: ubuntu-18.04
-    outputs:
-      skip: ${{ steps.check_docs_only.outputs.skip }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - id: check_docs_only
-        # Since PR's are squashed prior to merging to the branch checked out (default branch),
-        # HEAD^ will resolve to the previous point in history.
-        run: |
-          REF="HEAD^"
-          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(test/check-docs-only.sh $REF)"
-
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest
-    needs: check_docs_only
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && needs.check_docs_only.outputs.skip != 'true'
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,23 +6,6 @@ on:
   pull_request:
 
 jobs:
-  check_docs_only:
-    name: check_docs_only
-    runs-on: ubuntu-18.04
-    outputs:
-      skip: ${{ steps.check_docs_only.outputs.skip }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - id: check_docs_only
-        # Since PR's are squashed prior to merging to the branch checked out (default branch),
-        # HEAD^ will resolve to the previous point in history.
-        run: |
-          REF="HEAD^"
-          [[ -z "${{ github.base_ref }}" ]] || REF=$(git show-ref ${{ github.base_ref }} | head -1 | cut -d' ' -f2)
-          echo "::set-output name=skip::$(test/check-docs-only.sh $REF)"
-
   test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -31,9 +14,8 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-    needs: check_docs_only
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && needs.check_docs_only.outputs.skip != 'true'
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Clone the code
         uses: actions/checkout@v3
@@ -61,10 +43,9 @@ jobs:
     name: Code coverage
     needs:
       - test
-      - check_docs_only
     runs-on: ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && needs.check_docs_only.outputs.skip != 'true'
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Clone the code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Remove the job to skip the checks when only docs are changed because it is broken and blocking the PRs from merging. We can review it and fix it afterwords. 