### PR TITLE
:bug: (CLI, deploy-image/v1alpha1, go/v4) Ensure consistent spacing in marker annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Provide clean library abstractions with clear and well exampled godocs.
   - Start minimal and provide progressive discovery of functionality
   - Provide sane defaults and allow users to override when they exist
 - Provide code generators to maintain common boilerplate that can't be addressed by interfaces
-  - Driven off of `//+` comments
+  - Driven off of `// +` comments
 - Provide bootstrapping commands to initialize new packages
 
 ## Versioning and Releasing

--- a/docs/book/src/cronjob-tutorial/testdata/emptyapi.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptyapi.go
@@ -69,8 +69,8 @@ a Kind.  Then, the `object` generator generates an implementation of the
 interface that all types representing Kinds must implement.
 */
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {
@@ -81,7 +81,7 @@ type CronJob struct {
 	Status CronJobStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CronJobList contains a list of CronJob
 type CronJobList struct {

--- a/docs/book/src/cronjob-tutorial/testdata/emptymain.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptymain.go
@@ -62,7 +62,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 /*

--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -38,9 +38,9 @@ import (
 By default, kubebuilder will include the RBAC rules necessary to update finalizers for CronJobs.
 */
 
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
 
 /*
 The code snippet below shows skeleton code for implementing a finalizer.

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -64,12 +64,12 @@ import (
 
 // CronJobSpec defines the desired state of CronJob
 type CronJobSpec struct {
-	//+kubebuilder:validation:MinLength=0
+	// +kubebuilder:validation:MinLength=0
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	Schedule string `json:"schedule"`
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// Optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
@@ -92,14 +92,14 @@ type CronJobSpec struct {
 	// Specifies the job that will be created when executing a CronJob.
 	JobTemplate batchv1.JobTemplateSpec `json:"jobTemplate"`
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// The number of successful finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty"`
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// The number of failed finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.
@@ -162,8 +162,8 @@ type CronJobStatus struct {
  we want a status subresource, so that we behave like built-in kubernetes types.
 */
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {
@@ -176,7 +176,7 @@ type CronJob struct {
 	Status CronJobStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CronJobList contains a list of CronJob
 type CronJobList struct {
@@ -189,4 +189,4 @@ func init() {
 	SchemeBuilder.Register(&CronJob{}, &CronJobList{})
 }
 
-//+kubebuilder:docs-gen:collapse=Root Object Definitions
+// +kubebuilder:docs-gen:collapse=Root Object Definitions

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -56,7 +56,7 @@ This marker is responsible for generating a mutating webhook manifest.
 The meaning of each marker can be found [here](/reference/markers/webhook.md).
 */
 
-//+kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 /*
 We use the `webhook.Defaulter` interface to set defaults to our CRD.
@@ -91,7 +91,7 @@ func (r *CronJob) Default() {
 This marker is responsible for generating a validating webhook manifest.
 */
 
-//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 /*
 We can validate our CRD beyond what's possible with declarative

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&CronJob{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -37,7 +37,7 @@ import (
 
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
 	"tutorial.kubebuilder.io/project/internal/controller"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
@@ -60,7 +60,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(batchv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 /*
@@ -166,7 +166,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -3,18 +3,18 @@
 # It should be run by config/default
 resources:
 - bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 - path: patches/webhook_in_cronjobs.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 - path: patches/cainjection_in_cronjobs.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/samples/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples of your project ##
 resources:
 - batch_v1_cronjob.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -74,11 +74,11 @@ managing jobs now, we'll need permissions for those, which means adding
 a couple more [markers](/reference/markers/rbac.md).
 */
 
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
 
 /*
 Now, we get to the heart of the controller -- the reconciler logic.

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -45,7 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 		This marker is what allows new schemas to be added here automatically when a new API is added to the project.
 	*/
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	/*
 		A client is created for our test CRUD operations.

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -449,12 +449,12 @@ manifest files present in `config/rbac/`. These markers can be found (and should
 how it is implemented in our example:
 
 ```go
-//+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 ```
 
 It's important to highlight that if you wish to add or modify RBAC rules, you can do so by updating or adding the respective markers in the controller.

--- a/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
+++ b/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
@@ -54,8 +54,8 @@ type MemcachedStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Memcached is the Schema for the memcacheds API
 type Memcached struct {
@@ -66,7 +66,7 @@ type Memcached struct {
 	Status MemcachedStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {

--- a/docs/book/src/getting-started/testdata/project/cmd/main.go
+++ b/docs/book/src/getting-started/testdata/project/cmd/main.go
@@ -36,7 +36,7 @@ import (
 
 	cachev1alpha1 "example.com/memcached/api/v1alpha1"
 	"example.com/memcached/internal/controller"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -48,7 +48,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(cachev1alpha1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -131,7 +131,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Memcached")
 		os.Exit(1)
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/docs/book/src/getting-started/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/crd/kustomization.yaml
@@ -3,17 +3,17 @@
 # It should be run by config/default
 resources:
 - bases/cache.example.com_memcacheds.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- path: patches/cainjection_in_memcacheds.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/docs/book/src/getting-started/testdata/project/config/samples/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples of your project ##
 resources:
 - cache_v1alpha1_memcached.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
@@ -60,12 +60,12 @@ type MemcachedReconciler struct {
 // when the command <make manifests> is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
-//+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cache.example.com,resources=memcacheds/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	cachev1alpha1 "example.com/memcached/api/v1alpha1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = cachev1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -36,12 +36,12 @@ import (
 
 // CronJobSpec defines the desired state of CronJob
 type CronJobSpec struct {
-	//+kubebuilder:validation:MinLength=0
+	// +kubebuilder:validation:MinLength=0
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	Schedule string `json:"schedule"`
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// Optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
@@ -64,14 +64,14 @@ type CronJobSpec struct {
 	// Specifies the job that will be created when executing a CronJob.
 	JobTemplate batchv1.JobTemplateSpec `json:"jobTemplate"`
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// The number of successful finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty"`
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// The number of failed finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.
@@ -126,9 +126,9 @@ type CronJobStatus struct {
  objects are created/updated after the change.
 */
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:storageversion
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {
@@ -142,7 +142,7 @@ type CronJob struct {
 /*
  */
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CronJobList contains a list of CronJob
 type CronJobList struct {
@@ -155,4 +155,4 @@ func init() {
 	SchemeBuilder.Register(&CronJob{}, &CronJobList{})
 }
 
-//+kubebuilder:docs-gen:collapse=old stuff
+// +kubebuilder:docs-gen:collapse=old stuff

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-//+kubebuilder:docs-gen:collapse=Go imports
+// +kubebuilder:docs-gen:collapse=Go imports
 
 // log is for logging in this package.
 var cronjoblog = logf.Log.WithName("cronjob-resource")
@@ -53,7 +53,7 @@ func (r *CronJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
 /*
  */
 
-//+kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &CronJob{}
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&CronJob{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
@@ -83,7 +83,7 @@ type CronJobSpec struct {
 	// +optional
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
 
-	//+kubebuilder:docs-gen:collapse=The rest of Spec
+	// +kubebuilder:docs-gen:collapse=The rest of Spec
 }
 
 /*
@@ -157,8 +157,8 @@ type CronJobStatus struct {
 	LastScheduleTime *metav1.Time `json:"lastScheduleTime,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {
@@ -169,7 +169,7 @@ type CronJob struct {
 	Status CronJobStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CronJobList contains a list of CronJob
 type CronJobList struct {

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&CronJob{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
@@ -38,7 +38,7 @@ import (
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
 	batchv2 "tutorial.kubebuilder.io/project/api/v2"
 	"tutorial.kubebuilder.io/project/internal/controller"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
@@ -56,7 +56,7 @@ func init() {
 	utilruntime.Must(kbatchv1.AddToScheme(scheme)) // we've added this ourselves
 	utilruntime.Must(batchv1.AddToScheme(scheme))
 	utilruntime.Must(batchv2.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 // +kubebuilder:docs-gen:collapse=existing setup
@@ -160,7 +160,7 @@ func main() {
 		}
 	}
 
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	/*
 	 */

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -3,7 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/batch.tutorial.kubebuilder.io_cronjobs.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -12,12 +12,12 @@ patches:
 - path: patches/webhook_in_cronjobs.yaml
 - path: patches/webhook_in_cronjobs.yaml
 - path: patches/webhook_in_cronjobs.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- path: patches/cainjection_in_cronjobs.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/samples/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/samples/kustomization.yaml
@@ -2,4 +2,4 @@
 resources:
 - batch_v1_cronjob.yaml
 - batch_v2_cronjob.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -74,11 +74,11 @@ managing jobs now, we'll need permissions for those, which means adding
 a couple more [markers](/reference/markers/rbac.md).
 */
 
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
 
 /*
 Now, we get to the heart of the controller -- the reconciler logic.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	err = batchv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/docs/book/src/reference/raising-events.md
+++ b/docs/book/src/reference/raising-events.md
@@ -99,7 +99,7 @@ You must also grant the RBAC rules permissions to allow your project to create E
 
 ```go
 ...
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 ...
 func (r *MyKindReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 ```

--- a/docs/book/src/reference/using_an_external_type.md
+++ b/docs/book/src/reference/using_an_external_type.md
@@ -84,13 +84,13 @@ type ExternalTypeReconciler struct {
 }
 
 // external types can be added like this
-//+kubebuilder:rbac:groups=theirgroup.theirs.com,resources=externaltypes,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=theirgroup.theirs.com,resources=externaltypes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=theirgroup.theirs.com,resources=externaltypes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=theirgroup.theirs.com,resources=externaltypes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=theirgroup.theirs.com,resources=externaltypes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=theirgroup.theirs.com,resources=externaltypes/finalizers,verbs=update
 // core types can be added like this
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 ```
 
 ### Register your Types
@@ -113,7 +113,7 @@ import (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(theirgroupv1alpha1.AddToScheme(scheme)) // this contains the external API types
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 ```
 
@@ -196,7 +196,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	theirgroupv1alpha1 "github.com/theiruser/theirproject/apis/theirgroup/v1alpha1"
 )
 
@@ -238,7 +238,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
     Expect(theirgroupv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})

--- a/docs/book/src/reference/watching-resources/testdata/external-indexed-field/api.go
+++ b/docs/book/src/reference/watching-resources/testdata/external-indexed-field/api.go
@@ -19,6 +19,7 @@ package external_indexed_field
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
 // +kubebuilder:docs-gen:collapse=Imports
 
 /*
@@ -50,8 +51,8 @@ type ConfigDeploymentStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // ConfigDeployment is the Schema for the configdeployments API
 type ConfigDeployment struct {
@@ -62,7 +63,7 @@ type ConfigDeployment struct {
 	Status ConfigDeploymentStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // ConfigDeploymentList contains a list of ConfigDeployment
 type ConfigDeploymentList struct {
@@ -74,4 +75,5 @@ type ConfigDeploymentList struct {
 func init() {
 	SchemeBuilder.Register(&ConfigDeployment{}, &ConfigDeploymentList{})
 }
+
 // +kubebuilder:docs-gen:collapse=Remaining API Code

--- a/docs/book/src/reference/watching-resources/testdata/external-indexed-field/controller.go
+++ b/docs/book/src/reference/watching-resources/testdata/external-indexed-field/controller.go
@@ -32,10 +32,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder" // Required for Watching
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler" // Required for Watching
+	"sigs.k8s.io/controller-runtime/pkg/handler"   // Required for Watching
 	"sigs.k8s.io/controller-runtime/pkg/predicate" // Required for Watching
 	"sigs.k8s.io/controller-runtime/pkg/reconcile" // Required for Watching
-	"sigs.k8s.io/controller-runtime/pkg/source" // Required for Watching
+	"sigs.k8s.io/controller-runtime/pkg/source"    // Required for Watching
 
 	appsv1 "tutorial.kubebuilder.io/project/api/v1"
 )
@@ -49,7 +49,7 @@ const (
 )
 
 /*
-*/
+ */
 
 // ConfigDeploymentReconciler reconciles a ConfigDeployment object
 type ConfigDeploymentReconciler struct {
@@ -57,6 +57,7 @@ type ConfigDeploymentReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
+
 // +kubebuilder:docs-gen:collapse=Reconciler Declaration
 
 /*
@@ -66,12 +67,12 @@ There are two additional resources that the controller needs to have access to, 
 All 3 of these are important, and you will see usages of each below.
 */
 
-//+kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=configdeployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=configdeployments/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=configdeployments/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=configdeployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=configdeployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=configdeployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 /*
 `Reconcile` will be in charge of reconciling the state of ConfigDeployments.
@@ -153,16 +154,16 @@ func (r *ConfigDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	/*
-	As explained in the CronJob tutorial, the controller will first register the Type that it manages, as well as the types of subresources that it controls.
-	Since we also want to watch ConfigMaps that are not controlled or managed by the controller, we will need to use the `Watches()` functionality as well.
+		As explained in the CronJob tutorial, the controller will first register the Type that it manages, as well as the types of subresources that it controls.
+		Since we also want to watch ConfigMaps that are not controlled or managed by the controller, we will need to use the `Watches()` functionality as well.
 
-	The `Watches()` function is a controller-runtime API that takes:
-	- A Kind (i.e. `ConfigMap`)
-	- A mapping function that converts a `ConfigMap` object to a list of reconcile requests for `ConfigDeployments`.
-	We have separated this out into a separate function.
-	- A list of options for watching the `ConfigMaps`
-	  - In our case, we only want the watch to be triggered when the ResourceVersion of the ConfigMap is changed.
-	 */
+		The `Watches()` function is a controller-runtime API that takes:
+		- A Kind (i.e. `ConfigMap`)
+		- A mapping function that converts a `ConfigMap` object to a list of reconcile requests for `ConfigDeployments`.
+		We have separated this out into a separate function.
+		- A list of options for watching the `ConfigMaps`
+		  - In our case, we only want the watch to be triggered when the ResourceVersion of the ConfigMap is changed.
+	*/
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.ConfigDeployment{}).
@@ -176,13 +177,13 @@ func (r *ConfigDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 /*
-	Because we have already created an index on the `configMap` reference field, this mapping function is quite straight forward.
-	We first need to list out all `ConfigDeployments` that use `ConfigMap` given in the mapping function.
-	This is done by merely submitting a List request using our indexed field as the field selector.
+Because we have already created an index on the `configMap` reference field, this mapping function is quite straight forward.
+We first need to list out all `ConfigDeployments` that use `ConfigMap` given in the mapping function.
+This is done by merely submitting a List request using our indexed field as the field selector.
 
-	When the list of `ConfigDeployments` that reference the `ConfigMap` is found,
-	we just need to loop through the list and create a reconcile request for each one.
-	If an error occurs fetching the list, or no `ConfigDeployments` are found, then no reconcile requests will be returned.
+When the list of `ConfigDeployments` that reference the `ConfigMap` is found,
+we just need to loop through the list and create a reconcile request for each one.
+If an error occurs fetching the list, or no `ConfigDeployments` are found, then no reconcile requests will be returned.
 */
 func (r *ConfigDeploymentReconciler) findObjectsForConfigMap(ctx context.Context, configMap client.Object) []reconcile.Request {
 	attachedConfigDeployments := &appsv1.ConfigDeploymentList{}

--- a/docs/book/src/reference/watching-resources/testdata/owned-resource/api.go
+++ b/docs/book/src/reference/watching-resources/testdata/owned-resource/api.go
@@ -19,6 +19,7 @@ package owned_resource
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
 // +kubebuilder:docs-gen:collapse=Imports
 
 /*
@@ -48,8 +49,8 @@ type SimpleDeploymentStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // SimpleDeployment is the Schema for the simpledeployments API
 type SimpleDeployment struct {
@@ -60,7 +61,7 @@ type SimpleDeployment struct {
 	Status SimpleDeploymentStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // SimpleDeploymentList contains a list of SimpleDeployment
 type SimpleDeploymentList struct {
@@ -72,4 +73,5 @@ type SimpleDeploymentList struct {
 func init() {
 	SchemeBuilder.Register(&SimpleDeployment{}, &SimpleDeploymentList{})
 }
+
 // +kubebuilder:docs-gen:collapse=Remaining API Code

--- a/docs/book/src/reference/watching-resources/testdata/owned-resource/controller.go
+++ b/docs/book/src/reference/watching-resources/testdata/owned-resource/controller.go
@@ -52,11 +52,11 @@ In addition to the `SimpleDeployment` permissions, we will also need permissions
 In order to fully manage the workflow of deployments, our app will need to be able to use all verbs on a deployment as well as "get" it's status.
 */
 
-//+kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=simpledeployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=simpledeployments/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=simpledeployments/finalizers,verbs=update
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+// +kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=simpledeployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=simpledeployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.tutorial.kubebuilder.io,resources=simpledeployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
 
 /*
 `Reconcile` will be in charge of reconciling the state of `SimpleDeployments`.

--- a/hack/docs/internal/cronjob-tutorial/api_design.go
+++ b/hack/docs/internal/cronjob-tutorial/api_design.go
@@ -50,12 +50,12 @@ const CronjobSpecExplaination = `
 `
 
 const CronjobSpecStruct = `
-	//+kubebuilder:validation:MinLength=0
+	// +kubebuilder:validation:MinLength=0
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	Schedule string` + " `" + `json:"schedule"` + "`" + `
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// Optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
@@ -78,14 +78,14 @@ const CronjobSpecStruct = `
 	// Specifies the job that will be created when executing a CronJob.
 	JobTemplate batchv1.JobTemplateSpec` + " `" + `json:"jobTemplate"` + "`" + `
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// The number of successful finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional
 	SuccessfulJobsHistoryLimit *int32` + " `" + `json:"successfulJobsHistoryLimit,omitempty"` + "`" + `
 
-	//+kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=0
 
 	// The number of failed finished jobs to retain.
 	// This is a pointer to distinguish between explicit zero and not specified.

--- a/hack/docs/internal/cronjob-tutorial/controller_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/controller_implementation.go
@@ -73,8 +73,8 @@ a couple more [markers](/reference/markers/rbac.md).
 `
 
 const ControllerReconcile = `
-//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
 
 /*
 Now, we get to the heart of the controller -- the reconciler logic.

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -201,7 +201,7 @@ func updateSpec(sp *Sample) {
 		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_types.go"),
 		`SchemeBuilder.Register(&CronJob{}, &CronJobList{})
 }`, `
-//+kubebuilder:docs-gen:collapse=Root Object Definitions`)
+// +kubebuilder:docs-gen:collapse=Root Object Definitions`)
 	CheckError("fixing cronjob_types.go", err)
 
 	err = pluginutil.ReplaceInFile(
@@ -282,7 +282,7 @@ func updateController(sp *Sample) {
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/cronjob_controller.go"),
-		`//+kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update`, ControllerReconcile)
+		`// +kubebuilder:rbac:groups=batch.tutorial.kubebuilder.io,resources=cronjobs/finalizers,verbs=update`, ControllerReconcile)
 	CheckError("fixing cronjob_controller.go", err)
 
 	err = pluginutil.ReplaceInFile(
@@ -319,13 +319,13 @@ func updateMain(sp *Sample) {
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "cmd/main.go"),
-		`//+kubebuilder:scaffold:imports
+		`// +kubebuilder:scaffold:imports
 )`, MainBatch)
 	CheckError("fixing main.go", err)
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "cmd/main.go"),
-		`//+kubebuilder:scaffold:scheme
+		`// +kubebuilder:scaffold:scheme
 }`, `
 /*
 The other thing that's changed is that kubebuilder has added a block calling our
@@ -411,12 +411,12 @@ Then, we set up the webhook with the manager.
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_webhook.go"),
-		`//+kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,admissionReviewVersions=v1`, "")
+		`// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,admissionReviewVersions=v1`, "")
 	CheckError("fixing cronjob_webhook.go by replacing marker", err)
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_webhook.go"),
-		`//+kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob.kb.io,admissionReviewVersions=v1`, "")
+		`// +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob.kb.io,admissionReviewVersions=v1`, "")
 	CheckError("fixing cronjob_webhook.go validate batch marker", err)
 
 	err = pluginutil.ReplaceInFile(
@@ -517,7 +517,7 @@ var testEnv *envtest.Environment
 	err = batchv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 `, SuiteTestAddSchema)
 	CheckError("updating suite_test.go to add schema", err)
 

--- a/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
@@ -44,7 +44,7 @@ This marker is responsible for generating a mutating webhook manifest.
 The meaning of each marker can be found [here](/reference/markers/webhook.md).
 */
 
-//+kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 /*
 We use the` + " `" + `webhook.Defaulter` + "`" + ` interface to set defaults to our CRD.
@@ -76,7 +76,7 @@ const WebhookValidate = `	cronjoblog.Info("default", "name", r.Name)
 This marker is responsible for generating a validating webhook manifest.
 */
 
-//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
+// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,versions=v1,name=vcronjob.kb.io,sideEffects=None,admissionReviewVersions=v1
 
 /*
 We can validate our CRD beyond what's possible with declarative

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -62,7 +62,7 @@ const SuiteTestAddSchema = `
 		This marker is what allows new schemas to be added here automatically when a new API is added to the project.
 	*/
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	/*
 		A client is created for our test CRUD operations.

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -54,7 +54,7 @@ func NewMarkerFor(path string, value string) Marker {
 
 // String implements Stringer
 func (m Marker) String() string {
-	return m.comment + prefix + m.value
+	return m.comment + " " + prefix + m.value
 }
 
 // EqualsLine compares a marker with a string representation to check if they are the same marker

--- a/pkg/machinery/marker_test.go
+++ b/pkg/machinery/marker_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Marker", func() {
 	Context("String", func() {
 		DescribeTable("should return the right string representation",
 			func(marker Marker, str string) { Expect(marker.String()).To(Equal(str)) },
-			Entry("for go files", Marker{comment: "//", value: "test"}, "//+kubebuilder:scaffold:test"),
-			Entry("for yaml files", Marker{comment: "#", value: "test"}, "#+kubebuilder:scaffold:test"),
+			Entry("for go files", Marker{comment: "//", value: "test"}, "// +kubebuilder:scaffold:test"),
+			Entry("for yaml files", Marker{comment: "#", value: "test"}, "# +kubebuilder:scaffold:test"),
 		)
 	})
 })

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -224,14 +224,14 @@ var _ = Describe("Scaffold", func() {
 				pathGo,
 				`package test
 
-//+kubebuilder:scaffold:-
+// +kubebuilder:scaffold:-
 `,
 				`package test
 
 var a int
 var b int
 
-//+kubebuilder:scaffold:-
+// +kubebuilder:scaffold:-
 `,
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathGo},
@@ -243,12 +243,12 @@ var b int
 			Entry("should insert lines for yaml files",
 				pathYaml,
 				`
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				`
 1
 2
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathYaml},
@@ -263,10 +263,10 @@ var b int
 				`
 1
 2
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				&fakeTemplate{fakeBuilder: fakeBuilder{path: pathYaml, ifExistsAction: OverwriteFile}, body: `
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `},
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathYaml},
@@ -281,10 +281,10 @@ var b int
 				`
 1
 2
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				&fakeTemplate{fakeBuilder: fakeBuilder{path: pathYaml, ifExistsAction: OverwriteFile}, body: `
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `},
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathYaml},
@@ -296,12 +296,12 @@ var b int
 			Entry("should use files over optional models",
 				pathYaml,
 				`
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				`
 1
 2
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				&fakeTemplate{fakeBuilder: fakeBuilder{path: pathYaml}, body: content},
 				fakeInserter{
@@ -314,14 +314,14 @@ var b int
 			Entry("should filter invalid markers",
 				pathYaml,
 				`
-#+kubebuilder:scaffold:-
-#+kubebuilder:scaffold:*
+# +kubebuilder:scaffold:-
+# +kubebuilder:scaffold:*
 `,
 				`
 1
 2
-#+kubebuilder:scaffold:-
-#+kubebuilder:scaffold:*
+# +kubebuilder:scaffold:-
+# +kubebuilder:scaffold:*
 `,
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathYaml},
@@ -336,18 +336,18 @@ var b int
 				pathYaml,
 				`
 1
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 3
 4
-#+kubebuilder:scaffold:*
+# +kubebuilder:scaffold:*
 `,
 				`
 1
 2
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 3
 4
-#+kubebuilder:scaffold:*
+# +kubebuilder:scaffold:*
 `,
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathYaml},
@@ -366,7 +366,7 @@ func init() {
 		return err
 	}
 	
-	//+kubebuilder:scaffold:-
+	// +kubebuilder:scaffold:-
 }
 `,
 				`package test
@@ -376,7 +376,7 @@ func init() {
 		return err
 	}
 	
-	//+kubebuilder:scaffold:-
+	// +kubebuilder:scaffold:-
 }
 `,
 				fakeInserter{
@@ -389,10 +389,10 @@ func init() {
 			Entry("should not insert anything if no code fragment",
 				pathYaml,
 				`
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				`
-#+kubebuilder:scaffold:-
+# +kubebuilder:scaffold:-
 `,
 				fakeInserter{
 					fakeBuilder: fakeBuilder{path: pathYaml},

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -103,14 +103,14 @@ type {{ .Resource.Kind }}Status struct {
 	Conditions []metav1.Condition ` + "`" + `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` + "`" + `
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 {{- if and (not .Resource.API.Namespaced) (not .Resource.IsRegularPlural) }}
-//+kubebuilder:resource:path={{ .Resource.Plural }},scope=Cluster
+// +kubebuilder:resource:path={{ .Resource.Plural }},scope=Cluster
 {{- else if not .Resource.API.Namespaced }}
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster
 {{- else if not .Resource.IsRegularPlural }}
-//+kubebuilder:resource:path={{ .Resource.Plural }}
+// +kubebuilder:resource:path={{ .Resource.Plural }}
 {{- end }}
 
 // {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
@@ -122,7 +122,7 @@ type {{ .Resource.Kind }} struct {
 	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}List struct {

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -114,12 +114,12 @@ type {{ .Resource.Kind }}Reconciler struct {
 // when the command <make manifests> is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
-//+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/group.go
@@ -55,8 +55,8 @@ func (f *Group) SetTemplateDefaults() error {
 const groupTemplate = `{{ .Boilerplate }}
 
 // Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
-//+kubebuilder:object:generate=true
-//+groupName={{ .Resource.QualifiedGroup }}
+// +kubebuilder:object:generate=true
+// +groupName={{ .Resource.QualifiedGroup }}
 package {{ .Resource.Version }}
 
 import (

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -87,14 +87,14 @@ type {{ .Resource.Kind }}Status struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 {{- if and (not .Resource.API.Namespaced) (not .Resource.IsRegularPlural) }}
-//+kubebuilder:resource:path={{ .Resource.Plural }},scope=Cluster
+// +kubebuilder:resource:path={{ .Resource.Plural }},scope=Cluster
 {{- else if not .Resource.API.Namespaced }}
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster
 {{- else if not .Resource.IsRegularPlural }}
-//+kubebuilder:resource:path={{ .Resource.Plural }}
+// +kubebuilder:resource:path={{ .Resource.Plural }}
 {{- end }}
 
 // {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
@@ -106,7 +106,7 @@ type {{ .Resource.Kind }} struct {
 	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty"` + "`" + `
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}List struct {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
@@ -110,7 +110,7 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 	//nolint:lll
 	defaultingWebhookTemplate = `
-//+kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
 var _ webhook.Defaulter = &{{ .Resource.Kind }}{}
 
@@ -127,7 +127,7 @@ func (r *{{ .Resource.Kind }}) Default() {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
 var _ webhook.Validator = &{{ .Resource.Kind }}{}
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
@@ -85,9 +85,9 @@ type {{ .Resource.Kind }}Reconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/finalizers,verbs=update
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }}/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
@@ -36,7 +36,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -50,7 +50,7 @@ func (r *Captain) Default() {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Captain{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1/bar_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1/bar_types.go
@@ -38,8 +38,8 @@ type BarStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Bar is the Schema for the bars API
 type Bar struct {
@@ -50,7 +50,7 @@ type Bar struct {
 	Status BarStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // BarList contains a list of Bar
 type BarList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1/healthcheckpolicy_types.go
@@ -38,8 +38,8 @@ type HealthCheckPolicyStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // HealthCheckPolicy is the Schema for the healthcheckpolicies API
 type HealthCheckPolicy struct {
@@ -50,7 +50,7 @@ type HealthCheckPolicy struct {
 	Status HealthCheckPolicyStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // HealthCheckPolicyList contains a list of HealthCheckPolicy
 type HealthCheckPolicyList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1/bar_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1/bar_types.go
@@ -38,8 +38,8 @@ type BarStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Bar is the Schema for the bars API
 type Bar struct {
@@ -50,7 +50,7 @@ type Bar struct {
 	Status BarStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // BarList contains a list of Bar
 type BarList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1/kraken_types.go
@@ -38,8 +38,8 @@ type KrakenStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Kraken is the Schema for the krakens API
 type Kraken struct {
@@ -50,7 +50,7 @@ type Kraken struct {
 	Status KrakenStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KrakenList contains a list of Kraken
 type KrakenList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2/leviathan_types.go
@@ -38,8 +38,8 @@ type LeviathanStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Leviathan is the Schema for the leviathans API
 type Leviathan struct {
@@ -50,7 +50,7 @@ type Leviathan struct {
 	Status LeviathanStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // LeviathanList contains a list of Leviathan
 type LeviathanList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_types.go
@@ -38,9 +38,9 @@ type DestroyerStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 
 // Destroyer is the Schema for the destroyers API
 type Destroyer struct {
@@ -51,7 +51,7 @@ type Destroyer struct {
 	Status DestroyerStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // DestroyerList contains a list of Destroyer
 type DestroyerList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
@@ -34,7 +34,7 @@ func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Destroyer{}
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Destroyer{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_types.go
@@ -38,8 +38,8 @@ type FrigateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Frigate is the Schema for the frigates API
 type Frigate struct {
@@ -50,7 +50,7 @@ type Frigate struct {
 	Status FrigateStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // FrigateList contains a list of Frigate
 type FrigateList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_types.go
@@ -38,9 +38,9 @@ type CruiserStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 
 // Cruiser is the Schema for the cruisers API
 type Cruiser struct {
@@ -51,7 +51,7 @@ type Cruiser struct {
 	Status CruiserStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CruiserList contains a list of Cruiser
 type CruiserList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
@@ -39,7 +39,7 @@ func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Cruiser{}
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Cruiser{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_types.go
@@ -38,8 +38,8 @@ type LakersStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Lakers is the Schema for the lakers API
 type Lakers struct {
@@ -50,7 +50,7 @@ type Lakers struct {
 	Status LakersStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // LakersList contains a list of Lakers
 type LakersList struct {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
@@ -36,7 +36,7 @@ func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Lakers{}
 
@@ -50,7 +50,7 @@ func (r *Lakers) Default() {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Lakers{}
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Lakers{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup-with-deploy-image/cmd/main.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/cmd/main.go
@@ -52,7 +52,7 @@ import (
 	foopolicycontroller "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy"
 	seacreaturescontroller "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures"
 	shipcontroller "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -73,7 +73,7 @@ func init() {
 	utilruntime.Must(foov1.AddToScheme(scheme))
 	utilruntime.Must(fizv1.AddToScheme(scheme))
 	utilruntime.Must(testprojectorgv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -255,7 +255,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 - bases/foo.testproject.org_bars.yaml
 - bases/fiz.testproject.org_bars.yaml
 - bases/testproject.org_lakers.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -22,7 +22,7 @@ patches:
 - path: patches/webhook_in_ship_destroyers.yaml
 - path: patches/webhook_in_ship_cruisers.yaml
 - path: patches/webhook_in_lakers.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
@@ -36,7 +36,7 @@ patches:
 #- path: patches/cainjection_in_foo_bars.yaml
 #- path: patches/cainjection_in_fiz_bars.yaml
 #- path: patches/cainjection_in_lakers.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4-multigroup-with-deploy-image/config/samples/kustomization.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/samples/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 - foo_v1_bar.yaml
 - fiz_v1_bar.yaml
 - v1_lakers.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/deployment_controller.go
@@ -32,9 +32,9 @@ type DeploymentReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/apps/suite_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	err = appsv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/captain_controller.go
@@ -33,9 +33,9 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/crew/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/bar_controller.go
@@ -33,9 +33,9 @@ type BarReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=fiz.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/finalizers,verbs=update
+// +kubebuilder:rbac:groups=fiz.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/fiz/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	fizv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = fizv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/healthcheckpolicy_controller.go
@@ -33,9 +33,9 @@ type HealthCheckPolicyReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo.policy/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	foopolicyv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = foopolicyv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/bar_controller.go
@@ -33,9 +33,9 @@ type BarReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=foo.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=foo.testproject.org,resources=bars/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=foo.testproject.org,resources=bars/finalizers,verbs=update
+// +kubebuilder:rbac:groups=foo.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=foo.testproject.org,resources=bars/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=foo.testproject.org,resources=bars/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/foo/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	foov1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = foov1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/lakers_controller.go
@@ -33,9 +33,9 @@ type LakersReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=testproject.org,resources=lakers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=testproject.org,resources=lakers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=testproject.org,resources=lakers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=testproject.org,resources=lakers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/kraken_controller.go
@@ -33,9 +33,9 @@ type KrakenReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/leviathan_controller.go
@@ -33,9 +33,9 @@ type LeviathanReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/sea-creatures/suite_test.go
@@ -34,7 +34,7 @@ import (
 
 	seacreaturesv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1"
 	seacreaturesv1beta2 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 	err = seacreaturesv1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/cruiser_controller.go
@@ -33,9 +33,9 @@ type CruiserReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/destroyer_controller.go
@@ -33,9 +33,9 @@ type DestroyerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/frigate_controller.go
@@ -33,9 +33,9 @@ type FrigateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/ship/suite_test.go
@@ -35,7 +35,7 @@ import (
 	shipv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1"
 	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1"
 	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup-with-deploy-image/internal/controller/suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/internal/controller/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	testprojectorgv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup-with-deploy-image/api/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = testprojectorgv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_types.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
@@ -36,7 +36,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -50,7 +50,7 @@ func (r *Captain) Default() {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v4-multigroup/api/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Captain{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup/api/fiz/v1/bar_types.go
+++ b/testdata/project-v4-multigroup/api/fiz/v1/bar_types.go
@@ -38,8 +38,8 @@ type BarStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Bar is the Schema for the bars API
 type Bar struct {
@@ -50,7 +50,7 @@ type Bar struct {
 	Status BarStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // BarList contains a list of Bar
 type BarList struct {

--- a/testdata/project-v4-multigroup/api/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v4-multigroup/api/foo.policy/v1/healthcheckpolicy_types.go
@@ -38,8 +38,8 @@ type HealthCheckPolicyStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // HealthCheckPolicy is the Schema for the healthcheckpolicies API
 type HealthCheckPolicy struct {
@@ -50,7 +50,7 @@ type HealthCheckPolicy struct {
 	Status HealthCheckPolicyStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // HealthCheckPolicyList contains a list of HealthCheckPolicy
 type HealthCheckPolicyList struct {

--- a/testdata/project-v4-multigroup/api/foo/v1/bar_types.go
+++ b/testdata/project-v4-multigroup/api/foo/v1/bar_types.go
@@ -38,8 +38,8 @@ type BarStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Bar is the Schema for the bars API
 type Bar struct {
@@ -50,7 +50,7 @@ type Bar struct {
 	Status BarStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // BarList contains a list of Bar
 type BarList struct {

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/kraken_types.go
@@ -38,8 +38,8 @@ type KrakenStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Kraken is the Schema for the krakens API
 type Kraken struct {
@@ -50,7 +50,7 @@ type Kraken struct {
 	Status KrakenStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // KrakenList contains a list of Kraken
 type KrakenList struct {

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/leviathan_types.go
@@ -38,8 +38,8 @@ type LeviathanStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Leviathan is the Schema for the leviathans API
 type Leviathan struct {
@@ -50,7 +50,7 @@ type Leviathan struct {
 	Status LeviathanStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // LeviathanList contains a list of Leviathan
 type LeviathanList struct {

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_types.go
@@ -38,9 +38,9 @@ type DestroyerStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 
 // Destroyer is the Schema for the destroyers API
 type Destroyer struct {
@@ -51,7 +51,7 @@ type Destroyer struct {
 	Status DestroyerStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // DestroyerList contains a list of Destroyer
 type DestroyerList struct {

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
@@ -34,7 +34,7 @@ func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Destroyer{}
 

--- a/testdata/project-v4-multigroup/api/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Destroyer{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_types.go
@@ -38,8 +38,8 @@ type FrigateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Frigate is the Schema for the frigates API
 type Frigate struct {
@@ -50,7 +50,7 @@ type Frigate struct {
 	Status FrigateStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // FrigateList contains a list of Frigate
 type FrigateList struct {

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_types.go
@@ -38,9 +38,9 @@ type CruiserStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 
 // Cruiser is the Schema for the cruisers API
 type Cruiser struct {
@@ -51,7 +51,7 @@ type Cruiser struct {
 	Status CruiserStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CruiserList contains a list of Cruiser
 type CruiserList struct {

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
@@ -39,7 +39,7 @@ func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Cruiser{}
 

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Cruiser{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup/api/v1/lakers_types.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_types.go
@@ -38,8 +38,8 @@ type LakersStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Lakers is the Schema for the lakers API
 type Lakers struct {
@@ -50,7 +50,7 @@ type Lakers struct {
 	Status LakersStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // LakersList contains a list of Lakers
 type LakersList struct {

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
@@ -36,7 +36,7 @@ func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Lakers{}
 
@@ -50,7 +50,7 @@ func (r *Lakers) Default() {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Lakers{}
 

--- a/testdata/project-v4-multigroup/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Lakers{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-multigroup/cmd/main.go
+++ b/testdata/project-v4-multigroup/cmd/main.go
@@ -52,7 +52,7 @@ import (
 	foopolicycontroller "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/internal/controller/foo.policy"
 	seacreaturescontroller "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/internal/controller/sea-creatures"
 	shipcontroller "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/internal/controller/ship"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -73,7 +73,7 @@ func init() {
 	utilruntime.Must(foov1.AddToScheme(scheme))
 	utilruntime.Must(fizv1.AddToScheme(scheme))
 	utilruntime.Must(testprojectorgv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -255,7 +255,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v4-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/crd/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 - bases/foo.testproject.org_bars.yaml
 - bases/fiz.testproject.org_bars.yaml
 - bases/testproject.org_lakers.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -22,7 +22,7 @@ patches:
 - path: patches/webhook_in_ship_destroyers.yaml
 - path: patches/webhook_in_ship_cruisers.yaml
 - path: patches/webhook_in_lakers.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
@@ -36,7 +36,7 @@ patches:
 #- path: patches/cainjection_in_foo_bars.yaml
 #- path: patches/cainjection_in_fiz_bars.yaml
 #- path: patches/cainjection_in_lakers.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4-multigroup/config/samples/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/samples/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 - foo_v1_bar.yaml
 - fiz_v1_bar.yaml
 - v1_lakers.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/deployment_controller.go
@@ -32,9 +32,9 @@ type DeploymentReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	err = appsv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/crew/captain_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/captain_controller.go
@@ -33,9 +33,9 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/crew/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller.go
@@ -33,9 +33,9 @@ type BarReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=fiz.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/finalizers,verbs=update
+// +kubebuilder:rbac:groups=fiz.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=fiz.testproject.org,resources=bars/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	fizv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/fiz/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = fizv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller.go
@@ -33,9 +33,9 @@ type HealthCheckPolicyReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=foo.policy.testproject.org,resources=healthcheckpolicies/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	foopolicyv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/foo.policy/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = foopolicyv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/foo/bar_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/bar_controller.go
@@ -33,9 +33,9 @@ type BarReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=foo.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=foo.testproject.org,resources=bars/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=foo.testproject.org,resources=bars/finalizers,verbs=update
+// +kubebuilder:rbac:groups=foo.testproject.org,resources=bars,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=foo.testproject.org,resources=bars/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=foo.testproject.org,resources=bars/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	foov1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/foo/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = foov1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/lakers_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/lakers_controller.go
@@ -33,9 +33,9 @@ type LakersReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=testproject.org,resources=lakers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=testproject.org,resources=lakers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=testproject.org,resources=lakers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=testproject.org,resources=lakers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller.go
@@ -33,9 +33,9 @@ type KrakenReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=krakens/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller.go
@@ -33,9 +33,9 @@ type LeviathanReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=sea-creatures.testproject.org,resources=leviathans/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -34,7 +34,7 @@ import (
 
 	seacreaturesv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/sea-creatures/v1beta1"
 	seacreaturesv1beta2 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/sea-creatures/v1beta2"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -79,7 +79,7 @@ var _ = BeforeSuite(func() {
 	err = seacreaturesv1beta2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller.go
@@ -33,9 +33,9 @@ type CruiserReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=cruisers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller.go
@@ -33,9 +33,9 @@ type DestroyerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=destroyers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller.go
@@ -33,9 +33,9 @@ type FrigateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ship.testproject.org,resources=frigates/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -35,7 +35,7 @@ import (
 	shipv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/ship/v1"
 	shipv1beta1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/ship/v1beta1"
 	shipv2alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/ship/v2alpha1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-multigroup/internal/controller/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	testprojectorgv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = testprojectorgv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/busybox_types.go
@@ -51,8 +51,8 @@ type BusyboxStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Busybox is the Schema for the busyboxes API
 type Busybox struct {
@@ -63,7 +63,7 @@ type Busybox struct {
 	Status BusyboxStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // BusyboxList contains a list of Busybox
 type BusyboxList struct {

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_types.go
@@ -54,8 +54,8 @@ type MemcachedStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Memcached is the Schema for the memcacheds API
 type Memcached struct {
@@ -66,7 +66,7 @@ type Memcached struct {
 	Status MemcachedStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
@@ -39,7 +39,7 @@ func (r *Memcached) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-example-com-testproject-org-v1alpha1-memcached,mutating=false,failurePolicy=fail,sideEffects=None,groups=example.com.testproject.org,resources=memcacheds,verbs=create;update,versions=v1alpha1,name=vmemcached.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-example-com-testproject-org-v1alpha1-memcached,mutating=false,failurePolicy=fail,sideEffects=None,groups=example.com.testproject.org,resources=memcacheds,verbs=create;update,versions=v1alpha1,name=vmemcached.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Memcached{}
 

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -116,7 +116,7 @@ var _ = BeforeSuite(func() {
 	err = (&Memcached{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4-with-deploy-image/cmd/main.go
+++ b/testdata/project-v4-with-deploy-image/cmd/main.go
@@ -36,7 +36,7 @@ import (
 
 	examplecomv1alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v4-with-deploy-image/api/v1alpha1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v4-with-deploy-image/internal/controller"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -48,7 +48,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(examplecomv1alpha1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -145,7 +145,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/crd/kustomization.yaml
@@ -4,19 +4,19 @@
 resources:
 - bases/example.com.testproject.org_memcacheds.yaml
 - bases/example.com.testproject.org_busyboxes.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 - path: patches/webhook_in_memcacheds.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- path: patches/cainjection_in_memcacheds.yaml
 #- path: patches/cainjection_in_busyboxes.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4-with-deploy-image/config/samples/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/kustomization.yaml
@@ -2,4 +2,4 @@
 resources:
 - example.com_v1alpha1_memcached.yaml
 - example.com_v1alpha1_busybox.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/busybox_controller.go
@@ -60,12 +60,12 @@ type BusyboxReconciler struct {
 // when the command <make manifests> is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
-//+kubebuilder:rbac:groups=example.com.testproject.org,resources=busyboxes,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=example.com.testproject.org,resources=busyboxes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=example.com.testproject.org,resources=busyboxes/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=example.com.testproject.org,resources=busyboxes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=example.com.testproject.org,resources=busyboxes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=example.com.testproject.org,resources=busyboxes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
@@ -60,12 +60,12 @@ type MemcachedReconciler struct {
 // when the command <make manifests> is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
-//+kubebuilder:rbac:groups=example.com.testproject.org,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=example.com.testproject.org,resources=memcacheds/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=example.com.testproject.org,resources=memcacheds/finalizers,verbs=update
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=example.com.testproject.org,resources=memcacheds,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=example.com.testproject.org,resources=memcacheds/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=example.com.testproject.org,resources=memcacheds/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4-with-deploy-image/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	examplecomv1alpha1 "sigs.k8s.io/kubebuilder/testdata/project-v4-with-deploy-image/api/v1alpha1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-with-grafana/cmd/main.go
+++ b/testdata/project-v4-with-grafana/cmd/main.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -119,7 +119,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v4/api/v1/admiral_types.go
+++ b/testdata/project-v4/api/v1/admiral_types.go
@@ -38,9 +38,9 @@ type AdmiralStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:path=admirales,scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=admirales,scope=Cluster
 
 // Admiral is the Schema for the admirales API
 type Admiral struct {
@@ -51,7 +51,7 @@ type Admiral struct {
 	Status AdmiralStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {

--- a/testdata/project-v4/api/v1/admiral_webhook.go
+++ b/testdata/project-v4/api/v1/admiral_webhook.go
@@ -34,7 +34,7 @@ func (r *Admiral) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirales,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirales,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Admiral{}
 

--- a/testdata/project-v4/api/v1/captain_types.go
+++ b/testdata/project-v4/api/v1/captain_types.go
@@ -38,8 +38,8 @@ type CaptainStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Captain is the Schema for the captains API
 type Captain struct {
@@ -50,7 +50,7 @@ type Captain struct {
 	Status CaptainStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // CaptainList contains a list of Captain
 type CaptainList struct {

--- a/testdata/project-v4/api/v1/captain_webhook.go
+++ b/testdata/project-v4/api/v1/captain_webhook.go
@@ -36,7 +36,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-//+kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &Captain{}
 
@@ -50,7 +50,7 @@ func (r *Captain) Default() {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-//+kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &Captain{}
 

--- a/testdata/project-v4/api/v1/firstmate_types.go
+++ b/testdata/project-v4/api/v1/firstmate_types.go
@@ -38,8 +38,8 @@ type FirstMateStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // FirstMate is the Schema for the firstmates API
 type FirstMate struct {
@@ -50,7 +50,7 @@ type FirstMate struct {
 	Status FirstMateStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {

--- a/testdata/project-v4/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4/api/v1/webhook_suite_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,7 +93,7 @@ var _ = BeforeSuite(func() {
 	err = admissionv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 	err = (&Admiral{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:webhook
+	// +kubebuilder:scaffold:webhook
 
 	go func() {
 		defer GinkgoRecover()

--- a/testdata/project-v4/cmd/main.go
+++ b/testdata/project-v4/cmd/main.go
@@ -36,7 +36,7 @@ import (
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4/api/v1"
 	"sigs.k8s.io/kubebuilder/testdata/project-v4/internal/controller"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 var (
@@ -48,7 +48,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(crewv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -169,7 +169,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Laker")
 		os.Exit(1)
 	}
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/testdata/project-v4/config/crd/kustomization.yaml
+++ b/testdata/project-v4/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/crew.testproject.org_captains.yaml
 - bases/crew.testproject.org_firstmates.yaml
 - bases/crew.testproject.org_admirales.yaml
-#+kubebuilder:scaffold:crdkustomizeresource
+# +kubebuilder:scaffold:crdkustomizeresource
 
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
@@ -13,14 +13,14 @@ patches:
 - path: patches/webhook_in_captains.yaml
 - path: patches/webhook_in_firstmates.yaml
 - path: patches/webhook_in_admirales.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- path: patches/cainjection_in_captains.yaml
 #- path: patches/cainjection_in_firstmates.yaml
 #- path: patches/cainjection_in_admirales.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/testdata/project-v4/config/samples/kustomization.yaml
+++ b/testdata/project-v4/config/samples/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 - crew_v1_captain.yaml
 - crew_v1_firstmate.yaml
 - crew_v1_admiral.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples
+# +kubebuilder:scaffold:manifestskustomizesamples

--- a/testdata/project-v4/internal/controller/admiral_controller.go
+++ b/testdata/project-v4/internal/controller/admiral_controller.go
@@ -33,9 +33,9 @@ type AdmiralReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirales,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirales/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=admirales/finalizers,verbs=update
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirales,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirales/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=admirales/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4/internal/controller/captain_controller.go
+++ b/testdata/project-v4/internal/controller/captain_controller.go
@@ -33,9 +33,9 @@ type CaptainReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4/internal/controller/firstmate_controller.go
+++ b/testdata/project-v4/internal/controller/firstmate_controller.go
@@ -33,9 +33,9 @@ type FirstMateReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=firstmates/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4/internal/controller/laker_controller.go
+++ b/testdata/project-v4/internal/controller/laker_controller.go
@@ -31,9 +31,9 @@ type LakerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=lakers/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4/api/v1"
-	//+kubebuilder:scaffold:imports
+	// +kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -75,7 +75,7 @@ var _ = BeforeSuite(func() {
 	err = crewv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	//+kubebuilder:scaffold:scheme
+	// +kubebuilder:scaffold:scheme
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This commit addresses the inconsistency in marker annotations within the kubebuilder project. Previously, kubebuilder markers did not have a space between `//` and `+marker`, unlike those in controller-tools and other related tools see; 
- controller-tools: https://github.com/search?q=repo%3Akubernetes-sigs%2Fcontroller-tools+%22%2F%2F+%2B%22&type=code. 
- controller-runtime: https://github.com/search?q=repo%3Akubernetes-sigs%2Fcontroller-runtime++%22%2F%2F+%2B%22&type=code

**This inconsistency was causing confusion for end users.**

To resolve this, all kubebuilder markers are now updated to include a space, ensuring uniformity across the project. After merging this commit, you can run `make all` to regenerate the markers. If any issues arise, use find/replace to change `//+` to `// +`.


Motivates by: https://github.com/kubernetes-sigs/kubebuilder/discussions/3801

c/c @mateusoliveira43