### PR TITLE
:bug: (deploy-image/v1-alpha1): Fix sample by ensuring the right labels

### DIFF
--- a/docs/book/src/getting-started/testdata/project/config/samples/cache_v1alpha1_memcached.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/samples/cache_v1alpha1_memcached.yaml
@@ -1,6 +1,9 @@
 apiVersion: cache.example.com/v1alpha1
 kind: Memcached
 metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
   name: memcached-sample
 spec:
   # TODO(user): edit the following value to ensure the number

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +30,7 @@ var _ machinery.Template = &CRDSample{}
 type CRDSample struct {
 	machinery.TemplateMixin
 	machinery.ResourceMixin
+	machinery.ProjectNameMixin
 
 	// Port if informed we will create the scaffold with this spec
 	Port string
@@ -54,6 +58,9 @@ func (f *CRDSample) SetTemplateDefaults() error {
 const crdSampleTemplate = `apiVersion: {{ .Resource.QualifiedGroup }}/{{ .Resource.Version }}
 kind: {{ .Resource.Kind }}
 metadata:
+  labels:
+    app.kubernetes.io/name: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
   name: {{ lower .Resource.Kind }}-sample
 spec:
   # TODO(user): edit the following value to ensure the number

--- a/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_busybox.yaml
@@ -1,6 +1,9 @@
 apiVersion: example.com.testproject.org/v1alpha1
 kind: Busybox
 metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
   name: busybox-sample
 spec:
   # TODO(user): edit the following value to ensure the number

--- a/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
+++ b/testdata/project-v4-with-deploy-image/config/samples/example.com_v1alpha1_memcached.yaml
@@ -1,6 +1,9 @@
 apiVersion: example.com.testproject.org/v1alpha1
 kind: Memcached
 metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-deploy-image
+    app.kubernetes.io/managed-by: kustomize
   name: memcached-sample
 spec:
   # TODO(user): edit the following value to ensure the number


### PR DESCRIPTION
The config/sample generated when we are using the plugin was missing the labels

````yaml
  labels:
    app.kubernetes.io/name: {{ .ProjectName }}
    app.kubernetes.io/managed-by: kustomize
```
