### PR TITLE
:book: fix formatting in quick start

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -96,7 +96,7 @@ If you are editing the API definitions, generate the manifests such as Custom Re
 make manifests
 ```
 
-<details><summary>Click here to see an example. `(api/v1/guestbook_types.go)` </summary>
+<details><summary>Click here to see an example. <tt>(api/v1/guestbook_types.go)</tt></summary>
 <p>
 
 ```go


### PR DESCRIPTION
Currently looks like this [on this page](https://book.kubebuilder.io/quick-start.html).
<img width="517" alt="image" src="https://github.com/kubernetes-sigs/kubebuilder/assets/480621/27c5b826-a236-485c-bf7c-c6a598b120f0">
