### PR TITLE
📖 add devpod to quickstart as alternative

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -15,6 +15,15 @@ This Quick Start guide will cover:
 - Access to a Kubernetes v1.11.3+ cluster.
 
 <aside class="note">
+<h1>Alternative: Use DevPod to work within a development container</h1>
+
+[![Open in DevPod!](https://devpod.sh/assets/open-in-devpod.svg)](https://devpod.sh/open#https://github.com/loft-sh/devpod-kubebuilder-template)
+
+You can use [DevPod](https://devpod.sh) and the [Kubebuilder template](https://github.com/loft-sh/devpod-kubebuilder-template) to automate the installation process by starting a development container with the needed tooling preinstalled.
+
+</aside>
+
+<aside class="note">
 <h1>Versions and Supportability</h1>
 
 Projects created by Kubebuilder contain a Makefile that will install tools at versions defined at creation time. Those tools are:


### PR DESCRIPTION
## Description

This PR adds [DevPod](https://github.com/loft-sh/devpod) as an alternative method to get started with Kubebuilder to the Quickstart. DevPod is a tool that uses a [devcontainer.json](https://containers.dev/) (like Github codespaces) to spin up a development container. The difference to Github Codespaces is that DevPod is Open-Source, client-only and works on any backend, such as local docker, kubernetes or any public cloud provider.

## Motivation

We saw interest for a `devcontainer.json` integration in issue #3432 and @csantanapr (who is organising the kubebuilder book club) and I decided to create a [DevPod kubebuilder template](https://github.com/loft-sh/devpod-kubebuilder-template). This template uses a `devcontainer.json` to simplify the onboarding experience for new users that are interested in trying out DevPod by creating a development container with all needed tooling preinstalled. 

This has worked pretty well so far and we think it would be a great addition to the kubebuilder book itself. Obviously, I'm also happy to change anything if needed!