### PR TITLE
📖 Simplify if condition in cronjob tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -115,10 +115,7 @@ var _ = Describe("CronJob controller", func() {
 			// We'll need to retry getting this newly created CronJob, given that creation may not immediately happen.
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, cronjobLookupKey, createdCronjob)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			// Let's make sure our Schedule string value was properly converted/handled.
 			Expect(createdCronjob.Spec.Schedule).Should(Equal("1 * * * *"))

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
@@ -134,10 +134,7 @@ var _ = Describe("CronJob controller", func() {
 			// We'll need to retry getting this newly created CronJob, given that creation may not immediately happen.
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, cronjobLookupKey, createdCronjob)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			// Let's make sure our Schedule string value was properly converted/handled.
 			Expect(createdCronjob.Spec.Schedule).Should(Equal("1 * * * *"))


### PR DESCRIPTION
In the "Writing tests" section of the cronjob tutorial, the following [code](https://github.com/kubernetes-sigs/kubebuilder/blob/0cb1258c00225720484f665dbf15d27190d75738/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go#L118-L121)
```
if err != nil {
	return false
}
return true
```
can be simplified to
```
return err == nil
```