### PR TITLE
✨ (kustomize/v2) Remove deprecated syntax usage by replacing patchesStrategicMerge with patches

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/config.tutorial.kubebuilder.io_projectconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_projectconfigs.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 - patches/webhook_in_cronjobs.yaml

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -110,7 +110,7 @@ var kustomizationTemplate = `# This kustomization.yaml is not intended to be run
 resources:
 %s
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 %s

--- a/testdata/project-v4-config/config/crd/kustomization.yaml
+++ b/testdata/project-v4-config/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - bases/crew.testproject.org_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_captains.yaml

--- a/testdata/project-v4-declarative-v1/config/crd/kustomization.yaml
+++ b/testdata/project-v4-declarative-v1/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - bases/crew.testproject.org_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_captains.yaml

--- a/testdata/project-v4-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/crd/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 - bases/testproject.org_lakers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_captains.yaml

--- a/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - bases/example.com.testproject.org_busyboxes.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_memcacheds.yaml

--- a/testdata/project-v4/config/crd/kustomization.yaml
+++ b/testdata/project-v4/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - bases/crew.testproject.org_admirales.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_captains.yaml


### PR DESCRIPTION

Fixes #3372 

 See that the default scaffolds:

Warning:
'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run
"kustomize edit fix' to update
your Kustomization automatically.

Therefore I replaced patchesStrategicMerge by patches in the kustomize/v2 templates code. 