### PR TITLE
🌱 Upgrade goreleaser

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -16,6 +16,8 @@
 # Make sure to check the documentation at http://goreleaser.com
 
 # Global environment variables that are needed for hooks and builds.
+version: 2
+
 env:
   - GO111MODULE=on
 

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -47,7 +47,7 @@ builds:
       - darwin_amd64
       - darwin_arm64
     env:
-      - KUBERNETES_VERSION=1.27.1
+      - KUBERNETES_VERSION=1.30.0
       - CGO_ENABLED=0
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.


### PR DESCRIPTION
Follow up of: Update release.yml - Update goreleaser from 1.11.2 to v2.1.0 by @camilamacedo86 in https://github.com/kubernetes-sigs/kubebuilder/pull/4031

Address the warning: 
>   • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
See: https://github.com/kubernetes-sigs/kubebuilder/actions/runs/10054234782/job/27788445242

And update k8s version which was not the correct one
