### PR TITLE
✨  Add Network Policy

### DIFF
--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           KUSTOMIZATION_FILE_PATH="testdata/project-v4/config/default/kustomization.yaml"
           sed -i '25s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '46s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '51s/^#//' $KUSTOMIZATION_FILE_PATH
 
       - name: Test
         run: |

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- allow-webhook-traffic.yaml
+- allow-metrics-traffic.yaml

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/docs/book/src/getting-started/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/docs/book/src/getting-started/testdata/project/config/network-policy/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/network-policy/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- allow-metrics-traffic.yaml

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -188,11 +188,19 @@ enhance the controller-runtime and address these considerations.
 </aside>
 
 
-### By using Network Policy
+### By using Network Policy (You can optionally enable)
 
 NetworkPolicy acts as a basic firewall for pods within a Kubernetes cluster, controlling traffic
-flow at the IP address or port level. However, it doesn't handle authentication (authn), authorization (authz),
-or encryption directly like [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) solution.
+flow at the IP address or port level. However, it doesn't handle `authn/authz`.
+
+Uncomment the following line in the `config/default/kustomization.yaml`:
+
+```
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which uses webhooks and applied on namespaces labeled 'webhooks: enabled' will be able to work properly.
+#- ../network-policy
+```
 
 ### By exposing the metrics endpoint using HTTPS and CertManager
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/init.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager"
+	network_policy "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac"
 )
@@ -79,6 +80,8 @@ func (s *initScaffolder) Scaffold() error {
 		&kdefault.ManagerMetricsPatch{},
 		&manager.Config{Image: imageName},
 		&kdefault.Kustomization{},
+		&network_policy.Kustomization{},
+		&network_policy.NetworkPolicyAllowMetrics{},
 		&prometheus.Kustomization{},
 		&prometheus.Monitor{},
 	}

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -72,6 +72,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-metrics-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-metrics-traffic.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_policy
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &NetworkPolicyAllowMetrics{}
+
+// NetworkPolicyAllowMetrics scaffolds a file that defines the NetworkPolicy
+// to allow access to the metrics endpoint
+type NetworkPolicyAllowMetrics struct {
+	machinery.TemplateMixin
+	machinery.ProjectNameMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *NetworkPolicyAllowMetrics) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "network-policy", "allow-metrics-traffic.yaml")
+	}
+
+	f.TemplateBody = metricsNetworkPolicyTemplate
+
+	return nil
+}
+
+const metricsNetworkPolicyTemplate = `# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP
+`

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_policy
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &NetworkPolicyAllowWebhooks{}
+
+// NetworkPolicyAllowWebhooks in scaffolds a file that defines the NetworkPolicy
+// to allow the webhook server can communicate
+type NetworkPolicyAllowWebhooks struct {
+	machinery.TemplateMixin
+	machinery.ProjectNameMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *NetworkPolicyAllowWebhooks) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "network-policy", "allow-webhook-traffic.yaml")
+	}
+
+	f.TemplateBody = webhooksNetworkPolicyTemplate
+
+	return nil
+}
+
+const webhooksNetworkPolicyTemplate = `# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP
+`

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/kustomization.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network_policy
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &Kustomization{}
+
+// Kustomization scaffolds a file that defines the kustomization scheme for the prometheus folder
+type Kustomization struct {
+	machinery.TemplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *Kustomization) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "network-policy", "kustomization.yaml")
+	}
+
+	f.TemplateBody = kustomizationTemplate
+
+	return nil
+}
+
+const kustomizationTemplate = `resources:
+- allow-metrics-traffic.yaml
+`

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -14,5 +14,7 @@
 
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true  # Disable the default CNI so that we can test NetworkPolicies
 nodes:
   - role: control-plane

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -27,6 +27,7 @@ install_kind
 #   export KIND_CLUSTER=<kind cluster name>
 #   create_cluster <k8s version>
 function create_cluster {
+  echo "Getting kind config..."
   KIND_VERSION=$1
   : ${KIND_CLUSTER:?"KIND_CLUSTER must be set"}
   : ${1:?"k8s version must be set as arg 1"}
@@ -36,7 +37,10 @@ function create_cluster {
     if test -f $(dirname "$0")/kind-config-${version_prefix}.yaml; then
       kind_config=$(dirname "$0")/kind-config-${version_prefix}.yaml
     fi
+    echo "Creating cluster..."
     kind create cluster -v 4 --name $KIND_CLUSTER --retain --wait=1m --config ${kind_config} --image=kindest/node:$1
+    echo "Installing Calico..."
+    kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
   fi
 }
 

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -119,6 +119,65 @@ func GenerateV4WithoutMetrics(kbc *utils.TestContext) {
 	}
 }
 
+// GenerateV4WithoutMetrics implements a go/v4 plugin project defined by a TestContext.
+func GenerateV4WithNetworkPoliciesWithoutWebhooks(kbc *utils.TestContext) {
+	initingTheProject(kbc)
+	creatingAPI(kbc)
+
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../prometheus", "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		metricsTarget, "#")).To(Succeed())
+	By("uncomment kustomization.yaml to enable network policy")
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../network-policy", "#")).To(Succeed())
+}
+
+// GenerateV4WithNetworkPolicies implements a go/v4 plugin project defined by a TestContext.
+func GenerateV4WithNetworkPolicies(kbc *utils.TestContext) {
+	initingTheProject(kbc)
+	creatingAPI(kbc)
+
+	By("scaffolding mutating and validating webhooks")
+	err := kbc.CreateWebhook(
+		"--group", kbc.Group,
+		"--version", kbc.Version,
+		"--kind", kbc.Kind,
+		"--defaulting",
+		"--programmatic-validation",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	By("implementing the mutating and validating webhooks")
+	err = pluginutil.ImplementWebhooks(filepath.Join(
+		kbc.Dir, "api", kbc.Version,
+		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind))))
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../certmanager", "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../prometheus", "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- path: webhookcainjection_patch.yaml", "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		metricsTarget, "#")).To(Succeed())
+	By("uncomment kustomization.yaml to enable network policy")
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../network-policy", "#")).To(Succeed())
+
+	ExpectWithOffset(1, pluginutil.UncommentCode(filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		certManagerTarget, "#")).To(Succeed())
+}
+
 // GenerateV4WithoutWebhooks implements a go/v4 plugin with APIs and enable Prometheus and CertManager
 func GenerateV4WithoutWebhooks(kbc *utils.TestContext) {
 	initingTheProject(kbc)

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/testdata/project-v4-multigroup-with-deploy-image/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/testdata/project-v4-multigroup-with-deploy-image/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/testdata/project-v4-multigroup-with-deploy-image/config/network-policy/kustomization.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/network-policy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- allow-webhook-traffic.yaml
+- allow-metrics-traffic.yaml

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/testdata/project-v4-multigroup/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/testdata/project-v4-multigroup/config/network-policy/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- allow-webhook-traffic.yaml
+- allow-metrics-traffic.yaml

--- a/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/testdata/project-v4-with-deploy-image/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-deploy-image/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/testdata/project-v4-with-deploy-image/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-deploy-image/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/testdata/project-v4-with-deploy-image/config/network-policy/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/network-policy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- allow-webhook-traffic.yaml
+- allow-metrics-traffic.yaml

--- a/testdata/project-v4-with-grafana/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-grafana/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/testdata/project-v4-with-grafana/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-grafana/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-grafana
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/testdata/project-v4-with-grafana/config/network-policy/kustomization.yaml
+++ b/testdata/project-v4-with-grafana/config/network-policy/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- allow-metrics-traffic.yaml

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -27,6 +27,11 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
+# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
+# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
+# be able to communicate with the Webhook Server.
+#- ../network-policy
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:

--- a/testdata/project-v4/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic
+# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
+# namespaces are able to gathering data from the metrics endpoint.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-metrics-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label metrics: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled  # Only from namespaces with this label
+      ports:
+        - port: 8443
+          protocol: TCP

--- a/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/testdata/project-v4/config/network-policy/kustomization.yaml
+++ b/testdata/project-v4/config/network-policy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- allow-webhook-traffic.yaml
+- allow-metrics-traffic.yaml


### PR DESCRIPTION
Now, users will be able to use a helper using network policies to protected the metrics endpoint. If webhooks are scaffold then, a Network Policy to allow the traffic within is also added to the project. 

**Motivations**

Partially Close: https://github.com/kubernetes-sigs/kubebuilder/issues/3871