### PR TITLE
🐛: (go/v4) Scaffold no header when lincense is type none

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -81,25 +81,32 @@ func (s *initScaffolder) Scaffold() error {
 		machinery.WithConfig(s.config),
 	)
 
-	bpFile := &hack.Boilerplate{
-		License: s.license,
-		Owner:   s.owner,
-	}
-	bpFile.Path = s.boilerplatePath
-	if err := scaffold.Execute(bpFile); err != nil {
-		return err
-	}
+	if s.license != "none" {
+		bpFile := &hack.Boilerplate{
+			License: s.license,
+			Owner:   s.owner,
+		}
+		bpFile.Path = s.boilerplatePath
+		if err := scaffold.Execute(bpFile); err != nil {
+			return err
+		}
 
-	boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
-	if err != nil {
-		return err
+		boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
+		if err != nil {
+			return err
+		}
+		// Initialize the machinery.Scaffold that will write the files to disk
+		scaffold = machinery.NewScaffold(s.fs,
+			machinery.WithConfig(s.config),
+			machinery.WithBoilerplate(string(boilerplate)),
+		)
+	} else {
+		s.boilerplatePath = ""
+		// Initialize the machinery.Scaffold without boilerplate
+		scaffold = machinery.NewScaffold(s.fs,
+			machinery.WithConfig(s.config),
+		)
 	}
-
-	// Initialize the machinery.Scaffold that will write the files to disk
-	scaffold = machinery.NewScaffold(s.fs,
-		machinery.WithConfig(s.config),
-		machinery.WithBoilerplate(string(boilerplate)),
-	)
 
 	// If the KustomizeV2 was used to do the scaffold then
 	// we need to ensure that we use its supported Kustomize Version

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate.go
@@ -106,8 +106,8 @@ Copyright {{ .Year }}.
 {{ index .Licenses .License }}*/`
 
 var knownLicenses = map[string]string{
-	"apache2": apache2,
-	"none":    "",
+	"apache2":   apache2,
+	"copyright": "",
 }
 
 const apache2 = `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -110,7 +110,11 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+	{{ if .BoilerplatePath -}}
 	$(CONTROLLER_GEN) object:headerFile={{printf "%q" .BoilerplatePath}} paths="./..."
+	{{- else -}}
+	$(CONTROLLER_GEN) object paths="./..."
+	{{- end }}
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.


### PR DESCRIPTION
**Description**
Fix #3377
Now it would not scaffold any header if we use 'none' in license option.
