### PR TITLE
🐛  (kustomize/v2,go/v4): fix kustomization yaml's webhooks patches file names for multgroup layouts

### DIFF
--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -31,6 +31,7 @@ var (
 // Kustomization scaffolds a file that defines the kustomization scheme for the crd folder
 type Kustomization struct {
 	machinery.TemplateMixin
+	machinery.MultiGroupMixin
 	machinery.ResourceMixin
 }
 
@@ -82,13 +83,17 @@ func (f *Kustomization) GetCodeFragments() machinery.CodeFragmentsMap {
 	res := make([]string, 0)
 	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.QualifiedGroup(), f.Resource.Plural))
 
+	suffix := f.Resource.Plural
+	if f.MultiGroup {
+		suffix = f.Resource.Group + "_" + f.Resource.Plural
+	}
 	// Generate resource code fragments
 	webhookPatch := make([]string, 0)
-	webhookPatch = append(webhookPatch, fmt.Sprintf(webhookPatchCodeFragment, f.Resource.Plural))
+	webhookPatch = append(webhookPatch, fmt.Sprintf(webhookPatchCodeFragment, suffix))
 
 	// Generate resource code fragments
 	caInjectionPatch := make([]string, 0)
-	caInjectionPatch = append(caInjectionPatch, fmt.Sprintf(caInjectionPatchCodeFragment, f.Resource.Plural))
+	caInjectionPatch = append(caInjectionPatch, fmt.Sprintf(caInjectionPatchCodeFragment, suffix))
 
 	// Only store code fragments in the map if the slices are non-empty
 	if len(res) != 0 {

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
@@ -27,13 +27,18 @@ var _ machinery.Template = &EnableCAInjectionPatch{}
 // EnableCAInjectionPatch scaffolds a file that defines the patch that injects CA into the CRD
 type EnableCAInjectionPatch struct {
 	machinery.TemplateMixin
+	machinery.MultiGroupMixin
 	machinery.ResourceMixin
 }
 
 // SetTemplateDefaults implements file.Template
 func (f *EnableCAInjectionPatch) SetTemplateDefaults() error {
 	if f.Path == "" {
-		f.Path = filepath.Join("config", "crd", "patches", "cainjection_in_%[plural].yaml")
+		if f.MultiGroup {
+			f.Path = filepath.Join("config", "crd", "patches", "cainjection_in_%[group]_%[plural].yaml")
+		} else {
+			f.Path = filepath.Join("config", "crd", "patches", "cainjection_in_%[plural].yaml")
+		}
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 

--- a/testdata/project-v4-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/crd/kustomization.yaml
@@ -19,32 +19,34 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- path: patches/webhook_in_captains.yaml
-#- path: patches/webhook_in_frigates.yaml
-#- path: patches/webhook_in_destroyers.yaml
-#- path: patches/webhook_in_cruisers.yaml
-#- path: patches/webhook_in_krakens.yaml
-#- path: patches/webhook_in_leviathans.yaml
-#- path: patches/webhook_in_healthcheckpolicies.yaml
-#- path: patches/webhook_in_bars.yaml
-#- path: patches/webhook_in_lakers.yaml
-#- path: patches/webhook_in_memcacheds.yaml
-#- path: patches/webhook_in_busyboxes.yaml
+#- path: patches/webhook_in_crew_captains.yaml
+#- path: patches/webhook_in_ship_frigates.yaml
+#- path: patches/webhook_in_ship_destroyers.yaml
+#- path: patches/webhook_in_ship_cruisers.yaml
+#- path: patches/webhook_in_sea-creatures_krakens.yaml
+#- path: patches/webhook_in_sea-creatures_leviathans.yaml
+#- path: patches/webhook_in_foo.policy_healthcheckpolicies.yaml
+#- path: patches/webhook_in_foo_bars.yaml
+#- path: patches/webhook_in_fiz_bars.yaml
+#- path: patches/webhook_in__lakers.yaml
+#- path: patches/webhook_in_example.com_memcacheds.yaml
+#- path: patches/webhook_in_example.com_busyboxes.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- path: patches/cainjection_in_captains.yaml
-#- path: patches/cainjection_in_frigates.yaml
-#- path: patches/cainjection_in_destroyers.yaml
-#- path: patches/cainjection_in_cruisers.yaml
-#- path: patches/cainjection_in_krakens.yaml
-#- path: patches/cainjection_in_leviathans.yaml
-#- path: patches/cainjection_in_healthcheckpolicies.yaml
-#- path: patches/cainjection_in_bars.yaml
-#- path: patches/cainjection_in_lakers.yaml
-#- path: patches/cainjection_in_memcacheds.yaml
-#- path: patches/cainjection_in_busyboxes.yaml
+#- path: patches/cainjection_in_crew_captains.yaml
+#- path: patches/cainjection_in_ship_frigates.yaml
+#- path: patches/cainjection_in_ship_destroyers.yaml
+#- path: patches/cainjection_in_ship_cruisers.yaml
+#- path: patches/cainjection_in_sea-creatures_krakens.yaml
+#- path: patches/cainjection_in_sea-creatures_leviathans.yaml
+#- path: patches/cainjection_in_foo.policy_healthcheckpolicies.yaml
+#- path: patches/cainjection_in_foo_bars.yaml
+#- path: patches/cainjection_in_fiz_bars.yaml
+#- path: patches/cainjection_in__lakers.yaml
+#- path: patches/cainjection_in_example.com_memcacheds.yaml
+#- path: patches/cainjection_in_example.com_busyboxes.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.


### PR DESCRIPTION
Fixes #3502

The comments about path of patch file name in `config/crd/kustomization.yaml` is not correct when enable multigroup

make test passed.
<img width="894" alt="image" src="https://github.com/kubernetes-sigs/kubebuilder/assets/21003791/203b776e-08bd-4cd4-9678-6a0535ba2113">
