### PR TITLE
🐛 Ensure external plugin can scaffold files in new directories

### DIFF
--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -168,7 +168,15 @@ func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, p
 	}
 
 	for filename, data := range res.Universe {
-		f, err := fs.FS.Create(filepath.Join(currentDir, filename))
+		path := filepath.Join(currentDir, filename)
+		dir := filepath.Dir(path)
+
+		// create the directory if it does not exist
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("error creating the directory: %v", err)
+		}
+
+		f, err := fs.FS.Create(path)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description:
Ensure the path specified in `PluginResponse.Universe` is created before the real scaffolding logic.

Example:
For the Universe:
```
universe["some/dir/file.yaml"] = `...`
```
Create `/home/user/foo-test/some/dir` before scaffolding so as to avoid errors like:
```
2023/08/02 11:56:23 failed to initialize project: unable to scaffold with "foo/v1": open /home/user/foo-test/some/dir/file.yaml: no such file or directory
```

### Motivation:
Aims to fix the corresponding issue https://github.com/kubernetes-sigs/kubebuilder/issues/3518


<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
