### PR TITLE
🐛: sync kb binary from source code for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ generate-testdata: ## Update/generate the testdata in $GOPATH/src/sigs.k8s.io/ku
 
 .PHONY: generate-docs
 generate-docs: ## Update/generate the docs in $GOPATH/src/sigs.k8s.io/kubebuilder
-	go run hack/docs/generate_samples.go
+	./hack/docs/generate.sh
 
 .PHONY: check-docs
 check-docs: ## Run the script to ensure that the docs are updated

--- a/hack/docs/check.sh
+++ b/hack/docs/check.sh
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source "$(dirname "$0")/../../test/common.sh"
-
-build_kb
-
 check_directory="$(dirname "$0")/../../docs/book/src/"
 
 # Check docs directory first. If there are any uncommitted change, fail the test.
@@ -27,7 +23,8 @@ if [[ $(git status ${check_directory} --porcelain) ]]; then
   exit 1
 fi
 
-make generate-docs
+
+$(dirname "$0")/generate.sh
 
 # Check if there are any changes to files under testdata directory.
 if [[ $(git status ${check_directory} --porcelain) ]]; then

--- a/hack/docs/generate.sh
+++ b/hack/docs/generate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "$0")/../../test/common.sh"
+
+build_kb
+
+docs_gen_directory="$(dirname "$0")/../../hack/docs/generate_samples.go"
+go run ${docs_gen_directory}
+

--- a/hack/docs/generate_samples.go
+++ b/hack/docs/generate_samples.go
@@ -21,8 +21,10 @@ import (
 
 	componentconfig "sigs.k8s.io/kubebuilder/v3/hack/docs/internal/component-config-tutorial"
 	cronjob "sigs.k8s.io/kubebuilder/v3/hack/docs/internal/cronjob-tutorial"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 )
+
+// Make sure executing `build_kb` to generate kb executable from the source code
+const KubebuilderBinName = "/tmp/kubebuilder/bin/kubebuilder"
 
 func main() {
 	fmt.Println("Generating documents...")
@@ -36,7 +38,7 @@ func main() {
 }
 
 func UpdateComponentConfigTutorial() {
-	binaryPath := util.KubebuilderBinName
+	binaryPath := KubebuilderBinName
 	samplePath := "docs/book/src/component-config-tutorial/testdata/project/"
 
 	sp := componentconfig.NewSample(binaryPath, samplePath)
@@ -51,7 +53,7 @@ func UpdateComponentConfigTutorial() {
 }
 
 func UpdateCronjobTutorial() {
-	binaryPath := util.KubebuilderBinName
+	binaryPath := KubebuilderBinName
 	samplePath := "docs/book/src/cronjob-tutorial/testdata/project/"
 
 	sp := cronjob.NewSample(binaryPath, samplePath)


### PR DESCRIPTION
## Description

This PR aims to ensure that the `Kubebuilder binary` used for docs generation is built from the source code so that the docs can be updated corresponding to the latest code change.

- Create a new `hack/docs/generate.sh` that builds the kb executable from source code and run the go code to re-generate docs samples
- Modify the target `generate-docs` to call `hack/docs/generate.sh`
- Modify the target `check-docs` to drop unnecessary import and call `hack/docs/generate.sh`
- Change the go code to use kb binary `/tmp/kubebuilder/bin/kubebuilder` which is generated by `build_kb` (instead of the default kb from user's os env).

## Motivation:

Partially resolve https://github.com/kubernetes-sigs/kubebuilder/issues/3435
See comments:
1. https://github.com/kubernetes-sigs/kubebuilder/issues/3435#issuecomment-1646613790
2. https://github.com/kubernetes-sigs/kubebuilder/issues/3435#issuecomment-1654203778

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
