### PR TITLE
✨  Upgrade golangci from 1.54 to 1.57

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -40,14 +40,14 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.57
           working-directory: testdata/project-v4-with-deploy-image
           args: --config .golangci.yml ./...
           skip-cache: true  # first lint action will handle
       - name: Run linter
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.57
           working-directory: testdata/project-v4-multigroup-with-deploy-image
           args: --config .golangci.yml ./...
           skip-cache: true  # first lint action will handle

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.57
 
   yamllint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.54.2 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.57.2 ;\
 	}
 
 .PHONY: apidiff

--- a/docs/book/src/component-config-tutorial/testdata/project/Makefile
+++ b/docs/book/src/component-config-tutorial/testdata/project/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/docs/book/src/component-config-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/docs/book/src/component-config-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"tutorial.kubebuilder.io/project/test/utils"

--- a/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/component-config-tutorial/testdata/project/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -29,7 +29,9 @@ import (
 	"reflect"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -34,7 +34,9 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"tutorial.kubebuilder.io/project/test/utils"

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller_test.go
@@ -23,7 +23,9 @@ import (
 	"time"
 
 	//nolint:golint
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"example.com/memcached/test/utils"

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -26,7 +26,9 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/webhook_suite_test.go
@@ -26,7 +26,9 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -25,7 +25,9 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"tutorial.kubebuilder.io/project/test/utils"

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
@@ -47,7 +47,9 @@ import (
 	"reflect"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/cli/alpha/generate.go
+++ b/pkg/cli/alpha/generate.go
@@ -32,10 +32,10 @@ using the current version of KubeBuilder binary available.
 $ kubebuilder alpha generate --input-dir="./test" --output-dir="./my-output"
 Then we will re-scaffold the project by Kubebuilder in the directory specified by 'output-dir'.
 		`,
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Validate()
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			if err := opts.Rescaffold(); err != nil {
 				log.Fatalf("Failed to rescaffold %s", err)
 			}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -22,7 +22,9 @@ import (
 	"os"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -36,7 +36,7 @@ Linux:
 MacOS:
   $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
 `, c.commandName),
-		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Root().GenBashCompletion(os.Stdout)
 		},
 	}
@@ -55,7 +55,7 @@ $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
 
 # You will need to start a new shell for this setup to take effect.
 `, c.commandName),
-		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Root().GenZshCompletion(os.Stdout)
 		},
 	}
@@ -71,7 +71,7 @@ $ %[1]s completion fish | source
 # To load completions for each session, execute once:
 $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
 `, c.commandName),
-		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Root().GenFishCompletion(os.Stdout, true)
 		},
 	}
@@ -81,7 +81,7 @@ func (CLI) newPowerShellCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "powershell",
 		Short: "Load powershell completions",
-		RunE: func(cmd *cobra.Command, cmdArgs []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Root().GenPowerShellCompletion(os.Stdout)
 		},
 	}

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cli
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -39,7 +39,7 @@ func (c CLI) newInitCmd() *cobra.Command {
 For further help about a specific plugin, set --plugins.
 `,
 		Example: c.getInitHelpExamples(),
-		Run:     func(cmd *cobra.Command, args []string) {},
+		Run:     func(_ *cobra.Command, _ []string) {},
 	}
 
 	// Register --project-version on the dynamically created command

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -23,7 +23,9 @@ import (
 	"path/filepath"
 	"runtime"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -383,7 +385,7 @@ var _ = Describe("Discover external plugins", func() {
 
 			It("should fail if pluginsroot is empty", func() {
 				errPluginsRoot := errors.New("could not retrieve plugins root")
-				retrievePluginsRoot = func(host string) (string, error) {
+				retrievePluginsRoot = func(_ string) (string, error) {
 					return "", errPluginsRoot
 				}
 
@@ -394,7 +396,7 @@ var _ = Describe("Discover external plugins", func() {
 			})
 
 			It("should skip parsing of directories if plugins root is not a directory", func() {
-				retrievePluginsRoot = func(host string) (string, error) {
+				retrievePluginsRoot = func(_ string) (string, error) {
 					return "externalplugin.sh", nil
 				}
 

--- a/pkg/cli/resource_test.go
+++ b/pkg/cli/resource_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cli
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -38,7 +38,7 @@ func (c CLI) newRootCmd() *cobra.Command {
 		Use:     c.commandName,
 		Long:    c.description,
 		Example: c.rootExamples(),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}

--- a/pkg/cli/suite_test.go
+++ b/pkg/cli/suite_test.go
@@ -19,7 +19,9 @@ package cli
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package cli
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/config/errors_test.go
+++ b/pkg/config/errors_test.go
@@ -19,7 +19,9 @@ package config
 import (
 	"fmt"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package config
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/config/store/errors_test.go
+++ b/pkg/config/store/errors_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/config/store/yaml/store_test.go
+++ b/pkg/config/store/yaml/store_test.go
@@ -21,7 +21,9 @@ import (
 	"os"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 

--- a/pkg/config/suite_test.go
+++ b/pkg/config/suite_test.go
@@ -19,7 +19,9 @@ package config
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/config/v2/config_test.go
+++ b/pkg/config/v2/config_test.go
@@ -20,7 +20,9 @@ package v2
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -21,7 +21,9 @@ import (
 	"sort"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/config/version_test.go
+++ b/pkg/config/version_test.go
@@ -19,7 +19,9 @@ package config
 import (
 	"sort"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/stage"

--- a/pkg/internal/validation/dns_test.go
+++ b/pkg/internal/validation/dns_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/machinery/errors_test.go
+++ b/pkg/machinery/errors_test.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"path/filepath"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/machinery/funcmap_test.go
+++ b/pkg/machinery/funcmap_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package machinery
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/machinery/injector_test.go
+++ b/pkg/machinery/injector_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package machinery
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/machinery/machinery_suite_test.go
+++ b/pkg/machinery/machinery_suite_test.go
@@ -19,7 +19,9 @@ package machinery
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/machinery/marker_test.go
+++ b/pkg/machinery/marker_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package machinery
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/machinery/mixins_test.go
+++ b/pkg/machinery/mixins_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package machinery
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -18,7 +18,9 @@ import (
 	"errors"
 	"os"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 

--- a/pkg/model/resource/api_test.go
+++ b/pkg/model/resource/api_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package resource
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/model/resource/gvk_test.go
+++ b/pkg/model/resource/gvk_test.go
@@ -19,7 +19,9 @@ package resource
 import (
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package resource
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/model/resource/suite_test.go
+++ b/pkg/model/resource/suite_test.go
@@ -19,7 +19,9 @@ package resource
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/model/resource/utils_test.go
+++ b/pkg/model/resource/utils_test.go
@@ -19,7 +19,9 @@ package resource
 import (
 	"path"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/model/resource/webhooks_test.go
+++ b/pkg/model/resource/webhooks_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package resource
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/model/stage/stage_test.go
+++ b/pkg/model/stage/stage_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	g "github.com/onsi/ginkgo/v2" // An alias is required because Context is defined elsewhere in this package.
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugin/bundle_test.go
+++ b/pkg/plugin/bundle_test.go
@@ -19,7 +19,9 @@ package plugin
 import (
 	"sort"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/plugin/errors_test.go
+++ b/pkg/plugin/errors_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package plugin
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugin/filter_test.go
+++ b/pkg/plugin/filter_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package plugin
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/plugin/helpers_test.go
+++ b/pkg/plugin/helpers_test.go
@@ -19,7 +19,9 @@ package plugin
 import (
 	"sort"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/plugin/suite_test.go
+++ b/pkg/plugin/suite_test.go
@@ -19,7 +19,9 @@ package plugin
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/plugin/util/exec_test.go
+++ b/pkg/plugin/util/exec_test.go
@@ -18,7 +18,9 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugin/util/helpers_test.go
+++ b/pkg/plugin/util/helpers_test.go
@@ -19,7 +19,9 @@ package util
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugin/util/util_test.go
+++ b/pkg/plugin/util/util_test.go
@@ -17,7 +17,9 @@ import (
 	"os"
 	"path/filepath"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugin/version_test.go
+++ b/pkg/plugin/version_test.go
@@ -19,7 +19,9 @@ package plugin
 import (
 	"sort"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/model/stage"

--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -23,7 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -84,7 +84,9 @@ import (
 	"fmt"
 
 	//nolint:golint
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -19,7 +19,9 @@ package golang
 import (
 	"sort"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -19,7 +19,9 @@ package golang
 import (
 	"path"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"

--- a/pkg/plugins/golang/suite_test.go
+++ b/pkg/plugins/golang/suite_test.go
@@ -19,7 +19,9 @@ package golang
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -127,6 +127,7 @@ import (
 	"path/filepath"
 	"testing"
 	. "github.com/onsi/ginkgo"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -140,7 +140,9 @@ import (
 	"testing"
 	"fmt"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	%s
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -131,7 +131,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -147,7 +147,9 @@ import (
 	"time"
 	"runtime"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	%s
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
@@ -75,6 +75,7 @@ const webhookTestTemplate = `{{ .Boilerplate }}
 package {{ .Resource.Version }}
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -141,7 +141,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
@@ -73,9 +73,11 @@ import (
 	{{ if .DoAPI -}}
 	"context"
 	{{- end }}
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 	{{ if .DoAPI -}}
 
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -239,7 +239,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= {{ .KustomizeVersion }}
 CONTROLLER_TOOLS_VERSION ?= {{ .ControllerToolsVersion }}
 ENVTEST_VERSION ?= {{ .EnvtestVersion }}
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -46,7 +46,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -48,7 +48,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	
 	"{{ .Repo }}/test/utils"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -47,6 +47,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/test/e2e/alphagenerate/e2e_suite_test.go
+++ b/test/e2e/alphagenerate/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -24,7 +24,9 @@ import (
 
 	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"

--- a/test/e2e/deployimage/e2e_suite_test.go
+++ b/test/e2e/deployimage/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -26,12 +26,9 @@ import (
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
-
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"

--- a/test/e2e/externalplugin/e2e_suite_test.go
+++ b/test/e2e/externalplugin/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/externalplugin/generate_test.go
+++ b/test/e2e/externalplugin/generate_test.go
@@ -21,15 +21,15 @@ import (
 
 	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"
 )
 

--- a/test/e2e/grafana/e2e_suite_test.go
+++ b/test/e2e/grafana/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/grafana/generate_test.go
+++ b/test/e2e/grafana/generate_test.go
@@ -21,12 +21,10 @@ import (
 
 	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"

--- a/test/e2e/utils/kubectl_test.go
+++ b/test/e2e/utils/kubectl_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/utils/suite_test.go
+++ b/test/e2e/utils/suite_test.go
@@ -19,7 +19,9 @@ package utils
 import (
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -27,7 +27,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	// nolint:revive
+	. "github.com/onsi/ginkgo/v2"
 )
 
 const (

--- a/test/e2e/v4/e2e_suite_test.go
+++ b/test/e2e/v4/e2e_suite_test.go
@@ -23,7 +23,9 @@ import (
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -21,15 +21,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	pluginutil "sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
 	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"
 )
 

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -28,12 +28,10 @@ import (
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/plugin/util"
 
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 
-	//nolint:golint
-	//nolint:revive
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v3/test/e2e/utils"

--- a/testdata/project-v2/controllers/suite_test.go
+++ b/testdata/project-v2/controllers/suite_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v3/api/v1/webhook_suite_test.go
+++ b/testdata/project-v3/api/v1/webhook_suite_test.go
@@ -25,10 +25,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
 	//+kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v3/controllers/suite_test.go
+++ b/testdata/project-v3/controllers/suite_test.go
@@ -20,7 +20,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/Makefile
+++ b/testdata/project-v4-multigroup-with-deploy-image/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2alpha1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package apps
 
 import (
+
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller_test.go
@@ -18,8 +18,9 @@ package crew
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller_test.go
@@ -18,8 +18,9 @@ package fiz
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
@@ -18,8 +18,9 @@ package foopolicy
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller_test.go
@@ -18,8 +18,9 @@ package foo
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller_test.go
@@ -18,8 +18,9 @@ package controller
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller_test.go
@@ -18,8 +18,9 @@ package seacreatures
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller_test.go
@@ -18,8 +18,9 @@ package seacreatures
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller_test.go
@@ -18,8 +18,9 @@ package ship
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller_test.go
@@ -18,8 +18,9 @@ package ship
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller_test.go
@@ -18,8 +18,9 @@ package ship
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup-with-deploy-image/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/testdata/project-v4-multigroup-with-deploy-image/test/e2e/e2e_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/test/utils"

--- a/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup/api/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup/api/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2alpha1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package apps
 
 import (
+
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/testdata/project-v4-multigroup/internal/controller/crew/captain_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/captain_controller_test.go
@@ -18,8 +18,9 @@ package crew
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller_test.go
@@ -18,8 +18,9 @@ package fiz
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
@@ -18,8 +18,9 @@ package foopolicy
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/internal/controller/foo/bar_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/bar_controller_test.go
@@ -18,8 +18,9 @@ package foo
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/internal/controller/lakers_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/lakers_controller_test.go
@@ -18,8 +18,9 @@ package controller
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller_test.go
@@ -18,8 +18,9 @@ package seacreatures
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller_test.go
@@ -18,8 +18,9 @@ package seacreatures
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller_test.go
@@ -18,8 +18,9 @@ package ship
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller_test.go
@@ -18,8 +18,9 @@ package ship
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller_test.go
@@ -18,8 +18,9 @@ package ship
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/internal/controller/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/testdata/project-v4-multigroup/test/e2e/e2e_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/test/utils"

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/testdata/project-v4-with-deploy-image/Makefile
+++ b/testdata/project-v4-with-deploy-image/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook_test.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller_test.go
@@ -23,7 +23,9 @@ import (
 	"time"
 
 	//nolint:golint
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller_test.go
@@ -23,7 +23,9 @@ import (
 	"time"
 
 	//nolint:golint
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/testdata/project-v4-with-deploy-image/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4-with-deploy-image/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-with-deploy-image/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/testdata/project-v4-with-deploy-image/test/e2e/e2e_test.go
+++ b/testdata/project-v4-with-deploy-image/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/testdata/project-v4-with-deploy-image/test/utils"

--- a/testdata/project-v4-with-deploy-image/test/utils/utils.go
+++ b/testdata/project-v4-with-deploy-image/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/testdata/project-v4-with-grafana/Makefile
+++ b/testdata/project-v4-with-grafana/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/testdata/project-v4-with-grafana/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-with-grafana/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/testdata/project-v4-with-grafana/test/e2e/e2e_test.go
+++ b/testdata/project-v4-with-grafana/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/testdata/project-v4-with-grafana/test/utils"

--- a/testdata/project-v4-with-grafana/test/utils/utils.go
+++ b/testdata/project-v4-with-grafana/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -161,7 +161,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/testdata/project-v4/api/v1/admiral_webhook_test.go
+++ b/testdata/project-v4/api/v1/admiral_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4/api/v1/captain_webhook_test.go
+++ b/testdata/project-v4/api/v1/captain_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4/api/v1/firstmate_webhook_test.go
+++ b/testdata/project-v4/api/v1/firstmate_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4/api/v1/webhook_suite_test.go
@@ -26,10 +26,12 @@ import (
 	"testing"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
-
 	admissionv1 "k8s.io/api/admission/v1"
+
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4/internal/controller/admiral_controller_test.go
+++ b/testdata/project-v4/internal/controller/admiral_controller_test.go
@@ -18,8 +18,9 @@ package controller
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4/internal/controller/captain_controller_test.go
+++ b/testdata/project-v4/internal/controller/captain_controller_test.go
@@ -18,8 +18,9 @@ package controller
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4/internal/controller/firstmate_controller_test.go
+++ b/testdata/project-v4/internal/controller/firstmate_controller_test.go
@@ -18,8 +18,9 @@ package controller
 
 import (
 	"context"
-
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/testdata/project-v4/internal/controller/laker_controller_test.go
+++ b/testdata/project-v4/internal/controller/laker_controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -22,7 +22,9 @@ import (
 	"runtime"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"

--- a/testdata/project-v4/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4/test/e2e/e2e_suite_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"testing"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 )
 

--- a/testdata/project-v4/test/e2e/e2e_test.go
+++ b/testdata/project-v4/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"os/exec"
 	"time"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2"
+	// nolint:revive
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/testdata/project-v4/test/utils"

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	// nolint:revive
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 )
 


### PR DESCRIPTION
* Upgrade golangci from 1.54 to 1.57
* Fix lint issues after upgrade by:

a) Ensure that in all places we are ignoring the exception equally

```go
         // nolint:revive
	. "github.com/onsi/ginkgo/v2"
	// nolint:revive
	. "github.com/onsi/gomega"
```

b) Ensure that we use `_` for args not explicit called in the funcs. Example

```go
PreRunE: func(_ *cobra.Command, _ []string) error {
```