### PR TITLE
:seedling:  Update destroy function 

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -232,9 +232,12 @@ func (t *TestContext) Tidy() error {
 // Destroy is for cleaning up the docker images for testing
 func (t *TestContext) Destroy() {
 	//nolint:gosec
-	cmd := exec.Command("docker", "rmi", "-f", t.ImageName)
-	if _, err := t.Run(cmd); err != nil {
-		warnError(err)
+	// if image name is not present or not provided skip execution of docker command
+	if t.ImageName != "" {
+		cmd := exec.Command("docker", "rmi", "-f", t.ImageName)
+		if _, err := t.Run(cmd); err != nil {
+			warnError(err)
+		}
 	}
 	if err := os.RemoveAll(t.Dir); err != nil {
 		warnError(err)


### PR DESCRIPTION

## Description
Updated destroy function to run docker only when image name is present. This removes the log error while generating docs.

Partial address: https://github.com/kubernetes-sigs/kubebuilder/issues/3435
