### PR TITLE
🐛 makefile: remove invalid comment 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -146,7 +146,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/testdata/project-v4-multigroup-with-deploy-image/Makefile
+++ b/testdata/project-v4-multigroup-with-deploy-image/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/testdata/project-v4-with-deploy-image/Makefile
+++ b/testdata/project-v4-with-deploy-image/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/testdata/project-v4-with-grafana/Makefile
+++ b/testdata/project-v4-with-grafana/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -69,7 +69,7 @@ test-e2e:
 	go test ./test/e2e/ -v -ginkgo.v
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
+lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix


### PR DESCRIPTION
## Why the changes were made

Fix command documentation.

## How the changes were made

When `make lint` command was added (https://github.com/kubernetes-sigs/kubebuilder/commit/46ea676fc75e7a8844bbf237cf8e1c4b66b24dd4#diff-e5d6d4f9d67174f1f3764674eb786688353c77cef8514e24d1323e55e5a4a7e8) I believe its documentation was copied from project Makefile (https://github.com/kubernetes-sigs/kubebuilder/commit/feb0c5463bb51d07dc9027a139a0c0a0cfc2253f#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) which does run `yamllint`, but not command generated by kubebuilder. So, removed that part from command doc.

After applying changes, ran `make generate`. 

## How to test the changes made

Confirm the documentation is correct now.
