### PR TITLE
🐛 (go/v4) resolve duplicate webhook name issue in multi-version API

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -75,6 +75,8 @@ A webhook will automatically be served that calls this defaulting.
 The `Default` method is expected to mutate the receiver, setting the defaults.
 */
 
+// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob-v1.kb.io,admissionReviewVersions=v1
+
 // +kubebuilder:object:generate=false
 // CronJobCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind CronJob when those are created or updated.
@@ -153,6 +155,7 @@ validate anything on deletion.
 
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CronJobCustomValidator struct is responsible for validating the CronJob resource

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/manifests.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/manifests.yaml
@@ -12,6 +12,26 @@ webhooks:
       namespace: system
       path: /mutate-batch-tutorial-kubebuilder-io-v1-cronjob
   failurePolicy: Fail
+  name: mcronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-batch-tutorial-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
   name: mcronjob.kb.io
   rules:
   - apiGroups:
@@ -30,6 +50,26 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
 webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-batch-tutorial-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: vcronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook.go
@@ -79,6 +79,8 @@ A webhook will automatically be served that calls this defaulting.
 The `Default` method is expected to mutate the receiver, setting the defaults.
 */
 
+// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob-v1.kb.io,admissionReviewVersions=v1
+
 // +kubebuilder:object:generate=false
 // CronJobCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind CronJob when those are created or updated.
@@ -157,6 +159,7 @@ validate anything on deletion.
 
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CronJobCustomValidator struct is responsible for validating the CronJob resource

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -457,16 +457,6 @@ Then, we set up the webhook with the manager.
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_webhook.go"),
-		`// +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob.kb.io,admissionReviewVersions=v1`, "")
-	hackutils.CheckError("fixing cronjob_webhook.go by replacing marker", err)
-
-	err = pluginutil.ReplaceInFile(
-		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_webhook.go"),
-		`// +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob.kb.io,admissionReviewVersions=v1`, "")
-	hackutils.CheckError("fixing cronjob_webhook.go validate batch marker", err)
-
-	err = pluginutil.ReplaceInFile(
-		filepath.Join(sp.ctx.Dir, "api/v1/cronjob_webhook.go"),
 		`// TODO(user): Add more fields as needed for defaulting`, fragmentForDefaultFields)
 	hackutils.CheckError("fixing cronjob_webhook.go by replacing TODO in Defaulter", err)
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook.go
@@ -121,7 +121,7 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 	//nolint:lll
 	defaultingWebhookTemplate = `
-// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
 // +kubebuilder:object:generate=false
 // {{ .Resource.Kind }}CustomDefaulter struct is responsible for setting default values on the custom resource of the 
@@ -154,7 +154,7 @@ func (d *{{ .Resource.Kind }}CustomDefaulter) Default(ctx context.Context, obj r
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ .QualifiedGroupWithDash }}-{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ .Resource.QualifiedGroup }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
 // +kubebuilder:object:generate=false
 // {{ .Resource.Kind }}CustomValidator struct is responsible for validating the {{ .Resource.Kind }} resource 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook.go
@@ -42,7 +42,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CaptainCustomDefaulter struct is responsible for setting default values on the custom resource of the
@@ -72,7 +72,7 @@ func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj runtime.Object
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CaptainCustomValidator struct is responsible for validating the Captain resource

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook.go
@@ -40,7 +40,7 @@ func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // DestroyerCustomDefaulter struct is responsible for setting default values on the custom resource of the

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook.go
@@ -44,7 +44,7 @@ func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser-v2alpha1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CruiserCustomValidator struct is responsible for validating the Cruiser resource

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook.go
@@ -42,7 +42,7 @@ func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // LakersCustomDefaulter struct is responsible for setting default values on the custom resource of the
@@ -72,7 +72,7 @@ func (d *LakersCustomDefaulter) Default(ctx context.Context, obj runtime.Object)
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // LakersCustomValidator struct is responsible for validating the Lakers resource

--- a/testdata/project-v4-multigroup-with-deploy-image/config/webhook/manifests.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: mcaptain.kb.io
+  name: mcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -32,7 +32,7 @@ webhooks:
       namespace: system
       path: /mutate-ship-testproject-org-v1-destroyer
   failurePolicy: Fail
-  name: mdestroyer.kb.io
+  name: mdestroyer-v1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -52,7 +52,7 @@ webhooks:
       namespace: system
       path: /mutate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: mlakers.kb.io
+  name: mlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org
@@ -78,7 +78,7 @@ webhooks:
       namespace: system
       path: /validate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: vcaptain.kb.io
+  name: vcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -98,7 +98,7 @@ webhooks:
       namespace: system
       path: /validate-ship-testproject-org-v2alpha1-cruiser
   failurePolicy: Fail
-  name: vcruiser.kb.io
+  name: vcruiser-v2alpha1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -118,7 +118,7 @@ webhooks:
       namespace: system
       path: /validate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: vlakers.kb.io
+  name: vlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org

--- a/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-multigroup-with-deploy-image/dist/install.yaml
@@ -1540,7 +1540,7 @@ webhooks:
       namespace: project-v4-multigroup-with-deploy-image-system
       path: /mutate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: mcaptain.kb.io
+  name: mcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -1560,7 +1560,7 @@ webhooks:
       namespace: project-v4-multigroup-with-deploy-image-system
       path: /mutate-ship-testproject-org-v1-destroyer
   failurePolicy: Fail
-  name: mdestroyer.kb.io
+  name: mdestroyer-v1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -1580,7 +1580,7 @@ webhooks:
       namespace: project-v4-multigroup-with-deploy-image-system
       path: /mutate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: mlakers.kb.io
+  name: mlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org
@@ -1606,7 +1606,7 @@ webhooks:
       namespace: project-v4-multigroup-with-deploy-image-system
       path: /validate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: vcaptain.kb.io
+  name: vcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -1626,7 +1626,7 @@ webhooks:
       namespace: project-v4-multigroup-with-deploy-image-system
       path: /validate-ship-testproject-org-v2alpha1-cruiser
   failurePolicy: Fail
-  name: vcruiser.kb.io
+  name: vcruiser-v2alpha1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -1646,7 +1646,7 @@ webhooks:
       namespace: project-v4-multigroup-with-deploy-image-system
       path: /validate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: vlakers.kb.io
+  name: vlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook.go
@@ -42,7 +42,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CaptainCustomDefaulter struct is responsible for setting default values on the custom resource of the
@@ -72,7 +72,7 @@ func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj runtime.Object
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CaptainCustomValidator struct is responsible for validating the Captain resource

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook.go
@@ -40,7 +40,7 @@ func (r *Destroyer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // DestroyerCustomDefaulter struct is responsible for setting default values on the custom resource of the

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook.go
@@ -44,7 +44,7 @@ func (r *Cruiser) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser-v2alpha1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CruiserCustomValidator struct is responsible for validating the Cruiser resource

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook.go
@@ -42,7 +42,7 @@ func (r *Lakers) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-testproject-org-v1-lakers,mutating=true,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=mlakers-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // LakersCustomDefaulter struct is responsible for setting default values on the custom resource of the
@@ -72,7 +72,7 @@ func (d *LakersCustomDefaulter) Default(ctx context.Context, obj runtime.Object)
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-testproject-org-v1-lakers,mutating=false,failurePolicy=fail,sideEffects=None,groups=testproject.org,resources=lakers,verbs=create;update,versions=v1,name=vlakers-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // LakersCustomValidator struct is responsible for validating the Lakers resource

--- a/testdata/project-v4-multigroup/config/webhook/manifests.yaml
+++ b/testdata/project-v4-multigroup/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: mcaptain.kb.io
+  name: mcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -32,7 +32,7 @@ webhooks:
       namespace: system
       path: /mutate-ship-testproject-org-v1-destroyer
   failurePolicy: Fail
-  name: mdestroyer.kb.io
+  name: mdestroyer-v1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -52,7 +52,7 @@ webhooks:
       namespace: system
       path: /mutate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: mlakers.kb.io
+  name: mlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org
@@ -78,7 +78,7 @@ webhooks:
       namespace: system
       path: /validate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: vcaptain.kb.io
+  name: vcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -98,7 +98,7 @@ webhooks:
       namespace: system
       path: /validate-ship-testproject-org-v2alpha1-cruiser
   failurePolicy: Fail
-  name: vcruiser.kb.io
+  name: vcruiser-v2alpha1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -118,7 +118,7 @@ webhooks:
       namespace: system
       path: /validate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: vlakers.kb.io
+  name: vlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -1540,7 +1540,7 @@ webhooks:
       namespace: project-v4-multigroup-system
       path: /mutate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: mcaptain.kb.io
+  name: mcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -1560,7 +1560,7 @@ webhooks:
       namespace: project-v4-multigroup-system
       path: /mutate-ship-testproject-org-v1-destroyer
   failurePolicy: Fail
-  name: mdestroyer.kb.io
+  name: mdestroyer-v1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -1580,7 +1580,7 @@ webhooks:
       namespace: project-v4-multigroup-system
       path: /mutate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: mlakers.kb.io
+  name: mlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org
@@ -1606,7 +1606,7 @@ webhooks:
       namespace: project-v4-multigroup-system
       path: /validate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: vcaptain.kb.io
+  name: vcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -1626,7 +1626,7 @@ webhooks:
       namespace: project-v4-multigroup-system
       path: /validate-ship-testproject-org-v2alpha1-cruiser
   failurePolicy: Fail
-  name: vcruiser.kb.io
+  name: vcruiser-v2alpha1.kb.io
   rules:
   - apiGroups:
     - ship.testproject.org
@@ -1646,7 +1646,7 @@ webhooks:
       namespace: project-v4-multigroup-system
       path: /validate-testproject-org-v1-lakers
   failurePolicy: Fail
-  name: vlakers.kb.io
+  name: vlakers-v1.kb.io
   rules:
   - apiGroups:
     - testproject.org

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook.go
@@ -44,7 +44,7 @@ func (r *Memcached) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-example-com-testproject-org-v1alpha1-memcached,mutating=false,failurePolicy=fail,sideEffects=None,groups=example.com.testproject.org,resources=memcacheds,verbs=create;update,versions=v1alpha1,name=vmemcached.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-example-com-testproject-org-v1alpha1-memcached,mutating=false,failurePolicy=fail,sideEffects=None,groups=example.com.testproject.org,resources=memcacheds,verbs=create;update,versions=v1alpha1,name=vmemcached-v1alpha1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // MemcachedCustomValidator struct is responsible for validating the Memcached resource

--- a/testdata/project-v4-with-deploy-image/config/webhook/manifests.yaml
+++ b/testdata/project-v4-with-deploy-image/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /validate-example-com-testproject-org-v1alpha1-memcached
   failurePolicy: Fail
-  name: vmemcached.kb.io
+  name: vmemcached-v1alpha1.kb.io
   rules:
   - apiGroups:
     - example.com.testproject.org

--- a/testdata/project-v4-with-deploy-image/dist/install.yaml
+++ b/testdata/project-v4-with-deploy-image/dist/install.yaml
@@ -664,7 +664,7 @@ webhooks:
       namespace: project-v4-with-deploy-image-system
       path: /validate-example-com-testproject-org-v1alpha1-memcached
   failurePolicy: Fail
-  name: vmemcached.kb.io
+  name: vmemcached-v1alpha1.kb.io
   rules:
   - apiGroups:
     - example.com.testproject.org

--- a/testdata/project-v4/api/v1/admiral_webhook.go
+++ b/testdata/project-v4/api/v1/admiral_webhook.go
@@ -40,7 +40,7 @@ func (r *Admiral) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirales,verbs=create;update,versions=v1,name=madmiral.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirales,verbs=create;update,versions=v1,name=madmiral-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // AdmiralCustomDefaulter struct is responsible for setting default values on the custom resource of the

--- a/testdata/project-v4/api/v1/captain_webhook.go
+++ b/testdata/project-v4/api/v1/captain_webhook.go
@@ -42,7 +42,7 @@ func (r *Captain) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CaptainCustomDefaulter struct is responsible for setting default values on the custom resource of the
@@ -72,7 +72,7 @@ func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj runtime.Object
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain-v1.kb.io,admissionReviewVersions=v1
 
 // +kubebuilder:object:generate=false
 // CaptainCustomValidator struct is responsible for validating the Captain resource

--- a/testdata/project-v4/config/webhook/manifests.yaml
+++ b/testdata/project-v4/config/webhook/manifests.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: system
       path: /mutate-crew-testproject-org-v1-admiral
   failurePolicy: Fail
-  name: madmiral.kb.io
+  name: madmiral-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -32,7 +32,7 @@ webhooks:
       namespace: system
       path: /mutate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: mcaptain.kb.io
+  name: mcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -58,7 +58,7 @@ webhooks:
       namespace: system
       path: /validate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: vcaptain.kb.io
+  name: vcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -630,7 +630,7 @@ webhooks:
       namespace: project-v4-system
       path: /mutate-crew-testproject-org-v1-admiral
   failurePolicy: Fail
-  name: madmiral.kb.io
+  name: madmiral-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -650,7 +650,7 @@ webhooks:
       namespace: project-v4-system
       path: /mutate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: mcaptain.kb.io
+  name: mcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org
@@ -676,7 +676,7 @@ webhooks:
       namespace: project-v4-system
       path: /validate-crew-testproject-org-v1-captain
   failurePolicy: Fail
-  name: vcaptain.kb.io
+  name: vcaptain-v1.kb.io
   rules:
   - apiGroups:
     - crew.testproject.org


### PR DESCRIPTION
Adjust webhook names for mutating and validating webhooks to avoid conflicts when creating multiple versions of the same API. 

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4144