### PR TITLE
:bug: (go/v4) Fix makefile target build-installer to discarding the previous content

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/Makefile
+++ b/docs/book/src/component-config-tutorial/testdata/project/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -192,10 +192,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/testdata/project-v4-multigroup-with-deploy-image/Makefile
+++ b/testdata/project-v4-multigroup-with-deploy-image/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/testdata/project-v4-with-deploy-image/Makefile
+++ b/testdata/project-v4-with-deploy-image/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/testdata/project-v4-with-grafana/Makefile
+++ b/testdata/project-v4-with-grafana/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -118,10 +118,11 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
+	echo "---" > dist/install.yaml # Clean previous content
 	@if [ -d "config/crd" ]; then \
 		$(KUSTOMIZE) build config/crd > dist/install.yaml; \
+		echo "---" >> dist/install.yaml; \
 	fi
-	echo "---" >> dist/install.yaml  # Add a document separator before appending
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default >> dist/install.yaml
 


### PR DESCRIPTION
**Description**:
current implementation of makefile target build-installer cannot work properly without crd. Root cause of problem is missing discard of content, if crd isn't used.
Result of problem is appending new content behind previous into dist/install.yaml and file content is growing and contains multiple versions.