### PR TITLE
🐛 (kustomize/v2,go/v4): add missing labels for config/default/manager_webhook_patch.yaml

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_webhook_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_webhook_patch.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
 spec:
   template:
     spec:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
@@ -27,6 +27,7 @@ var _ machinery.Template = &ManagerWebhookPatch{}
 // ManagerWebhookPatch scaffolds a file that defines the patch that enables webhooks on the manager
 type ManagerWebhookPatch struct {
 	machinery.TemplateMixin
+	machinery.ProjectNameMixin
 
 	Force bool
 }
@@ -54,6 +55,9 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app.kubernetes.io/name: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
 spec:
   template:
     spec:

--- a/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/default/manager_webhook_patch.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
 spec:
   template:
     spec:

--- a/testdata/project-v4-multigroup/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/manager_webhook_patch.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
 spec:
   template:
     spec:

--- a/testdata/project-v4-with-deploy-image/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4-with-deploy-image/config/default/manager_webhook_patch.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app.kubernetes.io/name: project-v4-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
 spec:
   template:
     spec:

--- a/testdata/project-v4/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4/config/default/manager_webhook_patch.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  labels:
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
 spec:
   template:
     spec:


### PR DESCRIPTION
Just add the missing labels for this kustomize file in order to ensure the project standards. 