### PR TITLE
✨ (deployImage) improve the controller tests scaffolded

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -109,6 +109,7 @@ var _ = Describe("{{ .Resource.Kind }} controller", func() {
 		}
 
 		typeNamespaceName := types.NamespacedName{Name: {{ .Resource.Kind }}Name, Namespace: {{ .Resource.Kind }}Name}
+		{{ lower .Resource.Kind }} := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
 
 		BeforeEach(func() {
 			By("Creating the Namespace to perform the tests")
@@ -118,22 +119,9 @@ var _ = Describe("{{ .Resource.Kind }} controller", func() {
 			By("Setting the Image ENV VAR which stores the Operand image")
 			err= os.Setenv("{{ upper .Resource.Kind }}_IMAGE", "example.com/image:test")
 			Expect(err).To(Not(HaveOccurred()))
-		})
 
-		AfterEach(func() {
-			// TODO(user): Attention if you improve this code by adding other context test you MUST
-			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
-			By("Deleting the Namespace to perform the tests")
-			_ = k8sClient.Delete(ctx, namespace);
-	
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("{{ upper .Resource.Kind }}_IMAGE")
-		})
-
-		It("should successfully reconcile a custom resource for {{ .Resource.Kind }}", func() {
-			By("Creating the custom resource for the Kind {{ .Resource.Kind }}")
-			{{ lower .Resource.Kind }} := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
-			err := k8sClient.Get(ctx, typeNamespaceName, {{ lower .Resource.Kind }})
+			By("creating the custom resource for the Kind {{ .Resource.Kind }}")
+			err = k8sClient.Get(ctx, typeNamespaceName, {{ lower .Resource.Kind }})
 			if err != nil && errors.IsNotFound(err) {
 				// Let's mock our custom resource at the same way that we would
 				// apply on the cluster the manifest under config/samples
@@ -152,8 +140,30 @@ var _ = Describe("{{ .Resource.Kind }} controller", func() {
 				
 				err = k8sClient.Create(ctx, {{ lower .Resource.Kind }})
 				Expect(err).To(Not(HaveOccurred()))
-			} 
+			}
+		})
 
+		AfterEach(func() {
+			By("removing the custom resource for the Kind {{ .Resource.Kind }}")
+			found := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
+			err := k8sClient.Get(ctx, typeNamespaceName, found)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Eventually(func() error {
+				return k8sClient.Delete(context.TODO(), found)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations. 
+			// More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
+			By("Deleting the Namespace to perform the tests")
+			_ = k8sClient.Delete(ctx, namespace);
+	
+			By("Removing the Image ENV VAR which stores the Operand image")
+			_ = os.Unsetenv("{{ upper .Resource.Kind }}_IMAGE")
+		})
+
+		It("should successfully reconcile a custom resource for {{ .Resource.Kind }}", func() {
 			By("Checking if the custom resource was successfully created")
 			Eventually(func() error {
 				found := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
@@ -166,7 +176,7 @@ var _ = Describe("{{ .Resource.Kind }} controller", func() {
 				Scheme: k8sClient.Scheme(),
 			}
 
-			_, err = {{ lower .Resource.Kind }}Reconciler.Reconcile(ctx, reconcile.Request{
+			_, err := {{ lower .Resource.Kind }}Reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespaceName,
 			})
 			Expect(err).To(Not(HaveOccurred()))

--- a/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Busybox controller", func() {
 		}
 
 		typeNamespaceName := types.NamespacedName{Name: BusyboxName, Namespace: BusyboxName}
+		busybox := &examplecomv1alpha1.Busybox{}
 
 		BeforeEach(func() {
 			By("Creating the Namespace to perform the tests")
@@ -58,22 +59,9 @@ var _ = Describe("Busybox controller", func() {
 			By("Setting the Image ENV VAR which stores the Operand image")
 			err = os.Setenv("BUSYBOX_IMAGE", "example.com/image:test")
 			Expect(err).To(Not(HaveOccurred()))
-		})
 
-		AfterEach(func() {
-			// TODO(user): Attention if you improve this code by adding other context test you MUST
-			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
-			By("Deleting the Namespace to perform the tests")
-			_ = k8sClient.Delete(ctx, namespace)
-
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("BUSYBOX_IMAGE")
-		})
-
-		It("should successfully reconcile a custom resource for Busybox", func() {
-			By("Creating the custom resource for the Kind Busybox")
-			busybox := &examplecomv1alpha1.Busybox{}
-			err := k8sClient.Get(ctx, typeNamespaceName, busybox)
+			By("creating the custom resource for the Kind Busybox")
+			err = k8sClient.Get(ctx, typeNamespaceName, busybox)
 			if err != nil && errors.IsNotFound(err) {
 				// Let's mock our custom resource at the same way that we would
 				// apply on the cluster the manifest under config/samples
@@ -90,7 +78,29 @@ var _ = Describe("Busybox controller", func() {
 				err = k8sClient.Create(ctx, busybox)
 				Expect(err).To(Not(HaveOccurred()))
 			}
+		})
 
+		AfterEach(func() {
+			By("removing the custom resource for the Kind Busybox")
+			found := &examplecomv1alpha1.Busybox{}
+			err := k8sClient.Get(ctx, typeNamespaceName, found)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Eventually(func() error {
+				return k8sClient.Delete(context.TODO(), found)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations.
+			// More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
+			By("Deleting the Namespace to perform the tests")
+			_ = k8sClient.Delete(ctx, namespace)
+
+			By("Removing the Image ENV VAR which stores the Operand image")
+			_ = os.Unsetenv("BUSYBOX_IMAGE")
+		})
+
+		It("should successfully reconcile a custom resource for Busybox", func() {
 			By("Checking if the custom resource was successfully created")
 			Eventually(func() error {
 				found := &examplecomv1alpha1.Busybox{}
@@ -103,7 +113,7 @@ var _ = Describe("Busybox controller", func() {
 				Scheme: k8sClient.Scheme(),
 			}
 
-			_, err = busyboxReconciler.Reconcile(ctx, reconcile.Request{
+			_, err := busyboxReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespaceName,
 			})
 			Expect(err).To(Not(HaveOccurred()))

--- a/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Memcached controller", func() {
 		}
 
 		typeNamespaceName := types.NamespacedName{Name: MemcachedName, Namespace: MemcachedName}
+		memcached := &examplecomv1alpha1.Memcached{}
 
 		BeforeEach(func() {
 			By("Creating the Namespace to perform the tests")
@@ -58,22 +59,9 @@ var _ = Describe("Memcached controller", func() {
 			By("Setting the Image ENV VAR which stores the Operand image")
 			err = os.Setenv("MEMCACHED_IMAGE", "example.com/image:test")
 			Expect(err).To(Not(HaveOccurred()))
-		})
 
-		AfterEach(func() {
-			// TODO(user): Attention if you improve this code by adding other context test you MUST
-			// be aware of the current delete namespace limitations. More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
-			By("Deleting the Namespace to perform the tests")
-			_ = k8sClient.Delete(ctx, namespace)
-
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("MEMCACHED_IMAGE")
-		})
-
-		It("should successfully reconcile a custom resource for Memcached", func() {
-			By("Creating the custom resource for the Kind Memcached")
-			memcached := &examplecomv1alpha1.Memcached{}
-			err := k8sClient.Get(ctx, typeNamespaceName, memcached)
+			By("creating the custom resource for the Kind Memcached")
+			err = k8sClient.Get(ctx, typeNamespaceName, memcached)
 			if err != nil && errors.IsNotFound(err) {
 				// Let's mock our custom resource at the same way that we would
 				// apply on the cluster the manifest under config/samples
@@ -91,7 +79,29 @@ var _ = Describe("Memcached controller", func() {
 				err = k8sClient.Create(ctx, memcached)
 				Expect(err).To(Not(HaveOccurred()))
 			}
+		})
 
+		AfterEach(func() {
+			By("removing the custom resource for the Kind Memcached")
+			found := &examplecomv1alpha1.Memcached{}
+			err := k8sClient.Get(ctx, typeNamespaceName, found)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Eventually(func() error {
+				return k8sClient.Delete(context.TODO(), found)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations.
+			// More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
+			By("Deleting the Namespace to perform the tests")
+			_ = k8sClient.Delete(ctx, namespace)
+
+			By("Removing the Image ENV VAR which stores the Operand image")
+			_ = os.Unsetenv("MEMCACHED_IMAGE")
+		})
+
+		It("should successfully reconcile a custom resource for Memcached", func() {
 			By("Checking if the custom resource was successfully created")
 			Eventually(func() error {
 				found := &examplecomv1alpha1.Memcached{}
@@ -104,7 +114,7 @@ var _ = Describe("Memcached controller", func() {
 				Scheme: k8sClient.Scheme(),
 			}
 
-			_, err = memcachedReconciler.Reconcile(ctx, reconcile.Request{
+			_, err := memcachedReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespaceName,
 			})
 			Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
## Description 

This PR removes from the controller test implemented by the Deploy Image plugin.
Improves the before and after each test by applying the CR on it to ensure better practices since, for each reconciliation test, we ought to apply the resource. So, also remove the CR applied after the tests are executed.