### PR TITLE
:book: Fix variable reference in docs

### DIFF
--- a/docs/book/src/reference/webhook-for-core-types.md
+++ b/docs/book/src/reference/webhook-for-core-types.md
@@ -60,7 +60,7 @@ If you need a client and/or decoder, just pass them in at struct construction ti
 mgr.GetWebhookServer().Register("/mutate-v1-pod", &webhook.Admission{
 	Handler: &podAnnotator{
 		Client:   mgr.GetClient(),
-		Decoder:  admission.NewDecoder(mgr.GetScheme()),
+		decoder:  admission.NewDecoder(mgr.GetScheme()),
 	},
 })
 ```


### PR DESCRIPTION

Fixes the reference of the struct var in the documentation as added in https://github.com/kubernetes-sigs/kubebuilder/pull/3613/files