### PR TITLE
📖 docs: client and its methods should be private to the controller

### DIFF
--- a/designs/code-generate-image-plugin.md
+++ b/designs/code-generate-image-plugin.md
@@ -56,7 +56,7 @@ Add the new plugin code generate which will scaffold code implementation to depl
 	size := {{ resource }}.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		err = r.Update(ctx, found)
+		err = r.Client.Update(ctx, found)
 		if err != nil {
 			log.Error(err, "Failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 			return ctrl.Result{}, err
@@ -115,7 +115,7 @@ func (r *{{ resource }}.Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 
 	// Fetch the {{ resource }} instance
 	{{ resource }} := &{{ apiimportalias }}.{{ resource }}{}
-	err := r.Get(ctx, req.NamespacedName, {{ resource }})
+	err := r.Client.Get(ctx, req.NamespacedName, {{ resource }})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -131,12 +131,12 @@ func (r *{{ resource }}.Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 
 	// Check if the deployment already exists, if not create a new one
 	found := &appsv1.Deployment{}
-	err = r.Get(ctx, types.NamespacedName{Name: {{ resource }}.Name, Namespace: {{ resource }}.Namespace}, found)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: {{ resource }}.Name, Namespace: {{ resource }}.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		// Define a new deployment
 		dep := r.deploymentFor{{ resource }}({{ resource }})
 		log.Info("Creating a new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
-		err = r.Create(ctx, dep)
+		err = r.Client.Create(ctx, dep)
 		if err != nil {
 			log.Error(err, "Failed to create new Deployment", "Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 			return ctrl.Result{}, err
@@ -152,7 +152,7 @@ func (r *{{ resource }}.Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	size := {{ resource }}.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		err = r.Update(ctx, found)
+		err = r.Client.Update(ctx, found)
 		if err != nil {
 			log.Error(err, "Failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 			return ctrl.Result{}, err

--- a/designs/simplified-scaffolding.md
+++ b/designs/simplified-scaffolding.md
@@ -468,7 +468,7 @@ import (
 )
 
 type MyKindReconciler struct {
-	client.Client
+	Client client.Client
 	log logr.Logger
 }
 

--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -41,7 +41,7 @@ objects, so these are added out of the box.
 
 // CronJobReconciler reconciles a CronJob object
 type CronJobReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -50,7 +50,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	log := r.Log.WithValues("cronjob", req.NamespacedName)
 
 	cronJob := &batchv1.CronJob{}
-	if err := r.Get(ctx, req.NamespacedName, cronJob); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, cronJob); err != nil {
 		log.Error(err, "unable to fetch CronJob")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
@@ -68,7 +68,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(cronJob, myFinalizerName) {
 			controllerutil.AddFinalizer(cronJob, myFinalizerName)
-			if err := r.Update(ctx, cronJob); err != nil {
+			if err := r.Client.Update(ctx, cronJob); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -84,7 +84,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// remove our finalizer from the list and update it.
 			controllerutil.RemoveFinalizer(cronJob, myFinalizerName)
-			if err := r.Update(ctx, cronJob); err != nil {
+			if err := r.Client.Update(ctx, cronJob); err != nil {
 				return ctrl.Result{}, err
 			}
 		}

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -47,7 +47,7 @@ Next, we'll need a Clock, which will allow us to fake timing in our tests.
 
 // CronJobReconciler reconciles a CronJob object
 type CronJobReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 	Clock
 }
@@ -112,7 +112,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Many client methods also take variadic options at the end.
 	*/
 	var cronJob batchv1.CronJob
-	if err := r.Get(ctx, req.NamespacedName, &cronJob); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, &cronJob); err != nil {
 		log.Error(err, "unable to fetch CronJob")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
@@ -128,7 +128,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		set the namespace and field match (which is actually an index lookup that we set up below).
 	*/
 	var childJobs kbatch.JobList
-	if err := r.List(ctx, &childJobs, client.InNamespace(req.Namespace), client.MatchingFields{jobOwnerKey: req.Name}); err != nil {
+	if err := r.Client.List(ctx, &childJobs, client.InNamespace(req.Namespace), client.MatchingFields{jobOwnerKey: req.Name}); err != nil {
 		log.Error(err, "unable to list child Jobs")
 		return ctrl.Result{}, err
 	}
@@ -255,7 +255,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		The status subresource ignores changes to spec, so it's less likely to conflict
 		with any other updates, and can have separate permissions.
 	*/
-	if err := r.Status().Update(ctx, &cronJob); err != nil {
+	if err := r.Client.Status().Update(ctx, &cronJob); err != nil {
 		log.Error(err, "unable to update CronJob status")
 		return ctrl.Result{}, err
 	}
@@ -283,7 +283,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
 				break
 			}
-			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
+			if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
 				log.Error(err, "unable to delete old failed job", "job", job)
 			} else {
 				log.V(0).Info("deleted old failed job", "job", job)
@@ -302,7 +302,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {
 				break
 			}
-			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 				log.Error(err, "unable to delete old successful job", "job", job)
 			} else {
 				log.V(0).Info("deleted old successful job", "job", job)
@@ -449,7 +449,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if cronJob.Spec.ConcurrencyPolicy == batchv1.ReplaceConcurrent {
 		for _, activeJob := range activeJobs {
 			// we don't care if the job was already deleted
-			if err := r.Delete(ctx, activeJob, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
+			if err := r.Client.Delete(ctx, activeJob, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
 				log.Error(err, "unable to delete active job", "job", activeJob)
 				return ctrl.Result{}, err
 			}
@@ -508,7 +508,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// ...and create it on the cluster
-	if err := r.Create(ctx, job); err != nil {
+	if err := r.Client.Create(ctx, job); err != nil {
 		log.Error(err, "unable to create Job for CronJob", "job", job)
 		return ctrl.Result{}, err
 	}

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
@@ -51,7 +51,7 @@ const (
 
 // MemcachedReconciler reconciles a Memcached object
 type MemcachedReconciler struct {
-	client.Client
+	Client   client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 }
@@ -85,7 +85,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// The purpose is check if the Custom Resource for the Kind Memcached
 	// is applied on the cluster if not we return nil to stop the reconciliation
 	memcached := &cachev1alpha1.Memcached{}
-	err := r.Get(ctx, req.NamespacedName, memcached)
+	err := r.Client.Get(ctx, req.NamespacedName, memcached)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If the custom resource is not found then it usually means that it was deleted or not created
@@ -101,7 +101,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Let's just set the status as Unknown when no status is available
 	if memcached.Status.Conditions == nil || len(memcached.Status.Conditions) == 0 {
 		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
-		if err = r.Status().Update(ctx, memcached); err != nil {
+		if err = r.Client.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
 		}
@@ -111,7 +111,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// raising the error "the object has been modified, please apply
 		// your changes to the latest version and try again" which would re-trigger the reconciliation
 		// if we try to update it again in the following operations
-		if err := r.Get(ctx, req.NamespacedName, memcached); err != nil {
+		if err := r.Client.Get(ctx, req.NamespacedName, memcached); err != nil {
 			log.Error(err, "Failed to re-fetch memcached")
 			return ctrl.Result{}, err
 		}
@@ -127,7 +127,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{Requeue: true}, nil
 		}
 
-		if err = r.Update(ctx, memcached); err != nil {
+		if err = r.Client.Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update custom resource to add finalizer")
 			return ctrl.Result{}, err
 		}
@@ -145,7 +145,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionUnknown, Reason: "Finalizing",
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", memcached.Name)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -162,7 +162,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// so that we have the latest state of the resource on the cluster and we will avoid
 			// raising the error "the object has been modified, please apply
 			// your changes to the latest version and try again" which would re-trigger the reconciliation
-			if err := r.Get(ctx, req.NamespacedName, memcached); err != nil {
+			if err := r.Client.Get(ctx, req.NamespacedName, memcached); err != nil {
 				log.Error(err, "Failed to re-fetch memcached")
 				return ctrl.Result{}, err
 			}
@@ -171,7 +171,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionTrue, Reason: "Finalizing",
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", memcached.Name)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -182,7 +182,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{Requeue: true}, nil
 			}
 
-			if err := r.Update(ctx, memcached); err != nil {
+			if err := r.Client.Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to remove finalizer for Memcached")
 				return ctrl.Result{}, err
 			}
@@ -192,7 +192,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Check if the deployment already exists, if not create a new one
 	found := &appsv1.Deployment{}
-	err = r.Get(ctx, types.NamespacedName{Name: memcached.Name, Namespace: memcached.Namespace}, found)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: memcached.Name, Namespace: memcached.Namespace}, found)
 	if err != nil && apierrors.IsNotFound(err) {
 		// Define a new deployment
 		dep, err := r.deploymentForMemcached(memcached)
@@ -204,7 +204,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionFalse, Reason: "Reconciling",
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -214,7 +214,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		log.Info("Creating a new Deployment",
 			"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
-		if err = r.Create(ctx, dep); err != nil {
+		if err = r.Client.Create(ctx, dep); err != nil {
 			log.Error(err, "Failed to create new Deployment",
 				"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 			return ctrl.Result{}, err
@@ -237,7 +237,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	size := memcached.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		if err = r.Update(ctx, found); err != nil {
+		if err = r.Client.Update(ctx, found); err != nil {
 			log.Error(err, "Failed to update Deployment",
 				"Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 
@@ -245,7 +245,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// so that we have the latest state of the resource on the cluster and we will avoid
 			// raising the error "the object has been modified, please apply
 			// your changes to the latest version and try again" which would re-trigger the reconciliation
-			if err := r.Get(ctx, req.NamespacedName, memcached); err != nil {
+			if err := r.Client.Get(ctx, req.NamespacedName, memcached); err != nil {
 				log.Error(err, "Failed to re-fetch memcached")
 				return ctrl.Result{}, err
 			}
@@ -255,7 +255,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionFalse, Reason: "Resizing",
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", memcached.Name, err)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -274,7 +274,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Status: metav1.ConditionTrue, Reason: "Reconciling",
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, size)})
 
-	if err := r.Status().Update(ctx, memcached); err != nil {
+	if err := r.Client.Status().Update(ctx, memcached); err != nil {
 		log.Error(err, "Failed to update Memcached status")
 		return ctrl.Result{}, err
 	}

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -47,7 +47,7 @@ Next, we'll need a Clock, which will allow us to fake timing in our tests.
 
 // CronJobReconciler reconciles a CronJob object
 type CronJobReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 	Clock
 }
@@ -103,7 +103,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Many client methods also take variadic options at the end.
 	*/
 	var cronJob batchv1.CronJob
-	if err := r.Get(ctx, req.NamespacedName, &cronJob); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, &cronJob); err != nil {
 		log.Error(err, "unable to fetch CronJob")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
@@ -119,7 +119,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		set the namespace and field match (which is actually an index lookup that we set up below).
 	*/
 	var childJobs kbatch.JobList
-	if err := r.List(ctx, &childJobs, client.InNamespace(req.Namespace), client.MatchingFields{jobOwnerKey: req.Name}); err != nil {
+	if err := r.Client.List(ctx, &childJobs, client.InNamespace(req.Namespace), client.MatchingFields{jobOwnerKey: req.Name}); err != nil {
 		log.Error(err, "unable to list child Jobs")
 		return ctrl.Result{}, err
 	}
@@ -246,7 +246,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		The status subresource ignores changes to spec, so it's less likely to conflict
 		with any other updates, and can have separate permissions.
 	*/
-	if err := r.Status().Update(ctx, &cronJob); err != nil {
+	if err := r.Client.Status().Update(ctx, &cronJob); err != nil {
 		log.Error(err, "unable to update CronJob status")
 		return ctrl.Result{}, err
 	}
@@ -274,7 +274,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
 				break
 			}
-			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
+			if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
 				log.Error(err, "unable to delete old failed job", "job", job)
 			} else {
 				log.V(0).Info("deleted old failed job", "job", job)
@@ -293,7 +293,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {
 				break
 			}
-			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+			if err := r.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 				log.Error(err, "unable to delete old successful job", "job", job)
 			} else {
 				log.V(0).Info("deleted old successful job", "job", job)
@@ -440,7 +440,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if cronJob.Spec.ConcurrencyPolicy == batchv1.ReplaceConcurrent {
 		for _, activeJob := range activeJobs {
 			// we don't care if the job was already deleted
-			if err := r.Delete(ctx, activeJob, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
+			if err := r.Client.Delete(ctx, activeJob, client.PropagationPolicy(metav1.DeletePropagationBackground)); client.IgnoreNotFound(err) != nil {
 				log.Error(err, "unable to delete active job", "job", activeJob)
 				return ctrl.Result{}, err
 			}
@@ -499,7 +499,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// ...and create it on the cluster
-	if err := r.Create(ctx, job); err != nil {
+	if err := r.Client.Create(ctx, job); err != nil {
 		log.Error(err, "unable to create Job for CronJob", "job", job)
 		return ctrl.Result{}, err
 	}

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -194,7 +194,7 @@ To overcome this limitation you can create a new namespace for each test. Even s
 
 ```go
 type MyCoolReconciler struct {
-	client.Client
+	Client client.Client
 	...
 	Namespace     string  // restrict namespaces to reconcile
 }

--- a/docs/book/src/reference/raising-events.md
+++ b/docs/book/src/reference/raising-events.md
@@ -70,7 +70,7 @@ import (
 )
 // MyKindReconciler reconciles a MyKind object
 type MyKindReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme   *runtime.Scheme
 	// See that we added the following code to allow us to pass the record.EventRecorder
 	Recorder record.EventRecorder

--- a/docs/book/src/reference/using_an_external_type.md
+++ b/docs/book/src/reference/using_an_external_type.md
@@ -79,7 +79,7 @@ file: internal/controller/externaltype_controller.go
 ```go
 // ExternalTypeReconciler reconciles a ExternalType object
 type ExternalTypeReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/docs/book/src/reference/watching-resources/testdata/owned-resource/controller.go
+++ b/docs/book/src/reference/watching-resources/testdata/owned-resource/controller.go
@@ -40,7 +40,7 @@ import (
 
 // SimpleDeploymentReconciler reconciles a SimpleDeployment object
 type SimpleDeploymentReconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
@@ -70,7 +70,7 @@ func (r *SimpleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	log := r.Log.WithValues("simpleDeployment", req.NamespacedName)
 
 	var simpleDeployment appsv1.SimpleDeployment
-	if err := r.Get(ctx, req.NamespacedName, &simpleDeployment); err != nil {
+	if err := r.Client.Get(ctx, req.NamespacedName, &simpleDeployment); err != nil {
 		log.Error(err, "unable to fetch SimpleDeployment")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them
@@ -104,15 +104,15 @@ func (r *SimpleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		- Update it if it is configured incorrectly.
 	*/
 	foundDeployment := &kapps.Deployment{}
-	err := r.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, foundDeployment)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, foundDeployment)
 	if err != nil && errors.IsNotFound(err) {
 		log.V(1).Info("Creating Deployment", "deployment", deployment.Name)
-		err = r.Create(ctx, deployment)
+		err = r.Client.Create(ctx, deployment)
 	} else if err == nil {
 		if foundDeployment.Spec.Replicas != deployment.Spec.Replicas {
 			foundDeployment.Spec.Replicas = deployment.Spec.Replicas
 			log.V(1).Info("Updating Deployment", "deployment", deployment.Name)
-			err = r.Update(ctx, foundDeployment)
+			err = r.Client.Update(ctx, foundDeployment)
 		}
 	}
 

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Resource", func() {
 					Kind:    "OtherKind",
 				},
 			}
-			Expect(r.Update(other)).NotTo(Succeed())
+			Expect(r.Client.Update(other)).NotTo(Succeed())
 		})
 
 		It("should fail for different Plurals", func() {
@@ -304,7 +304,7 @@ var _ = Describe("Resource", func() {
 				GVK:    gvk,
 				Plural: "types",
 			}
-			Expect(r.Update(other)).NotTo(Succeed())
+			Expect(r.Client.Update(other)).NotTo(Succeed())
 		})
 
 		It("should work for a new path", func() {
@@ -314,7 +314,7 @@ var _ = Describe("Resource", func() {
 				GVK:  gvk,
 				Path: path,
 			}
-			Expect(r.Update(other)).To(Succeed())
+			Expect(r.Client.Update(other)).To(Succeed())
 			Expect(r.Path).To(Equal(path))
 		})
 
@@ -327,7 +327,7 @@ var _ = Describe("Resource", func() {
 				GVK:  gvk,
 				Path: "apis/group/v1",
 			}
-			Expect(r.Update(other)).NotTo(Succeed())
+			Expect(r.Client.Update(other)).NotTo(Succeed())
 		})
 
 		Context("API", func() {
@@ -337,7 +337,7 @@ var _ = Describe("Resource", func() {
 					GVK: gvk,
 					API: &API{CRDVersion: v1},
 				}
-				Expect(r.Update(other)).To(Succeed())
+				Expect(r.Client.Update(other)).To(Succeed())
 				Expect(r.API).NotTo(BeNil())
 				Expect(r.API.CRDVersion).To(Equal(v1))
 			})
@@ -351,7 +351,7 @@ var _ = Describe("Resource", func() {
 					GVK: gvk,
 					API: &API{CRDVersion: v1beta1},
 				}
-				Expect(r.Update(other)).NotTo(Succeed())
+				Expect(r.Client.Update(other)).NotTo(Succeed())
 			})
 
 			// The rest of the cases are tested in API.Update
@@ -364,7 +364,7 @@ var _ = Describe("Resource", func() {
 					GVK:        gvk,
 					Controller: true,
 				}
-				Expect(r.Update(other)).To(Succeed())
+				Expect(r.Client.Update(other)).To(Succeed())
 				Expect(r.Controller).To(BeTrue())
 			})
 
@@ -376,7 +376,7 @@ var _ = Describe("Resource", func() {
 
 				By("not providing it")
 				other = Resource{GVK: gvk}
-				Expect(r.Update(other)).To(Succeed())
+				Expect(r.Client.Update(other)).To(Succeed())
 				Expect(r.Controller).To(BeTrue())
 
 				By("providing it")
@@ -384,14 +384,14 @@ var _ = Describe("Resource", func() {
 					GVK:        gvk,
 					Controller: true,
 				}
-				Expect(r.Update(other)).To(Succeed())
+				Expect(r.Client.Update(other)).To(Succeed())
 				Expect(r.Controller).To(BeTrue())
 			})
 
 			It("should not set the controller flag if not provided and not previously set", func() {
 				r = Resource{GVK: gvk}
 				other = Resource{GVK: gvk}
-				Expect(r.Update(other)).To(Succeed())
+				Expect(r.Client.Update(other)).To(Succeed())
 				Expect(r.Controller).To(BeFalse())
 			})
 		})
@@ -403,7 +403,7 @@ var _ = Describe("Resource", func() {
 					GVK:      gvk,
 					Webhooks: &Webhooks{WebhookVersion: v1},
 				}
-				Expect(r.Update(other)).To(Succeed())
+				Expect(r.Client.Update(other)).To(Succeed())
 				Expect(r.Webhooks).NotTo(BeNil())
 				Expect(r.Webhooks.WebhookVersion).To(Equal(v1))
 			})
@@ -417,7 +417,7 @@ var _ = Describe("Resource", func() {
 					GVK:      gvk,
 					Webhooks: &Webhooks{WebhookVersion: v1beta1},
 				}
-				Expect(r.Update(other)).NotTo(Succeed())
+				Expect(r.Client.Update(other)).NotTo(Succeed())
 			})
 
 			// The rest of the cases are tested in Webhooks.Update

--- a/pkg/plugins/golang/declarative/v1/scaffolds/internal/templates/controller.go
+++ b/pkg/plugins/golang/declarative/v1/scaffolds/internal/templates/controller.go
@@ -96,7 +96,7 @@ var _ reconcile.Reconciler = &{{ .Resource.Kind }}Reconciler{}
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
 type {{ .Resource.Kind }}Reconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 

--- a/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v2/scaffolds/internal/templates/controllers/controller.go
@@ -80,7 +80,7 @@ import (
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
 type {{ .Resource.Kind }}Reconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }

--- a/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v3/scaffolds/internal/templates/controllers/controller.go
@@ -80,7 +80,7 @@ import (
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
 type {{ .Resource.Kind }}Reconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
@@ -81,7 +81,7 @@ import (
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
 type {{ .Resource.Kind }}Reconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v2/controllers/admiral_controller.go
+++ b/testdata/project-v2/controllers/admiral_controller.go
@@ -29,7 +29,7 @@ import (
 
 // AdmiralReconciler reconciles a Admiral object
 type AdmiralReconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }

--- a/testdata/project-v2/controllers/captain_controller.go
+++ b/testdata/project-v2/controllers/captain_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CaptainReconciler reconciles a Captain object
 type CaptainReconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }

--- a/testdata/project-v2/controllers/firstmate_controller.go
+++ b/testdata/project-v2/controllers/firstmate_controller.go
@@ -29,7 +29,7 @@ import (
 
 // FirstMateReconciler reconciles a FirstMate object
 type FirstMateReconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }

--- a/testdata/project-v2/controllers/laker_controller.go
+++ b/testdata/project-v2/controllers/laker_controller.go
@@ -27,7 +27,7 @@ import (
 
 // LakerReconciler reconciles a Laker object
 type LakerReconciler struct {
-	client.Client
+	Client client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }

--- a/testdata/project-v3/controllers/admiral_controller.go
+++ b/testdata/project-v3/controllers/admiral_controller.go
@@ -29,7 +29,7 @@ import (
 
 // AdmiralReconciler reconciles a Admiral object
 type AdmiralReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v3/controllers/captain_controller.go
+++ b/testdata/project-v3/controllers/captain_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CaptainReconciler reconciles a Captain object
 type CaptainReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v3/controllers/firstmate_controller.go
+++ b/testdata/project-v3/controllers/firstmate_controller.go
@@ -29,7 +29,7 @@ import (
 
 // FirstMateReconciler reconciles a FirstMate object
 type FirstMateReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v3/controllers/laker_controller.go
+++ b/testdata/project-v3/controllers/laker_controller.go
@@ -27,7 +27,7 @@ import (
 
 // LakerReconciler reconciles a Laker object
 type LakerReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller.go
@@ -28,7 +28,7 @@ import (
 
 // DeploymentReconciler reconciles a Deployment object
 type DeploymentReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CaptainReconciler reconciles a Captain object
 type CaptainReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller.go
@@ -29,7 +29,7 @@ import (
 
 // BarReconciler reconciles a Bar object
 type BarReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller.go
@@ -29,7 +29,7 @@ import (
 
 // HealthCheckPolicyReconciler reconciles a HealthCheckPolicy object
 type HealthCheckPolicyReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller.go
@@ -29,7 +29,7 @@ import (
 
 // BarReconciler reconciles a Bar object
 type BarReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller.go
@@ -29,7 +29,7 @@ import (
 
 // LakersReconciler reconciles a Lakers object
 type LakersReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller.go
@@ -29,7 +29,7 @@ import (
 
 // KrakenReconciler reconciles a Kraken object
 type KrakenReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller.go
@@ -29,7 +29,7 @@ import (
 
 // LeviathanReconciler reconciles a Leviathan object
 type LeviathanReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CruiserReconciler reconciles a Cruiser object
 type CruiserReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller.go
@@ -29,7 +29,7 @@ import (
 
 // DestroyerReconciler reconciles a Destroyer object
 type DestroyerReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller.go
@@ -29,7 +29,7 @@ import (
 
 // FrigateReconciler reconciles a Frigate object
 type FrigateReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller.go
@@ -28,7 +28,7 @@ import (
 
 // DeploymentReconciler reconciles a Deployment object
 type DeploymentReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/crew/captain_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/captain_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CaptainReconciler reconciles a Captain object
 type CaptainReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller.go
@@ -29,7 +29,7 @@ import (
 
 // BarReconciler reconciles a Bar object
 type BarReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller.go
@@ -29,7 +29,7 @@ import (
 
 // HealthCheckPolicyReconciler reconciles a HealthCheckPolicy object
 type HealthCheckPolicyReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/foo/bar_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/bar_controller.go
@@ -29,7 +29,7 @@ import (
 
 // BarReconciler reconciles a Bar object
 type BarReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/lakers_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/lakers_controller.go
@@ -29,7 +29,7 @@ import (
 
 // LakersReconciler reconciles a Lakers object
 type LakersReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller.go
@@ -29,7 +29,7 @@ import (
 
 // KrakenReconciler reconciles a Kraken object
 type KrakenReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller.go
@@ -29,7 +29,7 @@ import (
 
 // LeviathanReconciler reconciles a Leviathan object
 type LeviathanReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CruiserReconciler reconciles a Cruiser object
 type CruiserReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller.go
@@ -29,7 +29,7 @@ import (
 
 // DestroyerReconciler reconciles a Destroyer object
 type DestroyerReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller.go
@@ -29,7 +29,7 @@ import (
 
 // FrigateReconciler reconciles a Frigate object
 type FrigateReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go
@@ -51,7 +51,7 @@ const (
 
 // BusyboxReconciler reconciles a Busybox object
 type BusyboxReconciler struct {
-	client.Client
+	Client   client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 }
@@ -85,7 +85,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// The purpose is check if the Custom Resource for the Kind Busybox
 	// is applied on the cluster if not we return nil to stop the reconciliation
 	busybox := &examplecomv1alpha1.Busybox{}
-	err := r.Get(ctx, req.NamespacedName, busybox)
+	err := r.Client.Get(ctx, req.NamespacedName, busybox)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If the custom resource is not found then it usually means that it was deleted or not created
@@ -101,7 +101,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Let's just set the status as Unknown when no status is available
 	if busybox.Status.Conditions == nil || len(busybox.Status.Conditions) == 0 {
 		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
-		if err = r.Status().Update(ctx, busybox); err != nil {
+		if err = r.Client.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")
 			return ctrl.Result{}, err
 		}
@@ -111,7 +111,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// raising the error "the object has been modified, please apply
 		// your changes to the latest version and try again" which would re-trigger the reconciliation
 		// if we try to update it again in the following operations
-		if err := r.Get(ctx, req.NamespacedName, busybox); err != nil {
+		if err := r.Client.Get(ctx, req.NamespacedName, busybox); err != nil {
 			log.Error(err, "Failed to re-fetch busybox")
 			return ctrl.Result{}, err
 		}
@@ -127,7 +127,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{Requeue: true}, nil
 		}
 
-		if err = r.Update(ctx, busybox); err != nil {
+		if err = r.Client.Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update custom resource to add finalizer")
 			return ctrl.Result{}, err
 		}
@@ -145,7 +145,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Status: metav1.ConditionUnknown, Reason: "Finalizing",
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", busybox.Name)})
 
-			if err := r.Status().Update(ctx, busybox); err != nil {
+			if err := r.Client.Status().Update(ctx, busybox); err != nil {
 				log.Error(err, "Failed to update Busybox status")
 				return ctrl.Result{}, err
 			}
@@ -162,7 +162,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// so that we have the latest state of the resource on the cluster and we will avoid
 			// raising the error "the object has been modified, please apply
 			// your changes to the latest version and try again" which would re-trigger the reconciliation
-			if err := r.Get(ctx, req.NamespacedName, busybox); err != nil {
+			if err := r.Client.Get(ctx, req.NamespacedName, busybox); err != nil {
 				log.Error(err, "Failed to re-fetch busybox")
 				return ctrl.Result{}, err
 			}
@@ -171,7 +171,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Status: metav1.ConditionTrue, Reason: "Finalizing",
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", busybox.Name)})
 
-			if err := r.Status().Update(ctx, busybox); err != nil {
+			if err := r.Client.Status().Update(ctx, busybox); err != nil {
 				log.Error(err, "Failed to update Busybox status")
 				return ctrl.Result{}, err
 			}
@@ -182,7 +182,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				return ctrl.Result{Requeue: true}, nil
 			}
 
-			if err := r.Update(ctx, busybox); err != nil {
+			if err := r.Client.Update(ctx, busybox); err != nil {
 				log.Error(err, "Failed to remove finalizer for Busybox")
 				return ctrl.Result{}, err
 			}
@@ -192,7 +192,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Check if the deployment already exists, if not create a new one
 	found := &appsv1.Deployment{}
-	err = r.Get(ctx, types.NamespacedName{Name: busybox.Name, Namespace: busybox.Namespace}, found)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: busybox.Name, Namespace: busybox.Namespace}, found)
 	if err != nil && apierrors.IsNotFound(err) {
 		// Define a new deployment
 		dep, err := r.deploymentForBusybox(busybox)
@@ -204,7 +204,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Status: metav1.ConditionFalse, Reason: "Reconciling",
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", busybox.Name, err)})
 
-			if err := r.Status().Update(ctx, busybox); err != nil {
+			if err := r.Client.Status().Update(ctx, busybox); err != nil {
 				log.Error(err, "Failed to update Busybox status")
 				return ctrl.Result{}, err
 			}
@@ -214,7 +214,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		log.Info("Creating a new Deployment",
 			"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
-		if err = r.Create(ctx, dep); err != nil {
+		if err = r.Client.Create(ctx, dep); err != nil {
 			log.Error(err, "Failed to create new Deployment",
 				"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 			return ctrl.Result{}, err
@@ -237,7 +237,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	size := busybox.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		if err = r.Update(ctx, found); err != nil {
+		if err = r.Client.Update(ctx, found); err != nil {
 			log.Error(err, "Failed to update Deployment",
 				"Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 
@@ -245,7 +245,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// so that we have the latest state of the resource on the cluster and we will avoid
 			// raising the error "the object has been modified, please apply
 			// your changes to the latest version and try again" which would re-trigger the reconciliation
-			if err := r.Get(ctx, req.NamespacedName, busybox); err != nil {
+			if err := r.Client.Get(ctx, req.NamespacedName, busybox); err != nil {
 				log.Error(err, "Failed to re-fetch busybox")
 				return ctrl.Result{}, err
 			}
@@ -255,7 +255,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Status: metav1.ConditionFalse, Reason: "Resizing",
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", busybox.Name, err)})
 
-			if err := r.Status().Update(ctx, busybox); err != nil {
+			if err := r.Client.Status().Update(ctx, busybox); err != nil {
 				log.Error(err, "Failed to update Busybox status")
 				return ctrl.Result{}, err
 			}
@@ -274,7 +274,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Status: metav1.ConditionTrue, Reason: "Reconciling",
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", busybox.Name, size)})
 
-	if err := r.Status().Update(ctx, busybox); err != nil {
+	if err := r.Client.Status().Update(ctx, busybox); err != nil {
 		log.Error(err, "Failed to update Busybox status")
 		return ctrl.Result{}, err
 	}

--- a/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
@@ -51,7 +51,7 @@ const (
 
 // MemcachedReconciler reconciles a Memcached object
 type MemcachedReconciler struct {
-	client.Client
+	Client   client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 }
@@ -85,7 +85,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// The purpose is check if the Custom Resource for the Kind Memcached
 	// is applied on the cluster if not we return nil to stop the reconciliation
 	memcached := &examplecomv1alpha1.Memcached{}
-	err := r.Get(ctx, req.NamespacedName, memcached)
+	err := r.Client.Get(ctx, req.NamespacedName, memcached)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If the custom resource is not found then it usually means that it was deleted or not created
@@ -101,7 +101,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Let's just set the status as Unknown when no status is available
 	if memcached.Status.Conditions == nil || len(memcached.Status.Conditions) == 0 {
 		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
-		if err = r.Status().Update(ctx, memcached); err != nil {
+		if err = r.Client.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
 		}
@@ -111,7 +111,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// raising the error "the object has been modified, please apply
 		// your changes to the latest version and try again" which would re-trigger the reconciliation
 		// if we try to update it again in the following operations
-		if err := r.Get(ctx, req.NamespacedName, memcached); err != nil {
+		if err := r.Client.Get(ctx, req.NamespacedName, memcached); err != nil {
 			log.Error(err, "Failed to re-fetch memcached")
 			return ctrl.Result{}, err
 		}
@@ -127,7 +127,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{Requeue: true}, nil
 		}
 
-		if err = r.Update(ctx, memcached); err != nil {
+		if err = r.Client.Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update custom resource to add finalizer")
 			return ctrl.Result{}, err
 		}
@@ -145,7 +145,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionUnknown, Reason: "Finalizing",
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", memcached.Name)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -162,7 +162,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// so that we have the latest state of the resource on the cluster and we will avoid
 			// raising the error "the object has been modified, please apply
 			// your changes to the latest version and try again" which would re-trigger the reconciliation
-			if err := r.Get(ctx, req.NamespacedName, memcached); err != nil {
+			if err := r.Client.Get(ctx, req.NamespacedName, memcached); err != nil {
 				log.Error(err, "Failed to re-fetch memcached")
 				return ctrl.Result{}, err
 			}
@@ -171,7 +171,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionTrue, Reason: "Finalizing",
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", memcached.Name)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -182,7 +182,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				return ctrl.Result{Requeue: true}, nil
 			}
 
-			if err := r.Update(ctx, memcached); err != nil {
+			if err := r.Client.Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to remove finalizer for Memcached")
 				return ctrl.Result{}, err
 			}
@@ -192,7 +192,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Check if the deployment already exists, if not create a new one
 	found := &appsv1.Deployment{}
-	err = r.Get(ctx, types.NamespacedName{Name: memcached.Name, Namespace: memcached.Namespace}, found)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: memcached.Name, Namespace: memcached.Namespace}, found)
 	if err != nil && apierrors.IsNotFound(err) {
 		// Define a new deployment
 		dep, err := r.deploymentForMemcached(memcached)
@@ -204,7 +204,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionFalse, Reason: "Reconciling",
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -214,7 +214,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		log.Info("Creating a new Deployment",
 			"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
-		if err = r.Create(ctx, dep); err != nil {
+		if err = r.Client.Create(ctx, dep); err != nil {
 			log.Error(err, "Failed to create new Deployment",
 				"Deployment.Namespace", dep.Namespace, "Deployment.Name", dep.Name)
 			return ctrl.Result{}, err
@@ -237,7 +237,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	size := memcached.Spec.Size
 	if *found.Spec.Replicas != size {
 		found.Spec.Replicas = &size
-		if err = r.Update(ctx, found); err != nil {
+		if err = r.Client.Update(ctx, found); err != nil {
 			log.Error(err, "Failed to update Deployment",
 				"Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 
@@ -245,7 +245,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			// so that we have the latest state of the resource on the cluster and we will avoid
 			// raising the error "the object has been modified, please apply
 			// your changes to the latest version and try again" which would re-trigger the reconciliation
-			if err := r.Get(ctx, req.NamespacedName, memcached); err != nil {
+			if err := r.Client.Get(ctx, req.NamespacedName, memcached); err != nil {
 				log.Error(err, "Failed to re-fetch memcached")
 				return ctrl.Result{}, err
 			}
@@ -255,7 +255,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Status: metav1.ConditionFalse, Reason: "Resizing",
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", memcached.Name, err)})
 
-			if err := r.Status().Update(ctx, memcached); err != nil {
+			if err := r.Client.Status().Update(ctx, memcached); err != nil {
 				log.Error(err, "Failed to update Memcached status")
 				return ctrl.Result{}, err
 			}
@@ -274,7 +274,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Status: metav1.ConditionTrue, Reason: "Reconciling",
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, size)})
 
-	if err := r.Status().Update(ctx, memcached); err != nil {
+	if err := r.Client.Status().Update(ctx, memcached); err != nil {
 		log.Error(err, "Failed to update Memcached status")
 		return ctrl.Result{}, err
 	}

--- a/testdata/project-v4/internal/controller/admiral_controller.go
+++ b/testdata/project-v4/internal/controller/admiral_controller.go
@@ -29,7 +29,7 @@ import (
 
 // AdmiralReconciler reconciles a Admiral object
 type AdmiralReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4/internal/controller/captain_controller.go
+++ b/testdata/project-v4/internal/controller/captain_controller.go
@@ -29,7 +29,7 @@ import (
 
 // CaptainReconciler reconciles a Captain object
 type CaptainReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4/internal/controller/firstmate_controller.go
+++ b/testdata/project-v4/internal/controller/firstmate_controller.go
@@ -29,7 +29,7 @@ import (
 
 // FirstMateReconciler reconciles a FirstMate object
 type FirstMateReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 

--- a/testdata/project-v4/internal/controller/laker_controller.go
+++ b/testdata/project-v4/internal/controller/laker_controller.go
@@ -27,7 +27,7 @@ import (
 
 // LakerReconciler reconciles a Laker object
 type LakerReconciler struct {
-	client.Client
+	Client client.Client
 	Scheme *runtime.Scheme
 }
 


### PR DESCRIPTION
**problem**: 
The controller example suggests to make the `Client` public in the controller,
which leads to:
- hard to understand calls like `r.Patch` (where does `Patch` come from -> scroll through the code)
- method overload issues if Patch/Get/etc are needed as methods on the controller
- the methods being publicly available on the controller for other parts of the codebase to use, which they should not be

**solution A**: make client private (ideal but abandoned)
this leads to:
- code like `FooReconciler{Client: client, ...}` breaking and these reconcilers needing `NewFooReconciler` methods ... which is technically correct but a lot of change
- old code breaking when new code is added since `r.Client` does not work

**solution B**: make Client not be mixed in (this PR)
this leads to new code being compatible with old code and less change in general
but it's not really private, but at least more obvious than before