### PR TITLE
:bug: fix(completion): Fix completion in deprecated projects

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -444,7 +444,7 @@ func (c *CLI) addExtraCommands() error {
 func (c CLI) printDeprecationWarnings() {
 	for _, p := range c.resolvedPlugins {
 		if p != nil && p.(plugin.Deprecated) != nil && len(p.(plugin.Deprecated).DeprecationWarning()) > 0 {
-			fmt.Printf(noticeColor, fmt.Sprintf(deprecationFmt, p.(plugin.Deprecated).DeprecationWarning()))
+			fmt.Fprintf(os.Stderr, noticeColor, fmt.Sprintf(deprecationFmt, p.(plugin.Deprecated).DeprecationWarning()))
 		}
 	}
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -592,13 +592,13 @@ plugins:
 				)
 				deprecatedPlugin := newMockDeprecatedPlugin("deprecated", "v1", deprecationWarning, projectVersion)
 
-				// Overwrite stdout to read the output and reset it afterwards
+				// Overwrite stderr to read the deprecation output and reset it afterwards
 				r, w, _ := os.Pipe()
-				temp := os.Stdout
+				temp := os.Stderr
 				defer func() {
-					os.Stdout = temp
+					os.Stderr = temp
 				}()
-				os.Stdout = w
+				os.Stderr = w
 
 				c, err = New(
 					WithPlugins(deprecatedPlugin),


### PR DESCRIPTION
Fixes #3473 

Currently, when initializing in a project with deprecated plugins the kubebuilder cli will immediately output a deprecation notice to stdout before even parsing the command. While this is acceptable and even desirable for interactive usage of the cli, it will "randomly" (i.e. dependent on $PWD and not on the command) break automated usage of the kubebuilder output. This, again is fine if kubebuilder makes no guarantees of stable machine readable output, but this does not hold for the completion sub commands which are only ever parsed by machines: The output of "kubebuilder completion <shell>" must always only output the exact script generated by cobra and the cobra internal commands __complete and __completeNoDesc must only only return an exact list of completion options.

In deprecated projects this will break shell completion if the shell is started in the directory and if the completion script is correctly initialized, all completion options will be polluted by the massive deprecation notice.

This commit instead changes the deprecation notice to output to stderr (while maintaining the return code of the actual command). This fixes the completion usecase which only reads in stdout, and should not break existing integrations, unless there exist scripts which use the length of stderr to check for errors rather than the return code of the call.

### Example broken completion output when deprecation notice is put out on stdout (ZSH)

```
source <(kubebuilder completion zsh)
# resulting error: /proc/self/fd/15:1: bad pattern: ^[[1

kubebuilder <tab>
# completion                                                                 
# create                                                                         
# edit                                                                           
# help                                                                           
# init                                                                           
# version                                                                        
# ^[[1;36m[Deprecation Notice] This version is deprecated.The `go/v3` cannot scaffold projects using kustomize versions v4x+ and cannot fully support Kubernetes 1.25+.It is recommended to upgrade your project to the latest versions available (go/v4).Please, check the migration guide to learn how to upgrade your project
```
