### PR TITLE
📖 Docs fixes for code blocks, links and minor typos

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -65,7 +65,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if cronJob.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
-		// registering our finalizer.
+		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(cronJob, myFinalizerName) {
 			controllerutil.AddFinalizer(cronJob, myFinalizerName)
 			if err := r.Update(ctx, cronJob); err != nil {
@@ -78,7 +78,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// our finalizer is present, so lets handle any external dependency
 			if err := r.deleteExternalResources(cronJob); err != nil {
 				// if fail to delete the external dependency here, return with error
-				// so that it can be retried
+				// so that it can be retried.
 				return ctrl.Result{}, err
 			}
 
@@ -105,4 +105,3 @@ func (r *Reconciler) deleteExternalResources(cronJob *batch.CronJob) error {
 	// Ensure that delete implementation is idempotent and safe to invoke
 	// multiple times for same object.
 }
-

--- a/docs/book/src/multiversion-tutorial/api-changes.md
+++ b/docs/book/src/multiversion-tutorial/api-changes.md
@@ -12,7 +12,7 @@ schedule: "*/1 * * * *"
 That's a pretty textbook example of a special string format (it's also
 pretty unreadable unless you're a Unix sysadmin).
 
-Let's make it a bit more structured.  According to the our [CronJob
+Let's make it a bit more structured.  According to our [CronJob
 code][cronjob-sched-code], we support "standard" Cron format.
 
 In Kubernetes, **all versions must be safely round-tripable through each
@@ -52,4 +52,4 @@ Now, let's copy over our existing types, and make the change:
 
 Now that we've got our types in place, we'll need to set up conversion...
 
-[cronjob-sched-code]: /TODO.md
+[cronjob-sched-code]: ./multiversion-tutorial/testdata/project/api/v2/cronjob_types.go "CronJob Code"

--- a/docs/book/src/reference/completion.md
+++ b/docs/book/src/reference/completion.md
@@ -27,7 +27,7 @@ if [ -f /usr/local/share/bash-completion/bash_completion ]; then
 fi
 . <(kubebuilder completion bash)
 ```
-- Restart terminal for the changes to be reflected.
+- Restart terminal for the changes to be reflected or `source` the changed bash file.
 
 <aside class="note">
 <h1>Zsh</h1>

--- a/docs/book/src/reference/platform.md
+++ b/docs/book/src/reference/platform.md
@@ -6,8 +6,7 @@ build and configure your workloads. This guide aims to help you properly configu
 ## Overview
 
 To provide support on specific or multiple platforms, you must ensure that all images used in workloads are built to 
-support the desired platforms. Note that may not be the same as the platform where you develop your solutions 
-and use KubeBuilder, but instead the platform(s) where your solution should run and be distributed. 
+support the desired platforms. Note that they may not be the same as the platform where you develop your solutions and use KubeBuilder, but instead the platform(s) where your solution should run and be distributed. 
 It is recommended to build solutions that work on multiple platforms so that your project works
 on any Kubernetes cluster regardless of the underlying operating system and architecture.
 

--- a/docs/book/src/reference/raising-events.md
+++ b/docs/book/src/reference/raising-events.md
@@ -76,7 +76,6 @@ type MyKindReconciler struct {
 	Recorder record.EventRecorder
 }
 ```
-
 ### Passing the EventRecorder to the Controller
 
 Events are published from a Controller using an [EventRecorder]`type CorrelatorOptions struct`,

--- a/docs/book/src/reference/webhook-overview.md
+++ b/docs/book/src/reference/webhook-overview.md
@@ -1,8 +1,8 @@
 # Webhook
 
 Webhooks are requests for information sent in a blocking fashion. A web
-application implementing webhooks will send an HTTP request to other application
-when certain event happens.
+application implementing webhooks will send a HTTP request to other applications
+when a certain event happens.
 
 In the kubernetes world, there are 3 kinds of webhooks:
 [admission webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks),


### PR DESCRIPTION
I've recently come across some issues while reading the Kubebuilder document.

This PR mainly addresses:
- formatting issues that do not properly render code blocks
- broken links that reference the Cronjob code
- minor typos and grammar for a smoother reading experience