### PR TITLE
📖 Update test examples not to set Status on create

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -163,9 +163,6 @@ var _ = Describe("CronJob controller", func() {
 						},
 					},
 				},
-				Status: batchv1.JobStatus{
-					Active: 2,
-				},
 			}
 
 			// Note that your CronJob’s GroupVersionKind is required to set up this owner reference.
@@ -175,6 +172,13 @@ var _ = Describe("CronJob controller", func() {
 			controllerRef := metav1.NewControllerRef(createdCronjob, gvk)
 			testJob.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
 			Expect(k8sClient.Create(ctx, testJob)).Should(Succeed())
+			// Note that you can not manage the status values while creating the resource. 
+			// The status field is managed separately to reflect the current state of the resource. 
+			// Therefore, it should be updated using a PATCH or PUT operation after the resource has been created.
+			// Additionally, it is recommended to use StatusConditions to manage the status. For further information see: 
+			// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+			testJob.Status.Active = 2
+			Expect(k8sClient.Status().Update(ctx, testJob)).Should(Succeed())
 			/*
 				Adding this Job to our test CronJob should trigger our controller’s reconciler logic.
 				After that, we can write a test that evaluates whether our controller eventually updates our CronJob’s Status field as expected!

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
@@ -182,9 +182,6 @@ var _ = Describe("CronJob controller", func() {
 						},
 					},
 				},
-				Status: batchv1.JobStatus{
-					Active: 2,
-				},
 			}
 
 			// Note that your CronJob’s GroupVersionKind is required to set up this owner reference.
@@ -194,6 +191,13 @@ var _ = Describe("CronJob controller", func() {
 			controllerRef := metav1.NewControllerRef(createdCronjob, gvk)
 			testJob.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
 			Expect(k8sClient.Create(ctx, testJob)).Should(Succeed())
+			// Note that you can not manage the status values while creating the resource. 
+			// The status field is managed separately to reflect the current state of the resource. 
+			// Therefore, it should be updated using a PATCH or PUT operation after the resource has been created.
+			// Additionally, it is recommended to use StatusConditions to manage the status. For further information see: 
+			// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+			testJob.Status.Active = 2
+			Expect(k8sClient.Status().Update(ctx, testJob)).Should(Succeed())
 			/*
 				Adding this Job to our test CronJob should trigger our controller’s reconciler logic.
 				After that, we can write a test that evaluates whether our controller eventually updates our CronJob’s Status field as expected!


### PR DESCRIPTION

Change the example tests not to attempt to set Status on Create. The kubernetes api will ignore the status field on creation, leaving it blank.  A new user trying to follow the book might be surprised to find their tests failing because of an empty status.

Instead the example will update the Status immediately after creation. 

Per conversation in the [slack](https://kubernetes.slack.com/archives/CAR30FCJZ/p1720657748942639) 

Related to #1778. Updates the book documentation to match the issue resolution. 