### PR TITLE
🐛 (kustomize/v1,go/v4): Fix yamllint warnings in the scaffolds done under config. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 .PHONY: yamllint
 yamllint:
-	@docker run --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest testdata -d "{extends: relaxed, rules: {line-length: {max: 120}}}" --no-warnings
+	@docker run --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest testdata -d '{extends: relaxed, rules: {line-length: {max: 120}}, ignore: "/testdata/project-v2/\n/testdata/project-v3/"}'
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:

--- a/docs/book/src/component-config-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/default/kustomization.yaml
@@ -32,7 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 - manager_config_patch.yaml

--- a/docs/book/src/component-config-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/docs/book/src/component-config-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/book/src/component-config-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -32,8 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - manager_webhook_patch.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_auth_proxy_patch.yaml
@@ -30,7 +30,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -78,10 +78,12 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-{{ if .ComponentConfig }}
+{{ if .ComponentConfig -}}
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-- manager_config_patch.yaml{{ end }}
+- manager_config_patch.yaml
+
+{{ end -}}
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/manager_auth_proxy_patch.go
@@ -59,7 +59,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -125,7 +125,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -41,8 +41,7 @@ func (f *Monitor) SetTemplateDefaults() error {
 	return nil
 }
 
-const serviceMonitorTemplate = `
-# Prometheus Monitor Service (Metrics)
+const serviceMonitorTemplate = `# Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook/service.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook/service.go
@@ -44,8 +44,7 @@ func (f *Service) SetTemplateDefaults() error {
 	return nil
 }
 
-const serviceTemplate = `
-apiVersion: v1
+const serviceTemplate = `apiVersion: v1
 kind: Service
 metadata:
   labels:

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -55,8 +55,8 @@ spec:
   # TODO(user): edit the following value to ensure the number
   # of Pods/Instances your Operand must have on cluster
   size: 1
-{{ if not (isEmptyStr .Port) -}}
+{{ if not (isEmptyStr .Port) }}
   # TODO(user): edit the following value to ensure the container has the right port to be initialized
   containerPort: {{ .Port }}
-{{- end }}
+{{ end -}}
 `

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/kustomization.yaml
@@ -32,8 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/testdata/project-v4-multigroup-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4-multigroup-with-deploy-image/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/testdata/project-v4-multigroup-with-deploy-image/config/webhook/service.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/webhook/service.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -32,8 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml

--- a/testdata/project-v4-multigroup/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4-multigroup/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/testdata/project-v4-multigroup/config/webhook/service.yaml
+++ b/testdata/project-v4-multigroup/config/webhook/service.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
@@ -32,8 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml

--- a/testdata/project-v4-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -81,7 +81,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4-with-deploy-image/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-with-deploy-image/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
@@ -6,4 +6,3 @@ spec:
   # TODO(user): edit the following value to ensure the number
   # of Pods/Instances your Operand must have on cluster
   size: 1
-

--- a/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
@@ -6,5 +6,6 @@ spec:
   # TODO(user): edit the following value to ensure the number
   # of Pods/Instances your Operand must have on cluster
   size: 1
-# TODO(user): edit the following value to ensure the container has the right port to be initialized
+
+  # TODO(user): edit the following value to ensure the container has the right port to be initialized
   containerPort: 11211

--- a/testdata/project-v4-with-deploy-image/config/webhook/service.yaml
+++ b/testdata/project-v4-with-deploy-image/config/webhook/service.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/testdata/project-v4-with-grafana/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-grafana/config/default/kustomization.yaml
@@ -32,8 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml

--- a/testdata/project-v4-with-grafana/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4-with-grafana/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/testdata/project-v4-with-grafana/config/manager/manager.yaml
+++ b/testdata/project-v4-with-grafana/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4-with-grafana/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-with-grafana/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -32,8 +32,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- manager_webhook_patch.yaml

--- a/testdata/project-v4/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/project-v4/config/default/manager_auth_proxy_patch.yaml
@@ -14,7 +14,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4/config/prometheus/monitor.yaml
+++ b/testdata/project-v4/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/testdata/project-v4/config/webhook/service.yaml
+++ b/testdata/project-v4/config/webhook/service.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Hi!
This PR fixes #3599 

Note: There are 5 warnings remaining in `project-v2` testdata. It's root cause isn't the kubebuilder itself, but those yaml files are generated by controller-tools `v0.3.0`. I tried to increase its version, but the code didn't work with the newer versions of controller-tools. So, I just decided to leave those warnings unfixed and add `project-v2` to yamllint's `ignore` config. Please tell me if you think we can solve this problem in a better way.

More Info: Those warnings are as follows. They're generated by running `make manifest` command in the testdata directory.
```
testdata/project-v2/config/webhook/manifests.yaml
  1:1       warning  too many blank lines (1 > 0)  (empty-lines)

testdata/project-v2/config/crd/bases/crew.testproject.org_admirals.yaml
  1:1       warning  too many blank lines (1 > 0)  (empty-lines)

testdata/project-v2/config/crd/bases/crew.testproject.org_firstmates.yaml
  1:1       warning  too many blank lines (1 > 0)  (empty-lines)

testdata/project-v2/config/crd/bases/crew.testproject.org_captains.yaml
  1:1       warning  too many blank lines (1 > 0)  (empty-lines)

testdata/project-v2/config/rbac/role.yaml
  1:1       warning  too many blank lines (1 > 0)  (empty-lines)
```
