### PR TITLE
📖 Addressing Deprecated Manager Options

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -30,8 +30,6 @@ import (
 	"flag"
 	"os"
 
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -45,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
### Description

This PR proposes an update to the documentation available at https://book.kubebuilder.io/cronjob-tutorial/empty-main.html#every-journey-needs-a-start-every-program-needs-a-main. The reason for this revision is that the current documentation still references deprecated cache settings, such as `cache.MultiNamespacedCacheBuilder`.

### Motivation

With the release of controller-runtime v0.15.0, several Manager Options have undergone refactoring and deprecation. As a result, the documentation needs an update since it still refers to old Manager Options.

### Related Issue

Fixes #3662 