### PR TITLE
 📖 fixes: syntax error in cert manager code example

### DIFF
--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -225,7 +225,7 @@ Following an example.
 
         By("installing the cert-manager")
         Expect(utils.InstallCertManager()).To(Succeed())
-    }
+    })
 
     // You can also remove them after the tests::
     AfterEach(func() {


### PR DESCRIPTION
noticed small syntax error in docs for cert manager and prometheus  in the envtest section.
fixed for accuracy.