### PR TITLE
:sparkles: (go/v4) Add GitHub Actions

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-e2e.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test-e2e.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test-e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-e2e.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
 	kustomizecommonv2 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/github"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils"
@@ -162,6 +163,9 @@ func (s *initScaffolder) Scaffold() error {
 		&e2e.Test{},
 		&e2e.WebhookTestUpdater{WireWebhook: false},
 		&e2e.SuiteTest{},
+		&github.E2eTestCi{},
+		&github.TestCi{},
+		&github.LintCi{},
 		&utils.Utils{},
 		&templates.DevContainer{},
 		&templates.DevContainerPostInstallScript{},

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &TestCi{}
+
+// LintCi scaffolds the GitHub Action to lint the project
+type LintCi struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *LintCi) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join(".github", "workflows", "lint.yml")
+	}
+
+	f.TemplateBody = lintCiTemplate
+
+	return nil
+}
+
+const lintCiTemplate = `name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
+`

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test-e2e.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test-e2e.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &E2eTestCi{}
+
+// E2eTestCi scaffolds the GitHub Action to call make test-e2e
+type E2eTestCi struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *E2eTestCi) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join(".github", "workflows", "test-e2e.yml")
+	}
+
+	f.TemplateBody = e2eTestCiTemplate
+
+	return nil
+}
+
+const e2eTestCiTemplate = `name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e
+`

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &TestCi{}
+
+// TestCi scaffolds the GitHub Action to call make test
+type TestCi struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *TestCi) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join(".github", "workflows", "test.yml")
+	}
+
+	f.TemplateBody = testCiTemplate
+
+	return nil
+}
+
+const testCiTemplate = `name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test
+`

--- a/test/check-license.sh
+++ b/test/check-license.sh
@@ -21,7 +21,9 @@ set -o pipefail
 source $(dirname "$0")/common.sh
 
 echo "Checking for license header..."
-allfiles=$(listFiles | grep -v -e './internal/bindata/...' -e '.devcontainer/post-install.sh')
+#TODO: See if we can improve the Bollerplate logic for the Hack/License to allow scaffold the licenses
+#using the comment prefix # for yaml files.
+allfiles=$(listFiles | grep -v -e './internal/bindata/...' -e '.devcontainer/post-install.sh' -e '.github/*')
 licRes=""
 for file in $allfiles; do
   if ! head -n4 "${file}" | grep -Eq "(Copyright|generated|GENERATED|Licensed)" ; then

--- a/testdata/project-v4-multigroup-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup-with-plugins/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/testdata/project-v4-multigroup-with-plugins/.github/workflows/test-e2e.yml
+++ b/testdata/project-v4-multigroup-with-plugins/.github/workflows/test-e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e

--- a/testdata/project-v4-multigroup-with-plugins/.github/workflows/test.yml
+++ b/testdata/project-v4-multigroup-with-plugins/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/testdata/project-v4-with-plugins/.github/workflows/test-e2e.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e

--- a/testdata/project-v4-with-plugins/.github/workflows/test.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/testdata/project-v4/.github/workflows/test-e2e.yml
+++ b/testdata/project-v4/.github/workflows/test-e2e.yml
@@ -1,0 +1,35 @@
+name: E2E Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-e2e:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Running Test e2e
+        run: |
+          go mod tidy
+          make test-e2e

--- a/testdata/project-v4/.github/workflows/test.yml
+++ b/testdata/project-v4/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.22'
+
+      - name: Running Tests
+        run: |
+          go mod tidy
+          make test


### PR DESCRIPTION
Within the changes of this PR new projects will become to be scaffold with GitHub actions which will allow users be aware of how to test their changes on the ci.

Either will make clear the purpose of the test-e2e and encorage common/best practices to ensure the quality of the properties

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4088
