### PR TITLE
🌱 : bump e2e tools version to support running Apple ARM instance

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -52,7 +52,7 @@ fi
 
 export KIND_K8S_VERSION="${KIND_K8S_VERSION:-"v1.28.0"}"
 tools_k8s_version=$(convert_to_tools_ver "${KIND_K8S_VERSION#v*}")
-kind_version=0.15.0
+kind_version=0.20.0
 goarch=amd64
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -56,11 +56,11 @@ function delete_cluster {
 function test_cluster {
   local flags="$@"
 
-  docker pull memcached:1.4.36-alpine
-  kind load docker-image --name $KIND_CLUSTER memcached:1.4.36-alpine
+  docker pull memcached:1.6.23-alpine
+  kind load docker-image --name $KIND_CLUSTER memcached:1.6.23-alpine
 
-  docker pull busybox:1.28
-  kind load docker-image --name $KIND_CLUSTER busybox:1.28
+  docker pull busybox:1.36.1
+  kind load docker-image --name $KIND_CLUSTER busybox:1.36.1
 
   go test $(dirname "$0")/grafana $flags -timeout 30m
   go test $(dirname "$0")/deployimage $flags -timeout 30m
@@ -70,11 +70,12 @@ function test_cluster {
 }
 
 function build_sample_external_plugin {
-  # TODO: Dynamically set exteranl plugin destination based on OS platform
-  # EXTERNAL_PLUGIN_DESTINATION_PREFIX="${HOME}/Library/Application Support/kubebuilder/plugins"
-  # For Linux:
-  XDG_CONFIG_HOME="${HOME}/.config"
-  EXTERNAL_PLUGIN_DESTINATION_PREFIX="$XDG_CONFIG_HOME/kubebuilder/plugins"
+  if [ "$(uname -s)" == "Darwin" ]; then
+    EXTERNAL_PLUGIN_DESTINATION_PREFIX="${HOME}/Library/Application Support/kubebuilder/plugins"
+  else
+    XDG_CONFIG_HOME="${HOME}/.config"
+    EXTERNAL_PLUGIN_DESTINATION_PREFIX="$XDG_CONFIG_HOME/kubebuilder/plugins"
+  fi
 
   PLUGIN_NAME="sampleexternalplugin"
   PLUGIN_VERSION="v1"


### PR DESCRIPTION
### Description
Bump tools and dynamically set external plugin path to support running e2e test on Apple ARM machines.
1. Tools updates
    - kind: `0.15.0` --> `0.20.0`
    - memcached image: `1.4.36-alpine` --> `1.6.23-alpine`
    - busybox image: `1.28` --> `1.36.1`
2. Use `uname -s` to detect the OS to determine the external plugin path.

### Motivation

Support running target `make test-e2e-local` available on Apple ARM machines.