### PR TITLE
:bug: change deprecated warning to yellow

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	noticeColor    = "\033[1;36m%s\033[0m"
+	noticeColor    = "\033[1;33m%s\033[0m"
 	deprecationFmt = "[Deprecation Notice] %s\n\n"
 
 	pluginsFlag        = "plugins"


### PR DESCRIPTION
## Description

Currently the deprecation notice is blue. However, the standard and common practice is to use yellow for warnings and deprecations. Changing that accordingly. See:

![Screenshot 2023-08-26 at 06 26 30](https://github.com/kubernetes-sigs/kubebuilder/assets/7708031/46852818-e7de-4a08-9181-5cced9f782e9)
