### PR TITLE
⚠️🐛 Fix RegularPlural

### DIFF
--- a/pkg/cli/resource_test.go
+++ b/pkg/cli/resource_test.go
@@ -102,8 +102,8 @@ var _ = Describe("resourceOptions", func() {
 				Expect(resource.Plural).To(Equal(plural))
 			},
 			Entry("for `FirstMate`", "FirstMate", "firstmates"),
-			Entry("for `Fish`", "Fish", "fish"),
-			Entry("for `Helmswoman`", "Helmswoman", "helmswomen"),
+			Entry("for `Fish`", "Fish", "fishs"),
+			Entry("for `Helmswoman`", "Helmswoman", "helmswomans"),
 		)
 	})
 })

--- a/pkg/model/resource/utils.go
+++ b/pkg/model/resource/utils.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"path"
 	"strings"
-
-	"github.com/gobuffalo/flect"
 )
 
 const V1beta1 = "v1beta1"
@@ -67,7 +65,24 @@ func APIPackagePathLegacy(repo, group, version string, multiGroup bool) string {
 	return path.Join(repo, "api", version)
 }
 
+var unpluralizedSuffixes = []string{
+	"endpoints",
+}
+
 // RegularPlural returns a default plural form when none was specified
+// refer to https://github.com/kubernetes/apimachinery/blob/master/pkg/api/meta/restmapper.go#L126
 func RegularPlural(singular string) string {
-	return flect.Pluralize(strings.ToLower(singular))
+	singularName := strings.ToLower(singular)
+	for _, skip := range unpluralizedSuffixes {
+		if strings.HasSuffix(singularName, skip) {
+			return singular
+		}
+	}
+	switch string(singularName[len(singularName)-1]) {
+	case "s":
+		return singularName + "es"
+	case "y":
+		return strings.TrimSuffix(singularName, "y") + "ies"
+	}
+	return singularName + "s"
 }

--- a/pkg/model/resource/utils_test.go
+++ b/pkg/model/resource/utils_test.go
@@ -69,9 +69,10 @@ var _ = Describe("APIPackagePathLegacy", func() {
 
 var _ = DescribeTable("RegularPlural should return the regular plural form",
 	func(singular, plural string) { Expect(RegularPlural(singular)).To(Equal(plural)) },
+	Entry("unpluralized", "endpoints", "endpoints"),
 	Entry("basic singular", "firstmate", "firstmates"),
 	Entry("capitalized singular", "Firstmate", "firstmates"),
 	Entry("camel-cased singular", "FirstMate", "firstmates"),
-	Entry("irregular well-known plurals", "fish", "fish"),
-	Entry("irregular well-known plurals", "helmswoman", "helmswomen"),
+	Entry("basic singular", "fish", "fishs"),
+	Entry("basic singular", "helmswoman", "helmswomans"),
 )


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

Fix https://github.com/kubernetes-sigs/kubebuilder/issues/3402

Optimize the function `RegularPlural` according to [`UnsafeGuessKindToResource`](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/meta/restmapper.go#L126) in k8s.
