### PR TITLE
📖 : apply kustomize dir with correct flags

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/README.md
+++ b/docs/book/src/component-config-tutorial/testdata/project/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/readme.go
@@ -45,7 +45,7 @@ func (f *Readme) SetTemplateDefaults() error {
 		"*/", "", 1)
 
 	f.TemplateBody = fmt.Sprintf(readmeFileTemplate,
-		codeFence("kubectl apply -f config/samples/"),
+		codeFence("kubectl apply -k config/samples/"),
 		codeFence("make docker-build docker-push IMG=<some-registry>/{{ .ProjectName }}:tag"),
 		codeFence("make deploy IMG=<some-registry>/{{ .ProjectName }}:tag"),
 		codeFence("make uninstall"),

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -45,7 +45,7 @@ func (f *Readme) SetTemplateDefaults() error {
 		"*/", "", 1)
 
 	f.TemplateBody = fmt.Sprintf(readmeFileTemplate,
-		codeFence("kubectl apply -f config/samples/"),
+		codeFence("kubectl apply -k config/samples/"),
 		codeFence("make docker-build docker-push IMG=<some-registry>/{{ .ProjectName }}:tag"),
 		codeFence("make deploy IMG=<some-registry>/{{ .ProjectName }}:tag"),
 		codeFence("make uninstall"),

--- a/testdata/project-v3/README.md
+++ b/testdata/project-v3/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/testdata/project-v4-declarative-v1/README.md
+++ b/testdata/project-v4-declarative-v1/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/testdata/project-v4-multigroup/.gitignore
+++ b/testdata/project-v4-multigroup/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v4-multigroup/README.md
+++ b/testdata/project-v4-multigroup/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/testdata/project-v4-with-deploy-image/README.md
+++ b/testdata/project-v4-with-deploy-image/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/testdata/project-v4-with-grafana/README.md
+++ b/testdata/project-v4-with-grafana/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:

--- a/testdata/project-v4/.gitignore
+++ b/testdata/project-v4/.gitignore
@@ -20,6 +20,7 @@ Dockerfile.cross
 
 # editor and IDE paraphernalia
 .idea
+.vscode
 *.swp
 *.swo
 *~

--- a/testdata/project-v4/README.md
+++ b/testdata/project-v4/README.md
@@ -12,7 +12,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 1. Install Instances of Custom Resources:
 
 ```sh
-kubectl apply -f config/samples/
+kubectl apply -k config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:


### PR DESCRIPTION
## Description

Use `-k` instead of `-f` when instructing users to call `kubectl apply` for *config/samples*.

The *config/samples* consists of kustomize manifests, and `kubectl apply -k` typically processes for a kustomization directory.

## Motivation

This is a following up from https://github.com/kubernetes-sigs/kubebuilder/issues/3499


<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
