### PR TITLE
✨ Add .vscode to autogenerated .gitignore files

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/component-config-tutorial/testdata/project/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/gitignore.go
@@ -59,6 +59,7 @@ bin
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/gitignore.go
@@ -61,6 +61,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
@@ -60,6 +60,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v2/.gitignore
+++ b/testdata/project-v2/.gitignore
@@ -19,6 +19,7 @@ bin
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v3/.gitignore
+++ b/testdata/project-v3/.gitignore
@@ -21,6 +21,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v4-declarative-v1/.gitignore
+++ b/testdata/project-v4-declarative-v1/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v4-with-deploy-image/.gitignore
+++ b/testdata/project-v4-with-deploy-image/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v4-with-grafana/.gitignore
+++ b/testdata/project-v4-with-grafana/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~


### PR DESCRIPTION
VS Code is a very popular editor, putting a directory specific to it in generated `.gitignore` files seems to be a nice improvement for end users.