### PR TITLE
 📖 Fix #the reference link

### DIFF
--- a/docs/book/src/reference/admission-webhook.md
+++ b/docs/book/src/reference/admission-webhook.md
@@ -100,4 +100,4 @@ While certain edge scenarios might allow a mutating webhook to seamlessly modify
 universally acclaimed or recommended strategy. Entrusting the controller logic with status updates remains the 
 most advocated approach.
 
-k8s-doc-admission-webhooks: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks
+[k8s-doc-admission-webhooks]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks


### PR DESCRIPTION
The [Admission webhooks][k8s-doc-admission-webhooks] is not working as a link at the beginning of the doc. Adding the missing [] for the link.

![image](https://github.com/kubernetes-sigs/kubebuilder/assets/17227434/261f8186-ae77-43b9-a4a9-f6dcf2b95764)
