### PR TITLE
:bug: remove RBAC for get on status subresource is unnecessary

### DIFF
--- a/docs/book/src/component-config-tutorial/testdata/project/config/rbac/projectconfig_editor_role.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/rbac/projectconfig_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - config.tutorial.kubebuilder.io
   resources:
   - projectconfigs/status
-  verbs:
-  - get

--- a/docs/book/src/component-config-tutorial/testdata/project/config/rbac/projectconfig_viewer_role.yaml
+++ b/docs/book/src/component-config-tutorial/testdata/project/config/rbac/projectconfig_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - config.tutorial.kubebuilder.io
   resources:
   - projectconfigs/status
-  verbs:
-  - get

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_editor_role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - batch.tutorial.kubebuilder.io
   resources:
   - cronjobs/status
-  verbs:
-  - get

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_viewer_role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - batch.tutorial.kubebuilder.io
   resources:
   - cronjobs/status
-  verbs:
-  - get

--- a/docs/book/src/getting-started/testdata/project/config/rbac/memcached_editor_role.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/memcached_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - cache.example.com
   resources:
   - memcacheds/status
-  verbs:
-  - get

--- a/docs/book/src/getting-started/testdata/project/config/rbac/memcached_viewer_role.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/memcached_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - cache.example.com
   resources:
   - memcacheds/status
-  verbs:
-  - get

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
@@ -90,6 +90,4 @@ rules:
   - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}/status
-  verbs:
-  - get
 `

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
@@ -86,6 +86,4 @@ rules:
   - {{ .Resource.QualifiedGroup }}
   resources:
   - {{ .Resource.Plural }}/status
-  verbs:
-  - get
 `

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/crew_captain_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/crew_captain_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/crew_captain_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/crew_captain_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/fiz_bar_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/fiz_bar_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/fiz_bar_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/fiz_bar_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo.policy_healthcheckpolicy_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo.policy_healthcheckpolicy_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo.policy_healthcheckpolicy_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo.policy_healthcheckpolicy_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo_bar_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo_bar_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo_bar_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/foo_bar_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/lakers_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/lakers_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/lakers_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/lakers_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_kraken_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_kraken_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_kraken_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_kraken_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_leviathan_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_leviathan_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_leviathan_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/sea-creatures_leviathan_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_cruiser_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_cruiser_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_cruiser_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_cruiser_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_destroyer_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_destroyer_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_destroyer_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_destroyer_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_frigate_editor_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_frigate_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_frigate_viewer_role.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/rbac/ship_frigate_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
@@ -671,8 +671,6 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -694,8 +692,6 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -721,8 +717,6 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -744,8 +738,6 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -771,8 +763,6 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -794,8 +784,6 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -821,8 +809,6 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -844,8 +830,6 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -871,8 +855,6 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -894,8 +876,6 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1247,8 +1227,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1270,8 +1248,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1297,8 +1273,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1320,8 +1294,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1347,8 +1319,6 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1370,8 +1340,6 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1397,8 +1365,6 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1420,8 +1386,6 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1447,8 +1411,6 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1470,8 +1432,6 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/testdata/project-v4-multigroup/config/rbac/crew_captain_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/crew_captain_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/crew_captain_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/crew_captain_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/fiz_bar_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/fiz_bar_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/fiz_bar_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/fiz_bar_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/foo_bar_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo_bar_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/foo_bar_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo_bar_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/lakers_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/lakers_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/lakers_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/lakers_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_cruiser_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_cruiser_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_cruiser_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_cruiser_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_destroyer_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_destroyer_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_destroyer_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_destroyer_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_frigate_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_frigate_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_frigate_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_frigate_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -671,8 +671,6 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -694,8 +692,6 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -721,8 +717,6 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -744,8 +738,6 @@ rules:
   - fiz.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -771,8 +763,6 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -794,8 +784,6 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -821,8 +809,6 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -844,8 +830,6 @@ rules:
   - foo.policy.testproject.org
   resources:
   - healthcheckpolicies/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -871,8 +855,6 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -894,8 +876,6 @@ rules:
   - testproject.org
   resources:
   - lakers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1247,8 +1227,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1270,8 +1248,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1297,8 +1273,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1320,8 +1294,6 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - leviathans/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1347,8 +1319,6 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1370,8 +1340,6 @@ rules:
   - ship.testproject.org
   resources:
   - cruisers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1397,8 +1365,6 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1420,8 +1386,6 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1447,8 +1411,6 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1470,8 +1432,6 @@ rules:
   - ship.testproject.org
   resources:
   - frigates/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/testdata/project-v4-with-deploy-image/config/rbac/busybox_editor_role.yaml
+++ b/testdata/project-v4-with-deploy-image/config/rbac/busybox_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - example.com.testproject.org
   resources:
   - busyboxes/status
-  verbs:
-  - get

--- a/testdata/project-v4-with-deploy-image/config/rbac/busybox_viewer_role.yaml
+++ b/testdata/project-v4-with-deploy-image/config/rbac/busybox_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - example.com.testproject.org
   resources:
   - busyboxes/status
-  verbs:
-  - get

--- a/testdata/project-v4-with-deploy-image/config/rbac/memcached_editor_role.yaml
+++ b/testdata/project-v4-with-deploy-image/config/rbac/memcached_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - example.com.testproject.org
   resources:
   - memcacheds/status
-  verbs:
-  - get

--- a/testdata/project-v4-with-deploy-image/config/rbac/memcached_viewer_role.yaml
+++ b/testdata/project-v4-with-deploy-image/config/rbac/memcached_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - example.com.testproject.org
   resources:
   - memcacheds/status
-  verbs:
-  - get

--- a/testdata/project-v4-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-with-deploy-image/dist/install.yaml
@@ -354,8 +354,6 @@ rules:
   - example.com.testproject.org
   resources:
   - busyboxes/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -377,8 +375,6 @@ rules:
   - example.com.testproject.org
   resources:
   - busyboxes/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -489,8 +485,6 @@ rules:
   - example.com.testproject.org
   resources:
   - memcacheds/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -512,8 +506,6 @@ rules:
   - example.com.testproject.org
   resources:
   - memcacheds/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/testdata/project-v4/config/rbac/admiral_editor_role.yaml
+++ b/testdata/project-v4/config/rbac/admiral_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - crew.testproject.org
   resources:
   - admirales/status
-  verbs:
-  - get

--- a/testdata/project-v4/config/rbac/admiral_viewer_role.yaml
+++ b/testdata/project-v4/config/rbac/admiral_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - crew.testproject.org
   resources:
   - admirales/status
-  verbs:
-  - get

--- a/testdata/project-v4/config/rbac/captain_editor_role.yaml
+++ b/testdata/project-v4/config/rbac/captain_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get

--- a/testdata/project-v4/config/rbac/captain_viewer_role.yaml
+++ b/testdata/project-v4/config/rbac/captain_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get

--- a/testdata/project-v4/config/rbac/firstmate_editor_role.yaml
+++ b/testdata/project-v4/config/rbac/firstmate_editor_role.yaml
@@ -23,5 +23,3 @@ rules:
   - crew.testproject.org
   resources:
   - firstmates/status
-  verbs:
-  - get

--- a/testdata/project-v4/config/rbac/firstmate_viewer_role.yaml
+++ b/testdata/project-v4/config/rbac/firstmate_viewer_role.yaml
@@ -19,5 +19,3 @@ rules:
   - crew.testproject.org
   resources:
   - firstmates/status
-  verbs:
-  - get

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -273,8 +273,6 @@ rules:
   - crew.testproject.org
   resources:
   - admirales/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -296,8 +294,6 @@ rules:
   - crew.testproject.org
   resources:
   - admirales/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -323,8 +319,6 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -346,8 +340,6 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -373,8 +365,6 @@ rules:
   - crew.testproject.org
   resources:
   - firstmates/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -396,8 +386,6 @@ rules:
   - crew.testproject.org
   resources:
   - firstmates/status
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3781