### PR TITLE
✨ (go/v4): Add tests for the webhooks and controllers which are created so that suite_test are no longer ignored

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("CronJob Webhook", func() {
+
+	Context("When creating CronJob under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+	Context("When creating CronJob under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -18,6 +18,7 @@ package scaffolds
 
 import (
 	"fmt"
+
 	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
 	log "github.com/sirupsen/logrus"

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -64,6 +64,8 @@ func (f *ControllerTest) SetTemplateDefaults() error {
 		f.PackageName = "controllers"
 	}
 
+	f.IfExistsAction = machinery.OverwriteFile
+
 	log.Println("creating import for %", f.Resource.Path)
 	f.TemplateBody = controllerTestTemplate
 

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -104,6 +104,7 @@ func (s *apiScaffolder) Scaffold() error {
 		if err := scaffold.Execute(
 			&controllers.SuiteTest{Force: s.force, K8SVersion: EnvtestK8SVersion},
 			&controllers.Controller{ControllerRuntimeVersion: ControllerRuntimeVersion, Force: s.force},
+			&controllers.ControllerTest{Force: s.force, DoAPI: doAPI},
 		); err != nil {
 			return fmt.Errorf("error scaffolding controller: %v", err)
 		}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &WebhookTest{}
+
+// WebhookTest scaffolds the file that sets up the webhook unit tests
+type WebhookTest struct { // nolint:maligned
+	machinery.TemplateMixin
+	machinery.MultiGroupMixin
+	machinery.BoilerplateMixin
+	machinery.ResourceMixin
+
+	Force bool
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *WebhookTest) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup && f.Resource.Group != "" {
+			f.Path = filepath.Join("api", "%[group]", "%[version]", "%[kind]_webhook_test.go")
+		} else {
+			f.Path = filepath.Join("api", "%[version]", "%[kind]_webhook_test.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	log.Println(f.Path)
+
+	webhookTestTemplate := webhookTestTemplate
+	templates := make([]string, 0)
+	if f.Resource.HasDefaultingWebhook() {
+		templates = append(templates, defaultWebhookTestTemplate)
+	}
+	if f.Resource.HasValidationWebhook() {
+		templates = append(templates, validateWebhookTestTemplate)
+	}
+	if f.Resource.HasConversionWebhook() {
+		templates = append(templates, conversionWebhookTestTemplate)
+	}
+	f.TemplateBody = fmt.Sprintf(webhookTestTemplate, strings.Join(templates, "\n"))
+
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	}
+
+	return nil
+}
+
+const webhookTestTemplate = `{{ .Boilerplate }}
+
+package {{ .Resource.Version }}
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("{{ .Resource.Kind }} Webhook", func() {
+	%s
+})
+`
+
+const conversionWebhookTestTemplate = `
+Context("When creating {{ .Resource.Kind }} under Conversion Webhook", func() {
+	It("Should get the converted version of {{ .Resource.Kind }}" , func() {
+
+		// TODO(user): Add your logic here
+
+	})
+})
+`
+
+const validateWebhookTestTemplate = `
+Context("When creating {{ .Resource.Kind }} under Validating Webhook", func() {
+	It("Should deny if a required field is empty", func() {
+
+		// TODO(user): Add your logic here
+
+	})
+
+	It("Should admit if all required fields are provided", func() {
+
+		// TODO(user): Add your logic here
+
+	})
+})
+`
+
+const defaultWebhookTestTemplate = `
+Context("When creating {{ .Resource.Kind }} under Defaulting Webhook", func() {
+	It("Should fill in the default value if a required field is empty", func() {
+
+		// TODO(user): Add your logic here
+
+	})
+})
+`

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &ControllerTest{}
+
+// ControllerTest scaffolds the file that sets up the controller unit tests
+// nolint:maligned
+type ControllerTest struct {
+	machinery.TemplateMixin
+	machinery.MultiGroupMixin
+	machinery.BoilerplateMixin
+	machinery.ResourceMixin
+
+	Force bool
+
+	DoAPI bool
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *ControllerTest) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup && f.Resource.Group != "" {
+			f.Path = filepath.Join("internal", "controller", "%[group]", "%[kind]_controller_test.go")
+		} else {
+			f.Path = filepath.Join("internal", "controller", "%[kind]_controller_test.go")
+		}
+	}
+
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	log.Println(f.Path)
+
+	f.TemplateBody = controllerTestTemplate
+
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	}
+
+	return nil
+}
+
+const controllerTestTemplate = `{{ .Boilerplate }}
+
+{{if and .MultiGroup .Resource.Group }}
+package {{ .Resource.PackageName }}
+{{else}}
+package controller
+{{end}}
+
+import (
+	{{ if .DoAPI -}}
+	"context"
+	{{- end }}
+	. "github.com/onsi/ginkgo/v2"
+	{{ if .DoAPI -}}
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	{{ if not (isEmptyStr .Resource.Path) -}}
+	{{ .Resource.ImportAlias }} "{{ .Resource.Path }}"
+	{{- end }}
+	{{- end }}
+)
+
+var _ = Describe("{{ .Resource.Kind }} Controller", func() {
+	Context("When reconciling a resource", func() {
+		{{ if .DoAPI -}}
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",  // TODO(user):Modify as needed
+		}
+		{{ lower .Resource.Kind }} := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind {{ .Resource.Kind }}")
+			err := k8sClient.Get(ctx, typeNamespacedName, {{ lower .Resource.Kind }})
+			if err != nil && errors.IsNotFound(err) {
+				resource := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance {{ .Resource.Kind }}")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		{{- end }}
+		It("should successfully reconcile the resource", func() {
+			{{ if .DoAPI -}}
+			By("Reconciling the created resource")
+			controllerReconciler := &{{ .Resource.Kind }}Reconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			{{- end }}
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})
+`

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -87,6 +87,7 @@ func (s *webhookScaffolder) Scaffold() error {
 	if err := scaffold.Execute(
 		&api.Webhook{Force: s.force},
 		&templates.MainUpdater{WireWebhook: true},
+		&api.WebhookTest{Force: s.force},
 	); err != nil {
 		return err
 	}

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Captain Webhook", func() {
+
+	Context("When creating Captain under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+	Context("When creating Captain under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Destroyer Webhook", func() {
+
+	Context("When creating Destroyer under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Frigate Webhook", func() {
+
+	Context("When creating Frigate under Conversion Webhook", func() {
+		It("Should get the converted version of Frigate", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Cruiser Webhook", func() {
+
+	Context("When creating Cruiser under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Lakers Webhook", func() {
+
+	Context("When creating Lakers under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+	Context("When creating Lakers under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Deployment Controller", func() {
+	Context("When reconciling a resource", func() {
+
+		It("should successfully reconcile the resource", func() {
+
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crew
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1"
+)
+
+var _ = Describe("Captain Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		captain := &crewv1.Captain{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Captain")
+			err := k8sClient.Get(ctx, typeNamespacedName, captain)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &crewv1.Captain{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &crewv1.Captain{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Captain")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &CaptainReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fiz
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fizv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1"
+)
+
+var _ = Describe("Bar Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		bar := &fizv1.Bar{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Bar")
+			err := k8sClient.Get(ctx, typeNamespacedName, bar)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &fizv1.Bar{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &fizv1.Bar{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Bar")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &BarReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foopolicy
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foopolicyv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1"
+)
+
+var _ = Describe("HealthCheckPolicy Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		healthcheckpolicy := &foopolicyv1.HealthCheckPolicy{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind HealthCheckPolicy")
+			err := k8sClient.Get(ctx, typeNamespacedName, healthcheckpolicy)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &foopolicyv1.HealthCheckPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &foopolicyv1.HealthCheckPolicy{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance HealthCheckPolicy")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &HealthCheckPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foo
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foov1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1"
+)
+
+var _ = Describe("Bar Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		bar := &foov1.Bar{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Bar")
+			err := k8sClient.Get(ctx, typeNamespacedName, bar)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &foov1.Bar{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &foov1.Bar{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Bar")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &BarReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testprojectorgv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/v1"
+)
+
+var _ = Describe("Lakers Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		lakers := &testprojectorgv1.Lakers{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Lakers")
+			err := k8sClient.Get(ctx, typeNamespacedName, lakers)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &testprojectorgv1.Lakers{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &testprojectorgv1.Lakers{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Lakers")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &LakersReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seacreatures
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seacreaturesv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1"
+)
+
+var _ = Describe("Kraken Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		kraken := &seacreaturesv1beta1.Kraken{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Kraken")
+			err := k8sClient.Get(ctx, typeNamespacedName, kraken)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &seacreaturesv1beta1.Kraken{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &seacreaturesv1beta1.Kraken{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Kraken")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &KrakenReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seacreatures
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seacreaturesv1beta2 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2"
+)
+
+var _ = Describe("Leviathan Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		leviathan := &seacreaturesv1beta2.Leviathan{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Leviathan")
+			err := k8sClient.Get(ctx, typeNamespacedName, leviathan)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &seacreaturesv1beta2.Leviathan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &seacreaturesv1beta2.Leviathan{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Leviathan")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &LeviathanReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ship
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1"
+)
+
+var _ = Describe("Cruiser Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		cruiser := &shipv2alpha1.Cruiser{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Cruiser")
+			err := k8sClient.Get(ctx, typeNamespacedName, cruiser)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &shipv2alpha1.Cruiser{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &shipv2alpha1.Cruiser{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Cruiser")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &CruiserReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ship
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1"
+)
+
+var _ = Describe("Destroyer Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		destroyer := &shipv1.Destroyer{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Destroyer")
+			err := k8sClient.Get(ctx, typeNamespacedName, destroyer)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &shipv1.Destroyer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &shipv1.Destroyer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Destroyer")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &DestroyerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ship
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1"
+)
+
+var _ = Describe("Frigate Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		frigate := &shipv1beta1.Frigate{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Frigate")
+			err := k8sClient.Get(ctx, typeNamespacedName, frigate)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &shipv1beta1.Frigate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &shipv1beta1.Frigate{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Frigate")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &FrigateReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Captain Webhook", func() {
+
+	Context("When creating Captain under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+	Context("When creating Captain under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Destroyer Webhook", func() {
+
+	Context("When creating Destroyer under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Frigate Webhook", func() {
+
+	Context("When creating Frigate under Conversion Webhook", func() {
+		It("Should get the converted version of Frigate", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Cruiser Webhook", func() {
+
+	Context("When creating Cruiser under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Lakers Webhook", func() {
+
+	Context("When creating Lakers under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+	Context("When creating Lakers under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apps
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Deployment Controller", func() {
+	Context("When reconciling a resource", func() {
+
+		It("should successfully reconcile the resource", func() {
+
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/crew/captain_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/captain_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crew
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/crew/v1"
+)
+
+var _ = Describe("Captain Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		captain := &crewv1.Captain{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Captain")
+			err := k8sClient.Get(ctx, typeNamespacedName, captain)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &crewv1.Captain{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &crewv1.Captain{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Captain")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &CaptainReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fiz
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fizv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/fiz/v1"
+)
+
+var _ = Describe("Bar Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		bar := &fizv1.Bar{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Bar")
+			err := k8sClient.Get(ctx, typeNamespacedName, bar)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &fizv1.Bar{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &fizv1.Bar{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Bar")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &BarReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foopolicy
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foopolicyv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/foo.policy/v1"
+)
+
+var _ = Describe("HealthCheckPolicy Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		healthcheckpolicy := &foopolicyv1.HealthCheckPolicy{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind HealthCheckPolicy")
+			err := k8sClient.Get(ctx, typeNamespacedName, healthcheckpolicy)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &foopolicyv1.HealthCheckPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &foopolicyv1.HealthCheckPolicy{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance HealthCheckPolicy")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &HealthCheckPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/foo/bar_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/bar_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package foo
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	foov1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/foo/v1"
+)
+
+var _ = Describe("Bar Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		bar := &foov1.Bar{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Bar")
+			err := k8sClient.Get(ctx, typeNamespacedName, bar)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &foov1.Bar{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &foov1.Bar{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Bar")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &BarReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/lakers_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/lakers_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testprojectorgv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/v1"
+)
+
+var _ = Describe("Lakers Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		lakers := &testprojectorgv1.Lakers{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Lakers")
+			err := k8sClient.Get(ctx, typeNamespacedName, lakers)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &testprojectorgv1.Lakers{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &testprojectorgv1.Lakers{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Lakers")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &LakersReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seacreatures
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seacreaturesv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/sea-creatures/v1beta1"
+)
+
+var _ = Describe("Kraken Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		kraken := &seacreaturesv1beta1.Kraken{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Kraken")
+			err := k8sClient.Get(ctx, typeNamespacedName, kraken)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &seacreaturesv1beta1.Kraken{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &seacreaturesv1beta1.Kraken{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Kraken")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &KrakenReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seacreatures
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seacreaturesv1beta2 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/sea-creatures/v1beta2"
+)
+
+var _ = Describe("Leviathan Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		leviathan := &seacreaturesv1beta2.Leviathan{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Leviathan")
+			err := k8sClient.Get(ctx, typeNamespacedName, leviathan)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &seacreaturesv1beta2.Leviathan{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &seacreaturesv1beta2.Leviathan{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Leviathan")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &LeviathanReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ship
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/ship/v2alpha1"
+)
+
+var _ = Describe("Cruiser Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		cruiser := &shipv2alpha1.Cruiser{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Cruiser")
+			err := k8sClient.Get(ctx, typeNamespacedName, cruiser)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &shipv2alpha1.Cruiser{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &shipv2alpha1.Cruiser{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Cruiser")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &CruiserReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ship
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/ship/v1"
+)
+
+var _ = Describe("Destroyer Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		destroyer := &shipv1.Destroyer{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Destroyer")
+			err := k8sClient.Get(ctx, typeNamespacedName, destroyer)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &shipv1.Destroyer{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &shipv1.Destroyer{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Destroyer")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &DestroyerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ship
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/ship/v1beta1"
+)
+
+var _ = Describe("Frigate Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		frigate := &shipv1beta1.Frigate{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Frigate")
+			err := k8sClient.Get(ctx, typeNamespacedName, frigate)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &shipv1beta1.Frigate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &shipv1beta1.Frigate{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Frigate")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &FrigateReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook_test.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Memcached Webhook", func() {
+
+	Context("When creating Memcached under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4/api/v1/admiral_webhook_test.go
+++ b/testdata/project-v4/api/v1/admiral_webhook_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Admiral Webhook", func() {
+
+	Context("When creating Admiral under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4/api/v1/captain_webhook_test.go
+++ b/testdata/project-v4/api/v1/captain_webhook_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Captain Webhook", func() {
+
+	Context("When creating Captain under Defaulting Webhook", func() {
+		It("Should fill in the default value if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+	Context("When creating Captain under Validating Webhook", func() {
+		It("Should deny if a required field is empty", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+
+		It("Should admit if all required fields are provided", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4/api/v1/firstmate_webhook_test.go
+++ b/testdata/project-v4/api/v1/firstmate_webhook_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("FirstMate Webhook", func() {
+
+	Context("When creating FirstMate under Conversion Webhook", func() {
+		It("Should get the converted version of FirstMate", func() {
+
+			// TODO(user): Add your logic here
+
+		})
+	})
+
+})

--- a/testdata/project-v4/internal/controller/admiral_controller_test.go
+++ b/testdata/project-v4/internal/controller/admiral_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4/api/v1"
+)
+
+var _ = Describe("Admiral Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		admiral := &crewv1.Admiral{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Admiral")
+			err := k8sClient.Get(ctx, typeNamespacedName, admiral)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &crewv1.Admiral{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &crewv1.Admiral{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Admiral")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &AdmiralReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4/internal/controller/captain_controller_test.go
+++ b/testdata/project-v4/internal/controller/captain_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4/api/v1"
+)
+
+var _ = Describe("Captain Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		captain := &crewv1.Captain{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind Captain")
+			err := k8sClient.Get(ctx, typeNamespacedName, captain)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &crewv1.Captain{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &crewv1.Captain{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance Captain")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &CaptainReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4/internal/controller/firstmate_controller_test.go
+++ b/testdata/project-v4/internal/controller/firstmate_controller_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4/api/v1"
+)
+
+var _ = Describe("FirstMate Controller", func() {
+	Context("When reconciling a resource", func() {
+		const resourceName = "test-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		firstmate := &crewv1.FirstMate{}
+
+		BeforeEach(func() {
+			By("creating the custom resource for the Kind FirstMate")
+			err := k8sClient.Get(ctx, typeNamespacedName, firstmate)
+			if err != nil && errors.IsNotFound(err) {
+				resource := &crewv1.FirstMate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+					},
+					// TODO(user): Specify other spec details if needed.
+				}
+				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			// TODO(user): Cleanup logic after each test, like removing the resource instance.
+			resource := &crewv1.FirstMate{}
+			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Cleanup the specific resource instance FirstMate")
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+		})
+		It("should successfully reconcile the resource", func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &FirstMateReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/testdata/project-v4/internal/controller/laker_controller_test.go
+++ b/testdata/project-v4/internal/controller/laker_controller_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Laker Controller", func() {
+	Context("When reconciling a resource", func() {
+
+		It("should successfully reconcile the resource", func() {
+
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})


### PR DESCRIPTION
## How to reproduce?

Add any valid ginkgo assert such as `Expect(1).To(Equal(2))` to the BeforeSuite and  AfterSuite. As a result, the test should fail, but it succeeds actually.


## What do these changes do?

Add the unit test template for webhook and controllers so that suite_test are no longer ignored.

Fixes #3646 

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
