### PR TITLE
🌱  ci- cleanup lint samples

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -1,14 +1,15 @@
-# Copyright 2023 The Caramello-io Authors.
-
-name: Sample Testdata Tests
+name: Lint Samples
 
 on:
   push:
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
-  test:
-    name: "Testdata - make test"
+  lint-samples:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:
@@ -18,36 +19,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '~1.22'
-      - name: Remove pre-installed kustomize
-        run: sudo rm -f /usr/local/bin/kustomize
-      - name: Run make test for project-v4-with-deploy-image
-        run: cd testdata/project-v4-with-deploy-image && go mod tidy && make all && make test
-      - name: Run make test for project-v4-multigroup-with-deploy-image
-        run: cd testdata/project-v4-multigroup-with-deploy-image && go mod tidy && make all && make test
-
-  lint:
-    name: "Testdata - Lint"
-    runs-on: ubuntu-latest
-    # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
-    steps:
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '~1.22'
-      - name: Clone the code
-        uses: actions/checkout@v4
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.57
+          version: v1.59
+          working-directory: testdata/project-v4
+          args: --config .golangci.yml ./...
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
           working-directory: testdata/project-v4-with-deploy-image
           args: --config .golangci.yml ./...
-          skip-cache: true  # first lint action will handle
-      - name: Run linter
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.57
-          working-directory: testdata/project-v4-multigroup-with-deploy-image
-          args: --config .golangci.yml ./...
-          skip-cache: true  # first lint action will handle


### PR DESCRIPTION
The lint sample should only run the lint checks for the samples
    Either, make no sense we run for all of them. We can ensure all plugins by just running project-v4 and project-v4-with-deploy-image which has further code scafold. By last, see that the `make tests` are called in the prow already.