### PR TITLE
🐛 Enhances the webhook test template.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
@@ -104,32 +104,28 @@ var _ = Describe("CronJob Webhook", func() {
 	Context("When creating or updating CronJob under Validating Webhook", func() {
 		It("Should deny creation if the name is too long", func() {
 			obj.ObjectMeta.Name = "this-name-is-way-too-long-and-should-fail-validation-because-it-is-way-too-long"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred(), "Expected name validation to fail for a too-long name")
-			Expect(warnings).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("must be no more than 52 characters"))
+			Expect(validator.ValidateCreate(ctx, obj)).Error().To(
+				MatchError(ContainSubstring("must be no more than 52 characters")),
+				"Expected name validation to fail for a too-long name")
 		})
 
 		It("Should admit creation if the name is valid", func() {
 			obj.ObjectMeta.Name = "valid-cronjob-name"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected name validation to pass for a valid name")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateCreate(ctx, obj)).To(BeNil(),
+				"Expected name validation to pass for a valid name")
 		})
 
 		It("Should deny creation if the schedule is invalid", func() {
 			obj.Spec.Schedule = "invalid-cron-schedule"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred(), "Expected spec validation to fail for an invalid schedule")
-			Expect(warnings).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("Expected exactly 5 fields, found 1: invalid-cron-schedule"))
+			Expect(validator.ValidateCreate(ctx, obj)).Error().To(
+				MatchError(ContainSubstring("Expected exactly 5 fields, found 1: invalid-cron-schedule")),
+				"Expected spec validation to fail for an invalid schedule")
 		})
 
 		It("Should admit creation if the schedule is valid", func() {
 			obj.Spec.Schedule = "*/5 * * * *"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected spec validation to pass for a valid schedule")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateCreate(ctx, obj)).To(BeNil(),
+				"Expected spec validation to pass for a valid schedule")
 		})
 
 		It("Should deny update if both name and spec are invalid", func() {
@@ -141,9 +137,8 @@ var _ = Describe("CronJob Webhook", func() {
 			obj.Spec.Schedule = "invalid-cron-schedule"
 
 			By("validating an update")
-			warnings, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).To(HaveOccurred(), "Expected validation to fail for both name and spec")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateUpdate(ctx, oldObj, obj)).Error().To(HaveOccurred(),
+				"Expected validation to fail for both name and spec")
 		})
 
 		It("Should admit update if both name and spec are valid", func() {
@@ -155,9 +150,8 @@ var _ = Describe("CronJob Webhook", func() {
 			obj.Spec.Schedule = "0 0 * * *"
 
 			By("validating an update")
-			warnings, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected validation to pass for a valid update")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil(),
+				"Expected validation to pass for a valid update")
 		})
 	})
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_webhook_test.go
@@ -104,32 +104,28 @@ var _ = Describe("CronJob Webhook", func() {
 	Context("When creating or updating CronJob under Validating Webhook", func() {
 		It("Should deny creation if the name is too long", func() {
 			obj.ObjectMeta.Name = "this-name-is-way-too-long-and-should-fail-validation-because-it-is-way-too-long"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred(), "Expected name validation to fail for a too-long name")
-			Expect(warnings).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("must be no more than 52 characters"))
+			Expect(validator.ValidateCreate(ctx, obj)).Error().To(
+				MatchError(ContainSubstring("must be no more than 52 characters")),
+				"Expected name validation to fail for a too-long name")
 		})
 
 		It("Should admit creation if the name is valid", func() {
 			obj.ObjectMeta.Name = "valid-cronjob-name"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected name validation to pass for a valid name")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateCreate(ctx, obj)).To(BeNil(),
+				"Expected name validation to pass for a valid name")
 		})
 
 		It("Should deny creation if the schedule is invalid", func() {
 			obj.Spec.Schedule = "invalid-cron-schedule"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred(), "Expected spec validation to fail for an invalid schedule")
-			Expect(warnings).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("Expected exactly 5 fields, found 1: invalid-cron-schedule"))
+			Expect(validator.ValidateCreate(ctx, obj)).Error().To(
+				MatchError(ContainSubstring("Expected exactly 5 fields, found 1: invalid-cron-schedule")),
+				"Expected spec validation to fail for an invalid schedule")
 		})
 
 		It("Should admit creation if the schedule is valid", func() {
 			obj.Spec.Schedule = "*/5 * * * *"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected spec validation to pass for a valid schedule")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateCreate(ctx, obj)).To(BeNil(),
+				"Expected spec validation to pass for a valid schedule")
 		})
 
 		It("Should deny update if both name and spec are invalid", func() {
@@ -141,9 +137,8 @@ var _ = Describe("CronJob Webhook", func() {
 			obj.Spec.Schedule = "invalid-cron-schedule"
 
 			By("validating an update")
-			warnings, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).To(HaveOccurred(), "Expected validation to fail for both name and spec")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateUpdate(ctx, oldObj, obj)).Error().To(HaveOccurred(),
+				"Expected validation to fail for both name and spec")
 		})
 
 		It("Should admit update if both name and spec are valid", func() {
@@ -155,9 +150,8 @@ var _ = Describe("CronJob Webhook", func() {
 			obj.Spec.Schedule = "0 0 * * *"
 
 			By("validating an update")
-			warnings, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected validation to pass for a valid update")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil(),
+				"Expected validation to pass for a valid update")
 		})
 	})
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_webhook_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("CronJob Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
@@ -54,40 +53,33 @@ var _ = Describe("CronJob Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 
 	Context("When creating CronJob under Conversion Webhook", func() {
-		It("Should convert the object correctly", func() {
-			// TODO (user): Add logic to convert the object to the desired version and verify the conversion
-			// Example:
-			// convertedObj := &CronJob{}
-			// err := obj.ConvertTo(convertedObj)
-			// Expect(err).NotTo(HaveOccurred())
-			// Expect(convertedObj).ToNot(BeNil())
-		})
+		// TODO (user): Add logic to convert the object to the desired version and verify the conversion
+		// Example:
+		// It("Should convert the object correctly", func() {
+		//     convertedObj := &CronJob{}
+		//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
+		//     Expect(convertedObj).ToNot(BeNil())
+		// })
 	})
 
 })

--- a/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
@@ -185,9 +185,8 @@ const webhookTestCreateDefaultingFragment = `// TODO (user): Add logic for defau
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })`
 
@@ -231,58 +230,48 @@ const webhookTestCreateDefaultingReplaceFragment = `It("Should apply defaults wh
 const webhookTestingValidatingTodoFragment = `// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })`
 
 const webhookTestingValidatingExampleFragment = `It("Should deny creation if the name is too long", func() {
 			obj.ObjectMeta.Name = "this-name-is-way-too-long-and-should-fail-validation-because-it-is-way-too-long"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred(), "Expected name validation to fail for a too-long name")
-			Expect(warnings).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("must be no more than 52 characters"))
+			Expect(validator.ValidateCreate(ctx, obj)).Error().To(
+				MatchError(ContainSubstring("must be no more than 52 characters")),
+				"Expected name validation to fail for a too-long name")
 		})
 
 		It("Should admit creation if the name is valid", func() {
 			obj.ObjectMeta.Name = "valid-cronjob-name"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected name validation to pass for a valid name")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateCreate(ctx, obj)).To(BeNil(),
+				"Expected name validation to pass for a valid name")
 		})
 
 		It("Should deny creation if the schedule is invalid", func() {
 			obj.Spec.Schedule = "invalid-cron-schedule"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred(), "Expected spec validation to fail for an invalid schedule")
-			Expect(warnings).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("Expected exactly 5 fields, found 1: invalid-cron-schedule"))
+			Expect(validator.ValidateCreate(ctx, obj)).Error().To(
+				MatchError(ContainSubstring("Expected exactly 5 fields, found 1: invalid-cron-schedule")),
+				"Expected spec validation to fail for an invalid schedule")
 		})
 
 		It("Should admit creation if the schedule is valid", func() {
 			obj.Spec.Schedule = "*/5 * * * *"
-			warnings, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected spec validation to pass for a valid schedule")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateCreate(ctx, obj)).To(BeNil(),
+				"Expected spec validation to pass for a valid schedule")
 		})
 
 		It("Should deny update if both name and spec are invalid", func() {
@@ -294,9 +283,8 @@ const webhookTestingValidatingExampleFragment = `It("Should deny creation if the
 			obj.Spec.Schedule = "invalid-cron-schedule"
 
 			By("validating an update")
-			warnings, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).To(HaveOccurred(), "Expected validation to fail for both name and spec")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateUpdate(ctx, oldObj, obj)).Error().To(HaveOccurred(),
+				"Expected validation to fail for both name and spec")
 		})
 
 		It("Should admit update if both name and spec are valid", func() {
@@ -308,9 +296,8 @@ const webhookTestingValidatingExampleFragment = `It("Should deny creation if the
 			obj.Spec.Schedule = "0 0 * * *"
 
 			By("validating an update")
-			warnings, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).NotTo(HaveOccurred(), "Expected validation to pass for a valid update")
-			Expect(warnings).To(BeNil())
+			Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil(),
+				"Expected validation to pass for a valid update")
 		})`
 
 const webhookTestsBeforeEachOriginal = `obj = &CronJob{}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
@@ -89,7 +89,7 @@ var _ = Describe("{{ .Resource.Kind }} Webhook", func() {
 	BeforeEach(func() {
 		obj = &{{ .Resource.Kind }}{}
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		
+
 		// TODO (user): Add any setup logic common to all tests
 	})
 
@@ -103,14 +103,13 @@ var _ = Describe("{{ .Resource.Kind }} Webhook", func() {
 
 const conversionWebhookTestTemplate = `
 Context("When creating {{ .Resource.Kind }} under Conversion Webhook", func() {
-	It("Should convert the object correctly", func() {
-		// TODO (user): Add logic to convert the object to the desired version and verify the conversion
-		// Example:
-		// convertedObj := &{{ .Resource.Kind }}{}
-		// err := obj.ConvertTo(convertedObj)
-		// Expect(err).NotTo(HaveOccurred())
-		// Expect(convertedObj).ToNot(BeNil())
-	})
+	// TODO (user): Add logic to convert the object to the desired version and verify the conversion
+	// Example:
+	// It("Should convert the object correctly", func() {
+	//     convertedObj := &{{ .Resource.Kind }}{}
+	//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
+	//     Expect(convertedObj).ToNot(BeNil())
+	// })
 })
 `
 
@@ -119,28 +118,22 @@ Context("When creating or updating {{ .Resource.Kind }} under Validating Webhook
 	// TODO (user): Add logic for validating webhooks
 	// Example:
 	// It("Should deny creation if a required field is missing", func() {
-	// 	   By("simulating an invalid creation scenario")
+	//     By("simulating an invalid creation scenario")
 	//     obj.SomeRequiredField = ""
-	//     warnings, err := obj.ValidateCreate(ctx)
-	//     Expect(err).To(HaveOccurred())
-	//     Expect(warnings).To(BeNil())
+	//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 	// })
 	//
 	// It("Should admit creation if all required fields are present", func() {
-	// 	   By("simulating an invalid creation scenario")
+	//     By("simulating an invalid creation scenario")
 	//     obj.SomeRequiredField = "valid_value"
-	//	   warnings, err := obj.ValidateCreate(ctx)
-	//	   Expect(err).NotTo(HaveOccurred())
-	//	   Expect(warnings).To(BeNil())
+	//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 	// })
 	//
 	// It("Should validate updates correctly", func() {
 	//     By("simulating a valid update scenario")
-	//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-	//	   obj.SomeRequiredField = "updated_value"
-	//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-	//	   Expect(err).NotTo(HaveOccurred())
-	//	   Expect(warnings).To(BeNil())
+	//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+	//     obj.SomeRequiredField = "updated_value"
+	//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 	// })
 })
 `
@@ -151,9 +144,8 @@ Context("When creating {{ .Resource.Kind }} under Defaulting Webhook", func() {
 	// Example:
 	// It("Should apply defaults when a required field is empty", func() {
 	//     By("simulating a scenario where defaults should be applied")
-	// 	   obj.SomeFieldWithDefault = ""
-	//	   err := obj.Default(ctx)
-	//	   Expect(err).NotTo(HaveOccurred())
+	//     obj.SomeFieldWithDefault = ""
+	//     Expect(obj.Default(ctx)).To(Succeed())
 	//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 	// })
 })

--- a/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/crew/v1/captain_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Captain Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
@@ -54,28 +53,22 @@ var _ = Describe("Captain Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1/destroyer_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Destroyer Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v1beta1/frigate_webhook_test.go
@@ -39,14 +39,13 @@ var _ = Describe("Frigate Webhook", func() {
 	})
 
 	Context("When creating Frigate under Conversion Webhook", func() {
-		It("Should convert the object correctly", func() {
-			// TODO (user): Add logic to convert the object to the desired version and verify the conversion
-			// Example:
-			// convertedObj := &Frigate{}
-			// err := obj.ConvertTo(convertedObj)
-			// Expect(err).NotTo(HaveOccurred())
-			// Expect(convertedObj).ToNot(BeNil())
-		})
+		// TODO (user): Add logic to convert the object to the desired version and verify the conversion
+		// Example:
+		// It("Should convert the object correctly", func() {
+		//     convertedObj := &Frigate{}
+		//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
+		//     Expect(convertedObj).ToNot(BeNil())
+		// })
 	})
 
 })

--- a/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/ship/v2alpha1/cruiser_webhook_test.go
@@ -42,28 +42,22 @@ var _ = Describe("Cruiser Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook_test.go
+++ b/testdata/project-v4-multigroup-with-deploy-image/api/v1/lakers_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Lakers Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
@@ -54,28 +53,22 @@ var _ = Describe("Lakers Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Captain Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
@@ -54,28 +53,22 @@ var _ = Describe("Captain Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Destroyer Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_webhook_test.go
@@ -39,14 +39,13 @@ var _ = Describe("Frigate Webhook", func() {
 	})
 
 	Context("When creating Frigate under Conversion Webhook", func() {
-		It("Should convert the object correctly", func() {
-			// TODO (user): Add logic to convert the object to the desired version and verify the conversion
-			// Example:
-			// convertedObj := &Frigate{}
-			// err := obj.ConvertTo(convertedObj)
-			// Expect(err).NotTo(HaveOccurred())
-			// Expect(convertedObj).ToNot(BeNil())
-		})
+		// TODO (user): Add logic to convert the object to the desired version and verify the conversion
+		// Example:
+		// It("Should convert the object correctly", func() {
+		//     convertedObj := &Frigate{}
+		//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
+		//     Expect(convertedObj).ToNot(BeNil())
+		// })
 	})
 
 })

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_webhook_test.go
@@ -42,28 +42,22 @@ var _ = Describe("Cruiser Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4-multigroup/api/v1/lakers_webhook_test.go
+++ b/testdata/project-v4-multigroup/api/v1/lakers_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Lakers Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
@@ -54,28 +53,22 @@ var _ = Describe("Lakers Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook_test.go
+++ b/testdata/project-v4-with-deploy-image/api/v1alpha1/memcached_webhook_test.go
@@ -42,28 +42,22 @@ var _ = Describe("Memcached Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4/api/v1/admiral_webhook_test.go
+++ b/testdata/project-v4/api/v1/admiral_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Admiral Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})

--- a/testdata/project-v4/api/v1/captain_webhook_test.go
+++ b/testdata/project-v4/api/v1/captain_webhook_test.go
@@ -43,9 +43,8 @@ var _ = Describe("Captain Webhook", func() {
 		// Example:
 		// It("Should apply defaults when a required field is empty", func() {
 		//     By("simulating a scenario where defaults should be applied")
-		// 	   obj.SomeFieldWithDefault = ""
-		//	   err := obj.Default(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
+		//     obj.SomeFieldWithDefault = ""
+		//     Expect(obj.Default(ctx)).To(Succeed())
 		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
 		// })
 	})
@@ -54,28 +53,22 @@ var _ = Describe("Captain Webhook", func() {
 		// TODO (user): Add logic for validating webhooks
 		// Example:
 		// It("Should deny creation if a required field is missing", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = ""
-		//     warnings, err := obj.ValidateCreate(ctx)
-		//     Expect(err).To(HaveOccurred())
-		//     Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).Error().To(HaveOccurred())
 		// })
 		//
 		// It("Should admit creation if all required fields are present", func() {
-		// 	   By("simulating an invalid creation scenario")
+		//     By("simulating an invalid creation scenario")
 		//     obj.SomeRequiredField = "valid_value"
-		//	   warnings, err := obj.ValidateCreate(ctx)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     Expect(obj.ValidateCreate(ctx)).To(BeNil())
 		// })
 		//
 		// It("Should validate updates correctly", func() {
 		//     By("simulating a valid update scenario")
-		//	   oldObj := &Captain{SomeRequiredField: "valid_value"}
-		//	   obj.SomeRequiredField = "updated_value"
-		//	   warnings, err := obj.ValidateUpdate(ctx, oldObj)
-		//	   Expect(err).NotTo(HaveOccurred())
-		//	   Expect(warnings).To(BeNil())
+		//     oldObj := &Captain{SomeRequiredField: "valid_value"}
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(obj.ValidateUpdate(ctx, oldObj)).To(BeNil())
 		// })
 	})
 

--- a/testdata/project-v4/api/v1/firstmate_webhook_test.go
+++ b/testdata/project-v4/api/v1/firstmate_webhook_test.go
@@ -39,14 +39,13 @@ var _ = Describe("FirstMate Webhook", func() {
 	})
 
 	Context("When creating FirstMate under Conversion Webhook", func() {
-		It("Should convert the object correctly", func() {
-			// TODO (user): Add logic to convert the object to the desired version and verify the conversion
-			// Example:
-			// convertedObj := &FirstMate{}
-			// err := obj.ConvertTo(convertedObj)
-			// Expect(err).NotTo(HaveOccurred())
-			// Expect(convertedObj).ToNot(BeNil())
-		})
+		// TODO (user): Add logic to convert the object to the desired version and verify the conversion
+		// Example:
+		// It("Should convert the object correctly", func() {
+		//     convertedObj := &FirstMate{}
+		//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
+		//     Expect(convertedObj).ToNot(BeNil())
+		// })
 	})
 
 })


### PR DESCRIPTION
The webhook scaffold had some oddly indented regions, resulting in the generated source code having a mix of tabs and spaces, and was generally looking quite ugly.

The gomega asserions are too chatty; errors, and return values are checked after first being assigned as variables in scope.  This is not needed, and Gomega checks all of this for us:

* Expect(someFunc()).Error().To(HaveOccurred()) checks both the error, but also that the other return values are zero or nil.
* Expect(someFunc()).To(ContainSubstring("X")) checks both the return value _and_ verifies that the error is nil.

Fixes #4148.  Part of #4135.

- Fixes odd indentation, now it is in line with the other scaffolds
- Simplifies gomega assertions, to use fewer statements
- Updated the cronjob tutorial's tests too 

