### PR TITLE
📖 Add prerequisite helm charts to README.md for cronjob tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -12,7 +12,7 @@
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster. (cluster must have cert-manager and prometheus installed)
   - [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
-  - [cert-manager](https://cert-manager.io/docs/installation/upgrade/#upgrading-using-static-manifests)
+  - [cert-manager](https://cert-manager.io/docs/installation/helm/#4-install-cert-manager)
   
 
 ### To Deploy on the cluster

--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -10,7 +10,10 @@
 - go version v1.20.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+- Access to a Kubernetes v1.11.3+ cluster. (cluster must have cert-manager and prometheus installed)
+  - [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+  - [cert-manager](https://cert-manager.io/docs/installation/upgrade/#upgrading-using-static-manifests)
+  
 
 ### To Deploy on the cluster
 **Build and push your image to the location specified by `IMG`:**


### PR DESCRIPTION
## Problem:

When following the tutorial for `docs/book/src/cronjob-tutorial/testdata/project` I ran into issues caused by the lack of operators in my cluster.

## Solution: 

I'm adding some documentation to the readme to help anyone following the tutorial understand what prerequisites are required for the cluster that they plan to use when following the cronjob tutorial.

## Motivation:
Following the cronjob tutorial to the end, after running `make manifests` and `make install`, I attempted to run `make deploy`

First I was confronted with missing CRDs
```
resource mapping not found for name: "project-serving-cert" namespace: "project-system" from "STDIN": no matches for kind "Certificate" in version "cert-manager.io/v1"
ensure CRDs are installed first
resource mapping not found for name: "project-selfsigned-issuer" namespace: "project-system" from "STDIN": no matches for kind "Issuer" in version "cert-manager.io/v1"
ensure CRDs are installed first
resource mapping not found for name: "project-controller-manager-metrics-monitor" namespace: "project-system" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
make: *** [deploy] Error 1
```
Which was remedied by installing [cert-manager](https://cert-manager.io/docs/installation/upgrade/#upgrading-using-static-manifests).

_Then_ I ran `make deploy` again, after which I encountered this 

```
resource mapping not found for name: "project-serving-cert" namespace: "project-system" from "STDIN": no matches for kind "Certificate" in version "cert-manager.io/v1"
ensure CRDs are installed first
resource mapping not found for name: "project-selfsigned-issuer" namespace: "project-system" from "STDIN": no matches for kind "Issuer" in version "cert-manager.io/v1"
ensure CRDs are installed first
resource mapping not found for name: "project-controller-manager-metrics-monitor" namespace: "project-system" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
make: *** [deploy] Error 1
```

Which was remedied by installing [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)

I was then able to run `make deploy` successfully.
