### PR TITLE
🌱 Update release branch with minor fixes/upgrades in GoReleaser to accomplish the latest release - 4.1.1.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '~1.22'
+      - name: Clean dist directory
+        run: rm -rf dist || true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           version: v2.1.0
-          args: release -f ./build/.goreleaser.yml --rm-dist
+          args: release -f ./build/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload assets

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -16,6 +16,8 @@
 # Make sure to check the documentation at http://goreleaser.com
 
 # Global environment variables that are needed for hooks and builds.
+version: 2
+
 env:
   - GO111MODULE=on
 
@@ -45,7 +47,7 @@ builds:
       - darwin_amd64
       - darwin_arm64
     env:
-      - KUBERNETES_VERSION=1.27.1
+      - KUBERNETES_VERSION=1.30.0
       - CGO_ENABLED=0
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.


### PR DESCRIPTION
See the latest release: https://github.com/kubernetes-sigs/kubebuilder/actions/runs/10054397436/job/27788908893