### PR TITLE
📖 Quote download URL in quickstart docs

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -31,7 +31,7 @@ Install [kubebuilder](https://sigs.k8s.io/kubebuilder):
 
 ```bash
 # download kubebuilder and install locally.
-curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)
+curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
 chmod +x kubebuilder && mv kubebuilder /usr/local/bin/
 ```
 


### PR DESCRIPTION
Copying and pasting the `curl` line in the installation docs conflicts with zsh (or perhaps ohmyzsh, and perhaps only on Mac), which incorrectly escapes parentheses. 

```sh
curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)
```

becomes:

```sh
curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$\(go env GOOS)/$(go env GOARCH)
```

Which of course doesn't have the desired result and errors out.

Double-quoting the URL should ensure the interpolated shell commands have the desired outcome. Tested on zsh and bash.
