### PR TITLE
:seedling: Image name edge cases covered

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -243,10 +243,16 @@ func (t *TestContext) Destroy() {
 	//nolint:gosec
 	// if image name is not present or not provided skip execution of docker command
 	if t.ImageName != "" {
-		cmd := exec.Command("docker", "rmi", "-f", t.ImageName)
-		if _, err := t.Run(cmd); err != nil {
-			warnError(err)
+		// Check white space from image name
+		if len(strings.TrimSpace(t.ImageName)) == 0 {
+			fmt.Println("Image not set, skip cleaning up of docker image")
+		} else {
+			cmd := exec.Command("docker", "rmi", "-f", t.ImageName)
+			if _, err := t.Run(cmd); err != nil {
+				warnError(err)
+			}
 		}
+
 	}
 	if err := os.RemoveAll(t.Dir); err != nil {
 		warnError(err)


### PR DESCRIPTION
## Description:
In generating docs, if there is no image present we can skip running docker command and this was covered in https://github.com/kubernetes-sigs/kubebuilder/pull/3508
but if the image name is  of  single character or in anyother edge case the code would crash. 
In this pr I have covered the Edge cases. 
Following up on: https://github.com/kubernetes-sigs/kubebuilder/pull/3508#discussion_r1279543133