### PR TITLE
Upgrade go version to fix issues to build tools for k8s 1.30

### DIFF
--- a/build/thirdparty/darwin/Dockerfile
+++ b/build/thirdparty/darwin/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION

--- a/build/thirdparty/windows/Dockerfile
+++ b/build/thirdparty/windows/Dockerfile
@@ -17,7 +17,7 @@
 # - kubectl (fetch)
 # - etcd (fetch)
 
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 # Version and platform args.
 ARG KUBERNETES_VERSION


### PR DESCRIPTION
To fix: https://github.com/kubernetes-sigs/kubebuilder/pull/3864#issuecomment-2069064057

c/c @sbueringer 