### PR TITLE
:book: bugfix: fix error in documentation Watching Externally Managed Resources

### DIFF
--- a/docs/book/src/reference/watching-resources/testdata/external-indexed-field/controller.go
+++ b/docs/book/src/reference/watching-resources/testdata/external-indexed-field/controller.go
@@ -169,7 +169,7 @@ func (r *ConfigDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&appsv1.ConfigDeployment{}).
 		Owns(&kapps.Deployment{}).
 		Watches(
-			&source.Kind{Type: &corev1.ConfigMap{}},
+			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForConfigMap),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).


### PR DESCRIPTION
I saw incorrect code in the documentation for
https://kubebuilder.io/reference/watching-resources/externally-managed
The provided code is not working
```
        Watches(
            &source.Kind{Type: &corev1.ConfigMap{}},
            handler.EnqueueRequestsFromMapFunc(r.findObjectsForConfigMap),
            builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
        ).

```

i am getting an error

`source.Kind (value of type func[T client.Object](cache "sigs.k8s.io/controller-runtime/pkg/cache".Cache, object T, handler handler.TypedEventHandler[T], predicates ...predicate.TypedPredicate[T]) source.SyncingSource) is not a type`

Should be

```
        Watches(
            &corev1.ConfigMap{},
            handler.EnqueueRequestsFromMapFunc(r.findObjectsForConfigMap),
            builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
        ).
```

this is [issue ](https://github.com/kubernetes-sigs/kubebuilder/issues/3583) closed but not full fixed 

- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation