### PR TITLE
📖 Add the `Admission webhooks` link in `docs/book/src/reference/admisson-webhook.md`

### DIFF
--- a/docs/book/src/reference/admission-webhook.md
+++ b/docs/book/src/reference/admission-webhook.md
@@ -1,6 +1,6 @@
 # Admission Webhooks
 
-[Admission webhooks][k8s-doc-admission-webhooks] are HTTP callbacks that receive admission requests, process
+[Admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks) are HTTP callbacks that receive admission requests, process
 them and return admission responses.
 
 Kubernetes provides the following types of admission webhooks:
@@ -99,5 +99,3 @@ spec:
 While certain edge scenarios might allow a mutating webhook to seamlessly modify the status, treading this path isn't a 
 universally acclaimed or recommended strategy. Entrusting the controller logic with status updates remains the 
 most advocated approach.
-
-[k8s-doc-admission-webhooks]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#what-are-admission-webhooks


### PR DESCRIPTION
The link to the Kubernetes docs for Admission webhooks was not present in the reference docs.
Adding for the sake of correctness.