### PR TITLE
 🐛  (go/v4): Fix linter issues in the scaffold 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -181,6 +181,7 @@ func main() {
 
 		We'll just make sure to set `ENABLE_WEBHOOKS=false` when we run locally.
 	*/
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&batchv1.CronJob{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CronJob")

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -392,6 +392,7 @@ func (sp *Sample) updateWebhook() {
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 `, WebhookIntro)
 	hackutils.CheckError("fixing cronjob_webhook.go", err)

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
@@ -95,6 +95,7 @@ import (
 
 )
 
+// nolint:unused
 // log is for logging in this package.
 var {{ lower .Resource.Kind }}log = logf.Log.WithName("{{ lower .Resource.Kind }}-resource")
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/main.go
@@ -114,7 +114,8 @@ const (
 		os.Exit(1)
 	}
 `
-	webhookSetupCodeFragment = `if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+	webhookSetupCodeFragment = `// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&%s.%s{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "%s")
 			os.Exit(1)

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var captainlog = logf.Log.WithName("captain-resource")
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var destroyerlog = logf.Log.WithName("destroyer-resource")
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook.go
@@ -21,6 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var frigatelog = logf.Log.WithName("frigate-resource")
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var cruiserlog = logf.Log.WithName("cruiser-resource")
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var lakerslog = logf.Log.WithName("lakers-resource")
 

--- a/testdata/project-v4-multigroup-with-deploy-image/cmd/main.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/cmd/main.go
@@ -176,6 +176,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Captain")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
@@ -189,6 +190,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Frigate")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&shipv1beta1.Frigate{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Frigate")
@@ -202,6 +204,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Destroyer")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&shipv1.Destroyer{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Destroyer")
@@ -215,6 +218,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Cruiser")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&shipv2alpha1.Cruiser{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Cruiser")
@@ -270,6 +274,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Lakers")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&testprojectorgv1.Lakers{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Lakers")

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var captainlog = logf.Log.WithName("captain-resource")
 

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var destroyerlog = logf.Log.WithName("destroyer-resource")
 

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook.go
@@ -21,6 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var frigatelog = logf.Log.WithName("frigate-resource")
 

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var cruiserlog = logf.Log.WithName("cruiser-resource")
 

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var lakerslog = logf.Log.WithName("lakers-resource")
 

--- a/testdata/project-v4-multigroup/cmd/main.go
+++ b/testdata/project-v4-multigroup/cmd/main.go
@@ -176,6 +176,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Captain")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
@@ -189,6 +190,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Frigate")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&shipv1beta1.Frigate{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Frigate")
@@ -202,6 +204,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Destroyer")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&shipv1.Destroyer{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Destroyer")
@@ -215,6 +218,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Cruiser")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&shipv2alpha1.Cruiser{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Cruiser")
@@ -270,6 +274,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Lakers")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&testprojectorgv1.Lakers{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Lakers")

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var memcachedlog = logf.Log.WithName("memcached-resource")
 

--- a/testdata/project-v4-with-deploy-image/cmd/main.go
+++ b/testdata/project-v4-with-deploy-image/cmd/main.go
@@ -160,6 +160,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Busybox")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&examplecomv1alpha1.Memcached{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Memcached")

--- a/testdata/project-v4/api/v1/admiral_webhook.go
+++ b/testdata/project-v4/api/v1/admiral_webhook.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var admirallog = logf.Log.WithName("admiral-resource")
 

--- a/testdata/project-v4/api/v1/captain_webhook.go
+++ b/testdata/project-v4/api/v1/captain_webhook.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var captainlog = logf.Log.WithName("captain-resource")
 

--- a/testdata/project-v4/api/v1/firstmate_webhook.go
+++ b/testdata/project-v4/api/v1/firstmate_webhook.go
@@ -21,6 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// nolint:unused
 // log is for logging in this package.
 var firstmatelog = logf.Log.WithName("firstmate-resource")
 

--- a/testdata/project-v4/cmd/main.go
+++ b/testdata/project-v4/cmd/main.go
@@ -151,6 +151,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Captain")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&crewv1.Captain{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Captain")
@@ -164,6 +165,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "FirstMate")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&crewv1.FirstMate{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "FirstMate")
@@ -177,6 +179,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Admiral")
 		os.Exit(1)
 	}
+	// nolint:goconst
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&crewv1.Admiral{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Admiral")


### PR DESCRIPTION
This PR fix the following issues:

```
$ make lint
testdata/project-v4/bin/golangci-lint run
cmd/main.go:154:37: string  has 3 occurrences, make it a constant (goconst)
if os.Getenv(ENABLE_WEBHOOKS) != false {
                                   ^
api/v1/firstmate_webhook.go:25:5: var  is unused (unused)
var firstmatelog = logf.Log.WithName(firstmate-resource)
```