### PR TITLE
🌱 fix error faced during release process by ensuring dist directory is cleaned before running GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '~1.22'
+      - name: Clean dist directory
+        run: rm -rf dist || true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: v2.1.0
-          args: release -f ./build/.goreleaser.yml --rm-dist
+          args: release -f ./build/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload assets


### PR DESCRIPTION
Follow up of: Update release.yml - Update goreleaser from 1.11.2 to v2.1.0 by @camilamacedo86 in https://github.com/kubernetes-sigs/kubebuilder/pull/4031

Note that the `--rm-dist` flag in GoReleaser was used to remove the dist directory before starting the release process. This ensured that any old build artifacts from previous runs were deleted, providing a clean environment for the new release.

Address the issue faced in the release of 4.1.1: https://github.com/kubernetes-sigs/kubebuilder/actions/runs/10054025442/job/27787845571

