### PR TITLE
🌱 runtime error on darwin arm64 machine: killed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ build: ## Build the project locally
 
 .PHONY: install
 install: build ## Build and install the binary with the current source code. Use it to test your changes locally.
+	rm -f $(GOBIN)/kubebuilder
 	cp ./bin/kubebuilder $(GOBIN)/kubebuilder
 
 ##@ Development


### PR DESCRIPTION
I meet this issue on apple m2  macbook. I don't know why. After run`make install` and then run new installed kb, it will still be killed, until I remove the old one and reinstall it.
```
[1]    59938 killed     $GOPATH/bin/kubebuilder version
```
<img width="1274" alt="image" src="https://github.com/kubernetes-sigs/kubebuilder/assets/21003791/a7eccd3c-1e5b-4783-9827-f982cf530543">

After rm it and re-install
<img width="1275" alt="image" src="https://github.com/kubernetes-sigs/kubebuilder/assets/21003791/52ef127a-9e46-4afe-8fc5-3366e7088256">


