### PR TITLE
📖 docs: correct typo in migration guide

### DIFF
--- a/docs/book/src/migration/migration_guide_gov3_to_gov4.md
+++ b/docs/book/src/migration/migration_guide_gov3_to_gov4.md
@@ -130,7 +130,7 @@ If there are any manual updates in `main.go` in v3, we need to port the changes 
 
 If there are additional manifests added under config directory, port them as well. Please, be aware that
 the new version go/v4 uses Kustomize v5x and no longer Kustomize v4. Therefore, if added customized
-implementations in the config you need to ensure that them can work with Kustomize v5 and/if not
+implementations in the config you need to ensure that they can work with Kustomize v5 and if not
 update/upgrade any breaking change that you might face.
 
 In v4, installation of Kustomize has been changed from bash script to `go get`. Change the `kustomize` dependency in Makefile to


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
### Summary
This PR will update the documentation to correct a typo that was found within the `migration_guide_gov3_to_gov4.md` doc.

Fixes #4014 

Please let me know if anything else needs to be correct. 😄 