### PR TITLE
🐛 [fix]: Bump k8s version for envtest to address CVE-2023-44487

### DIFF
--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -9,9 +9,8 @@ jobs:
     name: Run on Ubuntu
     runs-on: ubuntu-latest
     env:
-      KIND_K8S_VERSION: v1.28.0
-      tools_k8s_version: 1.28.0
-      kind_version: 0.15.0
+      tools_k8s_version: 1.28.3
+      kind_version: 0.20.0
     steps:
       - name: Clone the code
         uses: actions/checkout@v4
@@ -32,8 +31,8 @@ jobs:
         run: setup-envtest use $tools_k8s_version
 
       - name: Create kind cluster
-        run: kind create cluster
-        
+        run: kind create cluster --image kindest/node:v$tools_k8s_version
+
       - name: Prepare the environment
         run: |
           KUSTOMIZATION_FILE_PATH="testdata/project-v4/config/default/kustomization.yaml"
@@ -48,4 +47,3 @@ jobs:
           go get -u ./...
           go mod tidy
           make test-e2e
-          


### PR DESCRIPTION
This PR updates k8s patch version for sample test which is corresponding to https://github.com/kubernetes-sigs/kubebuilder/pull/3665 .

Not quite sure if it is necessary, we can close it if not.

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
