### PR TITLE
📖 Added user prompt for multi version api doc

### DIFF
--- a/docs/book/src/multiversion-tutorial/api-changes.md
+++ b/docs/book/src/multiversion-tutorial/api-changes.md
@@ -40,6 +40,8 @@ We'll need a new API version for this change.  Let's call it v2:
 kubebuilder create api --group batch --version v2 --kind CronJob
 ```
 
+Press `y` for "Create Resource" and `n` for "Create Controller".
+
 Now, let's copy over our existing types, and make the change:
 
 {{#literatego ./testdata/project/api/v2/cronjob_types.go}}


### PR DESCRIPTION
Description:
This PR will improve the document by adding instructions when creating a new version API

Motivation:
When going through the documentation, I saw for the first chapter the prompt was given (https://github.com/kubernetes-sigs/kubebuilder/blob/3c8a6264f45edaaf9c2f1c9ce82ce7de26c16097/docs/book/src/cronjob-tutorial/new-api.md?plain=1#L11) but it wasn't given for chapter 2

so it confused me when running `kubebuilder create api --group batch --version v2 --kind CronJob`  which will output **error**  when I  chose y for both "Create Resource" and "Create Controller`
"Create Controller" is created on chapter 1 so it's no needed over here