### PR TITLE
🌱  Bump kube-rbac-proxy 0.16

### DIFF
--- a/build-legacy/cloudbuild_kube-rbac-proxy.yaml
+++ b/build-legacy/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.15.0
+  _KUBE_RBAC_PROXY_VERSION: v0.16.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   env:

--- a/build/cloudbuild_kube-rbac-proxy.yaml
+++ b/build/cloudbuild_kube-rbac-proxy.yaml
@@ -14,7 +14,7 @@
 
 substitutions:
   # This is the kube-rbac-proxy version, source image tags for which must exist remotely.
-  _KUBE_RBAC_PROXY_VERSION: v0.15.0
+  _KUBE_RBAC_PROXY_VERSION: v0.16.0
 steps:
 - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
   env:


### PR DESCRIPTION
Just bump latest release: https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.16.0 