### PR TITLE
🌱 ci: fix testdata due golang module changes

### DIFF
--- a/.github/workflows/testdata.yml
+++ b/.github/workflows/testdata.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version: '1.22.3'
       - name: Remove pre-installed kustomize
         # This step is needed as the following one tries to remove
         # kustomize for each test but has no permission to do so


### PR DESCRIPTION
See that how Golang works now we are facing changes in the files and testdata will fail every time that a new patch release be made se we need to add a fix version to the git hub action to avoid it. 