### PR TITLE
🌱  (make generate) : fix error of 'Permission denied' about binary file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ generate: generate-testdata generate-docs ## Update/generate all mock data. You 
 
 .PHONY: generate-testdata
 generate-testdata: ## Update/generate the testdata in $GOPATH/src/sigs.k8s.io/kubebuilder
+	chmod -R +w testdata/
 	rm -rf testdata/
 	./test/testdata/generate.sh
 


### PR DESCRIPTION
sometimes, the permission of files in testdata dir is 555 without write permission.
if no write permission to those binary file, error occurs 'etcd: Permission denied'


<img width="947" alt="image" src="https://github.com/kubernetes-sigs/kubebuilder/assets/21003791/dce706e8-26a2-484a-9e48-9201fccb6e7c">

