### PR TITLE
:bug:  (kustomize/v2,go/v4): fix uncomment kustomize files config accordinly when webhooks are generate

### DIFF
--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -542,20 +542,9 @@ var _ = AfterSuite(func() {
 
 func updateKustomization(sp *Sample) {
 	var err error
-	// uncomment default/kustomization
-	err = pluginutil.UncommentCode(
-		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
-		`#- ../webhook`, `#`)
-	CheckError("fixing default/kustomization", err)
-
 	err = pluginutil.UncommentCode(
 		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
 		`#- ../certmanager`, `#`)
-	CheckError("fixing default/kustomization", err)
-
-	err = pluginutil.UncommentCode(
-		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
-		`#- manager_webhook_patch.yaml`, `#`)
 	CheckError("fixing default/kustomization", err)
 
 	err = pluginutil.UncommentCode(
@@ -572,12 +561,6 @@ func updateKustomization(sp *Sample) {
 		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
 		DefaultKustomization, `#`)
 	CheckError("fixing default/kustomization", err)
-
-	// uncomment crd/kustomization
-	err = pluginutil.UncommentCode(
-		filepath.Join(sp.ctx.Dir, "config/crd/kustomization.yaml"),
-		`#- path: patches/webhook_in_cronjobs.yaml`, `#`)
-	CheckError("fixing crd/kustomization", err)
 
 	err = pluginutil.UncommentCode(
 		filepath.Join(sp.ctx.Dir, "config/crd/kustomization.yaml"),

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -82,25 +82,12 @@ Count int `+"`"+`json:"count,omitempty"`+"`"+`
 		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind))))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	By("uncomment kustomization.yaml to enable webhook and ca injection")
-	ExpectWithOffset(1, pluginutil.UncommentCode(
-		filepath.Join(kbc.Dir, "config", "crd", "kustomization.yaml"),
-		fmt.Sprintf("#- path: patches/webhook_in_%s.yaml", kbc.Resources), "#")).To(Succeed())
-	ExpectWithOffset(1, pluginutil.UncommentCode(
-		filepath.Join(kbc.Dir, "config", "crd", "kustomization.yaml"),
-		fmt.Sprintf("#- path: patches/cainjection_in_%s.yaml", kbc.Resources), "#")).To(Succeed())
-	ExpectWithOffset(1, pluginutil.UncommentCode(
-		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
-		"#- ../webhook", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- ../certmanager", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- ../prometheus", "#")).To(Succeed())
-	ExpectWithOffset(1, pluginutil.UncommentCode(
-		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
-		"#- manager_webhook_patch.yaml", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- webhookcainjection_patch.yaml", "#")).To(Succeed())

--- a/testdata/project-v4-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/crd/kustomization.yaml
@@ -19,12 +19,12 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- path: patches/webhook_in_crew_captains.yaml
-#- path: patches/webhook_in_ship_frigates.yaml
-#- path: patches/webhook_in_ship_destroyers.yaml
-#- path: patches/webhook_in_ship_cruisers.yaml
-#- path: patches/webhook_in_sea-creatures_krakens.yaml
-#- path: patches/webhook_in_sea-creatures_leviathans.yaml
+- path: patches/webhook_in_crew_captains.yaml
+- path: patches/webhook_in_ship_frigates.yaml
+- path: patches/webhook_in_ship_destroyers.yaml
+- path: patches/webhook_in_ship_cruisers.yaml
+- path: patches/webhook_in_sea-creatures_krakens.yaml
+- path: patches/webhook_in_sea-creatures_leviathans.yaml
 #- path: patches/webhook_in_foo.policy_healthcheckpolicies.yaml
 #- path: patches/webhook_in_foo_bars.yaml
 #- path: patches/webhook_in_fiz_bars.yaml

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -36,7 +36,7 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- path: patches/webhook_in_memcacheds.yaml
+- path: patches/webhook_in_memcacheds.yaml
 #- path: patches/webhook_in_busyboxes.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 

--- a/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -36,7 +36,7 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/testdata/project-v4/config/crd/kustomization.yaml
+++ b/testdata/project-v4/config/crd/kustomization.yaml
@@ -10,9 +10,9 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- path: patches/webhook_in_captains.yaml
-#- path: patches/webhook_in_firstmates.yaml
-#- path: patches/webhook_in_admirales.yaml
+- path: patches/webhook_in_captains.yaml
+- path: patches/webhook_in_firstmates.yaml
+- path: patches/webhook_in_admirales.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -36,7 +36,7 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.


### PR DESCRIPTION
## Description

We should NOT let the webhook configuration be commented on when a webhook is created. Therefore, this PR ensures that when we run kubebuilder to create a webhook we will uncomment the required places under the config so that webhooks are enabled by default. 
