### PR TITLE
📖  Fix generation of markers based on controller-tools 

### DIFF
--- a/docs/book/utils/markerdocs/html.go
+++ b/docs/book/utils/markerdocs/html.go
@@ -77,8 +77,7 @@ func (t Tag) WriteHTML(w io.Writer) error {
 	if t.Attrs != nil {
 		attrsOut = t.Attrs.ToAttrs()
 	}
-	if _, err := fmt.Fprintf((w, "<%s %s>", t.Name, attrsOut)
-	err != nil{
+	if _, err := fmt.Fprintf(w, "<%s %s>", t.Name, attrsOut); err != nil {
 		return err
 	}
 
@@ -88,8 +87,7 @@ func (t Tag) WriteHTML(w io.Writer) error {
 		}
 	}
 
-	if _, err := fmt.Fprintf((w, "</%s>", t.Name)
-	err != nil{
+	if _, err := fmt.Fprintf(w, "</%s>", t.Name); err != nil {
 		return err
 	}
 

--- a/docs/book/utils/markerdocs/main.go
+++ b/docs/book/utils/markerdocs/main.go
@@ -164,7 +164,7 @@ func (p MarkerDocs) Process(input *plugin.Input) error {
 		content := new(strings.Builder)
 
 		// NB(directxman12): wrap this in a div to prevent the markdown processor from inserting extra paragraphs
-		_, err := fmt.Fprintf((content, "<div><input checked type=\"checkbox\" class=\"markers-summarize\" id=\"markers-summarize-%[1]s\"></input><label class=\"markers-summarize\" for=\"markers-summarize-%[1]s\">Show Detailed Argument Help</label><dl class=\"markers\">", categoryAlias)
+		_, err := fmt.Fprintf(content, "<div><input checked type=\"checkbox\" class=\"markers-summarize\" id=\"markers-summarize-%[1]s\"></input><label class=\"markers-summarize\" for=\"markers-summarize-%[1]s\">Show Detailed Argument Help</label><dl class=\"markers\">", categoryAlias)
 		if err != nil {
 			return "", fmt.Errorf("unable to render marker documentation summary: %v", err)
 		}
@@ -176,8 +176,7 @@ func (p MarkerDocs) Process(input *plugin.Input) error {
 			}
 		}
 
-		if _, err = _, _ = fmt.Fprintf(content, "</dl></div>")
-		err != nil{
+		if _, err = fmt.Fprintf(content, "</dl></div>"); err != nil {
 			return "", fmt.Errorf("unable to render marker documentation: %v", err)
 		}
 


### PR DESCRIPTION
# Description:

This PR fixes the issue https://github.com/kubernetes-sigs/kubebuilder/issues/4044

## Fixes #4044

Due to changes in the commit: https://github.com/kubernetes-sigs/kubebuilder/commit/bf42d50683595602edd28d56549ee33ef2df30cb, the build for the markerdocs application was failing.

For future reference, the error is being ignored in the build part of markerdocs app. 
https://github.com/kubernetes-sigs/kubebuilder/blob/f97e8734409a804e831d9863e625b18cbb08862d/docs/book/markerdocs.sh#L23C3-L24C1

I wasn't sure if the script was supposed to be fixed or not as the build failure is ignored.

# Motivation:

The documentation for the CRD Generation screen in broken
<img width="861" alt="image" src="https://github.com/user-attachments/assets/2c18219d-ad8f-4989-87b0-8415d3f096cd">
