### PR TITLE
✨ [Add] Bump kube-rbac-proxy to 0.15.0

### DIFF
--- a/build-legacy/cloudbuild_kube-rbac-proxy.yaml
+++ b/build-legacy/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.14.4
+  _KUBE_RBAC_PROXY_VERSION: v0.15.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   env:

--- a/build/cloudbuild_kube-rbac-proxy.yaml
+++ b/build/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.14.4
+  _KUBE_RBAC_PROXY_VERSION: v0.15.0
 steps:
 - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
   env:


### PR DESCRIPTION
The recent release of brancz/kube-rbac-proxy
introduces options to disable http/2 or fine tune
its configuration.

More details refer: https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.15.0

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
