### PR TITLE
🌱 drop unnecessary file change for unit test

### DIFF
--- a/pkg/plugin/util/testdata/exampleFile.txt
+++ b/pkg/plugin/util/testdata/exampleFile.txt
@@ -1,1 +1,1 @@
-exampleTargetexampleCodeexampleCodeexampleCodeexampleCodeexampleCodeexampleCodeexampleCodeexampleCode
+exampleTarget

--- a/pkg/plugin/util/util_test.go
+++ b/pkg/plugin/util/util_test.go
@@ -14,14 +14,28 @@ limitations under the License.
 package util
 
 import (
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("InsertCode", func() {
+var _ = Describe("InsertCode", Ordered, func() {
 	path := filepath.Join("testdata", "exampleFile.txt")
+	var originalContent []byte
+
+	BeforeAll(func() {
+		var err error
+		originalContent, err = os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		err := os.WriteFile(path, originalContent, 0644)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	DescribeTable("should not succeed",
 		func(target string) {
 			Expect(InsertCode(path, target, "exampleCode")).ShouldNot(Succeed())


### PR DESCRIPTION
### Motivation:
Resolve https://github.com/kubernetes-sigs/kubebuilder/issues/3748

### Description:
Drop the latest append `exampleCode` which is only for unit test, so as to avoid checkout that file each time.
