### PR TITLE
📖 : documentation: corrected install CRD command in quick start

### DIFF
--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -180,7 +180,7 @@ If you pressed `y` for Create Resource [y/n] then you created a CR for your CRD 
 API definition):
 
 ```bash
-kubectl apply -k config/samples/
+make deploy
 ```
 
 ## Run It On the Cluster


### PR DESCRIPTION

The command in quick-start page is not working, I send this PR to fix it.
`make deploy 
`
is the correct command.