### PR TITLE
🌱 (ci) - Fix the job to check the PR title and no longer use deprecated github action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,18 +1,22 @@
-name: PR Verifier
+name: "PR Title Verifier"
 
 on:
-  pull_request_target:
-    types: [opened, edited, reopened]
-
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
-
   verify:
-    name: Verify PR contents
     runs-on: ubuntu-latest
+
     steps:
-    - name: Verifier action
-      id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get PR title
+        id: get_title
+        run: echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
+
+      - name: Run PR Title Checker
+        id: check_title
+        run: |
+          ./hack/ci/pr_title_checker.sh "${{ env.title }}"

--- a/hack/ci/pr_title_checker.sh
+++ b/hack/ci/pr_title_checker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define regex patterns
+WIP_REGEX="^\W?WIP\W"
+TAG_REGEX="^\[[[:alnum:]\._-]*\]"
+PR_TITLE="$1"
+
+# Trim WIP and tags from title
+trimmed_title=$(echo "$PR_TITLE" | sed -E "s/$WIP_REGEX//" | sed -E "s/$TAG_REGEX//" | xargs)
+
+# Check PR type prefix
+if [[ "$trimmed_title" =~ ^⚠ ]] || [[ "$trimmed_title" =~ ^✨ ]] || [[ "$trimmed_title" =~ ^🐛 ]] || [[ "$trimmed_title" =~ ^📖 ]] || [[ "$trimmed_title" =~ ^🚀 ]] || [[ "$trimmed_title" =~ ^🌱 ]]; then
+    echo "PR title is valid: $trimmed_title"
+    exit 0
+else
+    echo "Error: No matching PR type indicator found in title."
+    echo "You need to have one of these as the prefix of your PR title:"
+    echo "- Breaking change: ⚠ (:warning:)"
+    echo "- Non-breaking feature: ✨ (:sparkles:)"
+    echo "- Patch fix: 🐛 (:bug:)"
+    echo "- Docs: 📖 (:book:)"
+    echo "- Release: 🚀 (:rocket:)"
+    echo "- Infra/Tests/Other: 🌱 (:seedling:)"
+    exit 1
+fi


### PR DESCRIPTION
The kubebuilder-release-tools project is no longer really maintained. The image required for checks is deprecated due 
the infrastructure used to build and promote it be deprecated. Given the minimal nature of the check, it's unnecessary to maintain a GitHub Action for this purpose.

Also, it broke 1 day ago. Note that we need to pass permissions via GitHub Token, which is not very safe. This is another reason why we need to proceed with these changes.


**When it fails:**

![Screenshot 2024-08-24 at 11 21 48](https://github.com/user-attachments/assets/8cf65a62-c9ef-4a5d-bb2c-8c6fedd0caa4)


**When the check pass:**

![Screenshot 2024-08-24 at 11 22 03](https://github.com/user-attachments/assets/4cc7f6a7-910d-4cfa-8ef3-4159c2dceea4)
