### PR TITLE
✨ feat(go/v4): add support for custom boilerplate path

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -321,7 +321,7 @@ func (s *apiScaffolder) scaffoldCreateAPIFromGolang(isLegacyLayout bool) error {
 		return golangV3Scaffolder.Scaffold()
 	}
 	golangV4Scaffolder := golangv4scaffolds.NewAPIScaffolder(s.config,
-		s.resource, true)
+		s.resource, golangv4scaffolds.DefaultBoilerplatePath, true)
 	golangV4Scaffolder.InjectFS(s.fs)
 	return golangV4Scaffolder.Scaffold()
 }

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -37,10 +37,10 @@ import (
 const (
 	// defaultCRDVersion is the default CRD API version to scaffold.
 	defaultCRDVersion = "v1"
-)
 
-// DefaultMainPath is default file path of main.go
-const DefaultMainPath = "cmd/main.go"
+	// DefaultMainPath is default file path of main.go
+	DefaultMainPath = "cmd/main.go"
+)
 
 var _ plugin.CreateAPISubcommand = &createAPISubcommand{}
 
@@ -60,6 +60,9 @@ type createAPISubcommand struct {
 
 	// runMake indicates whether to run make or not after scaffolding APIs
 	runMake bool
+
+	// Path to refer a boilerplate file
+	boilerplatePath string
 }
 
 func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -100,6 +103,8 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&p.force, "force", false,
 		"attempt to create resource even if it already exists")
+
+	fs.StringVar(&p.boilerplatePath, "boilerplatePath", scaffolds.DefaultBoilerplatePath, "specifies the boilerplate file path (e.g. license) to prepend to generated files.")
 
 	p.options = &goPlugin.Options{}
 
@@ -171,7 +176,7 @@ func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {
 }
 
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewAPIScaffolder(p.config, *p.resource, p.force)
+	scaffolder := scaffolds.NewAPIScaffolder(p.config, *p.resource, p.boilerplatePath, p.force)
 	scaffolder.InjectFS(fs)
 	return scaffolder.Scaffold()
 }

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -57,6 +57,9 @@ type initSubcommand struct {
 	// flags
 	fetchDeps          bool
 	skipGoVersionCheck bool
+
+	// Path to refer a boilerplate file
+	boilerplatePath string
 }
 
 func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -88,6 +91,7 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.license, "license", "apache2",
 		"license to use to boilerplate, may be one of 'apache2', 'none'")
 	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
+	fs.StringVar(&p.boilerplatePath, "boilerplatePath", scaffolds.DefaultBoilerplatePath, "specifies the boilerplate file path (e.g. license) to prepend to generated files.")
 
 	// project args
 	fs.StringVar(&p.repo, "repo", "", "name to use for go module (e.g., github.com/user/repo), "+
@@ -122,7 +126,7 @@ func (p *initSubcommand) PreScaffold(machinery.Filesystem) error {
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewInitScaffolder(p.config, p.license, p.owner)
+	scaffolder := scaffolds.NewInitScaffolder(p.config, p.license, p.owner, p.boilerplatePath)
 	scaffolder.InjectFS(fs)
 	err := scaffolder.Scaffold()
 	if err != nil {

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates/api"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
 )
 
 var _ plugins.Scaffolder = &apiScaffolder{}
@@ -38,8 +37,9 @@ var _ plugins.Scaffolder = &apiScaffolder{}
 // apiScaffolder contains configuration for generating scaffolding for Go type
 // representing the API and controller that implements the behavior for the API.
 type apiScaffolder struct {
-	config   config.Config
-	resource resource.Resource
+	config          config.Config
+	resource        resource.Resource
+	boilerplatePath string
 
 	// fs is the filesystem that will be used by the scaffolder
 	fs machinery.Filesystem
@@ -49,11 +49,12 @@ type apiScaffolder struct {
 }
 
 // NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
-func NewAPIScaffolder(config config.Config, res resource.Resource, force bool) plugins.Scaffolder {
+func NewAPIScaffolder(config config.Config, res resource.Resource, boilerplatePath string, force bool) plugins.Scaffolder {
 	return &apiScaffolder{
-		config:   config,
-		resource: res,
-		force:    force,
+		config:          config,
+		resource:        res,
+		boilerplatePath: boilerplatePath,
+		force:           force,
 	}
 }
 
@@ -67,7 +68,7 @@ func (s *apiScaffolder) Scaffold() error {
 	log.Println("Writing scaffold for you to edit...")
 
 	// Load the boilerplate
-	boilerplate, err := afero.ReadFile(s.fs.FS, hack.DefaultBoilerplatePath)
+	boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
 	if err != nil {
 		if errors.Is(err, afero.ErrFileNotFound) {
 			boilerplate = []byte("")

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"path/filepath"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
@@ -44,6 +46,9 @@ const (
 
 var _ plugins.Scaffolder = &initScaffolder{}
 
+// DefaultBoilerplatePath is the default path to the boilerplate file
+var DefaultBoilerplatePath = filepath.Join("hack", "boilerplate.go.txt")
+
 var kustomizeVersion string
 
 type initScaffolder struct {
@@ -57,10 +62,10 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config config.Config, license, owner string) plugins.Scaffolder {
+func NewInitScaffolder(config config.Config, license, owner, boilerplatePath string) plugins.Scaffolder {
 	return &initScaffolder{
 		config:          config,
-		boilerplatePath: hack.DefaultBoilerplatePath,
+		boilerplatePath: boilerplatePath,
 		license:         license,
 		owner:           owner,
 	}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
@@ -17,10 +17,15 @@ limitations under the License.
 package templates
 
 import (
+	"path/filepath"
+
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 )
 
 var _ machinery.Template = &DockerIgnore{}
+
+// DefaultBoilerplatePath is the default path to the boilerplate file
+var DefaultBoilerplatePath = filepath.Join("hack", "boilerplate.go.txt")
 
 // DockerIgnore scaffolds a file that defines which files should be ignored by the containerized build process
 type DockerIgnore struct {

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates/api"
-	"sigs.k8s.io/kubebuilder/v3/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
 )
 
 var _ plugins.Scaffolder = &webhookScaffolder{}
@@ -42,14 +41,17 @@ type webhookScaffolder struct {
 
 	// force indicates whether to scaffold controller files even if it exists or not
 	force bool
+
+	boilerplatePath string
 }
 
 // NewWebhookScaffolder returns a new Scaffolder for v2 webhook creation operations
-func NewWebhookScaffolder(config config.Config, resource resource.Resource, force bool) plugins.Scaffolder {
+func NewWebhookScaffolder(config config.Config, resource resource.Resource, boilerplatePath string, force bool) plugins.Scaffolder {
 	return &webhookScaffolder{
-		config:   config,
-		resource: resource,
-		force:    force,
+		config:          config,
+		resource:        resource,
+		boilerplatePath: boilerplatePath,
+		force:           force,
 	}
 }
 
@@ -63,7 +65,7 @@ func (s *webhookScaffolder) Scaffold() error {
 	log.Println("Writing scaffold for you to edit...")
 
 	// Load the boilerplate
-	boilerplate, err := afero.ReadFile(s.fs.FS, hack.DefaultBoilerplatePath)
+	boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
 	if err != nil {
 		return fmt.Errorf("error scaffolding webhook: unable to load boilerplate: %w", err)
 	}

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -46,6 +46,9 @@ type createWebhookSubcommand struct {
 
 	// force indicates that the resource should be created even if it already exists
 	force bool
+
+	// Path to refer a boilerplate file
+	boilerplatePath string
 }
 
 func (p *createWebhookSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -78,6 +81,8 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&p.force, "force", false,
 		"attempt to create resource even if it already exists")
+
+	fs.StringVar(&p.boilerplatePath, "boilerplatePath", scaffolds.DefaultBoilerplatePath, "specifies the boilerplate file path (e.g. license) to prepend to generated files.")
 }
 
 func (p *createWebhookSubcommand) InjectConfig(c config.Config) error {
@@ -112,7 +117,7 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 }
 
 func (p *createWebhookSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewWebhookScaffolder(p.config, *p.resource, p.force)
+	scaffolder := scaffolds.NewWebhookScaffolder(p.config, *p.resource, p.boilerplatePath, p.force)
 	scaffolder.InjectFS(fs)
 	return scaffolder.Scaffold()
 }


### PR DESCRIPTION
> Related to #3697 

## Description

Add support to a custom boilerplate path for the `base.go.kubebuilder.io/v4` plugin.

The following are changes involved in this feature request:
1. add `--boilerplatePath` flag to `kubebuilder --plugin "base.go.kubebuilder.io/v4" init`
2. add `--boilerplatePath` flag to `kubebuilder --plugin "base.go.kubebuilder.io/v4" create api`
3. add `--boilerplatePath` flag to `kubebuilder --plugin "base.go.kubebuilder.io/v4" create webhook`

## Expectation

After applying this feature, you can customize the boilerplate file path to any path other than the default (`hack/boilerplate.go.txt`), like the following examples:

* `Init`
```bash
kubebuilder init --plugins base.go.kubebuilder.io/v4 --license apache2 --owner example.com --boilerplatePath tools/hack/boilerplate.go.txt
```

* `Create API`
```bash
kubebuilder create api --controller=false --group example --kind CustomPlugin --version v1alpha1 --boilerplatePath tools/hack/boilerplate.go.txt
```

* `Create Webhook`
```bash
kubebuilder create webhook --group example --kind CustomPlugin --version v1alpha1 --defaulting --programmatic-validation --boilerplatePath tools/hack/boilerplate.go.txt
```