### PR TITLE
🐛 Uncomment config/crd/kustomization.yaml in e2e test

### DIFF
--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -84,6 +84,12 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 
 	By("uncomment kustomization.yaml to enable webhook and ca injection")
 	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "crd", "kustomization.yaml"),
+		fmt.Sprintf("#- patches/webhook_in_%s.yaml", kbc.Resources), "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "crd", "kustomization.yaml"),
+		fmt.Sprintf("#- patches/cainjection_in_%s.yaml", kbc.Resources), "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- ../webhook", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(


### PR DESCRIPTION
This PR should cause a failing e2e run in CI and represents a reproducer of #3425 and should not be merged directly. If it looks good, these changes will be bundled into #3456 