### PR TITLE
✨  Externalize config struct to be available for external plugin

### DIFF
--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -52,7 +52,7 @@ func (ss *stringSlice) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type cfg struct {
+type Cfg struct {
 	// Version
 	Version config.Version `json:"version"`
 
@@ -81,7 +81,7 @@ type pluginConfig interface{}
 
 // New returns a new config.Config
 func New() config.Config {
-	return &cfg{Version: Version}
+	return &Cfg{Version: Version}
 }
 
 func init() {
@@ -89,95 +89,95 @@ func init() {
 }
 
 // GetVersion implements config.Config
-func (c cfg) GetVersion() config.Version {
+func (c Cfg) GetVersion() config.Version {
 	return c.Version
 }
 
 // GetDomain implements config.Config
-func (c cfg) GetDomain() string {
+func (c Cfg) GetDomain() string {
 	return c.Domain
 }
 
 // SetDomain implements config.Config
-func (c *cfg) SetDomain(domain string) error {
+func (c *Cfg) SetDomain(domain string) error {
 	c.Domain = domain
 	return nil
 }
 
 // GetRepository implements config.Config
-func (c cfg) GetRepository() string {
+func (c Cfg) GetRepository() string {
 	return c.Repository
 }
 
 // SetRepository implements config.Config
-func (c *cfg) SetRepository(repository string) error {
+func (c *Cfg) SetRepository(repository string) error {
 	c.Repository = repository
 	return nil
 }
 
 // GetProjectName implements config.Config
-func (c cfg) GetProjectName() string {
+func (c Cfg) GetProjectName() string {
 	return c.Name
 }
 
 // SetProjectName implements config.Config
-func (c *cfg) SetProjectName(name string) error {
+func (c *Cfg) SetProjectName(name string) error {
 	c.Name = name
 	return nil
 }
 
 // GetPluginChain implements config.Config
-func (c cfg) GetPluginChain() []string {
+func (c Cfg) GetPluginChain() []string {
 	return c.PluginChain
 }
 
 // SetPluginChain implements config.Config
-func (c *cfg) SetPluginChain(pluginChain []string) error {
+func (c *Cfg) SetPluginChain(pluginChain []string) error {
 	c.PluginChain = pluginChain
 	return nil
 }
 
 // IsMultiGroup implements config.Config
-func (c cfg) IsMultiGroup() bool {
+func (c Cfg) IsMultiGroup() bool {
 	return c.MultiGroup
 }
 
 // SetMultiGroup implements config.Config
-func (c *cfg) SetMultiGroup() error {
+func (c *Cfg) SetMultiGroup() error {
 	c.MultiGroup = true
 	return nil
 }
 
 // ClearMultiGroup implements config.Config
-func (c *cfg) ClearMultiGroup() error {
+func (c *Cfg) ClearMultiGroup() error {
 	c.MultiGroup = false
 	return nil
 }
 
 // IsComponentConfig implements config.Config
-func (c cfg) IsComponentConfig() bool {
+func (c Cfg) IsComponentConfig() bool {
 	return c.ComponentConfig
 }
 
 // SetComponentConfig implements config.Config
-func (c *cfg) SetComponentConfig() error {
+func (c *Cfg) SetComponentConfig() error {
 	c.ComponentConfig = true
 	return nil
 }
 
 // ClearComponentConfig implements config.Config
-func (c *cfg) ClearComponentConfig() error {
+func (c *Cfg) ClearComponentConfig() error {
 	c.ComponentConfig = false
 	return nil
 }
 
 // ResourcesLength implements config.Config
-func (c cfg) ResourcesLength() int {
+func (c Cfg) ResourcesLength() int {
 	return len(c.Resources)
 }
 
 // HasResource implements config.Config
-func (c cfg) HasResource(gvk resource.GVK) bool {
+func (c Cfg) HasResource(gvk resource.GVK) bool {
 	for _, res := range c.Resources {
 		if gvk.IsEqualTo(res.GVK) {
 			return true
@@ -188,7 +188,7 @@ func (c cfg) HasResource(gvk resource.GVK) bool {
 }
 
 // GetResource implements config.Config
-func (c cfg) GetResource(gvk resource.GVK) (resource.Resource, error) {
+func (c Cfg) GetResource(gvk resource.GVK) (resource.Resource, error) {
 	for _, res := range c.Resources {
 		if gvk.IsEqualTo(res.GVK) {
 			r := res.Copy()
@@ -206,7 +206,7 @@ func (c cfg) GetResource(gvk resource.GVK) (resource.Resource, error) {
 }
 
 // GetResources implements config.Config
-func (c cfg) GetResources() ([]resource.Resource, error) {
+func (c Cfg) GetResources() ([]resource.Resource, error) {
 	resources := make([]resource.Resource, 0, len(c.Resources))
 	for _, res := range c.Resources {
 		r := res.Copy()
@@ -223,7 +223,7 @@ func (c cfg) GetResources() ([]resource.Resource, error) {
 }
 
 // AddResource implements config.Config
-func (c *cfg) AddResource(res resource.Resource) error {
+func (c *Cfg) AddResource(res resource.Resource) error {
 	// As res is passed by value it is already a shallow copy, but we need to make a deep copy
 	res = res.Copy()
 
@@ -239,7 +239,7 @@ func (c *cfg) AddResource(res resource.Resource) error {
 }
 
 // UpdateResource implements config.Config
-func (c *cfg) UpdateResource(res resource.Resource) error {
+func (c *Cfg) UpdateResource(res resource.Resource) error {
 	// As res is passed by value it is already a shallow copy, but we need to make a deep copy
 	res = res.Copy()
 
@@ -259,7 +259,7 @@ func (c *cfg) UpdateResource(res resource.Resource) error {
 }
 
 // HasGroup implements config.Config
-func (c cfg) HasGroup(group string) bool {
+func (c Cfg) HasGroup(group string) bool {
 	// Return true if the target group is found in the tracked resources
 	for _, r := range c.Resources {
 		if strings.EqualFold(group, r.Group) {
@@ -272,7 +272,7 @@ func (c cfg) HasGroup(group string) bool {
 }
 
 // ListCRDVersions implements config.Config
-func (c cfg) ListCRDVersions() []string {
+func (c Cfg) ListCRDVersions() []string {
 	// Make a map to remove duplicates
 	versionSet := make(map[string]struct{})
 	for _, r := range c.Resources {
@@ -290,7 +290,7 @@ func (c cfg) ListCRDVersions() []string {
 }
 
 // ListWebhookVersions implements config.Config
-func (c cfg) ListWebhookVersions() []string {
+func (c Cfg) ListWebhookVersions() []string {
 	// Make a map to remove duplicates
 	versionSet := make(map[string]struct{})
 	for _, r := range c.Resources {
@@ -308,7 +308,7 @@ func (c cfg) ListWebhookVersions() []string {
 }
 
 // DecodePluginConfig implements config.Config
-func (c cfg) DecodePluginConfig(key string, configObj interface{}) error {
+func (c Cfg) DecodePluginConfig(key string, configObj interface{}) error {
 	if len(c.Plugins) == 0 {
 		return config.PluginKeyNotFoundError{Key: key}
 	}
@@ -329,7 +329,7 @@ func (c cfg) DecodePluginConfig(key string, configObj interface{}) error {
 }
 
 // EncodePluginConfig will return an error if used on any project version < v3.
-func (c *cfg) EncodePluginConfig(key string, configObj interface{}) error {
+func (c *Cfg) EncodePluginConfig(key string, configObj interface{}) error {
 	// Get object's bytes and set them under key in extra fields.
 	b, err := yaml.Marshal(configObj)
 	if err != nil {
@@ -347,7 +347,7 @@ func (c *cfg) EncodePluginConfig(key string, configObj interface{}) error {
 }
 
 // Marshal implements config.Config
-func (c cfg) MarshalYAML() ([]byte, error) {
+func (c Cfg) MarshalYAML() ([]byte, error) {
 	for i, r := range c.Resources {
 		// If API is empty, omit it (prevents `api: {}`).
 		if r.API != nil && r.API.IsEmpty() {
@@ -368,7 +368,7 @@ func (c cfg) MarshalYAML() ([]byte, error) {
 }
 
 // Unmarshal implements config.Config
-func (c *cfg) UnmarshalYAML(b []byte) error {
+func (c *Cfg) UnmarshalYAML(b []byte) error {
 	if err := yaml.UnmarshalStrict(b, c); err != nil {
 		return config.UnmarshalError{Err: err}
 	}

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -33,7 +33,7 @@ func TestConfigV3(t *testing.T) {
 	RunSpecs(t, "Config V3 Suite")
 }
 
-var _ = Describe("cfg", func() {
+var _ = Describe("Cfg", func() {
 	const (
 		domain = "my.domain"
 		repo   = "myrepo"
@@ -45,7 +45,7 @@ var _ = Describe("cfg", func() {
 	)
 
 	var (
-		c cfg
+		c Cfg
 
 		pluginChain = []string{"go.kubebuilder.io/v2"}
 
@@ -53,7 +53,7 @@ var _ = Describe("cfg", func() {
 	)
 
 	BeforeEach(func() {
-		c = cfg{
+		c = Cfg{
 			Version:     Version,
 			Domain:      domain,
 			Repository:  repo,
@@ -376,14 +376,14 @@ var _ = Describe("cfg", func() {
 		)
 
 		var (
-			c0 = cfg{
+			c0 = Cfg{
 				Version:     Version,
 				Domain:      domain,
 				Repository:  repo,
 				Name:        name,
 				PluginChain: pluginChain,
 			}
-			c1 = cfg{
+			c1 = Cfg{
 				Version:     Version,
 				Domain:      domain,
 				Repository:  repo,
@@ -395,7 +395,7 @@ var _ = Describe("cfg", func() {
 					},
 				},
 			}
-			c2 = cfg{
+			c2 = Cfg{
 				Version:     Version,
 				Domain:      domain,
 				Repository:  repo,
@@ -429,7 +429,7 @@ var _ = Describe("cfg", func() {
 		})
 
 		DescribeTable("DecodePluginConfig should retrieve the plugin data correctly",
-			func(inputConfig cfg, expectedPluginConfig PluginConfig) {
+			func(inputConfig Cfg, expectedPluginConfig PluginConfig) {
 				var pluginConfig PluginConfig
 				Expect(inputConfig.DecodePluginConfig(key, &pluginConfig)).To(Succeed())
 				Expect(pluginConfig).To(Equal(expectedPluginConfig))
@@ -441,7 +441,7 @@ var _ = Describe("cfg", func() {
 		)
 
 		DescribeTable("EncodePluginConfig should encode the plugin data correctly",
-			func(pluginConfig PluginConfig, expectedConfig cfg) {
+			func(pluginConfig PluginConfig, expectedConfig Cfg) {
 				Expect(c.EncodePluginConfig(key, pluginConfig)).To(Succeed())
 				Expect(c).To(Equal(expectedConfig))
 			},
@@ -455,14 +455,14 @@ var _ = Describe("cfg", func() {
 	Context("Persistence", func() {
 		var (
 			// BeforeEach is called after the entries are evaluated, and therefore, c is not available
-			c1 = cfg{
+			c1 = Cfg{
 				Version:     Version,
 				Domain:      domain,
 				Repository:  repo,
 				Name:        name,
 				PluginChain: pluginChain,
 			}
-			c2 = cfg{
+			c2 = Cfg{
 				Version:         Version,
 				Domain:          otherDomain,
 				Repository:      otherRepo,
@@ -591,7 +591,7 @@ version: "3"
 		)
 
 		DescribeTable("MarshalYAML should succeed",
-			func(c cfg, content string) {
+			func(c Cfg, content string) {
 				b, err := c.MarshalYAML()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(b)).To(Equal(content))
@@ -601,8 +601,8 @@ version: "3"
 		)
 
 		DescribeTable("UnmarshalYAML should succeed",
-			func(content string, c cfg) {
-				var unmarshalled cfg
+			func(content string, c Cfg) {
+				var unmarshalled Cfg
 				Expect(unmarshalled.UnmarshalYAML([]byte(content))).To(Succeed())
 				Expect(unmarshalled.Version.Compare(c.Version)).To(Equal(0))
 				Expect(unmarshalled.Domain).To(Equal(c.Domain))
@@ -622,7 +622,7 @@ version: "3"
 
 		DescribeTable("UnmarshalYAML should fail",
 			func(content string) {
-				var c cfg
+				var c Cfg
 				Expect(c.UnmarshalYAML([]byte(content))).NotTo(Succeed())
 			},
 			Entry("for unknown fields", `field: 1


### PR DESCRIPTION
## Description:
Make `cfg` from an internal struct to be a public one.

## Motivation:
Externalize `cfg` to make it be accessible for external plugin.
Part of effort for https://github.com/kubernetes-sigs/kubebuilder/issues/3553

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
