### PR TITLE
⚠️  (cleanup/fix): ImplementWebhooks method should only be used by the e2e tests and should be under its package

### DIFF
--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -218,60 +218,6 @@ func CommentCode(filename, target, prefix string) error {
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }
 
-// ImplementWebhooks will mock an webhook data
-func ImplementWebhooks(filename string) error {
-	// false positive
-	// nolint:gosec
-	bs, err := os.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-	str := string(bs)
-
-	str, err = EnsureExistAndReplace(
-		str,
-		"import (",
-		`import (
-	"errors"`)
-	if err != nil {
-		return err
-	}
-
-	// implement defaulting webhook logic
-	str, err = EnsureExistAndReplace(
-		str,
-		"// TODO(user): fill in your defaulting logic.",
-		`if r.Spec.Count == 0 {
-		r.Spec.Count = 5
-	}`)
-	if err != nil {
-		return err
-	}
-
-	// implement validation webhook logic
-	str, err = EnsureExistAndReplace(
-		str,
-		"// TODO(user): fill in your validation logic upon object creation.",
-		`if r.Spec.Count < 0 {
-		return nil, errors.New(".spec.count must >= 0")
-	}`)
-	if err != nil {
-		return err
-	}
-	str, err = EnsureExistAndReplace(
-		str,
-		"// TODO(user): fill in your validation logic upon object update.",
-		`if r.Spec.Count < 0 {
-		return nil, errors.New(".spec.count must >= 0")
-	}`)
-	if err != nil {
-		return err
-	}
-	// false positive
-	// nolint:gosec
-	return os.WriteFile(filename, []byte(str), 0644)
-}
-
 // EnsureExistAndReplace check if the content exists and then do the replace
 func EnsureExistAndReplace(input, match, replace string) (string, error) {
 	if !strings.Contains(input, match) {

--- a/test/e2e/utils/webhooks.go
+++ b/test/e2e/utils/webhooks.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"os"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+)
+
+// ImplementWebhooks will mock an webhook data
+func ImplementWebhooks(filename string) error {
+	// false positive
+	// nolint:gosec
+	bs, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	str := string(bs)
+
+	str, err = util.EnsureExistAndReplace(
+		str,
+		"import (",
+		`import (
+	"errors"`)
+	if err != nil {
+		return err
+	}
+
+	// implement defaulting webhook logic
+	str, err = util.EnsureExistAndReplace(
+		str,
+		"// TODO(user): fill in your defaulting logic.",
+		`if r.Spec.Count == 0 {
+		r.Spec.Count = 5
+	}`)
+	if err != nil {
+		return err
+	}
+
+	// implement validation webhook logic
+	str, err = util.EnsureExistAndReplace(
+		str,
+		"// TODO(user): fill in your validation logic upon object creation.",
+		`if r.Spec.Count < 0 {
+		return nil, errors.New(".spec.count must >= 0")
+	}`)
+	if err != nil {
+		return err
+	}
+	str, err = util.EnsureExistAndReplace(
+		str,
+		"// TODO(user): fill in your validation logic upon object update.",
+		`if r.Spec.Count < 0 {
+		return nil, errors.New(".spec.count must >= 0")
+	}`)
+	if err != nil {
+		return err
+	}
+	// false positive
+	// nolint:gosec
+	return os.WriteFile(filename, []byte(str), 0644)
+}

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -49,7 +49,7 @@ func GenerateV4(kbc *utils.TestContext) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("implementing the mutating and validating webhooks")
-	err = pluginutil.ImplementWebhooks(filepath.Join(
+	err = utils.ImplementWebhooks(filepath.Join(
 		kbc.Dir, "api", kbc.Version,
 		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind))))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -89,7 +89,7 @@ func GenerateV4WithoutMetrics(kbc *utils.TestContext) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("implementing the mutating and validating webhooks")
-	err = pluginutil.ImplementWebhooks(filepath.Join(
+	err = utils.ImplementWebhooks(filepath.Join(
 		kbc.Dir, "api", kbc.Version,
 		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind))))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -152,7 +152,7 @@ func GenerateV4WithNetworkPolicies(kbc *utils.TestContext) {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("implementing the mutating and validating webhooks")
-	err = pluginutil.ImplementWebhooks(filepath.Join(
+	err = utils.ImplementWebhooks(filepath.Join(
 		kbc.Dir, "api", kbc.Version,
 		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind))))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())


### PR DESCRIPTION
This code implementation is valid only for the e2e tests and is not an Plugin Utils that can be used for those who consumes Kuebebuilder as a lib and should in this way be under tests/e2e/