### PR TITLE
:bug: fix Invalid leader election ID generated when domain is empty

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/main.go
@@ -279,7 +279,11 @@ func main() {
 		WebhookServer: webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "{{ hashFNV .Repo }}.{{ .Domain }}",
+		{{- if not .Domain }}
+		LeaderElectionID:        "{{ hashFNV .Repo }}",
+		{{- else }}
+		LeaderElectionID:        "{{ hashFNV .Repo }}.{{ .Domain }}",
+		{{- end }}
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
If the domain is not informed then we cannot use it to generate the ID for the leader election

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3790
