### PR TITLE
🐛(kustomize/v2, go/v4): Fix labels according to conventions and conveys. `app.kubernetes.io/name` now have the ProjectName and the labels  app.kubernetes.io/instance, app.kubernetes.io/component, app.kubernetes.io/created-by, app.kubernetes.io/part-of were removed

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/rbac/service_account.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/part-of: project
+    app.kubernetes.io/name: project
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/docs/book/src/component-config-tutorial/testdata/project/config/samples/config_v2_projectconfig.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/samples/config_v2_projectconfig.yaml
@@ -2,11 +2,8 @@ apiVersion: config.tutorial.kubebuilder.io/v2
 kind: ProjectConfig
 metadata:
   labels:
-    app.kubernetes.io/name: projectconfig
-    app.kubernetes.io/instance: projectconfig-sample
-    app.kubernetes.io/part-of: project
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project
+    app.kubernetes.io/name: project
+	app.kubernetes.io/managed-by: kustomize
   name: projectconfig-sample
 spec:
   # TODO(user): Add fields here

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/service_account.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/part-of: project
+    app.kubernetes.io/name: project
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/samples/batch_v1_cronjob.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/samples/batch_v1_cronjob.yaml
@@ -2,11 +2,8 @@ apiVersion: batch.tutorial.kubebuilder.io/v1
 kind: CronJob
 metadata:
   labels:
-    app.kubernetes.io/name: cronjob
-    app.kubernetes.io/instance: cronjob-sample
-    app.kubernetes.io/part-of: project
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project
+    app.kubernetes.io/name: project
+	app.kubernetes.io/managed-by: kustomize
   name: cronjob-sample
 spec:
   schedule: "*/1 * * * *"

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/part-of: project
+    app.kubernetes.io/name: project
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/docs/book/src/getting-started/testdata/project/config/rbac/service_account.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project
-    app.kubernetes.io/part-of: project
+    app.kubernetes.io/name: project
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
@@ -409,11 +409,9 @@ func labelsForMemcached(name string) map[string]string {
 	if err == nil {
 		imageTag = strings.Split(image, ":")[1]
 	}
-	return map[string]string{"app.kubernetes.io/name": "Memcached",
-		"app.kubernetes.io/instance":   name,
+	return map[string]string{"app.kubernetes.io/name": "project",
 		"app.kubernetes.io/version":    imageTag,
-		"app.kubernetes.io/part-of":    "project",
-		"app.kubernetes.io/created-by": "controller-manager",
+		"app.kubernetes.io/managed-by": "MemcachedController",
 	}
 }
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/service_account.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/service_account.go
@@ -45,11 +45,7 @@ const serviceAccountTemplate = `apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: {{ .ProjectName }}
-    app.kubernetes.io/part-of: {{ .ProjectName }}
+    app.kubernetes.io/name: {{ .ProjectName }}
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -55,11 +55,8 @@ const crdSampleTemplate = `apiVersion: {{ .Resource.QualifiedGroup }}/{{ .Resour
 kind: {{ .Resource.Kind }}
 metadata:
   labels:
-    app.kubernetes.io/name: {{ lower .Resource.Kind }}
-    app.kubernetes.io/instance: {{ lower .Resource.Kind }}-sample
-    app.kubernetes.io/part-of: {{ .ProjectName }}
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: {{ .ProjectName }}
+    app.kubernetes.io/name: {{ .ProjectName }}
+	app.kubernetes.io/managed-by: kustomize
   name: {{ lower .Resource.Kind }}-sample
 spec:
   # TODO(user): Add fields here

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook/service.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook/service.go
@@ -48,11 +48,7 @@ const serviceTemplate = `apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: {{ .ProjectName }}
-    app.kubernetes.io/part-of: {{ .ProjectName }}
+    app.kubernetes.io/name: {{ .ProjectName }}
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -456,11 +456,9 @@ func labelsFor{{ .Resource.Kind }}(name string) map[string]string {
 	if err == nil {
 		imageTag = strings.Split(image, ":")[1]
 	}
-	return map[string]string{"app.kubernetes.io/name": "{{ .Resource.Kind }}",
-		"app.kubernetes.io/instance": name,
+	return map[string]string{"app.kubernetes.io/name": "{{ .ProjectName }}",
 		"app.kubernetes.io/version": imageTag,
-		"app.kubernetes.io/part-of": "{{ .ProjectName }}",
-		"app.kubernetes.io/created-by": "controller-manager",
+		"app.kubernetes.io/managed-by": "{{ .Resource.Kind }}Controller",
 	}
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/service_account.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/_v1_lakers.yaml
@@ -2,11 +2,8 @@ apiVersion: testproject.org/v1
 kind: Lakers
 metadata:
   labels:
-    app.kubernetes.io/name: lakers
-    app.kubernetes.io/instance: lakers-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: lakers-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/crew_v1_captain.yaml
@@ -2,11 +2,8 @@ apiVersion: crew.testproject.org/v1
 kind: Captain
 metadata:
   labels:
-    app.kubernetes.io/name: captain
-    app.kubernetes.io/instance: captain-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: captain-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/fiz_v1_bar.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/fiz_v1_bar.yaml
@@ -2,11 +2,8 @@ apiVersion: fiz.testproject.org/v1
 kind: Bar
 metadata:
   labels:
-    app.kubernetes.io/name: bar
-    app.kubernetes.io/instance: bar-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: bar-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -2,11 +2,8 @@ apiVersion: foo.policy.testproject.org/v1
 kind: HealthCheckPolicy
 metadata:
   labels:
-    app.kubernetes.io/name: healthcheckpolicy
-    app.kubernetes.io/instance: healthcheckpolicy-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: healthcheckpolicy-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/foo_v1_bar.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/foo_v1_bar.yaml
@@ -2,11 +2,8 @@ apiVersion: foo.testproject.org/v1
 kind: Bar
 metadata:
   labels:
-    app.kubernetes.io/name: bar
-    app.kubernetes.io/instance: bar-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: bar-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -2,11 +2,8 @@ apiVersion: sea-creatures.testproject.org/v1beta1
 kind: Kraken
 metadata:
   labels:
-    app.kubernetes.io/name: kraken
-    app.kubernetes.io/instance: kraken-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: kraken-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -2,11 +2,8 @@ apiVersion: sea-creatures.testproject.org/v1beta2
 kind: Leviathan
 metadata:
   labels:
-    app.kubernetes.io/name: leviathan
-    app.kubernetes.io/instance: leviathan-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: leviathan-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/ship_v1_destroyer.yaml
@@ -2,11 +2,8 @@ apiVersion: ship.testproject.org/v1
 kind: Destroyer
 metadata:
   labels:
-    app.kubernetes.io/name: destroyer
-    app.kubernetes.io/instance: destroyer-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: destroyer-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/ship_v1beta1_frigate.yaml
@@ -2,11 +2,8 @@ apiVersion: ship.testproject.org/v1beta1
 kind: Frigate
 metadata:
   labels:
-    app.kubernetes.io/name: frigate
-    app.kubernetes.io/instance: frigate-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: frigate-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/ship_v2alpha1_cruiser.yaml
@@ -2,11 +2,8 @@ apiVersion: ship.testproject.org/v2alpha1
 kind: Cruiser
 metadata:
   labels:
-    app.kubernetes.io/name: cruiser
-    app.kubernetes.io/instance: cruiser-sample
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+	app.kubernetes.io/managed-by: kustomize
   name: cruiser-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup-with-deploy-image/config/webhook/service.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/webhook/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project-v4-multigroup-with-deploy-image
-    app.kubernetes.io/part-of: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/testdata/project-v4-multigroup/config/rbac/service_account.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4-multigroup
-    app.kubernetes.io/part-of: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/testdata/project-v4-multigroup/config/samples/_v1_lakers.yaml
+++ b/testdata/project-v4-multigroup/config/samples/_v1_lakers.yaml
@@ -2,11 +2,8 @@ apiVersion: testproject.org/v1
 kind: Lakers
 metadata:
   labels:
-    app.kubernetes.io/name: lakers
-    app.kubernetes.io/instance: lakers-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: lakers-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4-multigroup/config/samples/crew_v1_captain.yaml
@@ -2,11 +2,8 @@ apiVersion: crew.testproject.org/v1
 kind: Captain
 metadata:
   labels:
-    app.kubernetes.io/name: captain
-    app.kubernetes.io/instance: captain-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: captain-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/fiz_v1_bar.yaml
+++ b/testdata/project-v4-multigroup/config/samples/fiz_v1_bar.yaml
@@ -2,11 +2,8 @@ apiVersion: fiz.testproject.org/v1
 kind: Bar
 metadata:
   labels:
-    app.kubernetes.io/name: bar
-    app.kubernetes.io/instance: bar-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: bar-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
+++ b/testdata/project-v4-multigroup/config/samples/foo.policy_v1_healthcheckpolicy.yaml
@@ -2,11 +2,8 @@ apiVersion: foo.policy.testproject.org/v1
 kind: HealthCheckPolicy
 metadata:
   labels:
-    app.kubernetes.io/name: healthcheckpolicy
-    app.kubernetes.io/instance: healthcheckpolicy-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: healthcheckpolicy-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/foo_v1_bar.yaml
+++ b/testdata/project-v4-multigroup/config/samples/foo_v1_bar.yaml
@@ -2,11 +2,8 @@ apiVersion: foo.testproject.org/v1
 kind: Bar
 metadata:
   labels:
-    app.kubernetes.io/name: bar
-    app.kubernetes.io/instance: bar-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: bar-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
+++ b/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta1_kraken.yaml
@@ -2,11 +2,8 @@ apiVersion: sea-creatures.testproject.org/v1beta1
 kind: Kraken
 metadata:
   labels:
-    app.kubernetes.io/name: kraken
-    app.kubernetes.io/instance: kraken-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: kraken-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
+++ b/testdata/project-v4-multigroup/config/samples/sea-creatures_v1beta2_leviathan.yaml
@@ -2,11 +2,8 @@ apiVersion: sea-creatures.testproject.org/v1beta2
 kind: Leviathan
 metadata:
   labels:
-    app.kubernetes.io/name: leviathan
-    app.kubernetes.io/instance: leviathan-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: leviathan-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/ship_v1_destroyer.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v1_destroyer.yaml
@@ -2,11 +2,8 @@ apiVersion: ship.testproject.org/v1
 kind: Destroyer
 metadata:
   labels:
-    app.kubernetes.io/name: destroyer
-    app.kubernetes.io/instance: destroyer-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: destroyer-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/ship_v1beta1_frigate.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v1beta1_frigate.yaml
@@ -2,11 +2,8 @@ apiVersion: ship.testproject.org/v1beta1
 kind: Frigate
 metadata:
   labels:
-    app.kubernetes.io/name: frigate
-    app.kubernetes.io/instance: frigate-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: frigate-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
+++ b/testdata/project-v4-multigroup/config/samples/ship_v2alpha1_cruiser.yaml
@@ -2,11 +2,8 @@ apiVersion: ship.testproject.org/v2alpha1
 kind: Cruiser
 metadata:
   labels:
-    app.kubernetes.io/name: cruiser
-    app.kubernetes.io/instance: cruiser-sample
-    app.kubernetes.io/part-of: project-v4-multigroup
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
+	app.kubernetes.io/managed-by: kustomize
   name: cruiser-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4-multigroup/config/webhook/service.yaml
+++ b/testdata/project-v4-multigroup/config/webhook/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project-v4-multigroup
-    app.kubernetes.io/part-of: project-v4-multigroup
+    app.kubernetes.io/name: project-v4-multigroup
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/testdata/project-v4-with-deploy-image/config/rbac/service_account.yaml
+++ b/testdata/project-v4-with-deploy-image/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4-with-deploy-image
-    app.kubernetes.io/part-of: project-v4-with-deploy-image
+    app.kubernetes.io/name: project-v4-with-deploy-image
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/testdata/project-v4-with-deploy-image/config/webhook/service.yaml
+++ b/testdata/project-v4-with-deploy-image/config/webhook/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project-v4-with-deploy-image
-    app.kubernetes.io/part-of: project-v4-with-deploy-image
+    app.kubernetes.io/name: project-v4-with-deploy-image
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/testdata/project-v4-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-with-deploy-image/dist/install.yaml
@@ -561,12 +561,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4-with-deploy-image
-    app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: project-v4-with-deploy-image
+    app.kubernetes.io/name: project-v4-with-deploy-image
   name: project-v4-with-deploy-image-controller-manager
   namespace: project-v4-with-deploy-image-system
 ---
@@ -829,12 +825,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project-v4-with-deploy-image
-    app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: project-v4-with-deploy-image
+    app.kubernetes.io/name: project-v4-with-deploy-image
   name: project-v4-with-deploy-image-webhook-service
   namespace: project-v4-with-deploy-image-system
 spec:

--- a/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go
@@ -403,11 +403,9 @@ func labelsForBusybox(name string) map[string]string {
 	if err == nil {
 		imageTag = strings.Split(image, ":")[1]
 	}
-	return map[string]string{"app.kubernetes.io/name": "Busybox",
-		"app.kubernetes.io/instance":   name,
+	return map[string]string{"app.kubernetes.io/name": "project-v4-with-deploy-image",
 		"app.kubernetes.io/version":    imageTag,
-		"app.kubernetes.io/part-of":    "project-v4-with-deploy-image",
-		"app.kubernetes.io/created-by": "controller-manager",
+		"app.kubernetes.io/managed-by": "BusyboxController",
 	}
 }
 

--- a/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
@@ -409,11 +409,9 @@ func labelsForMemcached(name string) map[string]string {
 	if err == nil {
 		imageTag = strings.Split(image, ":")[1]
 	}
-	return map[string]string{"app.kubernetes.io/name": "Memcached",
-		"app.kubernetes.io/instance":   name,
+	return map[string]string{"app.kubernetes.io/name": "project-v4-with-deploy-image",
 		"app.kubernetes.io/version":    imageTag,
-		"app.kubernetes.io/part-of":    "project-v4-with-deploy-image",
-		"app.kubernetes.io/created-by": "controller-manager",
+		"app.kubernetes.io/managed-by": "MemcachedController",
 	}
 }
 

--- a/testdata/project-v4-with-grafana/config/rbac/service_account.yaml
+++ b/testdata/project-v4-with-grafana/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4-with-grafana
-    app.kubernetes.io/part-of: project-v4-with-grafana
+    app.kubernetes.io/name: project-v4-with-grafana
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/testdata/project-v4-with-grafana/dist/install.yaml
+++ b/testdata/project-v4-with-grafana/dist/install.yaml
@@ -16,12 +16,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4-with-grafana
-    app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: project-v4-with-grafana
+    app.kubernetes.io/name: project-v4-with-grafana
   name: project-v4-with-grafana-controller-manager
   namespace: project-v4-with-grafana-system
 ---

--- a/testdata/project-v4/config/rbac/service_account.yaml
+++ b/testdata/project-v4/config/rbac/service_account.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4
-    app.kubernetes.io/part-of: project-v4
+    app.kubernetes.io/name: project-v4
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/testdata/project-v4/config/samples/crew_v1_admiral.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_admiral.yaml
@@ -2,11 +2,8 @@ apiVersion: crew.testproject.org/v1
 kind: Admiral
 metadata:
   labels:
-    app.kubernetes.io/name: admiral
-    app.kubernetes.io/instance: admiral-sample
-    app.kubernetes.io/part-of: project-v4
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4
+    app.kubernetes.io/name: project-v4
+	app.kubernetes.io/managed-by: kustomize
   name: admiral-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4/config/samples/crew_v1_captain.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_captain.yaml
@@ -2,11 +2,8 @@ apiVersion: crew.testproject.org/v1
 kind: Captain
 metadata:
   labels:
-    app.kubernetes.io/name: captain
-    app.kubernetes.io/instance: captain-sample
-    app.kubernetes.io/part-of: project-v4
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4
+    app.kubernetes.io/name: project-v4
+	app.kubernetes.io/managed-by: kustomize
   name: captain-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4/config/samples/crew_v1_firstmate.yaml
+++ b/testdata/project-v4/config/samples/crew_v1_firstmate.yaml
@@ -2,11 +2,8 @@ apiVersion: crew.testproject.org/v1
 kind: FirstMate
 metadata:
   labels:
-    app.kubernetes.io/name: firstmate
-    app.kubernetes.io/instance: firstmate-sample
-    app.kubernetes.io/part-of: project-v4
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: project-v4
+    app.kubernetes.io/name: project-v4
+	app.kubernetes.io/managed-by: kustomize
   name: firstmate-sample
 spec:
   # TODO(user): Add fields here

--- a/testdata/project-v4/config/webhook/service.yaml
+++ b/testdata/project-v4/config/webhook/service.yaml
@@ -2,11 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project-v4
-    app.kubernetes.io/part-of: project-v4
+    app.kubernetes.io/name: project-v4
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -399,12 +399,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: project-v4
-    app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/part-of: project-v4
+    app.kubernetes.io/name: project-v4
   name: project-v4-controller-manager
   namespace: project-v4-system
 ---
@@ -692,12 +688,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: project-v4
-    app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: project-v4
+    app.kubernetes.io/name: project-v4
   name: project-v4-webhook-service
   namespace: project-v4-system
 spec:


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
- updates the labels to project naming conventions as suggested. It removes unnecessary labels according to project guidelines. 
- The changes ensure consistency and alignment with project standards. 
-  #3783 
