### PR TITLE
✨ (go/v4): Added DevContainer support for seamless development in environments like GitHub Workspaces without local setup.

### DIFF
--- a/.github/workflows/test-devcontainer.yaml
+++ b/.github/workflows/test-devcontainer.yaml
@@ -1,0 +1,41 @@
+name: Test DevContainer Image
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-devcontainer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Go 1.22.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+
+      - name: Setup NodeJS 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Setup Devcontainer CLI
+        run: |
+          npm install -g @devcontainers/cli
+
+      - name: Build and Validate DevContainer
+        run: |
+          cd testdata/project-v4
+
+          OUTPUT=$(devcontainer up --workspace-folder=./)
+          STATUS=$(echo "$OUTPUT" | jq -r '.outcome')
+
+          if [[ "$STATUS" == "success" ]]; then
+            echo "Devcontainer setup was successful."
+            exit 0
+          else
+            echo "Devcontainer setup failed."
+            exit 1
+          fi

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -162,5 +162,7 @@ func (s *initScaffolder) Scaffold() error {
 		&e2e.Test{},
 		&e2e.SuiteTest{},
 		&utils.Utils{},
+		&templates.DevContainer{},
+		&templates.DevContainerPostInstallScript{},
 	)
 }

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+const devContainerTemplate = `{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+
+`
+
+const postInstallScript = `#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client
+`
+
+var _ machinery.Template = &DevContainer{}
+var _ machinery.Template = &DevContainerPostInstallScript{}
+
+// DevCotaniner scaffoldds a `devcontainer.json` configurations file for
+// creating Kubebuilder & Kind based DevContainer.
+type DevContainer struct {
+	machinery.TemplateMixin
+}
+
+type DevContainerPostInstallScript struct {
+	machinery.TemplateMixin
+}
+
+func (f *DevContainer) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = ".devcontainer/devcontainer.json"
+	}
+
+	f.TemplateBody = devContainerTemplate
+
+	return nil
+}
+
+func (f *DevContainerPostInstallScript) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = ".devcontainer/post-install.sh"
+	}
+
+	f.TemplateBody = postInstallScript
+
+	return nil
+}

--- a/test/check-license.sh
+++ b/test/check-license.sh
@@ -21,7 +21,7 @@ set -o pipefail
 source $(dirname "$0")/common.sh
 
 echo "Checking for license header..."
-allfiles=$(listFiles|grep -v ./internal/bindata/...)
+allfiles=$(listFiles | grep -v -e './internal/bindata/...' -e '.devcontainer/post-install.sh')
 licRes=""
 for file in $allfiles; do
   if ! head -n4 "${file}" | grep -Eq "(Copyright|generated|GENERATED|Licensed)" ; then

--- a/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup-with-deploy-image/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/testdata/project-v4-multigroup/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client

--- a/testdata/project-v4-with-deploy-image/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-deploy-image/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-deploy-image/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client

--- a/testdata/project-v4-with-grafana/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-grafana/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-grafana/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Kubebuilder DevContainer",
+  "image": "golang:1.22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  "runArgs": ["--network=host"],
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
+  },
+
+  "onCreateCommand": "bash .devcontainer/post-install.sh"
+}
+

--- a/testdata/project-v4/.devcontainer/post-install.sh
+++ b/testdata/project-v4/.devcontainer/post-install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -x
+
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind
+mv ./kind /usr/local/bin/kind
+
+curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
+chmod +x kubebuilder
+mv kubebuilder /usr/local/bin/
+
+KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/kubectl
+
+docker network create -d=bridge --subnet=172.19.0.0/24 kind
+
+kind version
+kubebuilder version
+docker --version
+go version
+kubectl version --client


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
# Issue Link
[3432](https://github.com/kubernetes-sigs/kubebuilder/issues/3432)

# Description
This PR add the functionality of generating DevContainer configuration files along with rest of the Kubebuilder project during scaffolding.

# Motivation
DevContainer is an Open Source tool which allows users consolidate their development environment into single container image. This image then can be shared across any environment by anyone. DevContainers can then be launched using any IDE including VSCode. Github's CodeSpaces uses the same tech underline.

In the context of Kubebuilder, having a DevContainer with Kind, Go, and Kubebuilder will allow any user to readily test their Operator's changes without installing any of the tools explicitly, thereby saving the time.
