### PR TITLE
✨ Upgrade cert-manager version used from v1.5.3 to v1.14.4

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -55,7 +55,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	certmanagerVersion        = "v1.5.3"
+	certmanagerVersion        = "v1.14.4"
 	certmanagerURLTmpl        = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 	prometheusOperatorVersion = "0.51"
 	prometheusOperatorURL     = "https://raw.githubusercontent.com/prometheus-operator/" +
@@ -274,8 +274,6 @@ func (t *TestContext) CreateManagerNamespace() error {
 // if a warning with `Warning: would violate PodSecurity` will be raised when the manifests are applied
 func (t *TestContext) LabelAllNamespacesToWarnAboutRestricted() error {
 	_, err := t.Kubectl.Command("label", "--overwrite", "ns", "--all",
-		"pod-security.kubernetes.io/audit=restricted",
-		"pod-security.kubernetes.io/enforce-version=v1.24",
 		"pod-security.kubernetes.io/warn=restricted")
 	return err
 }

--- a/test/e2e/v4/e2e_suite_test.go
+++ b/test/e2e/v4/e2e_suite_test.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
+	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -30,3 +33,32 @@ func TestE2E(t *testing.T) {
 	fmt.Fprintf(GinkgoWriter, "Starting kubebuilder suite\n")
 	RunSpecs(t, "Kubebuilder e2e suite")
 }
+
+// BeforeSuite run before any specs are run to perform the required actions for all e2e Go tests.
+var _ = BeforeSuite(func() {
+	var err error
+
+	kbc, err := utils.NewTestContext(util.KubebuilderBinName, "GO111MODULE=on")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(kbc.Prepare()).To(Succeed())
+
+	By("installing the cert-manager bundle")
+	Expect(kbc.InstallCertManager()).To(Succeed())
+
+	By("installing the Prometheus operator")
+	Expect(kbc.InstallPrometheusOperManager()).To(Succeed())
+})
+
+// AfterSuite run after all the specs have run, regardless of whether any tests have failed to ensures that
+// all be cleaned up
+var _ = AfterSuite(func() {
+	kbc, err := utils.NewTestContext(util.KubebuilderBinName, "GO111MODULE=on")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(kbc.Prepare()).To(Succeed())
+
+	By("uninstalling the Prometheus manager bundle")
+	kbc.UninstallPrometheusOperManager()
+
+	By("uninstalling the cert-manager bundle")
+	kbc.UninstallCertManager()
+})

--- a/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-with-deploy-image/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4-with-grafana/test/utils/utils.go
+++ b/testdata/project-v4-with-grafana/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -30,7 +30,7 @@ const (
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 
-	certmanagerVersion = "v1.5.3"
+	certmanagerVersion = "v1.14.4"
 	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 


### PR DESCRIPTION
Upgrade cert-manager version used from v1.5.3 to v1.14.4

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3760