### PR TITLE
🌱 Bump golang 1.21 and alpine 3.19

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION
@@ -66,7 +66,7 @@ WORKDIR /usr/local
 RUN tar -czvf /kubebuilder_${OS}_${ARCH}.tar.gz kubebuilder/
 
 # Copy tarball to final image.
-FROM alpine:3.18
+FROM alpine:3.19
 
 # Platform args.
 ARG OS=windows


### PR DESCRIPTION
**Description**
- Upgrade Golang version used to build the binaries to 1.21
- Upgrade the alpine version from 3.18 to 3.19 in for Windows targets. 