### PR TITLE
:book: Fix typo in cronjob-tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -60,7 +60,7 @@ type realClock struct{}
 
 func (_ realClock) Now() time.Time { return time.Now() }
 
-// clock knows how to get the current time.
+// Clock knows how to get the current time.
 // It can be used to fake out timing for testing.
 type Clock interface {
 	Now() time.Time

--- a/hack/docs/internal/cronjob-tutorial/controller_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/controller_implementation.go
@@ -57,7 +57,7 @@ type realClock struct{}
 
 func (_ realClock) Now() time.Time { return time.Now() }
 
-// clock knows how to get the current time.
+// Clock knows how to get the current time.
 // It can be used to fake out timing for testing.
 type Clock interface {
 	Now() time.Time


### PR DESCRIPTION
Fixes #3772 