### PR TITLE
🌱 Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,9 +4,7 @@ aliases:
   # active folks who can be contacted to perform admin-related
   # tasks on the repo, or otherwise approve any PRs.
   kubebuilder-admins:
-    - pwittrock
     - camilamacedo86
-    - jmrodri
     - varshaprasad96
 
   # non-admin folks who can approve any PRs in the repo
@@ -28,3 +26,5 @@ aliases:
   - mengqiy
   - estroz
   - adirio
+  - jmrodri
+  - pwittrock


### PR DESCRIPTION
## Description

As requested, update the Owner alias accordingly so they know who they should contact when/if required. 

Sadly @jmrodri and @pwittrock have no longer been directly involved, but they are still part of our community and within the permissions granted under emeritus.
