### PR TITLE
:book: Fix typo in designs template

### DIFF
--- a/designs/template.md
+++ b/designs/template.md
@@ -1,6 +1,6 @@
 | Authors       | Creation Date | Status      | Extra |
 |---------------|---------------|-------------|---|
-| @name | date | Implementeble | - |
+| @name | date | Implementable | - |
 
 Title of the Design/Proposal
 ===================


### PR DESCRIPTION
This patch fixes a typo inside designs template.
"Implementeble" should be replaced by "Implementable".

Signed-off-by: gabriele-wolfox <gabriele.wolfox@gmail.com>
