### PR TITLE
:bug: fix generate command not respecting --namespaced=false of APIs

### DIFF
--- a/pkg/rescaffold/migrate.go
+++ b/pkg/rescaffold/migrate.go
@@ -287,6 +287,8 @@ func getAPIResourceFlags(resource resource.Resource) []string {
 		args = append(args, "--resource")
 		if resource.API.Namespaced {
 			args = append(args, "--namespaced")
+		} else {
+			args = append(args, "--namespaced=false")
 		}
 	}
 

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -123,6 +123,17 @@ func ReGenerateProject(kbc *utils.TestContext) {
 	)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
+	By("create APIs non namespaced with resource and controller")
+	err = kbc.CreateAPI(
+		"--group", "crew",
+		"--version", "v1",
+		"--kind", "Admiral",
+		"--namespaced=false",
+		"--resource",
+		"--controller",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
 	By("create APIs with deploy-image plugin")
 	err = kbc.CreateAPI(
 		"--group", "crew",
@@ -209,6 +220,18 @@ func ReGenerateProject(kbc *utils.TestContext) {
 		filepath.Join(kbc.Dir, "testdir2", "PROJECT"), webhook)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	ExpectWithOffset(1, fileContainsExpr).To(BeTrue())
+
+	By("checking if the project file was generated without namespace: true")
+	var nonNamespacedFields = fmt.Sprintf(`api:
+    crdVersion: v1
+  controller: true
+  domain: %s
+  group: crew
+  kind: Admiral`, kbc.Domain)
+	fileContainsExpr, err = pluginutil.HasFileContentWith(
+		filepath.Join(kbc.Dir, "testdir2", "PROJECT"), nonNamespacedFields)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	Expect(fileContainsExpr).To(BeTrue())
 
 	By("checking if the project file was generated with the expected deploy-image plugin fields")
 	var deployImagePlugin = "deploy-image.go.kubebuilder.io/v1-alpha"


### PR DESCRIPTION
Change the getAPIResourceFlags function to return `--namespaced=false` if resource.API.Namespaced and add corresponding test.
This is needed since currently `kubebuilder alpha migrate` always create namespaced APIs due to the default of namespaced being true.

Fixes #3969