### PR TITLE
📖 Add context to handler func

### DIFF
--- a/docs/book/src/reference/watching-resources/testdata/external-indexed-field/controller.go
+++ b/docs/book/src/reference/watching-resources/testdata/external-indexed-field/controller.go
@@ -184,13 +184,13 @@ func (r *ConfigDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	we just need to loop through the list and create a reconcile request for each one.
 	If an error occurs fetching the list, or no `ConfigDeployments` are found, then no reconcile requests will be returned.
 */
-func (r *ConfigDeploymentReconciler) findObjectsForConfigMap(configMap client.Object) []reconcile.Request {
+func (r *ConfigDeploymentReconciler) findObjectsForConfigMap(ctx context.Context, configMap client.Object) []reconcile.Request {
 	attachedConfigDeployments := &appsv1.ConfigDeploymentList{}
 	listOps := &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(configMapField, configMap.GetName()),
 		Namespace:     configMap.GetNamespace(),
 	}
-	err := r.List(context.TODO(), attachedConfigDeployments, listOps)
+	err := r.List(ctx, attachedConfigDeployments, listOps)
 	if err != nil {
 		return []reconcile.Request{}
 	}


### PR DESCRIPTION
This aligns the examples with the changes in `controller-runtime`. I am adding context to handler funcs, because the signature of `MapFunc` changed in `controller-runtime` to allow context to be passed in all handler funcs[1]

[1] https://github.com/kubernetes-sigs/controller-runtime/commit/2464a9d7af4911c6bf6e0baaaf8dc0ab08c7452c

* Fixes #3583
* Tested in the controller I'm writing and watches work perfectly with these changes.
