### PR TITLE
✨ Update Makefile and Enhance `test-e2e`

### DIFF
--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -110,6 +110,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: {{ .Image }}
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -140,9 +140,9 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	@echo "Check for kubernetes version $(K8S_VERSION_TRIMMED_V) in $(ENVTEST)"
-	@$(ENVTEST) list | grep -q $(K8S_VERSION_TRIMMED_V)
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(K8S_VERSION_TRIMMED_V) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(K8S_VERSION_TRIMMED_V) --bin-dir $(LOCALBIN) -p path)" && \
+		test $? && \
+		go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -221,21 +221,21 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete -n $(NAMESPACE) --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --namespace $(NAMESPACE) --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) -n $(NAMESPACE) apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) --namespace $(NAMESPACE) apply -f -
 	$(KUBECTL) wait deployment.apps/{{ .ProjectName }}-controller-manager --for condition=Available --namespace $(NAMESPACE) --timeout 5m
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete -n $(NAMESPACE) --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --namespace $(NAMESPACE) --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: redeploy
 redeploy: deploy ## Redeploy controller with new docker image.
-	$(KUBECTL) rollout restart -n $(NAMESPACE) deploy/{{ .ProjectName }}-controller-manager
+	$(KUBECTL) rollout restart --namespace $(NAMESPACE) deploy/{{ .ProjectName }}-controller-manager
 
 .PHONY: kind-load
 kind-load: docker-build kind ## Build and upload docker image to the local Kind cluster.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -73,10 +73,11 @@ func (f *Makefile) SetTemplateDefaults() error {
 //nolint:lll
 const makefileTemplate = `# Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
-# K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-# It also refers to the version of Kubernetes that is deployed by Kind.
-K8S_VERSION = v1.30.0
-K8S_VERSION_TRIMMED_V = $(subst v,,$(K8S_VERSION))
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+ENVTEST_K8S_VERSION = 1.30.0
+
+# KIND_K8S_VERSION refers to the version of Kubernetes that is deployed by Kind.
+KIND_K8S_VERSION = v1.30.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -140,7 +141,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(K8S_VERSION_TRIMMED_V) --bin-dir $(LOCALBIN) -p path)" && \
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" && \
 		test $? && \
 		go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
@@ -205,7 +206,7 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 
 KIND_CLUSTER_NAME ?= {{ .ProjectName }}-kind
 NAMESPACE ?= {{ .ProjectName }}-system
-KIND_IMAGE ?= kindest/node:$(K8S_VERSION)
+KIND_IMAGE ?= kindest/node:$(KIND_K8S_VERSION)
 
 PROMETHEUS_OPERATOR_VERSION = v0.74.0
 CERT_MANAGER_VERSION = v1.15.0

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -141,9 +141,9 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" && \
-		test $? && \
-		go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)"; \
+	test -d "$$KUBEBUILDER_ASSETS"; \
+	go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -129,7 +129,7 @@ var _ = Describe("controller", Ordered, func() {
 			localPortStr := strconv.Itoa(localPort)
 
 			// Call the function to run port forward
-			err = utils.RunPortForward(config, namespace, pods.Items[0].Name, []string{fmt.Sprintf("%s:8081", localPortStr)}, stopCh, readyCh)
+			err = utils.RunPortForward(kubeconfig, namespace, pods.Items[0].Name, []string{fmt.Sprintf("%s:8081", localPortStr)}, stopCh, readyCh)
 			if err != nil {
 				panic(err.Error())
 			}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -87,8 +87,8 @@ var _ = Describe("controller", Ordered, func() {
 
 	AfterAll(func() {
 		var err error
-		By("delete kind environment", func() {
-			cmd := exec.Command("make", "kind-delete")
+		By("cleanup", func() {
+			cmd := exec.Command("make", "undeploy")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		})

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -65,14 +65,20 @@ const deploymentName = "{{ .ProjectName }}-controller-manager"
 var _ = Describe("controller", Ordered, func() {
 	BeforeAll(func() {
 		var err error
-		By("prepare kind environment", func() {
-			cmd := exec.Command("make", "kind-prepare")
+		By("create kind environment", func() {
+			cmd := exec.Command("make", "kind-create")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		})
 
 		By("upload latest image to kind cluster", func() {
 			cmd := exec.Command("make", "kind-load")
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		})
+
+		By("prepare k8s", func() {
+			cmd := exec.Command("make", "k8s-prepare")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		})

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -48,6 +48,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strconv"
 	"time"
 
@@ -102,8 +103,8 @@ var _ = Describe("controller", Ordered, func() {
 
 	Context("Operator", func() {
 		It("should run successfully", func() {
-			config, err := utils.GetConfig()
-			clientset, err := utils.GetClientset(config)
+			kubeconfig := config.GetConfigOrDie()
+			clientset, err := utils.GetClientset(kubeconfig)
 
 			deployment, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 			if err != nil {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -46,14 +46,15 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/go-resty/resty/v2"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"os/exec"
 	"strconv"
 	"time"
+
+	"github.com/go-resty/resty/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"{{ .Repo }}/test/utils"
 )

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -43,22 +43,19 @@ package utils
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
-	"k8s.io/client-go/util/homedir"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 )
 
 // Run executes the provided command within this context
@@ -89,23 +86,6 @@ func GetProjectDir() (string, error) {
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
-}
-
-// GetConfig retrieves the Kubernetes configuration file.
-func GetConfig() (*rest.Config, error) {
-	var kubeconfig *string
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-	flag.Parse()
-
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
-	if err != nil {
-		panic(err)
-	}
-	return config, nil
 }
 
 // GetClientset returns a kubernetes Clientset.


### PR DESCRIPTION
This PR includes the following changes:

1. **Makefile Updates:**
   - Introduce `kind` and `yq` as tools to the Makefile for better management and automation
   - Create `kind-*` targets that helpful during development process

2. **`test-e2e` Rework:**
   - Enhance the `test-e2e` target by extending its functionality. Instead of just building and uploading the image to the cluster, it now includes a call to the readiness endpoint of the operator-controller as part of the tests.

---

This update improves our testing process by ensuring that the operator-controller is fully ready and operational after deployment.