### PR TITLE
:bug: Fix kustomize syntax during conversion to patches

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -8,12 +8,12 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_projectconfigs.yaml
+#- path: patches/webhook_in_projectconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_projectconfigs.yaml
+#- path: patches/cainjection_in_projectconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -8,12 +8,12 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_cronjobs.yaml
+- path: patches/webhook_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_cronjobs.yaml
+- path: patches/cainjection_in_cronjobs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -581,12 +581,12 @@ func updateKustomization(sp *Sample) {
 	// uncomment crd/kustomization
 	err = pluginutil.UncommentCode(
 		filepath.Join(sp.ctx.Dir, "config/crd/kustomization.yaml"),
-		`#- patches/webhook_in_cronjobs.yaml`, `#`)
+		`#- path: patches/webhook_in_cronjobs.yaml`, `#`)
 	CheckError("fixing crd/kustomization", err)
 
 	err = pluginutil.UncommentCode(
 		filepath.Join(sp.ctx.Dir, "config/crd/kustomization.yaml"),
-		`#- patches/cainjection_in_cronjobs.yaml`, `#`)
+		`#- path: patches/cainjection_in_cronjobs.yaml`, `#`)
 	CheckError("fixing crd/kustomization", err)
 }
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -68,9 +68,9 @@ func (f *Kustomization) GetMarkers() []machinery.Marker {
 const (
 	resourceCodeFragment = `- bases/%s_%s.yaml
 `
-	webhookPatchCodeFragment = `#- patches/webhook_in_%s.yaml
+	webhookPatchCodeFragment = `#- path: patches/webhook_in_%s.yaml
 `
-	caInjectionPatchCodeFragment = `#- patches/cainjection_in_%s.yaml
+	caInjectionPatchCodeFragment = `#- path: patches/cainjection_in_%s.yaml
 `
 )
 

--- a/pkg/plugins/golang/declarative/v1/api.go
+++ b/pkg/plugins/golang/declarative/v1/api.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	"fmt"
 
-	goPluginV3 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3"
-
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
@@ -29,6 +27,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/declarative/v1/scaffolds"
 	goPluginV2 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v2"
+	goPluginV3 "sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v3"
 )
 
 const (

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -84,6 +84,12 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 
 	By("uncomment kustomization.yaml to enable webhook and ca injection")
 	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "crd", "kustomization.yaml"),
+		fmt.Sprintf("#- path: patches/webhook_in_%s.yaml", kbc.Resources), "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "crd", "kustomization.yaml"),
+		fmt.Sprintf("#- path: patches/cainjection_in_%s.yaml", kbc.Resources), "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- ../webhook", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(

--- a/testdata/project-v4-declarative-v1/config/crd/kustomization.yaml
+++ b/testdata/project-v4-declarative-v1/config/crd/kustomization.yaml
@@ -10,16 +10,16 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_captains.yaml
-#- patches/webhook_in_firstmates.yaml
-#- patches/webhook_in_admirals.yaml
+#- path: patches/webhook_in_captains.yaml
+#- path: patches/webhook_in_firstmates.yaml
+#- path: patches/webhook_in_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_captains.yaml
-#- patches/cainjection_in_firstmates.yaml
-#- patches/cainjection_in_admirals.yaml
+#- path: patches/cainjection_in_captains.yaml
+#- path: patches/cainjection_in_firstmates.yaml
+#- path: patches/cainjection_in_admirals.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/crd/kustomization.yaml
@@ -17,28 +17,28 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_captains.yaml
-#- patches/webhook_in_frigates.yaml
-#- patches/webhook_in_destroyers.yaml
-#- patches/webhook_in_cruisers.yaml
-#- patches/webhook_in_krakens.yaml
-#- patches/webhook_in_leviathans.yaml
-#- patches/webhook_in_healthcheckpolicies.yaml
-#- patches/webhook_in_bars.yaml
-#- patches/webhook_in_lakers.yaml
+#- path: patches/webhook_in_captains.yaml
+#- path: patches/webhook_in_frigates.yaml
+#- path: patches/webhook_in_destroyers.yaml
+#- path: patches/webhook_in_cruisers.yaml
+#- path: patches/webhook_in_krakens.yaml
+#- path: patches/webhook_in_leviathans.yaml
+#- path: patches/webhook_in_healthcheckpolicies.yaml
+#- path: patches/webhook_in_bars.yaml
+#- path: patches/webhook_in_lakers.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_captains.yaml
-#- patches/cainjection_in_frigates.yaml
-#- patches/cainjection_in_destroyers.yaml
-#- patches/cainjection_in_cruisers.yaml
-#- patches/cainjection_in_krakens.yaml
-#- patches/cainjection_in_leviathans.yaml
-#- patches/cainjection_in_healthcheckpolicies.yaml
-#- patches/cainjection_in_bars.yaml
-#- patches/cainjection_in_lakers.yaml
+#- path: patches/cainjection_in_captains.yaml
+#- path: patches/cainjection_in_frigates.yaml
+#- path: patches/cainjection_in_destroyers.yaml
+#- path: patches/cainjection_in_cruisers.yaml
+#- path: patches/cainjection_in_krakens.yaml
+#- path: patches/cainjection_in_leviathans.yaml
+#- path: patches/cainjection_in_healthcheckpolicies.yaml
+#- path: patches/cainjection_in_bars.yaml
+#- path: patches/cainjection_in_lakers.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
@@ -9,14 +9,14 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_memcacheds.yaml
-#- patches/webhook_in_busyboxes.yaml
+#- path: patches/webhook_in_memcacheds.yaml
+#- path: patches/webhook_in_busyboxes.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_memcacheds.yaml
-#- patches/cainjection_in_busyboxes.yaml
+#- path: patches/cainjection_in_memcacheds.yaml
+#- path: patches/cainjection_in_busyboxes.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4/config/crd/kustomization.yaml
+++ b/testdata/project-v4/config/crd/kustomization.yaml
@@ -10,16 +10,16 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_captains.yaml
-#- patches/webhook_in_firstmates.yaml
-#- patches/webhook_in_admirales.yaml
+#- path: patches/webhook_in_captains.yaml
+#- path: patches/webhook_in_firstmates.yaml
+#- path: patches/webhook_in_admirales.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_captains.yaml
-#- patches/cainjection_in_firstmates.yaml
-#- patches/cainjection_in_admirales.yaml
+#- path: patches/cainjection_in_captains.yaml
+#- path: patches/cainjection_in_firstmates.yaml
+#- path: patches/cainjection_in_admirales.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.


### PR DESCRIPTION
This commit fixes the syntax error introduced in #3374 where pathcesStrategicMerge was replaced with patches, which now requires that every patch additionally have a "path" key when multiple patches are specified in a file.

Fixes #3425
