### PR TITLE
 🐛 ( cherry-pick to backport to v3 ) - fix: preserve existing flags when applying metrics patch 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_metrics_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"

--- a/docs/book/src/getting-started/testdata/project/config/default/manager_metrics_patch.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/enable_matrics_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/enable_matrics_patch.go
@@ -55,5 +55,10 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"
 `

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"

--- a/testdata/project-v4-multigroup/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"

--- a/testdata/project-v4-with-deploy-image/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"

--- a/testdata/project-v4-with-grafana/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4-with-grafana/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"

--- a/testdata/project-v4/config/default/manager_metrics_patch.yaml
+++ b/testdata/project-v4/config/default/manager_metrics_patch.yaml
@@ -10,4 +10,9 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-bind-address=0.0.0.0:8080"
+          # Ensure that the the patch has the args
+          # provided in the config/manager/manager.yaml
+          # More info: https://github.com/kubernetes-sigs/kubebuilder/issues/3934
+          - "--metrics-bind-address=0.0.0.0:8080"
+          - "--leader-elect"
+          - "--health-probe-bind-address=:8081"


### PR DESCRIPTION
See: https://github.com/kubernetes-sigs/kubebuilder/pull/3937
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3934