### PR TITLE
:book: fix link for reference doc to manager and crd scopes

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -96,7 +96,7 @@
   - [Artifacts](./reference/artifacts.md)
   - [Platform Support](./reference/platform.md)
 
-  - [Manager and CRDs Scope](./reference/scopes)
+  - [Manager and CRDs Scope](./reference/scopes.md)
 
   - [Sub-Module Layouts](./reference/submodule-layouts.md)
   - [Using an external Type / API](./reference/using_an_external_type.md)


### PR DESCRIPTION
Just fix the link it is broken 