### PR TITLE
🌱 Remove plugin flag from generate docs samples

### DIFF
--- a/hack/docs/internal/component-config-tutorial/generate_component_config.go
+++ b/hack/docs/internal/component-config-tutorial/generate_component_config.go
@@ -72,7 +72,6 @@ func (sp *Sample) GenerateSampleProject() {
 		"--repo", "tutorial.kubebuilder.io/project",
 		"--license", "apache2",
 		"--owner", "The Kubernetes authors",
-		"--plugins=go/v4",
 		"--component-config",
 	)
 	CheckError("Initializing the component config project", err)

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -67,7 +67,6 @@ func (sp *Sample) GenerateSampleProject() {
 	log.Infof("Initializing the cronjob project")
 
 	err := sp.ctx.Init(
-		"--plugins", "go/v4",
 		"--domain", "tutorial.kubebuilder.io",
 		"--repo", "tutorial.kubebuilder.io/project",
 		"--license", "apache2",


### PR DESCRIPTION
Remove plugin flag from generate docs samples to ensure that it will be generated from the default plugin always. (Make easier we maintain the project)