### PR TITLE
:bug: (go/v4): Standardize 'AS' Keyword Capitalization in Dockerfile for Clarity

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/component-config-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup-with-deploy-image/Dockerfile
+++ b/testdata/project-v4-multigroup-with-deploy-image/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-deploy-image/Dockerfile
+++ b/testdata/project-v4-with-deploy-image/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-grafana/Dockerfile
+++ b/testdata/project-v4-with-grafana/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Description
Update Dockerfile template for golang/v4 plugin (v2 and v3 are deprecated and will be removed soon).

## Motivation
Use recommended Docker syntax.

## Related issues
No related issues
