### PR TITLE
:bug: fix: Remove empty line at beginning of generated files

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/component-config-tutorial/testdata/project/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/docs/book/src/component-config-tutorial/testdata/project/Makefile
+++ b/docs/book/src/component-config-tutorial/testdata/project/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/docs/book/src/getting-started/testdata/project/.gitignore
+++ b/docs/book/src/getting-started/testdata/project/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
@@ -38,8 +38,7 @@ func (f *GitIgnore) SetTemplateDefaults() error {
 	return nil
 }
 
-const gitignoreTemplate = `
-# Binaries for programs and plugins
+const gitignoreTemplate = `# Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
@@ -43,8 +43,7 @@ func (f *GoMod) SetTemplateDefaults() error {
 	return nil
 }
 
-const goModTemplate = `
-module {{ .Repo }}
+const goModTemplate = `module {{ .Repo }}
 
 go 1.21
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -68,8 +68,7 @@ func (f *Makefile) SetTemplateDefaults() error {
 }
 
 //nolint:lll
-const makefileTemplate = `
-# Image URL to use all building/pushing image targets
+const makefileTemplate = `# Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0

--- a/testdata/project-v4-multigroup-with-deploy-image/.gitignore
+++ b/testdata/project-v4-multigroup-with-deploy-image/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/testdata/project-v4-multigroup-with-deploy-image/Makefile
+++ b/testdata/project-v4-multigroup-with-deploy-image/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/testdata/project-v4-multigroup/.gitignore
+++ b/testdata/project-v4-multigroup/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/testdata/project-v4-with-deploy-image/.gitignore
+++ b/testdata/project-v4-with-deploy-image/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/testdata/project-v4-with-deploy-image/Makefile
+++ b/testdata/project-v4-with-deploy-image/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/testdata/project-v4-with-grafana/.gitignore
+++ b/testdata/project-v4-with-grafana/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/testdata/project-v4-with-grafana/Makefile
+++ b/testdata/project-v4-with-grafana/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/testdata/project-v4/.gitignore
+++ b/testdata/project-v4/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -1,4 +1,3 @@
-
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.


### PR DESCRIPTION
## Why the changes were made

Noticed that after generating project with kubebuilder, some files had an empty line in their first line. This PR fixes this.

## How the changes were made

Tried to find all files templates that started with an empty line in `pkg/plugins/golang/v4/scaffolds/internal/templates` folder. Removed it from them and ran `make generate`.

## How to test the changes made

Confirm the changes do not break any use case.
