### PR TITLE
:book: remove notes about crd-version and webhook-version flags which are no longer supported and provided 

### DIFF
--- a/docs/book/src/cronjob-tutorial/new-api.md
+++ b/docs/book/src/cronjob-tutorial/new-api.md
@@ -13,20 +13,6 @@ Press `y` for "Create Resource" and "Create Controller".
 The first time we call this command for each group-version, it will create
 a directory for the new group-version.
 
-<aside class="note">
-
-<h1>Supporting older cluster versions</h1>
-
-The default CustomResourceDefinition manifests created alongside your Go API types
-use API version `v1`. If your project intends to support Kubernetes cluster versions older
-than v1.16, you must set `--crd-version v1beta1` and remove `preserveUnknownFields=false`
-from the `CRD_OPTIONS` Makefile variable.
-See the [CustomResourceDefinition generation reference][crd-reference] for details.
-
-[crd-reference]: /reference/generating-crd.md#supporting-older-cluster-versions
-
-</aside>
-
 In this case, the
 [`api/v1/`](https://sigs.k8s.io/kubebuilder/docs/book/src/cronjob-tutorial/testdata/project/api/v1)
 directory is created, corresponding to the

--- a/docs/book/src/cronjob-tutorial/webhook-implementation.md
+++ b/docs/book/src/cronjob-tutorial/webhook-implementation.md
@@ -19,17 +19,4 @@ kubebuilder create webhook --group batch --version v1 --kind CronJob --defaultin
 
 This will scaffold the webhook functions and register your webhook with the manager in your `main.go` for you.
 
-<aside class="note">
-
-<h1>Supporting older cluster versions</h1>
-
-The default WebhookConfiguration manifests created alongside your Go webhook implementation
-use API version `v1`. If your project intends to support Kubernetes cluster versions older
-than v1.16, set `--webhook-version v1beta1`. See the [webhook reference][webhook-reference]
-for more information.
-
-[webhook-reference]: /reference/webhook-overview.md#supporting-older-cluster-versions
-
-</aside>
-
 {{#literatego ./testdata/project/api/v1/cronjob_webhook.go}}

--- a/docs/book/src/migration/legacy/migration_guide_v2tov3.md
+++ b/docs/book/src/migration/legacy/migration_guide_v2tov3.md
@@ -77,18 +77,6 @@ For this example, we are going to consider that we need to scaffold both the API
 kubebuilder create api --group batch --version v1 --kind CronJob
 ```
 
-<aside class="note">
-<h1>How to still keep `apiextensions.k8s.io/v1beta1` for CRDs?</h1>
-
-From now on, the CRDs that will be created by controller-gen will be using the Kubernetes API version `apiextensions.k8s.io/v1`  by default, instead of `apiextensions.k8s.io/v1beta1`.
-
-The `apiextensions.k8s.io/v1beta1` was deprecated in Kubernetes `1.16` and was removed in Kubernetes `1.22`.
-
-So, if you would like to keep using the previous version use the flag `--crd-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
-However, it is no longer recommended.
-
-</aside>
-
 ### Migrate the APIs
 
 <aside class="note">
@@ -144,19 +132,6 @@ following command with the `--defaulting` and `--programmatic-validation` flags
 ```bash
 kubebuilder create webhook --group batch --version v1 --kind CronJob --defaulting --programmatic-validation
 ```
-
-<aside class="note">
-<h1>How to keep using `apiextensions.k8s.io/v1beta1` for Webhooks?</h1>
-
-From now on, the Webhooks that will be created by Kubebuilder using by default the Kubernetes API version `admissionregistration.k8s.io/v1` instead of `admissionregistration.k8s.io/v1beta1` and the `cert-manager.io/v1` to replace `cert-manager.io/v1alpha2`.
-
-Note that `apiextensions/v1beta1` and `admissionregistration.k8s.io/v1beta1` were deprecated in Kubernetes `1.16` and will be removed  in Kubernetes `1.22`. If you use `apiextensions/v1` and `admissionregistration.k8s.io/v1` then you need to use `cert-manager.io/v1` which will be the API adopted per Kubebuilder CLI by default in this case.
-
-The API `cert-manager.io/v1alpha2` is not compatible with the latest Kubernetes API versions.
-
-So, if you would like to keep using the previous version use the flag `--webhook-version=v1beta1` in the above command which is only needed if you want your operator to support Kubernetes `1.15` and earlier.
-
-</aside>
 
 Now, let's copy the webhook definition from `api/v1/<kind>_webhook.go` from our old project to the new one.
 

--- a/docs/book/src/reference/generating-crd.md
+++ b/docs/book/src/reference/generating-crd.md
@@ -170,28 +170,6 @@ Then, you can use the `+kubebuilder:storageversion` [marker][crd-markers]
 to indicate the [GVK](/cronjob-tutorial/gvks.md "Group-Version-Kind") that
 should be used to store data by the API server.
 
-### Supporting older cluster versions
-
-By default, `kubebuilder create api` will create CRDs of API version `v1`,
-a version introduced in Kubernetes v1.16. If your project intends to support
-Kubernetes cluster versions older than v1.16, you must use the `v1beta1` API version:
-
-```sh
-kubebuilder create api --crd-version v1beta1 ...
-```
-
-To support Kubernetes clusters of version v1.14 or lower, you'll also need to
-remove the controller-gen option `preserveUnknownFields=false` from your Makefile.
-This is done by switching the line that says
-`CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false`
-to `CRD_OPTIONS ?= crd:trivialVersions=true`
-
-<aside class="note">
-
-`v1beta1` is deprecated and was removed in Kubernetes v1.22, so upgrading is essential.
-
-</aside>
-
 ## Under the hood
 
 Kubebuilder scaffolds out make rules to run `controller-gen`.  The rules

--- a/docs/book/src/reference/webhook-overview.md
+++ b/docs/book/src/reference/webhook-overview.md
@@ -18,18 +18,3 @@ feature entered beta).
 Kubernetes supports the conversion webhooks as of version 1.15 (when the
 feature entered beta).
 
-### Supporting older cluster versions
-
-By default, `kubebuilder create webhook` will create webhook configs of API version `v1`,
-a version introduced in Kubernetes v1.16. If your project intends to support
-Kubernetes cluster versions older than v1.16, you must use the `v1beta1` API version:
-
-```sh
-kubebuilder create webhook --webhook-version v1beta1 ...
-```
-
-<aside class="note">
-
-`v1beta1` is deprecated and will be removed in a future Kubernetes release, so upgrading is recommended.
-
-</aside>


### PR DESCRIPTION
Those flgas were added to allow users still using the versions v1beta1 which is no longer supported and prvided since k8s 1.22 and were deprecated a long time ago and cannot be used with go/v4. Those are removed since is no longer possible to support those older version with the dependencies versions used currently. More info: https://github.com/kubernetes-sigs/kubebuilder/discussions/3622
