### PR TITLE
:sparkles: (go/v4) - Upgrade Prometheus version used in the tests from v0.68.0 to v0.72.0

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -51,7 +51,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-with-deploy-image/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4-with-grafana/test/utils/utils.go
+++ b/testdata/project-v4-with-grafana/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.68.0"
+	prometheusOperatorVersion = "v0.72.0"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 


### PR DESCRIPTION
 (go/v4) - Upgrade Prometheus version used in the tests from v0.68.0 to v0.72.0