### PR TITLE
🐛  fix validation used to ensure Kind versions pattern

### DIFF
--- a/pkg/model/resource/gvk_test.go
+++ b/pkg/model/resource/gvk_test.go
@@ -25,18 +25,21 @@ import (
 
 var _ = Describe("GVK", func() {
 	const (
-		group   = "group"
-		domain  = "my.domain"
-		version = "v1"
-		kind    = "Kind"
+		group           = "group"
+		domain          = "my.domain"
+		version         = "v1"
+		kind            = "Kind"
+		internalVersion = "__internal"
 	)
 
 	gvk := GVK{Group: group, Domain: domain, Version: version, Kind: kind}
 
 	Context("Validate", func() {
-		It("should succeed for a valid GVK", func() {
-			Expect(gvk.Validate()).To(Succeed())
-		})
+		DescribeTable("should pass valid GVKs",
+			func(gvk GVK) { Expect(gvk.Validate()).To(Succeed()) },
+			Entry("Standard GVK", gvk),
+			Entry("Version (__internal)", GVK{Group: group, Domain: domain, Version: internalVersion, Kind: kind}),
+		)
 
 		DescribeTable("should fail for invalid GVKs",
 			func(gvk GVK) { Expect(gvk.Validate()).NotTo(Succeed()) },
@@ -47,13 +50,11 @@ var _ = Describe("GVK", func() {
 			Entry("Domain (non-alpha characters)", GVK{Group: group, Domain: "_*?", Version: version, Kind: kind}),
 			Entry("Group and Domain (empty)", GVK{Group: "", Domain: "", Version: version, Kind: kind}),
 			Entry("Version (empty)", GVK{Group: group, Domain: domain, Version: "", Kind: kind}),
-			Entry("Version (no v prefix)", GVK{Group: group, Domain: domain, Version: "1", Kind: kind}),
-			Entry("Version (wrong prefix)", GVK{Group: group, Domain: domain, Version: "a1", Kind: kind}),
-			Entry("Version (unstable no v prefix)", GVK{Group: group, Domain: domain, Version: "1beta1", Kind: kind}),
-			Entry("Version (unstable no alpha/beta number)",
-				GVK{Group: group, Domain: domain, Version: "v1beta", Kind: kind}),
-			Entry("Version (multiple unstable)",
-				GVK{Group: group, Domain: domain, Version: "v1beta1alpha1", Kind: kind}),
+			Entry("Version (wrong prefix)", GVK{Group: group, Domain: domain, Version: "-example.com", Kind: kind}),
+			Entry("Version (wrong suffix)", GVK{Group: group, Domain: domain, Version: "example.com-", Kind: kind}),
+			Entry("Version (uppercase)", GVK{Group: group, Domain: domain, Version: "Example.com", Kind: kind}),
+			Entry("Version (special characters)", GVK{Group: group, Domain: domain, Version: "example!domain.com", Kind: kind}),
+			Entry("Version (consecutive dots)", GVK{Group: group, Domain: domain, Version: "example..com", Kind: kind}),
 			Entry("Kind (empty)", GVK{Group: group, Domain: domain, Version: version, Kind: ""}),
 			Entry("Kind (whitespaces)", GVK{Group: group, Domain: domain, Version: version, Kind: "Ki nd"}),
 			Entry("Kind (lowercase)", GVK{Group: group, Domain: domain, Version: version, Kind: "kind"}),


### PR DESCRIPTION
### Description

Refactor the version validation to allow version values follow:
- Either literal string `__internal`
- OR DNS-1123

### Motivation

Resolve https://github.com/kubernetes-sigs/kubebuilder/issues/3739