### PR TITLE
:sparkles: Update ETCD from 3.5.7 to 3.5.8

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.20 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.7
+ARG ETCD_VERSION=v3.5.8
 ARG OS=darwin
 ARG ARCH
 

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.17 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.7
+ARG ETCD_VERSION=v3.5.8
 ARG OS=linux
 ARG ARCH
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.7
+ARG ETCD_VERSION=v3.5.8
 ARG OS=windows
 ARG ARCH
 


### PR DESCRIPTION
## Description 

:sparkles: Update ETCD from 3.5.7 to 3.5.8
More info: https://github.com/etcd-io/etcd/releases/tag/v3.5.8