### PR TITLE
📖 Upgrade controller-gen used to generated the docs and remove redirects for artefact images 

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -71,7 +71,7 @@ chmod +x /tmp/mdbook
 
 echo "grabbing the latest released controller-gen"
 go version
-go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.12.1
+go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
 
 # make sure we add the go bin directory to our path
 gobin=$(go env GOBIN)

--- a/docs/book/src/reference/artifacts.md
+++ b/docs/book/src/reference/artifacts.md
@@ -1,16 +1,44 @@
 # Artifacts
 
+# Artifacts
+
+<aside class="note warning">
+<h1>IMPORTANT: Kubebuilder no longer produces artifacts</h1>
+
+Kubebuilder has been building those artifacts binaries to allow users
+to use the [ENV TEST][env-test-doc] functionality provided by [controller-runtime][controller-runtime]
+for several years. However, Google Cloud Platform has [deprecated the Container Registry](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr),
+which has been used to build and promote these binaries tarballs.
+
+Additionally, ongoing changes and the phase-out of the previous GCP infrastructure mean
+that **Kubebuilder maintainers are no longer able to build or ensure the promotion of these binaries.**
+
+Therefore, since those have been building to allow the controller-runtime
+[ENV TEST][env-test-doc] library to work, it has been started to be built by [controller-runtime][controller-runtime] itself
+under the [controller-gen releases page][controller-gen]. From [controller-runtime][controller-runtime]
+release `v0.19.0` the binaries will begin to be pulled out from this page instead.
+For more information, see the PR that introduces this change [here](https://github.com/kubernetes-sigs/controller-runtime/pull/2811).
+
+</aside>
+
+
 Kubebuilder publishes test binaries and container images in addition
 to the main binary releases.
 
-## Test Binaries
+## **(Deprecated)** - Test Binaries (Used by ENV TEST)
 
 You can find test binary tarballs for all Kubernetes versions and host platforms at `https://go.kubebuilder.io/test-tools`.
 You can find a test binary tarball for a particular Kubernetes version and host platform at `https://go.kubebuilder.io/test-tools/${version}/${os}/${arch}`.
 
-## Container Images
+<aside class="note">
+<h1>Setup ENV TEST tool</h1>
+To know more about the tooling used to configure ENVTEST which is used in the setup-envtest target in the Makefile
+of the projects build with Kubebuilder see the [README][readme]
+of its tooling.
+</aside>
 
-You can find all container image versions for a particular platform at `https://go.kubebuilder.io/images/${os}/${arch}`
-or at `gcr.io/kubebuilder/thirdparty-${os}-${arch}`.
-You can find the container image for a particular Kubernetes version and host platform at `https://go.kubebuilder.io/images/${os}/${arch}/${version}`
-or at `gcr.io/kubebuilder/thirdparty-${os}-${arch}:${version}`.
+
+[env-test-doc]: ./envtest.md
+[controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
+[controller-gen]: https://github.com/kubernetes-sigs/controller-tools/releases
+[readme]: https://github.com/kubernetes-sigs/controller-runtime/blob/main/tools/setup-envtest/README.md

--- a/docs/book/src/reference/envtest.md
+++ b/docs/book/src/reference/envtest.md
@@ -318,9 +318,17 @@ testEnv = &envtest.Environment{
 }
 ```
 
+<aside class="note">
+<h1>Setup ENV TEST tool</h1>
+To know more about the tooling used to configure ENVTEST which is used in the setup-envtest target in the Makefile
+of the projects build with Kubebuilder see the [README][readme]
+of its tooling.
+</aside>
+
 [metrics]: https://book.kubebuilder.io/reference/metrics.html
 [envtest]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest
 [setup-envtest]: https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest
 [cert-manager]: https://book.kubebuilder.io/cronjob-tutorial/cert-manager.html
 [sdk-e2e-sample-example]: https://github.com/operator-framework/operator-sdk/tree/master/testdata/go/v4/memcached-operator/test/e2e
 [sdk]: https://github.com/operator-framework/operator-sdk
+[readme]: https://github.com/kubernetes-sigs/controller-runtime/blob/main/tools/setup-envtest/README.md

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
     base = "docs/book"
-    command = "GO_VERSION=1.20 ./install-and-build.sh"
+    command = "GO_VERSION=1.22.0 ./install-and-build.sh"
     publish = "docs/book/book"
     functions = "docs/book/functions"
 
@@ -118,31 +118,6 @@
 [[redirects]]
     from = "https://go.kubebuilder.io/test-tools/:k8sversion/:os/:arch"
     to = "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-:k8sversion-:os-:arch.tar.gz"
-    status = 302
-    force = true
-
-# Image redirects.
-[[redirects]]
-    from = "https://go.kubebuilder.io/images"
-    to = "gcr.io/kubebuilder"
-    status = 302
-    force = true
-
-[[redirects]]
-    from = "https://go.kubebuilder.io/images/:os"
-    to = "https://go.kubebuilder.io/images/:os/amd64"
-    status = 302
-    force = true
-
-[[redirects]]
-    from = "https://go.kubebuilder.io/images/:os/:arch"
-    to = "gcr.io/kubebuilder/thirdparty-:os-:arch"
-    status = 302
-    force = true
-
-[[redirects]]
-    from = "https://go.kubebuilder.io/images/:os/:arch/:k8sversion"
-    to = "gcr.io/kubebuilder/thirdparty-:os-:arch::k8sversion"
     status = 302
     force = true
 


### PR DESCRIPTION
This PR update the deps used to generate the data in the docs.
It should update the markers to address https://github.com/kubernetes-sigs/kubebuilder/issues/4009

Furthermore, for we are able to move forward here we need to remove the redirect for `https://go.kubebuilder.io/images` and `gcr.io/kubebuilder/thirdparty` which are deprecated and/or no longer used.

We are either adding a note in the in the Artefacts page to clarify that ENV TEST binaries are no longer produced by Kubebuilder and its build and promotion was moved to controller-gen. 

Close: https://github.com/kubernetes-sigs/kubebuilder/issues/4009