### PR TITLE
🐛 (go/v4): fix linter issues to allow pass in the stricter linter checks such as; godot, gofumpt, nlreturn

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -62,7 +62,7 @@ import (
  the fields.
 */
 
-// CronJobSpec defines the desired state of CronJob
+// CronJobSpec defines the desired state of CronJob.
 type CronJobSpec struct {
 	// +kubebuilder:validation:MinLength=0
 
@@ -142,7 +142,7 @@ const (
  serialization, as mentioned above.
 */
 
-// CronJobStatus defines the observed state of CronJob
+// CronJobStatus defines the observed state of CronJob.
 type CronJobStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -165,7 +165,7 @@ type CronJobStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// CronJob is the Schema for the cronjobs API
+// CronJob is the Schema for the cronjobs API.
 type CronJob struct {
 	/*
 	 */
@@ -178,7 +178,7 @@ type CronJob struct {
 
 // +kubebuilder:object:root=true
 
-// CronJobList contains a list of CronJob
+// CronJobList contains a list of CronJob.
 type CronJobList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -45,7 +45,7 @@ var cronjoblog = logf.Log.WithName("cronjob-resource")
 Then, we set up the webhook with the manager.
 */
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *CronJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -92,7 +92,7 @@ type CronJobCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &CronJobCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob.
 func (d *CronJobCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	cronjob, ok := obj.(*CronJob)
 	if !ok {
@@ -161,7 +161,7 @@ type CronJobCustomValidator struct {
 
 var _ webhook.CustomValidator = &CronJobCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type CronJob
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
 func (v *CronJobCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cronjob, ok := obj.(*CronJob)
 	if !ok {
@@ -172,7 +172,7 @@ func (v *CronJobCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, cronjob.validateCronJob()
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type CronJob
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
 func (v *CronJobCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	cronjob, ok := newObj.(*CronJob)
 	if !ok {
@@ -183,7 +183,7 @@ func (v *CronJobCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, cronjob.validateCronJob()
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type CronJob
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
 func (v *CronJobCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cronjob, ok := obj.(*CronJob)
 	if !ok {

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/groupversion_info.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/groupversion_info.go
@@ -23,7 +23,7 @@ former, while the latter is used by the CRD generator to generate the right
 metadata for the CRDs it creates from this package.
 */
 
-// Package v1 contains API Schema definitions for the batch v1 API group
+// Package v1 contains API Schema definitions for the batch v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=batch.tutorial.kubebuilder.io
 package v1
@@ -41,10 +41,10 @@ some other `Scheme`. SchemeBuilder makes this easy for us.
 */
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "batch.tutorial.kubebuilder.io", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/docs/book/src/getting-started/testdata/project/api/v1alpha1/groupversion_info.go
+++ b/docs/book/src/getting-started/testdata/project/api/v1alpha1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the cache v1alpha1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=cache.example.com
 package v1alpha1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "cache.example.com", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
+++ b/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
@@ -26,7 +26,7 @@ import (
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-// MemcachedSpec defines the desired state of Memcached
+// MemcachedSpec defines the desired state of Memcached.
 type MemcachedSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -40,7 +40,7 @@ type MemcachedSpec struct {
 	Size int32 `json:"size,omitempty"`
 }
 
-// MemcachedStatus defines the observed state of Memcached
+// MemcachedStatus defines the observed state of Memcached.
 type MemcachedStatus struct {
 	// Represents the observations of a Memcached's current state.
 	// Memcached.status.conditions.type are: "Available", "Progressing", and "Degraded"
@@ -57,7 +57,7 @@ type MemcachedStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Memcached is the Schema for the memcacheds API
+// Memcached is the Schema for the memcacheds API.
 type Memcached struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -68,7 +68,7 @@ type Memcached struct {
 
 // +kubebuilder:object:root=true
 
-// MemcachedList contains a list of Memcached
+// MemcachedList contains a list of Memcached.
 type MemcachedList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/docs/book/src/getting-started/testdata/project/config/crd/bases/cache.example.com_memcacheds.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/crd/bases/cache.example.com_memcacheds.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Memcached is the Schema for the memcacheds API
+        description: Memcached is the Schema for the memcacheds API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: MemcachedSpec defines the desired state of Memcached
+            description: MemcachedSpec defines the desired state of Memcached.
             properties:
               size:
                 description: |-
@@ -50,7 +50,7 @@ spec:
                 type: integer
             type: object
           status:
-            description: MemcachedStatus defines the observed state of Memcached
+            description: MemcachedStatus defines the observed state of Memcached.
             properties:
               conditions:
                 items:

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -194,8 +194,8 @@ func (sp *Sample) updateSpec() {
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_types.go"),
-		`// CronJob is the Schema for the cronjobs API
-type CronJob struct {`, `// CronJob is the Schema for the cronjobs API
+		`// CronJob is the Schema for the cronjobs API.
+type CronJob struct {`, `// CronJob is the Schema for the cronjobs API.
 type CronJob struct {`+`
 	/*
 	 */`)

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/group.go
@@ -54,7 +54,7 @@ func (f *Group) SetTemplateDefaults() error {
 //nolint:lll
 const groupTemplate = `{{ .Boilerplate }}
 
-// Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group
+// Package {{ .Resource.Version }} contains API Schema definitions for the {{ .Resource.Group }} {{ .Resource.Version }} API group.
 // +kubebuilder:object:generate=true
 // +groupName={{ .Resource.QualifiedGroup }}
 package {{ .Resource.Version }}
@@ -65,10 +65,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "{{ .Resource.QualifiedGroup }}", Version: "{{ .Resource.Version }}"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -72,7 +72,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// {{ .Resource.Kind }}Spec defines the desired state of {{ .Resource.Kind }}
+// {{ .Resource.Kind }}Spec defines the desired state of {{ .Resource.Kind }}.
 type {{ .Resource.Kind }}Spec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -81,7 +81,7 @@ type {{ .Resource.Kind }}Spec struct {
 	Foo string ` + "`" + `json:"foo,omitempty"` + "`" + `
 }
 
-// {{ .Resource.Kind }}Status defines the observed state of {{ .Resource.Kind }}
+// {{ .Resource.Kind }}Status defines the observed state of {{ .Resource.Kind }}.
 type {{ .Resource.Kind }}Status struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -97,7 +97,7 @@ type {{ .Resource.Kind }}Status struct {
 // +kubebuilder:resource:path={{ .Resource.Plural }}
 {{- end }}
 
-// {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API
+// {{ .Resource.Kind }} is the Schema for the {{ .Resource.Plural }} API.
 type {{ .Resource.Kind }} struct {
 	metav1.TypeMeta   ` + "`" + `json:",inline"` + "`" + `
 	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
@@ -108,7 +108,7 @@ type {{ .Resource.Kind }} struct {
 
 // +kubebuilder:object:root=true
 
-// {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
+// {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}.
 type {{ .Resource.Kind }}List struct {
 	metav1.TypeMeta ` + "`" + `json:",inline"` + "`" + `
 	metav1.ListMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
@@ -103,7 +103,7 @@ import (
 // log is for logging in this package.
 var {{ lower .Resource.Kind }}log = logf.Log.WithName("{{ lower .Resource.Kind }}-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -135,7 +135,7 @@ type {{ .Resource.Kind }}CustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &{{ .Resource.Kind }}CustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind {{ .Resource.Kind }}
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind {{ .Resource.Kind }}.
 func (d *{{ .Resource.Kind }}CustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	{{ lower .Resource.Kind }}, ok := obj.(*{{ .Resource.Kind }})
 	if !ok {
@@ -168,7 +168,7 @@ type {{ .Resource.Kind }}CustomValidator struct{
 
 var _ webhook.CustomValidator = &{{ .Resource.Kind }}CustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}.
 func (v *{{ .Resource.Kind }}CustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	{{ lower .Resource.Kind }}, ok := obj.(*{{ .Resource.Kind }})
 	if !ok {
@@ -181,7 +181,7 @@ func (v *{{ .Resource.Kind }}CustomValidator) ValidateCreate(ctx context.Context
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}.
 func (v *{{ .Resource.Kind }}CustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	{{ lower .Resource.Kind }}, ok := newObj.(*{{ .Resource.Kind }})
 	if !ok {
@@ -194,7 +194,7 @@ func (v *{{ .Resource.Kind }}CustomValidator) ValidateUpdate(ctx context.Context
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}.
 func (v *{{ .Resource.Kind }}CustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	{{ lower .Resource.Kind }}, ok := obj.(*{{ .Resource.Kind }})
 	if !ok {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_suitetest.go
@@ -164,11 +164,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel context.CancelFunc
+	cfg *rest.Config
+	ctx context.Context
+	k8sClient client.Client
+	testEnv *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -218,7 +220,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme,
@@ -241,7 +243,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%s", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -249,9 +251,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close();
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// CaptainSpec defines the desired state of Captain
+// CaptainSpec defines the desired state of Captain.
 type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type CaptainSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// CaptainStatus defines the observed state of Captain
+// CaptainStatus defines the observed state of Captain.
 type CaptainStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type CaptainStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Captain is the Schema for the captains API
+// Captain is the Schema for the captains API.
 type Captain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Captain struct {
 
 // +kubebuilder:object:root=true
 
-// CaptainList contains a list of Captain
+// CaptainList contains a list of Captain.
 type CaptainList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var captainlog = logf.Log.WithName("captain-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -56,7 +56,7 @@ type CaptainCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &CaptainCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain.
 func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	captain, ok := obj.(*Captain)
 	if !ok {
@@ -86,7 +86,7 @@ type CaptainCustomValidator struct {
 
 var _ webhook.CustomValidator = &CaptainCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	captain, ok := obj.(*Captain)
 	if !ok {
@@ -99,7 +99,7 @@ func (v *CaptainCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	captain, ok := newObj.(*Captain)
 	if !ok {
@@ -112,7 +112,7 @@ func (v *CaptainCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	captain, ok := obj.(*Captain)
 	if !ok {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the crew v1 API group
+// Package v1 contains API Schema definitions for the crew v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=crew.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "crew.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1/bar_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1/bar_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// BarSpec defines the desired state of Bar
+// BarSpec defines the desired state of Bar.
 type BarSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type BarSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// BarStatus defines the observed state of Bar
+// BarStatus defines the observed state of Bar.
 type BarStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type BarStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Bar is the Schema for the bars API
+// Bar is the Schema for the bars API.
 type Bar struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Bar struct {
 
 // +kubebuilder:object:root=true
 
-// BarList contains a list of Bar
+// BarList contains a list of Bar.
 type BarList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/fiz/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the fiz v1 API group
+// Package v1 contains API Schema definitions for the fiz v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=fiz.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "fiz.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the foo.policy v1 API group
+// Package v1 contains API Schema definitions for the foo.policy v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=foo.policy.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "foo.policy.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/foo.policy/v1/healthcheckpolicy_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
+// HealthCheckPolicySpec defines the desired state of HealthCheckPolicy.
 type HealthCheckPolicySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type HealthCheckPolicySpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy
+// HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy.
 type HealthCheckPolicyStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type HealthCheckPolicyStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// HealthCheckPolicy is the Schema for the healthcheckpolicies API
+// HealthCheckPolicy is the Schema for the healthcheckpolicies API.
 type HealthCheckPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type HealthCheckPolicy struct {
 
 // +kubebuilder:object:root=true
 
-// HealthCheckPolicyList contains a list of HealthCheckPolicy
+// HealthCheckPolicyList contains a list of HealthCheckPolicy.
 type HealthCheckPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1/bar_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1/bar_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// BarSpec defines the desired state of Bar
+// BarSpec defines the desired state of Bar.
 type BarSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type BarSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// BarStatus defines the observed state of Bar
+// BarStatus defines the observed state of Bar.
 type BarStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type BarStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Bar is the Schema for the bars API
+// Bar is the Schema for the bars API.
 type Bar struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Bar struct {
 
 // +kubebuilder:object:root=true
 
-// BarList contains a list of Bar
+// BarList contains a list of Bar.
 type BarList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/foo/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the foo v1 API group
+// Package v1 contains API Schema definitions for the foo v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=foo.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "foo.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta1 contains API Schema definitions for the sea-creatures v1beta1 API group
+// Package v1beta1 contains API Schema definitions for the sea-creatures v1beta1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=sea-creatures.testproject.org
 package v1beta1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "sea-creatures.testproject.org", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta1/kraken_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// KrakenSpec defines the desired state of Kraken
+// KrakenSpec defines the desired state of Kraken.
 type KrakenSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type KrakenSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// KrakenStatus defines the observed state of Kraken
+// KrakenStatus defines the observed state of Kraken.
 type KrakenStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type KrakenStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Kraken is the Schema for the krakens API
+// Kraken is the Schema for the krakens API.
 type Kraken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Kraken struct {
 
 // +kubebuilder:object:root=true
 
-// KrakenList contains a list of Kraken
+// KrakenList contains a list of Kraken.
 type KrakenList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta2 contains API Schema definitions for the sea-creatures v1beta2 API group
+// Package v1beta2 contains API Schema definitions for the sea-creatures v1beta2 API group.
 // +kubebuilder:object:generate=true
 // +groupName=sea-creatures.testproject.org
 package v1beta2
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "sea-creatures.testproject.org", Version: "v1beta2"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/sea-creatures/v1beta2/leviathan_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// LeviathanSpec defines the desired state of Leviathan
+// LeviathanSpec defines the desired state of Leviathan.
 type LeviathanSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type LeviathanSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// LeviathanStatus defines the observed state of Leviathan
+// LeviathanStatus defines the observed state of Leviathan.
 type LeviathanStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type LeviathanStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Leviathan is the Schema for the leviathans API
+// Leviathan is the Schema for the leviathans API.
 type Leviathan struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Leviathan struct {
 
 // +kubebuilder:object:root=true
 
-// LeviathanList contains a list of Leviathan
+// LeviathanList contains a list of Leviathan.
 type LeviathanList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// DestroyerSpec defines the desired state of Destroyer
+// DestroyerSpec defines the desired state of Destroyer.
 type DestroyerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type DestroyerSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// DestroyerStatus defines the observed state of Destroyer
+// DestroyerStatus defines the observed state of Destroyer.
 type DestroyerStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -42,7 +42,7 @@ type DestroyerStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// Destroyer is the Schema for the destroyers API
+// Destroyer is the Schema for the destroyers API.
 type Destroyer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +53,7 @@ type Destroyer struct {
 
 // +kubebuilder:object:root=true
 
-// DestroyerList contains a list of Destroyer
+// DestroyerList contains a list of Destroyer.
 type DestroyerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
@@ -30,7 +30,7 @@ import (
 // log is for logging in this package.
 var destroyerlog = logf.Log.WithName("destroyer-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -54,7 +54,7 @@ type DestroyerCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &DestroyerCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Destroyer
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Destroyer.
 func (d *DestroyerCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	destroyer, ok := obj.(*Destroyer)
 	if !ok {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the ship v1 API group
+// Package v1 contains API Schema definitions for the ship v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=ship.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ship.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// FrigateSpec defines the desired state of Frigate
+// FrigateSpec defines the desired state of Frigate.
 type FrigateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type FrigateSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// FrigateStatus defines the observed state of Frigate
+// FrigateStatus defines the observed state of Frigate.
 type FrigateStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type FrigateStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Frigate is the Schema for the frigates API
+// Frigate is the Schema for the frigates API.
 type Frigate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Frigate struct {
 
 // +kubebuilder:object:root=true
 
-// FrigateList contains a list of Frigate
+// FrigateList contains a list of Frigate.
 type FrigateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook.go
@@ -25,7 +25,7 @@ import (
 // log is for logging in this package.
 var frigatelog = logf.Log.WithName("frigate-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Frigate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta1 contains API Schema definitions for the ship v1beta1 API group
+// Package v1beta1 contains API Schema definitions for the ship v1beta1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=ship.testproject.org
 package v1beta1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ship.testproject.org", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// CruiserSpec defines the desired state of Cruiser
+// CruiserSpec defines the desired state of Cruiser.
 type CruiserSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type CruiserSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// CruiserStatus defines the observed state of Cruiser
+// CruiserStatus defines the observed state of Cruiser.
 type CruiserStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -42,7 +42,7 @@ type CruiserStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// Cruiser is the Schema for the cruisers API
+// Cruiser is the Schema for the cruisers API.
 type Cruiser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +53,7 @@ type Cruiser struct {
 
 // +kubebuilder:object:root=true
 
-// CruiserList contains a list of Cruiser
+// CruiserList contains a list of Cruiser.
 type CruiserList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var cruiserlog = logf.Log.WithName("cruiser-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -58,7 +58,7 @@ type CruiserCustomValidator struct {
 
 var _ webhook.CustomValidator = &CruiserCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
 func (v *CruiserCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cruiser, ok := obj.(*Cruiser)
 	if !ok {
@@ -71,7 +71,7 @@ func (v *CruiserCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
 func (v *CruiserCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	cruiser, ok := newObj.(*Cruiser)
 	if !ok {
@@ -84,7 +84,7 @@ func (v *CruiserCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Cruiser
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
 func (v *CruiserCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cruiser, ok := obj.(*Cruiser)
 	if !ok {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v2alpha1 contains API Schema definitions for the ship v2alpha1 API group
+// Package v2alpha1 contains API Schema definitions for the ship v2alpha1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=ship.testproject.org
 package v2alpha1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ship.testproject.org", Version: "v2alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the  v1 API group
+// Package v1 contains API Schema definitions for the  v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_types.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// LakersSpec defines the desired state of Lakers
+// LakersSpec defines the desired state of Lakers.
 type LakersSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type LakersSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// LakersStatus defines the observed state of Lakers
+// LakersStatus defines the observed state of Lakers.
 type LakersStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type LakersStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Lakers is the Schema for the lakers API
+// Lakers is the Schema for the lakers API.
 type Lakers struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Lakers struct {
 
 // +kubebuilder:object:root=true
 
-// LakersList contains a list of Lakers
+// LakersList contains a list of Lakers.
 type LakersList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var lakerslog = logf.Log.WithName("lakers-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -56,7 +56,7 @@ type LakersCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &LakersCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Lakers
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Lakers.
 func (d *LakersCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	lakers, ok := obj.(*Lakers)
 	if !ok {
@@ -86,7 +86,7 @@ type LakersCustomValidator struct {
 
 var _ webhook.CustomValidator = &LakersCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Lakers
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Lakers.
 func (v *LakersCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	lakers, ok := obj.(*Lakers)
 	if !ok {
@@ -99,7 +99,7 @@ func (v *LakersCustomValidator) ValidateCreate(ctx context.Context, obj runtime.
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Lakers
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Lakers.
 func (v *LakersCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	lakers, ok := newObj.(*Lakers)
 	if !ok {
@@ -112,7 +112,7 @@ func (v *LakersCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newO
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Lakers
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Lakers.
 func (v *LakersCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	lakers, ok := obj.(*Lakers)
 	if !ok {

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/crew.testproject.org_captains.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Captain is the Schema for the captains API
+        description: Captain is the Schema for the captains API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CaptainSpec defines the desired state of Captain
+            description: CaptainSpec defines the desired state of Captain.
             properties:
               foo:
                 description: Foo is an example field of Captain. Edit captain_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CaptainStatus defines the observed state of Captain
+            description: CaptainStatus defines the observed state of Captain.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/fiz.testproject.org_bars.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/fiz.testproject.org_bars.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API
+        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
+            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy.
             properties:
               foo:
                 description: Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy
+            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/foo.testproject.org_bars.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/foo.testproject.org_bars.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Kraken is the Schema for the krakens API
+        description: Kraken is the Schema for the krakens API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KrakenSpec defines the desired state of Kraken
+            description: KrakenSpec defines the desired state of Kraken.
             properties:
               foo:
                 description: Foo is an example field of Kraken. Edit kraken_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: KrakenStatus defines the observed state of Kraken
+            description: KrakenStatus defines the observed state of Kraken.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1beta2
     schema:
       openAPIV3Schema:
-        description: Leviathan is the Schema for the leviathans API
+        description: Leviathan is the Schema for the leviathans API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LeviathanSpec defines the desired state of Leviathan
+            description: LeviathanSpec defines the desired state of Leviathan.
             properties:
               foo:
                 description: Foo is an example field of Leviathan. Edit leviathan_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LeviathanStatus defines the observed state of Leviathan
+            description: LeviathanStatus defines the observed state of Leviathan.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: Cruiser is the Schema for the cruisers API
+        description: Cruiser is the Schema for the cruisers API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CruiserSpec defines the desired state of Cruiser
+            description: CruiserSpec defines the desired state of Cruiser.
             properties:
               foo:
                 description: Foo is an example field of Cruiser. Edit cruiser_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CruiserStatus defines the observed state of Cruiser
+            description: CruiserStatus defines the observed state of Cruiser.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Destroyer is the Schema for the destroyers API
+        description: Destroyer is the Schema for the destroyers API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DestroyerSpec defines the desired state of Destroyer
+            description: DestroyerSpec defines the desired state of Destroyer.
             properties:
               foo:
                 description: Foo is an example field of Destroyer. Edit destroyer_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: DestroyerStatus defines the observed state of Destroyer
+            description: DestroyerStatus defines the observed state of Destroyer.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Frigate is the Schema for the frigates API
+        description: Frigate is the Schema for the frigates API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FrigateSpec defines the desired state of Frigate
+            description: FrigateSpec defines the desired state of Frigate.
             properties:
               foo:
                 description: Foo is an example field of Frigate. Edit frigate_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: FrigateStatus defines the observed state of Frigate
+            description: FrigateStatus defines the observed state of Frigate.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/testproject.org_lakers.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/crd/bases/testproject.org_lakers.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Lakers is the Schema for the lakers API
+        description: Lakers is the Schema for the lakers API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LakersSpec defines the desired state of Lakers
+            description: LakersSpec defines the desired state of Lakers.
             properties:
               foo:
                 description: Foo is an example field of Lakers. Edit lakers_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LakersStatus defines the observed state of Lakers
+            description: LakersStatus defines the observed state of Lakers.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
@@ -25,7 +25,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -53,7 +53,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true
@@ -79,7 +79,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -99,7 +99,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -107,7 +107,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true
@@ -143,7 +143,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Captain is the Schema for the captains API
+        description: Captain is the Schema for the captains API.
         properties:
           apiVersion:
             description: |-
@@ -163,7 +163,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CaptainSpec defines the desired state of Captain
+            description: CaptainSpec defines the desired state of Captain.
             properties:
               foo:
                 description: Foo is an example field of Captain. Edit captain_types.go
@@ -171,7 +171,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CaptainStatus defines the observed state of Captain
+            description: CaptainStatus defines the observed state of Captain.
             type: object
         type: object
     served: true
@@ -207,7 +207,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: Cruiser is the Schema for the cruisers API
+        description: Cruiser is the Schema for the cruisers API.
         properties:
           apiVersion:
             description: |-
@@ -227,7 +227,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CruiserSpec defines the desired state of Cruiser
+            description: CruiserSpec defines the desired state of Cruiser.
             properties:
               foo:
                 description: Foo is an example field of Cruiser. Edit cruiser_types.go
@@ -235,7 +235,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CruiserStatus defines the observed state of Cruiser
+            description: CruiserStatus defines the observed state of Cruiser.
             type: object
         type: object
     served: true
@@ -271,7 +271,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Destroyer is the Schema for the destroyers API
+        description: Destroyer is the Schema for the destroyers API.
         properties:
           apiVersion:
             description: |-
@@ -291,7 +291,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DestroyerSpec defines the desired state of Destroyer
+            description: DestroyerSpec defines the desired state of Destroyer.
             properties:
               foo:
                 description: Foo is an example field of Destroyer. Edit destroyer_types.go
@@ -299,7 +299,7 @@ spec:
                 type: string
             type: object
           status:
-            description: DestroyerStatus defines the observed state of Destroyer
+            description: DestroyerStatus defines the observed state of Destroyer.
             type: object
         type: object
     served: true
@@ -335,7 +335,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Frigate is the Schema for the frigates API
+        description: Frigate is the Schema for the frigates API.
         properties:
           apiVersion:
             description: |-
@@ -355,7 +355,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FrigateSpec defines the desired state of Frigate
+            description: FrigateSpec defines the desired state of Frigate.
             properties:
               foo:
                 description: Foo is an example field of Frigate. Edit frigate_types.go
@@ -363,7 +363,7 @@ spec:
                 type: string
             type: object
           status:
-            description: FrigateStatus defines the observed state of Frigate
+            description: FrigateStatus defines the observed state of Frigate.
             type: object
         type: object
     served: true
@@ -389,7 +389,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API
+        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API.
         properties:
           apiVersion:
             description: |-
@@ -409,7 +409,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
+            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy.
             properties:
               foo:
                 description: Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go
@@ -417,7 +417,7 @@ spec:
                 type: string
             type: object
           status:
-            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy
+            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy.
             type: object
         type: object
     served: true
@@ -443,7 +443,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Kraken is the Schema for the krakens API
+        description: Kraken is the Schema for the krakens API.
         properties:
           apiVersion:
             description: |-
@@ -463,7 +463,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KrakenSpec defines the desired state of Kraken
+            description: KrakenSpec defines the desired state of Kraken.
             properties:
               foo:
                 description: Foo is an example field of Kraken. Edit kraken_types.go
@@ -471,7 +471,7 @@ spec:
                 type: string
             type: object
           status:
-            description: KrakenStatus defines the observed state of Kraken
+            description: KrakenStatus defines the observed state of Kraken.
             type: object
         type: object
     served: true
@@ -507,7 +507,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Lakers is the Schema for the lakers API
+        description: Lakers is the Schema for the lakers API.
         properties:
           apiVersion:
             description: |-
@@ -527,7 +527,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LakersSpec defines the desired state of Lakers
+            description: LakersSpec defines the desired state of Lakers.
             properties:
               foo:
                 description: Foo is an example field of Lakers. Edit lakers_types.go
@@ -535,7 +535,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LakersStatus defines the observed state of Lakers
+            description: LakersStatus defines the observed state of Lakers.
             type: object
         type: object
     served: true
@@ -561,7 +561,7 @@ spec:
   - name: v1beta2
     schema:
       openAPIV3Schema:
-        description: Leviathan is the Schema for the leviathans API
+        description: Leviathan is the Schema for the leviathans API.
         properties:
           apiVersion:
             description: |-
@@ -581,7 +581,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LeviathanSpec defines the desired state of Leviathan
+            description: LeviathanSpec defines the desired state of Leviathan.
             properties:
               foo:
                 description: Foo is an example field of Leviathan. Edit leviathan_types.go
@@ -589,7 +589,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LeviathanStatus defines the observed state of Leviathan
+            description: LeviathanStatus defines the observed state of Leviathan.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_types.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// CaptainSpec defines the desired state of Captain
+// CaptainSpec defines the desired state of Captain.
 type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type CaptainSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// CaptainStatus defines the observed state of Captain
+// CaptainStatus defines the observed state of Captain.
 type CaptainStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type CaptainStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Captain is the Schema for the captains API
+// Captain is the Schema for the captains API.
 type Captain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Captain struct {
 
 // +kubebuilder:object:root=true
 
-// CaptainList contains a list of Captain
+// CaptainList contains a list of Captain.
 type CaptainList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var captainlog = logf.Log.WithName("captain-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -56,7 +56,7 @@ type CaptainCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &CaptainCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain.
 func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	captain, ok := obj.(*Captain)
 	if !ok {
@@ -86,7 +86,7 @@ type CaptainCustomValidator struct {
 
 var _ webhook.CustomValidator = &CaptainCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	captain, ok := obj.(*Captain)
 	if !ok {
@@ -99,7 +99,7 @@ func (v *CaptainCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	captain, ok := newObj.(*Captain)
 	if !ok {
@@ -112,7 +112,7 @@ func (v *CaptainCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	captain, ok := obj.(*Captain)
 	if !ok {

--- a/testdata/project-v4-multigroup/api/crew/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the crew v1 API group
+// Package v1 contains API Schema definitions for the crew v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=crew.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "crew.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup/api/fiz/v1/bar_types.go
+++ b/testdata/project-v4-multigroup/api/fiz/v1/bar_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// BarSpec defines the desired state of Bar
+// BarSpec defines the desired state of Bar.
 type BarSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type BarSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// BarStatus defines the observed state of Bar
+// BarStatus defines the observed state of Bar.
 type BarStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type BarStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Bar is the Schema for the bars API
+// Bar is the Schema for the bars API.
 type Bar struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Bar struct {
 
 // +kubebuilder:object:root=true
 
-// BarList contains a list of Bar
+// BarList contains a list of Bar.
 type BarList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/fiz/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/fiz/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the fiz v1 API group
+// Package v1 contains API Schema definitions for the fiz v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=fiz.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "fiz.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/foo.policy/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/foo.policy/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the foo.policy v1 API group
+// Package v1 contains API Schema definitions for the foo.policy v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=foo.policy.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "foo.policy.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v4-multigroup/api/foo.policy/v1/healthcheckpolicy_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
+// HealthCheckPolicySpec defines the desired state of HealthCheckPolicy.
 type HealthCheckPolicySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type HealthCheckPolicySpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy
+// HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy.
 type HealthCheckPolicyStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type HealthCheckPolicyStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// HealthCheckPolicy is the Schema for the healthcheckpolicies API
+// HealthCheckPolicy is the Schema for the healthcheckpolicies API.
 type HealthCheckPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type HealthCheckPolicy struct {
 
 // +kubebuilder:object:root=true
 
-// HealthCheckPolicyList contains a list of HealthCheckPolicy
+// HealthCheckPolicyList contains a list of HealthCheckPolicy.
 type HealthCheckPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/foo/v1/bar_types.go
+++ b/testdata/project-v4-multigroup/api/foo/v1/bar_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// BarSpec defines the desired state of Bar
+// BarSpec defines the desired state of Bar.
 type BarSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type BarSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// BarStatus defines the observed state of Bar
+// BarStatus defines the observed state of Bar.
 type BarStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type BarStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Bar is the Schema for the bars API
+// Bar is the Schema for the bars API.
 type Bar struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Bar struct {
 
 // +kubebuilder:object:root=true
 
-// BarList contains a list of Bar
+// BarList contains a list of Bar.
 type BarList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/foo/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/foo/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the foo v1 API group
+// Package v1 contains API Schema definitions for the foo v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=foo.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "foo.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta1 contains API Schema definitions for the sea-creatures v1beta1 API group
+// Package v1beta1 contains API Schema definitions for the sea-creatures v1beta1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=sea-creatures.testproject.org
 package v1beta1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "sea-creatures.testproject.org", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/kraken_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// KrakenSpec defines the desired state of Kraken
+// KrakenSpec defines the desired state of Kraken.
 type KrakenSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type KrakenSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// KrakenStatus defines the observed state of Kraken
+// KrakenStatus defines the observed state of Kraken.
 type KrakenStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type KrakenStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Kraken is the Schema for the krakens API
+// Kraken is the Schema for the krakens API.
 type Kraken struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Kraken struct {
 
 // +kubebuilder:object:root=true
 
-// KrakenList contains a list of Kraken
+// KrakenList contains a list of Kraken.
 type KrakenList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta2 contains API Schema definitions for the sea-creatures v1beta2 API group
+// Package v1beta2 contains API Schema definitions for the sea-creatures v1beta2 API group.
 // +kubebuilder:object:generate=true
 // +groupName=sea-creatures.testproject.org
 package v1beta2
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "sea-creatures.testproject.org", Version: "v1beta2"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/leviathan_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// LeviathanSpec defines the desired state of Leviathan
+// LeviathanSpec defines the desired state of Leviathan.
 type LeviathanSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type LeviathanSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// LeviathanStatus defines the observed state of Leviathan
+// LeviathanStatus defines the observed state of Leviathan.
 type LeviathanStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type LeviathanStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Leviathan is the Schema for the leviathans API
+// Leviathan is the Schema for the leviathans API.
 type Leviathan struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Leviathan struct {
 
 // +kubebuilder:object:root=true
 
-// LeviathanList contains a list of Leviathan
+// LeviathanList contains a list of Leviathan.
 type LeviathanList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// DestroyerSpec defines the desired state of Destroyer
+// DestroyerSpec defines the desired state of Destroyer.
 type DestroyerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type DestroyerSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// DestroyerStatus defines the observed state of Destroyer
+// DestroyerStatus defines the observed state of Destroyer.
 type DestroyerStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -42,7 +42,7 @@ type DestroyerStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// Destroyer is the Schema for the destroyers API
+// Destroyer is the Schema for the destroyers API.
 type Destroyer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +53,7 @@ type Destroyer struct {
 
 // +kubebuilder:object:root=true
 
-// DestroyerList contains a list of Destroyer
+// DestroyerList contains a list of Destroyer.
 type DestroyerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
@@ -30,7 +30,7 @@ import (
 // log is for logging in this package.
 var destroyerlog = logf.Log.WithName("destroyer-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -54,7 +54,7 @@ type DestroyerCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &DestroyerCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Destroyer
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Destroyer.
 func (d *DestroyerCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	destroyer, ok := obj.(*Destroyer)
 	if !ok {

--- a/testdata/project-v4-multigroup/api/ship/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the ship v1 API group
+// Package v1 contains API Schema definitions for the ship v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=ship.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ship.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// FrigateSpec defines the desired state of Frigate
+// FrigateSpec defines the desired state of Frigate.
 type FrigateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type FrigateSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// FrigateStatus defines the observed state of Frigate
+// FrigateStatus defines the observed state of Frigate.
 type FrigateStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type FrigateStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Frigate is the Schema for the frigates API
+// Frigate is the Schema for the frigates API.
 type Frigate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Frigate struct {
 
 // +kubebuilder:object:root=true
 
-// FrigateList contains a list of Frigate
+// FrigateList contains a list of Frigate.
 type FrigateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook.go
@@ -25,7 +25,7 @@ import (
 // log is for logging in this package.
 var frigatelog = logf.Log.WithName("frigate-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Frigate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1beta1 contains API Schema definitions for the ship v1beta1 API group
+// Package v1beta1 contains API Schema definitions for the ship v1beta1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=ship.testproject.org
 package v1beta1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ship.testproject.org", Version: "v1beta1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// CruiserSpec defines the desired state of Cruiser
+// CruiserSpec defines the desired state of Cruiser.
 type CruiserSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type CruiserSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// CruiserStatus defines the observed state of Cruiser
+// CruiserStatus defines the observed state of Cruiser.
 type CruiserStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -42,7 +42,7 @@ type CruiserStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// Cruiser is the Schema for the cruisers API
+// Cruiser is the Schema for the cruisers API.
 type Cruiser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +53,7 @@ type Cruiser struct {
 
 // +kubebuilder:object:root=true
 
-// CruiserList contains a list of Cruiser
+// CruiserList contains a list of Cruiser.
 type CruiserList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var cruiserlog = logf.Log.WithName("cruiser-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -58,7 +58,7 @@ type CruiserCustomValidator struct {
 
 var _ webhook.CustomValidator = &CruiserCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
 func (v *CruiserCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cruiser, ok := obj.(*Cruiser)
 	if !ok {
@@ -71,7 +71,7 @@ func (v *CruiserCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
 func (v *CruiserCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	cruiser, ok := newObj.(*Cruiser)
 	if !ok {
@@ -84,7 +84,7 @@ func (v *CruiserCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Cruiser
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
 func (v *CruiserCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cruiser, ok := obj.(*Cruiser)
 	if !ok {

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v2alpha1 contains API Schema definitions for the ship v2alpha1 API group
+// Package v2alpha1 contains API Schema definitions for the ship v2alpha1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=ship.testproject.org
 package v2alpha1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "ship.testproject.org", Version: "v2alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup/api/v1/groupversion_info.go
+++ b/testdata/project-v4-multigroup/api/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the  v1 API group
+// Package v1 contains API Schema definitions for the  v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-multigroup/api/v1/lakers_types.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// LakersSpec defines the desired state of Lakers
+// LakersSpec defines the desired state of Lakers.
 type LakersSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type LakersSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// LakersStatus defines the observed state of Lakers
+// LakersStatus defines the observed state of Lakers.
 type LakersStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type LakersStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Lakers is the Schema for the lakers API
+// Lakers is the Schema for the lakers API.
 type Lakers struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Lakers struct {
 
 // +kubebuilder:object:root=true
 
-// LakersList contains a list of Lakers
+// LakersList contains a list of Lakers.
 type LakersList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var lakerslog = logf.Log.WithName("lakers-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -56,7 +56,7 @@ type LakersCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &LakersCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Lakers
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Lakers.
 func (d *LakersCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	lakers, ok := obj.(*Lakers)
 	if !ok {
@@ -86,7 +86,7 @@ type LakersCustomValidator struct {
 
 var _ webhook.CustomValidator = &LakersCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Lakers
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Lakers.
 func (v *LakersCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	lakers, ok := obj.(*Lakers)
 	if !ok {
@@ -99,7 +99,7 @@ func (v *LakersCustomValidator) ValidateCreate(ctx context.Context, obj runtime.
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Lakers
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Lakers.
 func (v *LakersCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	lakers, ok := newObj.(*Lakers)
 	if !ok {
@@ -112,7 +112,7 @@ func (v *LakersCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newO
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Lakers
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Lakers.
 func (v *LakersCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	lakers, ok := obj.(*Lakers)
 	if !ok {

--- a/testdata/project-v4-multigroup/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/api/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/crew.testproject.org_captains.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Captain is the Schema for the captains API
+        description: Captain is the Schema for the captains API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CaptainSpec defines the desired state of Captain
+            description: CaptainSpec defines the desired state of Captain.
             properties:
               foo:
                 description: Foo is an example field of Captain. Edit captain_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CaptainStatus defines the observed state of Captain
+            description: CaptainStatus defines the observed state of Captain.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/fiz.testproject.org_bars.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/fiz.testproject.org_bars.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/foo.policy.testproject.org_healthcheckpolicies.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API
+        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
+            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy.
             properties:
               foo:
                 description: Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy
+            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/foo.testproject.org_bars.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/foo.testproject.org_bars.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/sea-creatures.testproject.org_krakens.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Kraken is the Schema for the krakens API
+        description: Kraken is the Schema for the krakens API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KrakenSpec defines the desired state of Kraken
+            description: KrakenSpec defines the desired state of Kraken.
             properties:
               foo:
                 description: Foo is an example field of Kraken. Edit kraken_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: KrakenStatus defines the observed state of Kraken
+            description: KrakenStatus defines the observed state of Kraken.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/sea-creatures.testproject.org_leviathans.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1beta2
     schema:
       openAPIV3Schema:
-        description: Leviathan is the Schema for the leviathans API
+        description: Leviathan is the Schema for the leviathans API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LeviathanSpec defines the desired state of Leviathan
+            description: LeviathanSpec defines the desired state of Leviathan.
             properties:
               foo:
                 description: Foo is an example field of Leviathan. Edit leviathan_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LeviathanStatus defines the observed state of Leviathan
+            description: LeviathanStatus defines the observed state of Leviathan.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/ship.testproject.org_cruisers.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: Cruiser is the Schema for the cruisers API
+        description: Cruiser is the Schema for the cruisers API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CruiserSpec defines the desired state of Cruiser
+            description: CruiserSpec defines the desired state of Cruiser.
             properties:
               foo:
                 description: Foo is an example field of Cruiser. Edit cruiser_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CruiserStatus defines the observed state of Cruiser
+            description: CruiserStatus defines the observed state of Cruiser.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/ship.testproject.org_destroyers.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Destroyer is the Schema for the destroyers API
+        description: Destroyer is the Schema for the destroyers API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DestroyerSpec defines the desired state of Destroyer
+            description: DestroyerSpec defines the desired state of Destroyer.
             properties:
               foo:
                 description: Foo is an example field of Destroyer. Edit destroyer_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: DestroyerStatus defines the observed state of Destroyer
+            description: DestroyerStatus defines the observed state of Destroyer.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/ship.testproject.org_frigates.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Frigate is the Schema for the frigates API
+        description: Frigate is the Schema for the frigates API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FrigateSpec defines the desired state of Frigate
+            description: FrigateSpec defines the desired state of Frigate.
             properties:
               foo:
                 description: Foo is an example field of Frigate. Edit frigate_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: FrigateStatus defines the observed state of Frigate
+            description: FrigateStatus defines the observed state of Frigate.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/testproject.org_lakers.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/testproject.org_lakers.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Lakers is the Schema for the lakers API
+        description: Lakers is the Schema for the lakers API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LakersSpec defines the desired state of Lakers
+            description: LakersSpec defines the desired state of Lakers.
             properties:
               foo:
                 description: Foo is an example field of Lakers. Edit lakers_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LakersStatus defines the observed state of Lakers
+            description: LakersStatus defines the observed state of Lakers.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -25,7 +25,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -45,7 +45,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -53,7 +53,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true
@@ -79,7 +79,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Bar is the Schema for the bars API
+        description: Bar is the Schema for the bars API.
         properties:
           apiVersion:
             description: |-
@@ -99,7 +99,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: BarSpec defines the desired state of Bar
+            description: BarSpec defines the desired state of Bar.
             properties:
               foo:
                 description: Foo is an example field of Bar. Edit bar_types.go to
@@ -107,7 +107,7 @@ spec:
                 type: string
             type: object
           status:
-            description: BarStatus defines the observed state of Bar
+            description: BarStatus defines the observed state of Bar.
             type: object
         type: object
     served: true
@@ -143,7 +143,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Captain is the Schema for the captains API
+        description: Captain is the Schema for the captains API.
         properties:
           apiVersion:
             description: |-
@@ -163,7 +163,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CaptainSpec defines the desired state of Captain
+            description: CaptainSpec defines the desired state of Captain.
             properties:
               foo:
                 description: Foo is an example field of Captain. Edit captain_types.go
@@ -171,7 +171,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CaptainStatus defines the observed state of Captain
+            description: CaptainStatus defines the observed state of Captain.
             type: object
         type: object
     served: true
@@ -207,7 +207,7 @@ spec:
   - name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: Cruiser is the Schema for the cruisers API
+        description: Cruiser is the Schema for the cruisers API.
         properties:
           apiVersion:
             description: |-
@@ -227,7 +227,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CruiserSpec defines the desired state of Cruiser
+            description: CruiserSpec defines the desired state of Cruiser.
             properties:
               foo:
                 description: Foo is an example field of Cruiser. Edit cruiser_types.go
@@ -235,7 +235,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CruiserStatus defines the observed state of Cruiser
+            description: CruiserStatus defines the observed state of Cruiser.
             type: object
         type: object
     served: true
@@ -271,7 +271,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Destroyer is the Schema for the destroyers API
+        description: Destroyer is the Schema for the destroyers API.
         properties:
           apiVersion:
             description: |-
@@ -291,7 +291,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DestroyerSpec defines the desired state of Destroyer
+            description: DestroyerSpec defines the desired state of Destroyer.
             properties:
               foo:
                 description: Foo is an example field of Destroyer. Edit destroyer_types.go
@@ -299,7 +299,7 @@ spec:
                 type: string
             type: object
           status:
-            description: DestroyerStatus defines the observed state of Destroyer
+            description: DestroyerStatus defines the observed state of Destroyer.
             type: object
         type: object
     served: true
@@ -335,7 +335,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Frigate is the Schema for the frigates API
+        description: Frigate is the Schema for the frigates API.
         properties:
           apiVersion:
             description: |-
@@ -355,7 +355,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FrigateSpec defines the desired state of Frigate
+            description: FrigateSpec defines the desired state of Frigate.
             properties:
               foo:
                 description: Foo is an example field of Frigate. Edit frigate_types.go
@@ -363,7 +363,7 @@ spec:
                 type: string
             type: object
           status:
-            description: FrigateStatus defines the observed state of Frigate
+            description: FrigateStatus defines the observed state of Frigate.
             type: object
         type: object
     served: true
@@ -389,7 +389,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API
+        description: HealthCheckPolicy is the Schema for the healthcheckpolicies API.
         properties:
           apiVersion:
             description: |-
@@ -409,7 +409,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy
+            description: HealthCheckPolicySpec defines the desired state of HealthCheckPolicy.
             properties:
               foo:
                 description: Foo is an example field of HealthCheckPolicy. Edit healthcheckpolicy_types.go
@@ -417,7 +417,7 @@ spec:
                 type: string
             type: object
           status:
-            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy
+            description: HealthCheckPolicyStatus defines the observed state of HealthCheckPolicy.
             type: object
         type: object
     served: true
@@ -443,7 +443,7 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: Kraken is the Schema for the krakens API
+        description: Kraken is the Schema for the krakens API.
         properties:
           apiVersion:
             description: |-
@@ -463,7 +463,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KrakenSpec defines the desired state of Kraken
+            description: KrakenSpec defines the desired state of Kraken.
             properties:
               foo:
                 description: Foo is an example field of Kraken. Edit kraken_types.go
@@ -471,7 +471,7 @@ spec:
                 type: string
             type: object
           status:
-            description: KrakenStatus defines the observed state of Kraken
+            description: KrakenStatus defines the observed state of Kraken.
             type: object
         type: object
     served: true
@@ -507,7 +507,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Lakers is the Schema for the lakers API
+        description: Lakers is the Schema for the lakers API.
         properties:
           apiVersion:
             description: |-
@@ -527,7 +527,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LakersSpec defines the desired state of Lakers
+            description: LakersSpec defines the desired state of Lakers.
             properties:
               foo:
                 description: Foo is an example field of Lakers. Edit lakers_types.go
@@ -535,7 +535,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LakersStatus defines the observed state of Lakers
+            description: LakersStatus defines the observed state of Lakers.
             type: object
         type: object
     served: true
@@ -561,7 +561,7 @@ spec:
   - name: v1beta2
     schema:
       openAPIV3Schema:
-        description: Leviathan is the Schema for the leviathans API
+        description: Leviathan is the Schema for the leviathans API.
         properties:
           apiVersion:
             description: |-
@@ -581,7 +581,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: LeviathanSpec defines the desired state of Leviathan
+            description: LeviathanSpec defines the desired state of Leviathan.
             properties:
               foo:
                 description: Foo is an example field of Leviathan. Edit leviathan_types.go
@@ -589,7 +589,7 @@ spec:
                 type: string
             type: object
           status:
-            description: LeviathanStatus defines the observed state of Leviathan
+            description: LeviathanStatus defines the observed state of Leviathan.
             type: object
         type: object
     served: true

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/groupversion_info.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains API Schema definitions for the example.com v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the example.com v1alpha1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=example.com.testproject.org
 package v1alpha1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "example.com.testproject.org", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var memcachedlog = logf.Log.WithName("memcached-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Memcached) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -58,7 +58,7 @@ type MemcachedCustomValidator struct {
 
 var _ webhook.CustomValidator = &MemcachedCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Memcached
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
 func (v *MemcachedCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	memcached, ok := obj.(*Memcached)
 	if !ok {
@@ -71,7 +71,7 @@ func (v *MemcachedCustomValidator) ValidateCreate(ctx context.Context, obj runti
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Memcached
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
 func (v *MemcachedCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	memcached, ok := newObj.(*Memcached)
 	if !ok {
@@ -84,7 +84,7 @@ func (v *MemcachedCustomValidator) ValidateUpdate(ctx context.Context, oldObj, n
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Memcached
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
 func (v *MemcachedCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	memcached, ok := obj.(*Memcached)
 	if !ok {

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -124,7 +126,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -132,9 +134,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4/api/v1/admiral_types.go
+++ b/testdata/project-v4/api/v1/admiral_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// AdmiralSpec defines the desired state of Admiral
+// AdmiralSpec defines the desired state of Admiral.
 type AdmiralSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type AdmiralSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// AdmiralStatus defines the observed state of Admiral
+// AdmiralStatus defines the observed state of Admiral.
 type AdmiralStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -42,7 +42,7 @@ type AdmiralStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=admirales,scope=Cluster
 
-// Admiral is the Schema for the admirales API
+// Admiral is the Schema for the admirales API.
 type Admiral struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,7 +53,7 @@ type Admiral struct {
 
 // +kubebuilder:object:root=true
 
-// AdmiralList contains a list of Admiral
+// AdmiralList contains a list of Admiral.
 type AdmiralList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4/api/v1/admiral_webhook.go
+++ b/testdata/project-v4/api/v1/admiral_webhook.go
@@ -30,7 +30,7 @@ import (
 // log is for logging in this package.
 var admirallog = logf.Log.WithName("admiral-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Admiral) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -54,7 +54,7 @@ type AdmiralCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &AdmiralCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Admiral
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Admiral.
 func (d *AdmiralCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	admiral, ok := obj.(*Admiral)
 	if !ok {

--- a/testdata/project-v4/api/v1/captain_types.go
+++ b/testdata/project-v4/api/v1/captain_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// CaptainSpec defines the desired state of Captain
+// CaptainSpec defines the desired state of Captain.
 type CaptainSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type CaptainSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// CaptainStatus defines the observed state of Captain
+// CaptainStatus defines the observed state of Captain.
 type CaptainStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type CaptainStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Captain is the Schema for the captains API
+// Captain is the Schema for the captains API.
 type Captain struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type Captain struct {
 
 // +kubebuilder:object:root=true
 
-// CaptainList contains a list of Captain
+// CaptainList contains a list of Captain.
 type CaptainList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4/api/v1/captain_webhook.go
+++ b/testdata/project-v4/api/v1/captain_webhook.go
@@ -31,7 +31,7 @@ import (
 // log is for logging in this package.
 var captainlog = logf.Log.WithName("captain-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
@@ -56,7 +56,7 @@ type CaptainCustomDefaulter struct {
 
 var _ webhook.CustomDefaulter = &CaptainCustomDefaulter{}
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain.
 func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 	captain, ok := obj.(*Captain)
 	if !ok {
@@ -86,7 +86,7 @@ type CaptainCustomValidator struct {
 
 var _ webhook.CustomValidator = &CaptainCustomValidator{}
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	captain, ok := obj.(*Captain)
 	if !ok {
@@ -99,7 +99,7 @@ func (v *CaptainCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	captain, ok := newObj.(*Captain)
 	if !ok {
@@ -112,7 +112,7 @@ func (v *CaptainCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain.
 func (v *CaptainCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	captain, ok := obj.(*Captain)
 	if !ok {

--- a/testdata/project-v4/api/v1/firstmate_types.go
+++ b/testdata/project-v4/api/v1/firstmate_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// FirstMateSpec defines the desired state of FirstMate
+// FirstMateSpec defines the desired state of FirstMate.
 type FirstMateSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -32,7 +32,7 @@ type FirstMateSpec struct {
 	Foo string `json:"foo,omitempty"`
 }
 
-// FirstMateStatus defines the observed state of FirstMate
+// FirstMateStatus defines the observed state of FirstMate.
 type FirstMateStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -41,7 +41,7 @@ type FirstMateStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// FirstMate is the Schema for the firstmates API
+// FirstMate is the Schema for the firstmates API.
 type FirstMate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,7 +52,7 @@ type FirstMate struct {
 
 // +kubebuilder:object:root=true
 
-// FirstMateList contains a list of FirstMate
+// FirstMateList contains a list of FirstMate.
 type FirstMateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/testdata/project-v4/api/v1/firstmate_webhook.go
+++ b/testdata/project-v4/api/v1/firstmate_webhook.go
@@ -25,7 +25,7 @@ import (
 // log is for logging in this package.
 var firstmatelog = logf.Log.WithName("firstmate-resource")
 
-// SetupWebhookWithManager will setup the manager to manage the webhooks
+// SetupWebhookWithManager will setup the manager to manage the webhooks.
 func (r *FirstMate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).

--- a/testdata/project-v4/api/v1/groupversion_info.go
+++ b/testdata/project-v4/api/v1/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the crew v1 API group
+// Package v1 contains API Schema definitions for the crew v1 API group.
 // +kubebuilder:object:generate=true
 // +groupName=crew.testproject.org
 package v1
@@ -25,10 +25,10 @@ import (
 )
 
 var (
-	// GroupVersion is group version used to register these objects
+	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "crew.testproject.org", Version: "v1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/testdata/project-v4/api/v1/webhook_suite_test.go
+++ b/testdata/project-v4/api/v1/webhook_suite_test.go
@@ -45,11 +45,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cancel    context.CancelFunc
+	cfg       *rest.Config
+	ctx       context.Context
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,7 +101,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// start webhook server using Manager
+	// start webhook server using Manager.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
@@ -127,7 +129,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 	}()
 
-	// wait for the webhook server to get ready
+	// wait for the webhook server to get ready.
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
@@ -135,9 +137,9 @@ var _ = BeforeSuite(func() {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/testdata/project-v4/config/crd/bases/crew.testproject.org_admirales.yaml
+++ b/testdata/project-v4/config/crd/bases/crew.testproject.org_admirales.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Admiral is the Schema for the admirales API
+        description: Admiral is the Schema for the admirales API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AdmiralSpec defines the desired state of Admiral
+            description: AdmiralSpec defines the desired state of Admiral.
             properties:
               foo:
                 description: Foo is an example field of Admiral. Edit admiral_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: AdmiralStatus defines the observed state of Admiral
+            description: AdmiralStatus defines the observed state of Admiral.
             type: object
         type: object
     served: true

--- a/testdata/project-v4/config/crd/bases/crew.testproject.org_captains.yaml
+++ b/testdata/project-v4/config/crd/bases/crew.testproject.org_captains.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Captain is the Schema for the captains API
+        description: Captain is the Schema for the captains API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CaptainSpec defines the desired state of Captain
+            description: CaptainSpec defines the desired state of Captain.
             properties:
               foo:
                 description: Foo is an example field of Captain. Edit captain_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CaptainStatus defines the observed state of Captain
+            description: CaptainStatus defines the observed state of Captain.
             type: object
         type: object
     served: true

--- a/testdata/project-v4/config/crd/bases/crew.testproject.org_firstmates.yaml
+++ b/testdata/project-v4/config/crd/bases/crew.testproject.org_firstmates.yaml
@@ -17,7 +17,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: FirstMate is the Schema for the firstmates API
+        description: FirstMate is the Schema for the firstmates API.
         properties:
           apiVersion:
             description: |-
@@ -37,7 +37,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FirstMateSpec defines the desired state of FirstMate
+            description: FirstMateSpec defines the desired state of FirstMate.
             properties:
               foo:
                 description: Foo is an example field of FirstMate. Edit firstmate_types.go
@@ -45,7 +45,7 @@ spec:
                 type: string
             type: object
           status:
-            description: FirstMateStatus defines the observed state of FirstMate
+            description: FirstMateStatus defines the observed state of FirstMate.
             type: object
         type: object
     served: true

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -35,7 +35,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Admiral is the Schema for the admirales API
+        description: Admiral is the Schema for the admirales API.
         properties:
           apiVersion:
             description: |-
@@ -55,7 +55,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: AdmiralSpec defines the desired state of Admiral
+            description: AdmiralSpec defines the desired state of Admiral.
             properties:
               foo:
                 description: Foo is an example field of Admiral. Edit admiral_types.go
@@ -63,7 +63,7 @@ spec:
                 type: string
             type: object
           status:
-            description: AdmiralStatus defines the observed state of Admiral
+            description: AdmiralStatus defines the observed state of Admiral.
             type: object
         type: object
     served: true
@@ -99,7 +99,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: Captain is the Schema for the captains API
+        description: Captain is the Schema for the captains API.
         properties:
           apiVersion:
             description: |-
@@ -119,7 +119,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: CaptainSpec defines the desired state of Captain
+            description: CaptainSpec defines the desired state of Captain.
             properties:
               foo:
                 description: Foo is an example field of Captain. Edit captain_types.go
@@ -127,7 +127,7 @@ spec:
                 type: string
             type: object
           status:
-            description: CaptainStatus defines the observed state of Captain
+            description: CaptainStatus defines the observed state of Captain.
             type: object
         type: object
     served: true
@@ -163,7 +163,7 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: FirstMate is the Schema for the firstmates API
+        description: FirstMate is the Schema for the firstmates API.
         properties:
           apiVersion:
             description: |-
@@ -183,7 +183,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: FirstMateSpec defines the desired state of FirstMate
+            description: FirstMateSpec defines the desired state of FirstMate.
             properties:
               foo:
                 description: Foo is an example field of FirstMate. Edit firstmate_types.go
@@ -191,7 +191,7 @@ spec:
                 type: string
             type: object
           status:
-            description: FirstMateStatus defines the observed state of FirstMate
+            description: FirstMateStatus defines the observed state of FirstMate.
             type: object
         type: object
     served: true


### PR DESCRIPTION
As described in https://github.com/kubernetes-sigs/kubebuilder/issues/4132 I'd like to propose to fix some minor format issues that prevents us from using a stricter linter out of the box.
