### PR TITLE
(:sparkles:) Minor typo fix (file should present -> file should be present)

### DIFF
--- a/pkg/plugins/golang/v3/api.go
+++ b/pkg/plugins/golang/v3/api.go
@@ -175,7 +175,7 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {
 	// check if main.go is present in the root directory
 	if _, err := os.Stat(DefaultMainPath); os.IsNotExist(err) {
-		return fmt.Errorf("%s file should present in the root directory", DefaultMainPath)
+		return fmt.Errorf("%s file should be present in the root directory", DefaultMainPath)
 	}
 
 	return nil

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -164,7 +164,7 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {
 	// check if main.go is present in the root directory
 	if _, err := os.Stat(DefaultMainPath); os.IsNotExist(err) {
-		return fmt.Errorf("%s file should present in the root directory", DefaultMainPath)
+		return fmt.Errorf("%s file should be present in the root directory", DefaultMainPath)
 	}
 
 	return nil


### PR DESCRIPTION
Minor fix for an ortographic issue detected in logs (`should present` to `should be present`)