### PR TITLE
✨ Bump envtest to 1.30

### DIFF
--- a/build/cloudbuild_tools.yaml
+++ b/build/cloudbuild_tools.yaml
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 substitutions:
-  _KUBERNETES_VERSION: 1.29.3
+  _KUBERNETES_VERSION: 1.30.0
 steps:
 - name: "gcr.io/cloud-builders/docker"
   args: [


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Might be one of the last envtest releases here, but let's see how it goes

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->


xref: https://github.com/kubernetes-sigs/controller-tools/pull/924