### PR TITLE
📖 Fix ComponentConfig

### DIFF
--- a/docs/book/src/component-config-tutorial/tutorial.md
+++ b/docs/book/src/component-config-tutorial/tutorial.md
@@ -10,6 +10,8 @@ no longer guaranteeing its functionality from version 3.11.0 onwards. You can fi
 
 Please, be aware that it will force Kubebuilder remove this option soon in future release.
 
+Instead of relying on ComponentConfig, you can now directly utilize `manager.Options` to achieve similar configuration capabilities.
+
 </aside>
 
 Nearly every project that is built for Kubernetes will eventually need to


### PR DESCRIPTION
* **Description:** Add an alternate to ComponentConfig in Docs
* **Motivation:** As ComponentConfig has been deprecated, it was needed to provide an alternate solution
* **Fixes:** #3457 

**Type:** 
- 📖 (:book:): documentation