### PR TITLE
📖 Fix command in Quick Start guide

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:


### PR DESCRIPTION
Use `apply -k` because folder contains a kustomization and command will fail otherwise