### PR TITLE
⚠️ (kustomize/v2) - deprecate component-config flag and component-config API methods

### DIFF
--- a/pkg/machinery/interfaces.go
+++ b/pkg/machinery/interfaces.go
@@ -83,6 +83,14 @@ type HasMultiGroup interface {
 	InjectMultiGroup(bool)
 }
 
+// Deprecated: The ComponentConfig has been deprecated in the Controller-Runtime since its version 0.15.0.
+// Fur further information see: https://github.com/kubernetes-sigs/controller-runtime/issues/895
+// Moreover, it has undergone breaking changes and is no longer functioning as intended.
+// As a result, Kubebuilder, which heavily relies on the Controller Runtime, has also deprecated this feature,
+// no longer guaranteeing its functionality from version 3.11.0 onwards.
+//
+// Please, be aware that it will force Kubebuilder remove this option soon in future release.
+//
 // HasComponentConfig allows the component-config flag to be used on a template
 type HasComponentConfig interface {
 	// InjectComponentConfig sets the template component-config flag

--- a/pkg/machinery/mixins.go
+++ b/pkg/machinery/mixins.go
@@ -129,6 +129,14 @@ func (m *MultiGroupMixin) InjectMultiGroup(flag bool) {
 	m.MultiGroup = flag
 }
 
+// Deprecated: The ComponentConfig has been deprecated in the Controller-Runtime since its version 0.15.0.
+// Fur further information see: https://github.com/kubernetes-sigs/controller-runtime/issues/895
+// Moreover, it has undergone breaking changes and is no longer functioning as intended.
+// As a result, Kubebuilder, which heavily relies on the Controller Runtime, has also deprecated this feature,
+// no longer guaranteeing its functionality from version 3.11.0 onwards.
+//
+// Please, be aware that it will force Kubebuilder remove this option soon in future release.
+//
 // ComponentConfigMixin provides templates with a injectable component-config flag field
 type ComponentConfigMixin struct {
 	// ComponentConfig is the component-config flag

--- a/pkg/plugins/common/kustomize/v2/init.go
+++ b/pkg/plugins/common/kustomize/v2/init.go
@@ -62,6 +62,11 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.name, "project-name", "", "name of this project")
 	fs.BoolVar(&p.componentConfig, "component-config", false,
 		"create a versioned ComponentConfig file, may be 'true' or 'false'")
+	_ = fs.MarkDeprecated("component-config", "the ComponentConfig has been deprecated in the "+
+		"Controller-Runtime since its version 0.15.0. Moreover, it has undergone breaking changes and is no longer "+
+		"functioning as intended. As a result, this tool, which heavily relies on the Controller Runtime, "+
+		"has also deprecated this feature, no longer guaranteeing its functionality from version 3.11.0 onwards. "+
+		"You can find additional details on https://github.com/kubernetes-sigs/controller-runtime/issues/895.")
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) error {


### PR DESCRIPTION
## Description

Deprecated component-config flag  and component-config API methods
Following up of: https://github.com/kubernetes-sigs/kubebuilder/pull/3442/files

Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/3023
Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/3022
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3418
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/2782
