### PR TITLE
:sparkles: (Only valid for those who consume Kubebuilder as a lib) - Allow usage of custom marker names

### DIFF
--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-const prefix = "+kubebuilder:scaffold:"
+const kbPrefix = "+kubebuilder:scaffold:"
 
 var commentsByExt = map[string]string{
 	".go":   "//",
@@ -33,16 +33,28 @@ var commentsByExt = map[string]string{
 
 // Marker represents a machine-readable comment that will be used for scaffolding purposes
 type Marker struct {
+	prefix  string
 	comment string
 	value   string
 }
 
-// NewMarkerFor creates a new marker customized for the specific file
-// Supported file extensions: .go, .yaml, .yml
+// NewMarkerFor creates a new marker customized for the specific file. The created marker
+// is prefixed with `+kubebuilder:scaffold:` the default prefix for kubebuilder.
+// Supported file extensions: .go, .yaml, .yml.
 func NewMarkerFor(path string, value string) Marker {
+	return NewMarkerWithPrefixFor(kbPrefix, path, value)
+}
+
+// NewMarkerWithPrefixFor creates a new custom prefixed marker customized for the specific file
+// Supported file extensions: .go, .yaml, .yml
+func NewMarkerWithPrefixFor(prefix string, path string, value string) Marker {
 	ext := filepath.Ext(path)
 	if comment, found := commentsByExt[ext]; found {
-		return Marker{comment, value}
+		return Marker{
+			prefix:  markerPrefix(prefix),
+			comment: comment,
+			value:   value,
+		}
 	}
 
 	extensions := make([]string, 0, len(commentsByExt))
@@ -54,13 +66,13 @@ func NewMarkerFor(path string, value string) Marker {
 
 // String implements Stringer
 func (m Marker) String() string {
-	return m.comment + " " + prefix + m.value
+	return m.comment + " " + m.prefix + m.value
 }
 
 // EqualsLine compares a marker with a string representation to check if they are the same marker
 func (m Marker) EqualsLine(line string) bool {
 	line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), m.comment))
-	return line == prefix+m.value
+	return line == m.prefix+m.value
 }
 
 // CodeFragments represents a set of code fragments
@@ -69,3 +81,17 @@ type CodeFragments []string
 
 // CodeFragmentsMap binds Markers and CodeFragments together
 type CodeFragmentsMap map[Marker]CodeFragments
+
+func markerPrefix(prefix string) string {
+	trimmed := strings.TrimSpace(prefix)
+	var builder strings.Builder
+	if !strings.HasPrefix(trimmed, "+") {
+		builder.WriteString("+")
+	}
+	builder.WriteString(trimmed)
+	if !strings.HasSuffix(trimmed, ":") {
+		builder.WriteString(":")
+	}
+
+	return builder.String()
+}

--- a/pkg/machinery/marker_test.go
+++ b/pkg/machinery/marker_test.go
@@ -39,8 +39,47 @@ var _ = Describe("Marker", func() {
 	Context("String", func() {
 		DescribeTable("should return the right string representation",
 			func(marker Marker, str string) { Expect(marker.String()).To(Equal(str)) },
-			Entry("for go files", Marker{comment: "//", value: "test"}, "// +kubebuilder:scaffold:test"),
-			Entry("for yaml files", Marker{comment: "#", value: "test"}, "# +kubebuilder:scaffold:test"),
+			Entry("for go files", Marker{prefix: kbPrefix, comment: "//", value: "test"}, "// +kubebuilder:scaffold:test"),
+			Entry("for yaml files", Marker{prefix: kbPrefix, comment: "#", value: "test"}, "# +kubebuilder:scaffold:test"),
+		)
+	})
+})
+
+var _ = Describe("NewMarkerFor", func() {
+	Context("String", func() {
+		DescribeTable("should return the right string representation",
+			func(marker Marker, str string) { Expect(marker.String()).To(Equal(str)) },
+			Entry("for yaml files", NewMarkerFor("test.yaml", "test"), "# +kubebuilder:scaffold:test"),
+		)
+	})
+})
+
+var _ = Describe("NewMarkerWithPrefixFor", func() {
+	Context("String", func() {
+		DescribeTable("should return the right string representation",
+			func(marker Marker, str string) { Expect(marker.String()).To(Equal(str)) },
+
+			Entry("for yaml files",
+				NewMarkerWithPrefixFor("custom:scaffold", "test.yaml", "test"), "# +custom:scaffold:test"),
+			Entry("for yaml files",
+				NewMarkerWithPrefixFor("+custom:scaffold", "test.yaml", "test"), "# +custom:scaffold:test"),
+			Entry("for yaml files",
+				NewMarkerWithPrefixFor("custom:scaffold:", "test.yaml", "test"), "# +custom:scaffold:test"),
+			Entry("for yaml files",
+				NewMarkerWithPrefixFor("+custom:scaffold:", "test.yaml", "test"), "# +custom:scaffold:test"),
+			Entry("for yaml files",
+				NewMarkerWithPrefixFor(" +custom:scaffold: ", "test.yaml", "test"), "# +custom:scaffold:test"),
+
+			Entry("for go files",
+				NewMarkerWithPrefixFor("custom:scaffold", "test.go", "test"), "// +custom:scaffold:test"),
+			Entry("for go files",
+				NewMarkerWithPrefixFor("+custom:scaffold", "test.go", "test"), "// +custom:scaffold:test"),
+			Entry("for go files",
+				NewMarkerWithPrefixFor("custom:scaffold:", "test.go", "test"), "// +custom:scaffold:test"),
+			Entry("for go files",
+				NewMarkerWithPrefixFor("+custom:scaffold:", "test.go", "test"), "// +custom:scaffold:test"),
+			Entry("for go files",
+				NewMarkerWithPrefixFor(" +custom:scaffold: ", "test.go", "test"), "// +custom:scaffold:test"),
 		)
 	})
 })


### PR DESCRIPTION
This PR adds a code implementation which allow Kubebuilder lib consumes use custom names for the markers
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3990
