### PR TITLE
🌱 cleanup plugin_cluster-test.go

### DIFF
--- a/test/e2e/deployimage/generate_test.go
+++ b/test/e2e/deployimage/generate_test.go
@@ -47,6 +47,7 @@ func creatingAPI(kbc *utils.TestContext) {
 		"--kind", kbc.Kind,
 		"--plugins", "deploy-image/v1-alpha",
 		"--image", "busybox:1.36.1",
+		"--run-as-user", "1001",
 		"--make=false",
 		"--manifests=false",
 	)


### PR DESCRIPTION
Part of #4135

This commits cleans up "plugin_cluster_test.go" to be less verbose and use better use of Gomega's capabilities.

Notably, variables are used only when the output of some command is used later on in the test.  If we only assert things about the command output, it is generally in-lined.

Eventually functions are converted from `() error` to `(g Gomega)`, and Expects are converted to g.Expect inside the functions.  All offsets have been removed, since this isn't "helper" code, we want to know which line the test failed on.

Finally, the test for verifying available status has been fixed so that it checks the correct pod.