### PR TITLE
🌱 : (deployimage): fix e2e tests which are using go/v3 which is dep…

### DIFF
--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 var _ = Describe("kubebuilder", func() {
-	Context("deploy image plugin 3", func() {
+	Context("deploy image plugin", func() {
 		var kbc *utils.TestContext
 
 		BeforeEach(func() {
@@ -82,7 +82,7 @@ var _ = Describe("kubebuilder", func() {
 
 			By("initializing a project with go/v3")
 			err = kbc.Init(
-				"--plugins", "go/v3",
+				"--plugins", "go/v4",
 				"--project-version", "3",
 				"--domain", kbc.Domain,
 			)
@@ -117,9 +117,9 @@ var _ = Describe("kubebuilder", func() {
 		It("should generate a runnable project with deploy-image/v1-alpha without options ", func() {
 			var err error
 
-			By("initializing a project with go/v3")
+			By("initializing a project with go/v4")
 			err = kbc.Init(
-				"--plugins", "go/v3",
+				"--plugins", "go/v4",
 				"--project-version", "3",
 				"--domain", kbc.Domain,
 			)


### PR DESCRIPTION
## Description

The e2e tests for DeployImage plugin are scaffolding projects with go/v3 when it should be using go/v4

## Motivation

Ensure that the e2e tests test the plugin using the layout which is not deprecated.