### PR TITLE
:sparkles: (Only relevant for users of Kubebuilder as a library) - Add new cli option and allow access to underlying cli command

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -462,3 +462,8 @@ func (c CLI) metadata() plugin.CLIMetadata {
 func (c CLI) Run() error {
 	return c.cmd.Execute()
 }
+
+// Command returns the underlying root command.
+func (c CLI) Command() *cobra.Command {
+	return c.cmd
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -600,5 +600,14 @@ plugins:
 					fmt.Sprintf(noticeColor, fmt.Sprintf(deprecationFmt, deprecationWarning))))
 			})
 		})
+
+		When("new succeeds", func() {
+			It("should return the underlying command", func() {
+				c, err = New()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.Command()).NotTo(BeNil())
+				Expect(c.Command()).To(Equal(c.cmd))
+			})
+		})
 	})
 })

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -31,6 +31,7 @@ import (
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/external"
 )
@@ -148,6 +149,18 @@ func WithExtraAlphaCommands(cmds ...*cobra.Command) Option {
 func WithCompletion() Option {
 	return func(c *CLI) error {
 		c.completionCommand = true
+		return nil
+	}
+}
+
+// WithFilesystem is an Option that allows to set the filesystem used in the CLI.
+func WithFilesystem(fs machinery.Filesystem) Option {
+	return func(c *CLI) error {
+		if fs.FS == nil {
+			return errors.New("invalid filesystem")
+		}
+
+		c.fs = fs
 		return nil
 	}
 }

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -717,4 +717,27 @@ var _ = Describe("CLI options", func() {
 			Expect(c.completionCommand).To(BeTrue())
 		})
 	})
+
+	Context("WithFilesystem", func() {
+		When("providing a valid filesystem", func() {
+			It("should use the provided filesystem", func() {
+				fs := machinery.Filesystem{
+					FS: afero.NewMemMapFs(),
+				}
+				c, err = newCLI(WithFilesystem(fs))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c).NotTo(BeNil())
+				Expect(c.fs).To(Equal(fs))
+			})
+		})
+
+		When("providing a invalid filesystem", func() {
+			It("should return an error", func() {
+				fs := machinery.Filesystem{}
+				c, err = newCLI(WithFilesystem(fs))
+				Expect(err).To(HaveOccurred())
+				Expect(c).To(BeNil())
+			})
+		})
+	})
 })


### PR DESCRIPTION
This PR introduces a new CLI option WithFilesystem to set the filesystem when using kubebuilder as library. Furthermore, it allows access to the underlying cobra command. 

**Motivations**
Both features are introduced to improve testability when using kubebilder as lib. Accessing the underlying command allows to pass call arguments to in tests. 

For more information see #4006