### PR TITLE
🐛 fix: preserve existing flags when applying metrics patch

### DIFF
--- a/.github/workflows/test-sample-go.yml
+++ b/.github/workflows/test-sample-go.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           KUSTOMIZATION_FILE_PATH="testdata/project-v4/config/default/kustomization.yaml"
           sed -i '25s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '27s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '42s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '46,142s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '39s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '44s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '48,144s/^#//' $KUSTOMIZATION_FILE_PATH
       
       - name: Test
         run: |

--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -76,7 +76,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_metrics_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         securityContext:

--- a/docs/book/src/getting-started/testdata/project/cmd/main.go
+++ b/docs/book/src/getting-started/testdata/project/cmd/main.go
@@ -57,7 +57,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/docs/book/src/getting-started/testdata/project/config/default/manager_metrics_patch.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         env:

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -46,9 +46,12 @@ First, you will need enable the Metrics by uncommenting the following line
 in the file `config/default/kustomization.yaml`, see:
 
 ```sh
-# [Metrics] The following patch will enable the metrics endpoint.
-# Ensure that you also protect this endpoint.
+# [METRICS] The following patch will enable the metrics endpoint. Ensure that you also protect this endpoint.
+# More info: https://book.kubebuilder.io/reference/metrics
+# If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 ```
 
 Note that projects are scaffolded by default passing the flag `--metrics-bind-address=0`

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -76,6 +76,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/manager_metrics_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/manager_metrics_patch.go
@@ -43,16 +43,7 @@ func (f *ManagerMetricsPatch) SetTemplateDefaults() error {
 }
 
 const kustomizeMetricsPatchTemplate = `# This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080
 `

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -109,7 +109,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: {{ .Image }}
         name: manager
         securityContext:

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/main.go
@@ -222,7 +222,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. " +
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. " +

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -65,7 +65,7 @@ func GenerateV4(kbc *utils.TestContext) {
 		"#- path: webhookcainjection_patch.yaml", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
-		"#- path: manager_metrics_patch.yaml", "#")).To(Succeed())
+		metricsTarget, "#")).To(Succeed())
 
 	ExpectWithOffset(1, pluginutil.UncommentCode(filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		certManagerTarget, "#")).To(Succeed())
@@ -125,7 +125,7 @@ func GenerateV4WithoutWebhooks(kbc *utils.TestContext) {
 		"#- ../prometheus", "#")).To(Succeed())
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
-		"#- path: manager_metrics_patch.yaml", "#")).To(Succeed())
+		metricsTarget, "#")).To(Succeed())
 
 	if kbc.IsRestricted {
 		By("uncomment kustomize files to ensure that pods are restricted")
@@ -165,6 +165,10 @@ func initingTheProject(kbc *utils.TestContext) {
 	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 }
+
+const metricsTarget = `#- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment`
 
 //nolint:lll
 const certManagerTarget = `#replacements:

--- a/testdata/project-v4-multigroup-with-deploy-image/cmd/main.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/cmd/main.go
@@ -82,7 +82,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/testdata/project-v4-multigroup-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
@@ -1531,7 +1531,6 @@ spec:
       - args:
         - --leader-elect
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=0
         command:
         - /manager
         image: controller:latest

--- a/testdata/project-v4-multigroup/cmd/main.go
+++ b/testdata/project-v4-multigroup/cmd/main.go
@@ -82,7 +82,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/testdata/project-v4-multigroup/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -1531,7 +1531,6 @@ spec:
       - args:
         - --leader-elect
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=0
         command:
         - /manager
         image: controller:latest

--- a/testdata/project-v4-with-deploy-image/cmd/main.go
+++ b/testdata/project-v4-with-deploy-image/cmd/main.go
@@ -57,7 +57,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/testdata/project-v4-with-deploy-image/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
+++ b/testdata/project-v4-with-deploy-image/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         env:

--- a/testdata/project-v4-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-with-deploy-image/dist/install.yaml
@@ -607,7 +607,6 @@ spec:
       - args:
         - --leader-elect
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=0
         command:
         - /manager
         env:

--- a/testdata/project-v4-with-grafana/cmd/main.go
+++ b/testdata/project-v4-with-grafana/cmd/main.go
@@ -53,7 +53,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/testdata/project-v4-with-grafana/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-grafana/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/testdata/project-v4-with-grafana/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-with-grafana/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/testdata/project-v4-with-grafana/config/manager/manager.yaml
+++ b/testdata/project-v4-with-grafana/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4-with-grafana/dist/install.yaml
+++ b/testdata/project-v4-with-grafana/dist/install.yaml
@@ -150,7 +150,6 @@ spec:
       - args:
         - --leader-elect
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=0
         command:
         - /manager
         image: controller:latest

--- a/testdata/project-v4/cmd/main.go
+++ b/testdata/project-v4/cmd/main.go
@@ -57,7 +57,8 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
+		"Use the port :8080. If not set, it will be '0 in order to disable the metrics server")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -31,6 +31,8 @@ patches:
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
 #- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/testdata/project-v4/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4/config/default/manager_metrics_patch.yaml
@@ -1,13 +1,4 @@
 # This patch adds the args to allow exposing the metrics endpoint securely
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --metrics-bind-address=:8080

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -63,7 +63,6 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-          - --metrics-bind-address=0
         image: controller:latest
         name: manager
         securityContext:

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -601,7 +601,6 @@ spec:
       - args:
         - --leader-elect
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=0
         command:
         - /manager
         image: controller:latest


### PR DESCRIPTION
Ensure that enabling the manager_metrics_patch.yaml in config/default/kustomization.yaml does not overwrite existing arguments in config/manager/manager.yaml. The patch now appends the --metrics-bind-address argument without replacing other arguments.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3934

