### PR TITLE
✨ Bump k8s and etcd to generate new tools/envtest versions

### DIFF
--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: 1.28.3
+  _KUBERNETES_VERSION: 1.29.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [

--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.20 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.10
+ARG ETCD_VERSION=v3.5.11
 ARG OS=darwin
 ARG ARCH
 

--- a/build/thirdparty/linux/Dockerfile
+++ b/build/thirdparty/linux/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.19 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.10
+ARG ETCD_VERSION=v3.5.11
 ARG OS=linux
 ARG ARCH
 

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -21,7 +21,7 @@ FROM golang:1.20 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
-ARG ETCD_VERSION=v3.5.10
+ARG ETCD_VERSION=v3.5.11
 ARG OS=windows
 ARG ARCH
 


### PR DESCRIPTION
**Description:**

* Bump k8s version from v1.28.3 to v1.29.0
* Update ETCD from v3.5.10 to v3.5.11
