### PR TITLE
🌱: Add prefix to bot PR title to respect community rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
     labels:
       - "ok-to-test"
 
@@ -31,26 +33,36 @@ updates:
     target-branch: "tools-releases"
     schedule:
       interval: daily
+    commit-message:
+      prefix: ":seedling:"
   - package-ecosystem: docker
     directory: "/build/thirdparty/linux"
     target-branch: "tools-releases"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
 
   # Maintain dependencies for dockerfile scaffold in the projects
   - package-ecosystem: docker
     directory: "testdata/project-v3"
     schedule:
       interval: daily
+    commit-message:
+      prefix: ":seedling:"
   - package-ecosystem: docker
     directory: "testdata/project-v4"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
 
   # Maintain dependencies for go in external plugin sample
   - package-ecosystem: "gomod"
     directory: "docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
     labels:
       - "ok-to-test"


### PR DESCRIPTION
#### Description

Add a condition to skip PR Verifier if the PR is created by dependabot

#### Motivation

Current PRs created by dependabot fail the CI/CD workflows as the title of the PR does not match the community's criteria.
It seems dependabot does NOT provide an entry to configure the title, so I am thinking if we can just skip the PR verifier in such scenarios.