### PR TITLE
✨ Bump k8s, etcd and golang to generate new tools/envtest versions

### DIFF
--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: 1.28.0
+  _KUBERNETES_VERSION: 1.28.3
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [

--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.20 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.9
+ARG ETCD_VERSION=v3.5.10
 ARG OS=darwin
 ARG ARCH
 

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.18 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.9
+ARG ETCD_VERSION=v3.5.10
 ARG OS=linux
 ARG ARCH
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.9
+ARG ETCD_VERSION=v3.5.10
 ARG OS=windows
 ARG ARCH
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION


### PR DESCRIPTION
**Description**

- Bump k8s version from v28.0 to v28.3
- Bump windows with Golang from 2.19 to 2.20
- Update ETCD from v3.5.9 to v3.5.10
