### PR TITLE
:bug: (go/v4) update gitignore template comments and fix some nit typo issues

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/component-config-tutorial/testdata/project/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
@@ -48,14 +48,16 @@ const gitignoreTemplate = `
 bin/*
 Dockerfile.cross
 
-# Test binary, build with ` + "`go test -c`" + `
+# Test binary, built with ` + "`go test -c`" + `
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/testdata/project-v4-multigroup-with-deploy-image/.gitignore
+++ b/testdata/project-v4-multigroup-with-deploy-image/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/testdata/project-v4-multigroup/.gitignore
+++ b/testdata/project-v4-multigroup/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/testdata/project-v4-with-deploy-image/.gitignore
+++ b/testdata/project-v4-with-deploy-image/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/testdata/project-v4-with-grafana/.gitignore
+++ b/testdata/project-v4-with-grafana/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia

--- a/testdata/project-v4/.gitignore
+++ b/testdata/project-v4/.gitignore
@@ -8,14 +8,16 @@
 bin/*
 Dockerfile.cross
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Kubernetes Generated files - skip generated files, except for vendored files
+# Go workspace file
+go.work
 
+# Kubernetes Generated files - skip generated files, except for vendored files
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia


### PR DESCRIPTION
## Description
Update gitignore template  for golang/v4 plugin (v2 and v3 are deprecated and will be removed soon) to be up to date with https://github.com/github/gitignore/blob/main/Go.gitignore

## Motivation
Use the default template of GitHub

## Related issues
No related issues


