### PR TITLE
:sparkles: Add revive golangci linter with comment-spacings rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,7 @@ linters-settings:
       #
       - name: bool-literal-in-expr
       - name: constant-logical-expr
+      - name: comment-spacings
 
 linters:
   disable-all: true

--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -35,7 +35,7 @@ var alphaCommands = []*cobra.Command{
 
 func newAlphaCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		//TODO: If we need to create alpha commands please add a new file for each command
+		// TODO: If we need to create alpha commands please add a new file for each command
 	}
 	return cmd
 }

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -78,9 +78,15 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings
 `

--- a/pkg/rescaffold/migrate.go
+++ b/pkg/rescaffold/migrate.go
@@ -330,7 +330,7 @@ func copyFile(src, des string) error {
 	if err != nil {
 		return fmt.Errorf("Source file path: %s does not exist. %v", src, err)
 	}
-	//Copy all the contents to the desitination file
+	// Copy all the contents to the desitination file
 	// nolint:gosec
 	return os.WriteFile(des, bytesRead, 0755)
 }

--- a/testdata/project-v4-multigroup-with-deploy-image/.golangci.yml
+++ b/testdata/project-v4-multigroup-with-deploy-image/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/testdata/project-v4-with-deploy-image/.golangci.yml
+++ b/testdata/project-v4-with-deploy-image/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/testdata/project-v4-with-grafana/.golangci.yml
+++ b/testdata/project-v4-with-grafana/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -34,8 +34,14 @@ linters:
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - typecheck
     - unconvert
     - unparam
     - unused
+
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings


### PR DESCRIPTION
## Why changes were made

Follow up PR as discussed here https://github.com/kubernetes-sigs/kubebuilder/pull/3904#issuecomment-2119929172

## How changes were made

Added rule to check comment spaces in revive linter, in golangci-lint config files; fixed comments spaces; and then run `make generate`.

## How to test changes made

Check that all Go files now enforce comment spaces.