### PR TITLE
 📖 : doc fix path error

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -82,7 +82,7 @@ kubebuilder create api --group webapp --version v1 --kind Guestbook
 <h1>Press Options</h1>
 
 If you press `y` for Create Resource [y/n] and for Create Controller [y/n] then this will create the files `api/v1/guestbook_types.go` where the API is defined
-and the `controllers/guestbook_controller.go` where the reconciliation business logic is implemented for this Kind(CRD).
+and the `internal/controllers/guestbook_controller.go` where the reconciliation business logic is implemented for this Kind(CRD).
 
 </aside>
 


### PR DESCRIPTION
#### Description
- The path to the generated `controller` file is incorrect in the quick start 
- Fixed the path by prefixing it with `internal/`