### PR TITLE
:book: fix missing fields in component config example

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/projectconfig_types.go
+++ b/docs/book/src/component-config-tutorial/testdata/projectconfig_types.go
@@ -36,7 +36,8 @@ we'll embed `cfg.ControllerManagerConfigurationSpec` in `ProjectConfig`.
 
 // ProjectConfig is the Schema for the projectconfigs API
 type ProjectConfig struct {
-	metav1.TypeMeta `json:",inline"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// ControllerManagerConfigurationSpec returns the configurations for controllers
 	cfg.ControllerManagerConfigurationSpec `json:",inline"`


### PR DESCRIPTION
The `ProjectConfig` `struct` in the [example file](docs/book/src/component-config-tutorial/testdata/projectconfig_types.go) (website link: https://book.kubebuilder.io/component-config-tutorial/config-type.html) is missing the embedded `ObjectMeta` from `k8s.io/apimachinery/pkg/apis/meta/v1`. This leads to the type being ignored when scaffolding and no crd being generated.

Adds the missing embedded `ObjectMeta` field to the example used in component config tutorial.
Without, the type is ignored while scaffolding.

Fixes #3384 