### PR TITLE
📖 (plugin deploy-image and envtest): use ref of project-v4  instead of v3 in the examples

### DIFF
--- a/docs/book/src/plugins/deploy-image-plugin-v1-alpha.md
+++ b/docs/book/src/plugins/deploy-image-plugin-v1-alpha.md
@@ -13,7 +13,7 @@ By using this plugin you will have:
 <aside class="note">
 <h1>Examples</h1>
 
-See the "project-v3-with-deploy-image" directory under the [testdata][testdata] directory of the Kubebuilder project to check an example of a scaffolding created using this plugin.
+See the "project-v4-with-deploy-image" directory under the [testdata][testdata] directory of the Kubebuilder project to check an example of a scaffolding created using this plugin.
 
 </aside>
 

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -81,7 +81,7 @@ Logs from the test runs are prefixed with `test-env`.
 
 You can use the plugin [DeployImage](https://book.kubebuilder.io/plugins/deploy-image-plugin-v1-alpha.html) to check examples. This plugin allows users to scaffold API/Controllers to deploy and manage an Operand (image) on the cluster following the guidelines and best practices. It abstracts the complexities of achieving this goal while allowing users to customize the generated code.
 
-Therefore, you can check that a test using ENV TEST will be generated for the controller which has the purpose to ensure that the Deployment is created successfully. You can see an example of its code implementation under the `testdata` directory with the [DeployImage](https://book.kubebuilder.io/plugins/deploy-image-plugin-v1-alpha.html) samples [here](https://github.com/kubernetes-sigs/kubebuilder/blob/v3.7.0/testdata/project-v3-with-deploy-image/controllers/busybox_controller_test.go).
+Therefore, you can check that a test using ENV TEST will be generated for the controller which has the purpose to ensure that the Deployment is created successfully. You can see an example of its code implementation under the `testdata` directory with the [DeployImage](https://book.kubebuilder.io/plugins/deploy-image-plugin-v1-alpha.html) samples [here](https://github.com/kubernetes-sigs/kubebuilder/blob/v3.7.0/testdata/project-v4-with-deploy-image/controllers/busybox_controller_test.go).
 
 </aside>
 


### PR DESCRIPTION
📖 (plugin deploy-image and envtest): use ref of project-v4  instead of v3 in the examples