### PR TITLE
🌱 (cleanup): cleanup tests for plugin/util functions

### DIFF
--- a/pkg/plugin/util/suite_test.go
+++ b/pkg/plugin/util/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/plugin/util/testdata/exampleFile.txt
+++ b/pkg/plugin/util/testdata/exampleFile.txt
@@ -1,1 +1,0 @@
-exampleTarget

--- a/pkg/plugin/util/util_test.go
+++ b/pkg/plugin/util/util_test.go
@@ -23,16 +23,26 @@ import (
 
 var _ = Describe("InsertCode", Ordered, func() {
 	path := filepath.Join("testdata", "exampleFile.txt")
-	var originalContent []byte
+	var content []byte
 
 	BeforeAll(func() {
-		var err error
-		originalContent, err = os.ReadFile(path)
+		err := os.MkdirAll("testdata", 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			err = os.WriteFile(path, []byte("exampleTarget"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		content, err = os.ReadFile(path)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
-		err := os.WriteFile(path, originalContent, 0644)
+		err := os.WriteFile(path, content, 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.RemoveAll("testdata")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
Have a suite test for the plugin utils and remove the need to have the testdata dir scaffolded