### PR TITLE
✨ : (go/v4): Replace `deadline` in favor of `timeout` in `golangci-lint` configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/docs/book/src/component-config-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/component-config-tutorial/testdata/project/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -43,7 +43,7 @@ func (f *Golangci) SetTemplateDefaults() error {
 
 //nolint:lll
 const golangciTemplate = `run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/testdata/project-v4-multigroup-with-deploy-image/.golangci.yml
+++ b/testdata/project-v4-multigroup-with-deploy-image/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/testdata/project-v4-with-deploy-image/.golangci.yml
+++ b/testdata/project-v4-with-deploy-image/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/testdata/project-v4-with-grafana/.golangci.yml
+++ b/testdata/project-v4-with-grafana/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:


### PR DESCRIPTION
As of 1.57 version, golangci-lint deprecated the `deadline` linter setting
(https://github.com/golangci/golangci-lint/releases/tag/v1.57.0). This PR changes `deadline` to `timeout` in the `.golangci.yml` configuration both for the project setup and for the `.golangci.yml` scaffolding.
