### PR TITLE
:seedling: Replacing destroy and improve info logs for hack docs script generation

### DIFF
--- a/hack/docs/internal/component-config-tutorial/generate_component_config.go
+++ b/hack/docs/internal/component-config-tutorial/generate_component_config.go
@@ -56,8 +56,10 @@ func newSampleContext(binaryPath string, samplePath string, env ...string) utils
 
 // Prepare the Context for the sample project
 func (sp *Sample) Prepare() {
-	log.Infof("destroying directory for sample project")
-	sp.ctx.Destroy()
+	log.Infof("destroying directory to create component config tutorial doc sample")
+	if err := os.RemoveAll(sp.ctx.Dir); err != nil {
+		log.Warning("unable to clean up the directory to generate reate component config tutorial doc sample ", err)
+	}
 
 	log.Infof("refreshing tools and creating directory...")
 	err := sp.ctx.Prepare()

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -56,8 +56,10 @@ func newSampleContext(binaryPath string, samplePath string, env ...string) utils
 
 // Prepare the Context for the sample project
 func (sp *Sample) Prepare() {
-	log.Infof("destroying directory for sample project")
-	sp.ctx.Destroy()
+	log.Infof("destroying directory to create CronjobTutorial")
+	if err := os.RemoveAll(sp.ctx.Dir); err != nil {
+		log.Warning("unable to clean up the directory to create CronjobTutoria", err)
+	}
 
 	log.Infof("refreshing tools and creating directory...")
 	err := sp.ctx.Prepare()
@@ -466,13 +468,13 @@ func updateSuiteTest(sp *Sample) {
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
 		`limitations under the License.
 */`, SuiteTestIntro)
-	CheckError("fixing suite_test.go", err)
+	CheckError("updating suite_test.go to add license intro", err)
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
 		`import (`, `
 	"context"`)
-	CheckError("fixing suite_test.go", err)
+	CheckError("updating suite_test.go to add context", err)
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
@@ -481,7 +483,7 @@ func updateSuiteTest(sp *Sample) {
 `, `
 	ctrl "sigs.k8s.io/controller-runtime"
 `)
-	CheckError("fixing suite_test.go", err)
+	CheckError("updating suite_test.go to add ctrl import", err)
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
@@ -490,14 +492,14 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 `, SuiteTestEnv)
-	CheckError("fixing suite_test.go", err)
+	CheckError("updating suite_test.go to add more variables", err)
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
 		`
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 `, SuiteTestReadCRD)
-	CheckError("fixing suite_test.go", err)
+	CheckError("updating suite_test.go to add text about CRD", err)
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
@@ -507,7 +509,7 @@ var testEnv *envtest.Environment
 	/*
 		Then, we start the envtest cluster.
 	*/`)
-	CheckError("fixing suite_test.go", err)
+	CheckError("updating suite_test.go to add text to show where envtest cluster start", err)
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),


### PR DESCRIPTION
## Description

- Replace Destroy func uses in the e2e to remove the image with code implementation to remove the doc samples directory and files in order to re-generate it
- Improve the logs by replacing `fixing suite_test.go` with meaningful info logs to help to troubleshooting when errors are faced. 