### PR TITLE
:bug: Revert ":sparkles: (go/v4): Upgrade CertManager and Prometheus versions used in the e2e tests"

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -51,11 +51,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-with-deploy-image/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-with-grafana/test/utils/utils.go
+++ b/testdata/project-v4-with-grafana/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.71.2"
+	prometheusOperatorVersion = "v0.68.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.13.3"
+	certmanagerVersion = "v1.5.3"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 


### PR DESCRIPTION
Reverts kubernetes-sigs/kubebuilder#3754

We have a test (project-v4-sample) which should be testing it.
However, the test passed, and we could check that the Prometheus Operator installer has an issue and cannot be applied directly. However, it seems that from k8s 1.29, we no longer see the error related to the CRD being too long. 

So the project-v4-sample is passing but it will not work in k8s versions which are lower the 1.29