### PR TITLE
📖 : changing title for external plugins

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -130,7 +130,7 @@
   - [Creating your own plugins](./plugins/creating-plugins.md)
   - [Testing your own plugins](./plugins/testing-plugins.md)
   - [Plugins Versioning](./plugins/plugins-versioning.md)
-  - [Extending Kubebuilder with external plugins](./plugins/external-plugins.md)
+  - [Creating external plugins](./plugins/external-plugins.md)
 
 ---
 

--- a/docs/book/src/plugins/external-plugins.md
+++ b/docs/book/src/plugins/external-plugins.md
@@ -1,4 +1,4 @@
-# Extending Kubebuilder with external plugins
+# Creating External Plugins
 
 ## Overview
 


### PR DESCRIPTION
## Description

Suggestion to replace `Extending Kubebuilder with external plugins` with `Creating external plugins`. It seems more aligned with the other titles and more clear about its purpose