### PR TITLE
:bug: (go/v4): fix make help instruction in the README

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/README.md
+++ b/docs/book/src/component-config-tutorial/testdata/project/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -114,7 +114,7 @@ You can apply the samples (examples) from the config/sample:
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run ` + "`make --help`" + ` for more information on all potential ` + "`make`" + ` targets
+**NOTE:** Run ` + "`make help`" + ` for more information on all potential ` + "`make`" + ` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/testdata/project-v4-multigroup-with-deploy-image/README.md
+++ b/testdata/project-v4-multigroup-with-deploy-image/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/testdata/project-v4-multigroup/README.md
+++ b/testdata/project-v4-multigroup/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/testdata/project-v4-with-deploy-image/README.md
+++ b/testdata/project-v4-with-deploy-image/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/testdata/project-v4-with-grafana/README.md
+++ b/testdata/project-v4-with-grafana/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/testdata/project-v4/README.md
+++ b/testdata/project-v4/README.md
@@ -69,7 +69,7 @@ make undeploy
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 


### PR DESCRIPTION
## Description
Update README template for golang/v4 plugin (v2 and v3 are deprecated and will be removed soon).

## Motivation
Use right command.

## Related issues
No related issues



