### PR TITLE
🌱 cleanup: Replace "-m=64" with "--memory-limit=64"

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -261,7 +261,7 @@ specifications, as demonstrated in the following example:
 							ContainerPort: 11211,
 							Name:          "memcached",
 						}},
-						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
+						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},
 				},
 			},

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
@@ -255,7 +255,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 							ContainerPort: 11211,
 							Name:          "memcached",
 						}},
-						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
+						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},
 				},
 			},

--- a/docs/book/src/plugins/creating-plugins.md
+++ b/docs/book/src/plugins/creating-plugins.md
@@ -112,7 +112,7 @@ Note that users are also able to use plugins to customize their scaffolds and ad
 See that Kubebuilder provides the [`deploy-image`][deploy-image] plugin that allows the user to create the controller & CRs which will deploy and manage an image on the cluster:
 
 ```sh
-kubebuilder create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached,-m=64,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha"
+kubebuilder create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached,--memory-limit=64,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha"
 ```
 
 This plugin will perform a custom scaffold following the [Operator Pattern][operator-pattern].

--- a/docs/book/src/plugins/deploy-image-plugin-v1-alpha.md
+++ b/docs/book/src/plugins/deploy-image-plugin-v1-alpha.md
@@ -31,7 +31,7 @@ After you create a new project with `kubebuilder init` you can create APIs using
 Then, by using this plugin you can [create APIs](https://book.kubebuilder.io/cronjob-tutorial/gvks.html) informing the image (Operand) that you would like to deploy on the cluster. Note that you can optionally specify the command that could be used to initialize this container via the flag `--image-container-command` and the port with `--image-container-port` flag. You can also specify the `RunAsUser` value for the Security Context of the container via the flag `--run-as-user`., i.e:
 
 ```sh
-kubebuilder create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached,-m=64,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha"
+kubebuilder create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached,--memory-limit=64,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha"
 ```
 
 <aside class="warning">

--- a/docs/book/src/reference/project-config.md
+++ b/docs/book/src/reference/project-config.md
@@ -23,7 +23,7 @@ plugins:
         group: example.com
         kind: Memcached
         options:
-          containerCommand: memcached,-m=64,-o,modern,-v
+          containerCommand: memcached,--memory-limit=64,-o,modern,-v
           containerPort: "11211"
           image: memcached:1.4.36-alpine
           runAsUser: "1001"
@@ -90,7 +90,7 @@ plugins:
         group: example.com
         kind: Memcached
         options:
-          containerCommand: memcached,-m=64,-o,modern,-v
+          containerCommand: memcached,--memory-limit=64,-o,modern,-v
           containerPort: "11211"
           image: memcached:memcached:1.6.26-alpine3.19
           runAsUser: "1001"

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -481,7 +481,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 							ContainerPort: 11211,
 							Name:          "memcached",
 						}},
-						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
+						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},
 				},
 			},

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -76,9 +76,9 @@ func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdM
 	
 	Note that in the following example we are also adding the optional options to let you inform the command which should be used to create the container and initialize itvia the flag --image-container-command as the Port that should be used
 
-	- By informing the command (--image-container-command="memcached,-m=64,-o,modern,-v") your deployment will be scaffold with, i.e.:
+	- By informing the command (--image-container-command="memcached,--memory-limit=64,-o,modern,-v") your deployment will be scaffold with, i.e.:
 
-		Command: []string{"memcached","-m=64","-o","modern","-v"},
+		Command: []string{"memcached","--memory-limit=64","-o","modern","-v"},
 
 	- By informing the Port (--image-container-port) will deployment will be scaffold with, i.e: 
 
@@ -89,7 +89,7 @@ func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdM
 
 	Therefore, the default values informed will be used to scaffold specs for the API. 
 
-  %[1]s create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached -m=64 modern -v" --image-container-port="11211" --plugins="deploy-image/v1-alpha" --make=false --namespaced=false
+  %[1]s create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached --memory-limit=64 modern -v" --image-container-port="11211" --plugins="deploy-image/v1-alpha" --make=false --namespaced=false
 
   # Generate the manifests
   make manifests
@@ -108,7 +108,8 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&p.imageContainerCommand, "image-container-command", "", "[Optional] if informed, "+
 		"will be used to scaffold the container command that should be used to init a container to run the image in "+
-		"the controller and its spec in the API (CRD/CR). (i.e. --image-container-command=\"memcached,-m=64,modern,-o,-v\")")
+		"the controller and its spec in the API (CRD/CR). (i.e. "+
+		"--image-container-command=\"memcached,--memory-limit=64,modern,-o,-v\")")
 	fs.StringVar(&p.imageContainerPort, "image-container-port", "", "[Optional] if informed, "+
 		"will be used to scaffold the container port that should be used by container image in "+
 		"the controller and its spec in the API (CRD/CR). (i.e --image-container-port=\"11211\") ")

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -140,7 +140,7 @@ func ReGenerateProject(kbc *utils.TestContext) {
 		"--version", "v1",
 		"--kind", "Memcached",
 		"--image=memcached:1.6.15-alpine",
-		"--image-container-command=memcached,-m=64,modern,-v",
+		"--image-container-command=memcached,--memory-limit=64,modern,-v",
 		"--image-container-port=11211",
 		"--run-as-user=1001",
 		"--plugins=\"deploy-image/v1-alpha\"",
@@ -241,7 +241,7 @@ func ReGenerateProject(kbc *utils.TestContext) {
 	Expect(fileContainsExpr).To(BeTrue())
 	var deployImagePluginFields = `kind: Memcached
       options:
-        containerCommand: memcached,-m=64,modern,-v
+        containerCommand: memcached,--memory-limit=64,modern,-v
         containerPort: "11211"
         image: memcached:1.6.15-alpine
         runAsUser: "1001"`

--- a/test/e2e/deployimage/generate_test.go
+++ b/test/e2e/deployimage/generate_test.go
@@ -63,7 +63,7 @@ func creatingAPIWithOptions(kbc *utils.TestContext) {
 		"--plugins", "deploy-image/v1-alpha",
 		"--image", "memcached:1.6.26-alpine3.19",
 		"--image-container-port", "11211",
-		"--image-container-command", "memcached,-m=64,-o,modern,-v",
+		"--image-container-command", "memcached,--memory-limit=64,-o,modern,-v",
 		"--run-as-user", "1001",
 		"--make=false",
 		"--manifests=false",

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -87,7 +87,7 @@ function scaffold_test_project {
     fi
   elif [[ $project =~ deploy-image ]]; then
       header_text 'Creating Memcached API with deploy-image plugin ...'
-      $kb create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:memcached:1.6.26-alpine3.19 --image-container-command="memcached,-m=64,-o,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha" --make=false
+      $kb create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:memcached:1.6.26-alpine3.19 --image-container-command="memcached,--memory-limit=64,-o,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha" --make=false
       $kb create api --group example.com --version v1alpha1 --kind Busybox --image=busybox:1.36.1 --plugins="deploy-image/v1-alpha" --make=false
       header_text 'Creating Memcached webhook ...'
       $kb create webhook --group example.com --version v1alpha1 --kind Memcached --programmatic-validation

--- a/testdata/project-v4-with-deploy-image/PROJECT
+++ b/testdata/project-v4-with-deploy-image/PROJECT
@@ -12,7 +12,7 @@ plugins:
       group: example.com
       kind: Memcached
       options:
-        containerCommand: memcached,-m=64,-o,modern,-v
+        containerCommand: memcached,--memory-limit=64,-o,modern,-v
         containerPort: "11211"
         image: memcached:memcached:1.6.26-alpine3.19
         runAsUser: "1001"

--- a/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-deploy-image/internal/controller/memcached_controller.go
@@ -386,7 +386,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 							ContainerPort: memcached.Spec.ContainerPort,
 							Name:          "memcached",
 						}},
-						Command: []string{"memcached", "-m=64", "-o", "modern", "-v"},
+						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},
 				},
 			},


### PR DESCRIPTION
The memcached image fails to run when "-m=64" is passed to it.

We could either drop it, or replace it with "--memory-limit=64" which works.

When it runs, I get the error message 

``` sh
$ docker run --rm -it memcached:1.6.26-alpine3.19 memcached -m=64 -o modern -v
Cannot set item size limit higher than 1/2 of memory max.
```

