### PR TITLE
🐛 (go/v4): fix readme content and instructions

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/README.md
+++ b/docs/book/src/component-config-tutorial/testdata/project/README.md
@@ -5,37 +5,62 @@
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-```sh
-kubectl apply -k config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
+### To Deploy on the cluster
+**Build and push your image to the location specified by `IMG`:**
 
 ```sh
 make docker-build docker-push IMG=<some-registry>/project:tag
 ```
 
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
+
+```sh
+make install
+```
+
+**Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
 make deploy IMG=<some-registry>/project:tag
 ```
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+```sh
+kubectl apply -k config/samples/
+```
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+```sh
+kubectl delete -k config/samples/
+```
+
+**Delete the APIs(CRDs) from the cluster:**
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**UnDeploy the controller from the cluster:**
 
 ```sh
 make undeploy
@@ -43,34 +68,6 @@ make undeploy
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -5,37 +5,62 @@
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-```sh
-kubectl apply -k config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
+### To Deploy on the cluster
+**Build and push your image to the location specified by `IMG`:**
 
 ```sh
 make docker-build docker-push IMG=<some-registry>/project:tag
 ```
 
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
+
+```sh
+make install
+```
+
+**Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
 make deploy IMG=<some-registry>/project:tag
 ```
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+```sh
+kubectl apply -k config/samples/
+```
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+```sh
+kubectl delete -k config/samples/
+```
+
+**Delete the APIs(CRDs) from the cluster:**
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**UnDeploy the controller from the cluster:**
 
 ```sh
 make undeploy
@@ -43,34 +68,6 @@ make undeploy
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -45,14 +45,13 @@ func (f *Readme) SetTemplateDefaults() error {
 		"*/", "", 1)
 
 	f.TemplateBody = fmt.Sprintf(readmeFileTemplate,
-		codeFence("kubectl apply -k config/samples/"),
 		codeFence("make docker-build docker-push IMG=<some-registry>/{{ .ProjectName }}:tag"),
-		codeFence("make deploy IMG=<some-registry>/{{ .ProjectName }}:tag"),
-		codeFence("make uninstall"),
-		codeFence("make undeploy"),
 		codeFence("make install"),
-		codeFence("make run"),
-		codeFence("make manifests"))
+		codeFence("make deploy IMG=<some-registry>/{{ .ProjectName }}:tag"),
+		codeFence("kubectl apply -k config/samples/"),
+		codeFence("kubectl delete -k config/samples/"),
+		codeFence("make uninstall"),
+		codeFence("make undeploy"))
 
 	return nil
 }
@@ -65,56 +64,55 @@ const readmeFileTemplate = `# {{ .ProjectName }}
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster ` + "`kubectl cluster-info`" + ` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-%s
-
-2. Build and push your image to the location specified by ` + "`IMG`" + `:
-
-%s
-
-3. Deploy the controller to the cluster with the image specified by ` + "`IMG`" + `:
+### To Deploy on the cluster
+**Build and push your image to the location specified by ` + "`IMG`" + `:**
 
 %s
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
 
 %s
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**Deploy the Manager to the cluster with the image specified by ` + "`IMG`" + `:**
+
+%s
+
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+%s
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+%s
+
+**Delete the APIs(CRDs) from the cluster:**
+
+%s
+
+**UnDeploy the controller from the cluster:**
 
 %s
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-%s
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-%s
-
-**NOTE:** You can also run this in one step by running: ` + "`make install run`" + `
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-%s
 
 **NOTE:** Run ` + "`make --help`" + ` for more information on all potential ` + "`make`" + ` targets
 

--- a/testdata/project-v4-multigroup/README.md
+++ b/testdata/project-v4-multigroup/README.md
@@ -5,37 +5,62 @@
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-```sh
-kubectl apply -k config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
+### To Deploy on the cluster
+**Build and push your image to the location specified by `IMG`:**
 
 ```sh
 make docker-build docker-push IMG=<some-registry>/project-v4-multigroup:tag
 ```
 
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
+
+```sh
+make install
+```
+
+**Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
 make deploy IMG=<some-registry>/project-v4-multigroup:tag
 ```
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+```sh
+kubectl apply -k config/samples/
+```
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+```sh
+kubectl delete -k config/samples/
+```
+
+**Delete the APIs(CRDs) from the cluster:**
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**UnDeploy the controller from the cluster:**
 
 ```sh
 make undeploy
@@ -43,34 +68,6 @@ make undeploy
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 

--- a/testdata/project-v4-with-deploy-image/README.md
+++ b/testdata/project-v4-with-deploy-image/README.md
@@ -5,37 +5,62 @@
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-```sh
-kubectl apply -k config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
+### To Deploy on the cluster
+**Build and push your image to the location specified by `IMG`:**
 
 ```sh
 make docker-build docker-push IMG=<some-registry>/project-v4-with-deploy-image:tag
 ```
 
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
+
+```sh
+make install
+```
+
+**Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
 make deploy IMG=<some-registry>/project-v4-with-deploy-image:tag
 ```
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+```sh
+kubectl apply -k config/samples/
+```
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+```sh
+kubectl delete -k config/samples/
+```
+
+**Delete the APIs(CRDs) from the cluster:**
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**UnDeploy the controller from the cluster:**
 
 ```sh
 make undeploy
@@ -43,34 +68,6 @@ make undeploy
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 

--- a/testdata/project-v4-with-grafana/README.md
+++ b/testdata/project-v4-with-grafana/README.md
@@ -5,37 +5,62 @@
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-```sh
-kubectl apply -k config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
+### To Deploy on the cluster
+**Build and push your image to the location specified by `IMG`:**
 
 ```sh
 make docker-build docker-push IMG=<some-registry>/project-v4-with-grafana:tag
 ```
 
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
+
+```sh
+make install
+```
+
+**Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
 make deploy IMG=<some-registry>/project-v4-with-grafana:tag
 ```
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+```sh
+kubectl apply -k config/samples/
+```
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+```sh
+kubectl delete -k config/samples/
+```
+
+**Delete the APIs(CRDs) from the cluster:**
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**UnDeploy the controller from the cluster:**
 
 ```sh
 make undeploy
@@ -43,34 +68,6 @@ make undeploy
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 

--- a/testdata/project-v4/README.md
+++ b/testdata/project-v4/README.md
@@ -5,37 +5,62 @@
 // TODO(user): An in-depth paragraph about your project and overview of use
 
 ## Getting Started
-You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
-**Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
-### Running on the cluster
-1. Install Instances of Custom Resources:
+### Prerequisites
+- go version v1.20.0+
+- docker version 17.03+.
+- kubectl version v1.11.3+.
+- Access to a Kubernetes v1.11.3+ cluster.
 
-```sh
-kubectl apply -k config/samples/
-```
-
-2. Build and push your image to the location specified by `IMG`:
+### To Deploy on the cluster
+**Build and push your image to the location specified by `IMG`:**
 
 ```sh
 make docker-build docker-push IMG=<some-registry>/project-v4:tag
 ```
 
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+**NOTE:** This image ought to be published in the personal registry you specified. 
+And it is required to have access to pull the image from the working environment. 
+Make sure you have the proper permission to the registry if the above commands don’t work.
+
+**Install the CRDs into the cluster:**
+
+```sh
+make install
+```
+
+**Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
 make deploy IMG=<some-registry>/project-v4:tag
 ```
 
-### Uninstall CRDs
-To delete the CRDs from the cluster:
+> **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin 
+privileges or be logged in as admin.
+
+**Create instances of your solution**
+You can apply the samples (examples) from the config/sample:
+
+```sh
+kubectl apply -k config/samples/
+```
+
+>**NOTE**: Ensure that the samples has default values to test it out.
+
+### To Uninstall
+**Delete the instances (CRs) from the cluster:**
+
+```sh
+kubectl delete -k config/samples/
+```
+
+**Delete the APIs(CRDs) from the cluster:**
 
 ```sh
 make uninstall
 ```
 
-### Undeploy controller
-UnDeploy the controller from the cluster:
+**UnDeploy the controller from the cluster:**
 
 ```sh
 make undeploy
@@ -43,34 +68,6 @@ make undeploy
 
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
-
-### How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
-
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/),
-which provide a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster.
-
-### Test It Out
-1. Install the CRDs into the cluster:
-
-```sh
-make install
-```
-
-2. Run your controller (this will run in the foreground, so switch to a new terminal if you want to leave it running):
-
-```sh
-make run
-```
-
-**NOTE:** You can also run this in one step by running: `make install run`
-
-### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
-
-```sh
-make manifests
-```
 
 **NOTE:** Run `make --help` for more information on all potential `make` targets
 


### PR DESCRIPTION
## Description
- Fix the readme instructions
- Ensure that you have a Prerequisites section
- Remove the KIND info (we should not suggest the k8s vendor)
- Remove the kubebuilder doc link and commands to update api since it does not seems to make sense in the readme and either if it would be added then, would be required a lot of more details such as how to generate RBAC and etc. 