### PR TITLE
📖  fix quickstart documentation to only apply sample CR

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -180,7 +180,7 @@ If you pressed `y` for Create Resource [y/n] then you created a CR for your CRD 
 API definition):
 
 ```bash
-kubectl apply -k config/samples/
+kubectl apply -f config/samples/webapp_v1_guestbook.yaml
 ```
 
 ## Run It On the Cluster


### PR DESCRIPTION
Following the quickstart guide results in the following error when applying the CRs:

```terminal
$ kubectl apply -f config/samples/
guestbook.webapp.my.domain/guestbook-sample created
error: error validating "config/samples/kustomization.yaml": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
```
Even though this is not an issue as the sample CR does get applied, it leads to a bit of confusion due to the error message.

As per [this comment](https://github.com/operator-framework/operator-sdk/issues/3225#issuecomment-643336975), our documentation should be updated to just apply the CR. 
