### PR TITLE
🐛 (kustomize/v2, go/v4): fix role and kustomize build when no CRDs are added to the project

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/rbac/role.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/rbac/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: project
+    app.kubernetes.io/part-of: project
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -18,6 +18,7 @@ package scaffolds
 
 import (
 	"fmt"
+	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
 	log "github.com/sirupsen/logrus"
 
@@ -88,6 +89,16 @@ func (s *apiScaffolder) Scaffold() error {
 		if s.resource.Group != "" || s.resource.Version != "" || s.resource.Kind != "" {
 			if err := scaffold.Execute(&samples.Kustomization{}); err != nil {
 				return fmt.Errorf("error scaffolding manifests: %v", err)
+			}
+		}
+
+		kustomizeFilePath := "config/default/kustomization.yaml"
+		err := pluginutil.UncommentCode(kustomizeFilePath, "#- ../crd", `#`)
+		if err != nil {
+			hasCRUncommented, err := pluginutil.HasFragment(kustomizeFilePath, "- ../crd")
+			if !hasCRUncommented || err != nil {
+				log.Errorf("Unable to find the target #- ../crd to uncomment in the file "+
+					"%s.", kustomizeFilePath)
 			}
 		}
 	}

--- a/pkg/plugins/common/kustomize/v2/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/init.go
@@ -69,6 +69,9 @@ func (s *initScaffolder) Scaffold() error {
 		&rbac.AuthProxyService{},
 		&rbac.AuthProxyClientRole{},
 		&rbac.RoleBinding{},
+		// We need to create a Role because if the project
+		// has not CRD define the controller-gen will not generate this file
+		&rbac.Role{},
 		&rbac.LeaderElectionRole{},
 		&rbac.LeaderElectionRoleBinding{},
 		&rbac.ServiceAccount{},

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -61,7 +61,7 @@ namePrefix: {{ .ProjectName }}-
 #    someName: someValue
 
 resources:
-- ../crd
+#- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/role.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &Role{}
+
+// Role scaffolds a file that defines the role for the manager
+type Role struct {
+	machinery.TemplateMixin
+	machinery.ProjectNameMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Role) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "rbac", "role.yaml")
+	}
+
+	f.TemplateBody = managerRoleTemplate
+
+	f.IfExistsAction = machinery.SkipFile
+
+	return nil
+}
+
+const managerRoleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ .ProjectName }}
+    app.kubernetes.io/part-of: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+`

--- a/testdata/project-v4-with-grafana/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-grafana/config/default/kustomization.yaml
@@ -15,7 +15,7 @@ namePrefix: project-v4-with-grafana-
 #    someName: someValue
 
 resources:
-- ../crd
+#- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in

--- a/testdata/project-v4-with-grafana/config/rbac/role.yaml
+++ b/testdata/project-v4-with-grafana/config/rbac/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: manager-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: project-v4-with-grafana
+    app.kubernetes.io/part-of: project-v4-with-grafana
+    app.kubernetes.io/managed-by: kustomize
+  name: manager-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Description

A project might have no CRDs generate their for:
- We should scaffold the project with the config/default/kustomization.yaml with crd commented when we run init
- We should generate the basic Role since controller-gen is only able to do that when markers are found in the controllers
- We should uncomment the crd config from config/default/kustomization.yaml when api is generated. 

