### PR TITLE
✨ Start to build CLI binary for linux_s390x as target

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -41,6 +41,7 @@ builds:
       - linux_amd64
       - linux_arm64
       - linux_ppc64le
+      - linux_s390x
       - darwin_amd64
       - darwin_arm64
     env:


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
Issue: https://github.com/kubernetes-sigs/kubebuilder/issues/3740

this PR adds support for s390x through go release so that the required binaries are generated when these assets are generated via GitHub-actions