### PR TITLE
🐛 (go/v4): Scaffold when no boilerplate file

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scaffolds
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/afero"
@@ -67,7 +68,11 @@ func (s *apiScaffolder) Scaffold() error {
 	// Load the boilerplate
 	boilerplate, err := afero.ReadFile(s.fs.FS, hack.DefaultBoilerplatePath)
 	if err != nil {
-		boilerplate = []byte("")
+		if errors.Is(err, afero.ErrFileNotFound) {
+			boilerplate = []byte("")
+		} else {
+			return fmt.Errorf("error scaffolding API/controller: unable to load boilerplate: %w", err)
+		}
 	}
 
 	// Initialize the machinery.Scaffold that will write the files to disk

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -67,7 +67,7 @@ func (s *apiScaffolder) Scaffold() error {
 	// Load the boilerplate
 	boilerplate, err := afero.ReadFile(s.fs.FS, hack.DefaultBoilerplatePath)
 	if err != nil {
-		return fmt.Errorf("error scaffolding API/controller: unable to load boilerplate: %w", err)
+		boilerplate = []byte("")
 	}
 
 	// Initialize the machinery.Scaffold that will write the files to disk


### PR DESCRIPTION
### Description
This pull request addresses issue #3373, which prevented kubebuilder from creating an API when no boilerplate file was present.
I have tested the changes locally with the following steps:
1. Rebuilt the Kubebuilder binary with updated code
2. Used Kubebuilder to initialize a new project
3. Deleted the 'boilerplate' file
4. Modified the 'generate' target in the Makefile as follows:
```makefile
.PHONY: generate
generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
	$(CONTROLLER_GEN) object paths="./..."
```
5. Executed the 'create api' command.

Additionally, I tried to make some changes that enable the 'create api' command to modify the 'Makefile' when there's no boilerplate file and let the user skip step 4 altogether, making it possible to successfully run 'post-scaffold'(make generate). It seems not a little change, but I'm glad to do that if it is worth doing. :)