### PR TITLE
:bug: (go/v4, deployimage): fix the name controllers test function

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -152,7 +152,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-config/internal/controller/suite_test.go
+++ b/testdata/project-v4-config/internal/controller/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-declarative-v1/internal/controller/suite_test.go
+++ b/testdata/project-v4-declarative-v1/internal/controller/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -40,7 +40,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -42,7 +42,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -43,7 +43,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-multigroup/internal/controller/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4-with-deploy-image/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -41,7 +41,7 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
-func TestAPIs(t *testing.T) {
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")


### PR DESCRIPTION
## Description

 fix the name controllers test function which has been scaffolded as` func TestAPIs(t *testing.T) {` for the controllers. 
