### PR TITLE
✨ Webhooks for external APIs

### DIFF
--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -90,7 +90,8 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 
 	if opts.DoDefaulting || opts.DoValidation || opts.DoConversion {
 		//nolint:staticcheck
-		res.Path = resource.APIPackagePath(c.GetRepository(), res.Group, res.Version, c.IsMultiGroup())
+		loadedRes, _ := c.GetResource(res.GVK)
+		res.Path = loadedRes.Path
 
 		res.Webhooks.WebhookVersion = "v1"
 		if opts.DoDefaulting {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/webhook_test_template.go
@@ -35,6 +35,8 @@ type WebhookTest struct { // nolint:maligned
 	machinery.BoilerplateMixin
 	machinery.ResourceMixin
 
+	ExternalAPI bool
+
 	Force bool
 }
 
@@ -77,17 +79,28 @@ package {{ .Resource.Version }}
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	{{- if .ExternalAPI }}
+	{{ .Resource.ImportAlias }} "{{ .Resource.Path }}"
+	{{- end }}
 
 	// TODO (user): Add any additional imports if needed
 )
 
 var _ = Describe("{{ .Resource.Kind }} Webhook", func() {
 	var (
+		{{- if .ExternalAPI }}
+		obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}
+		{{- else }}
 		obj *{{ .Resource.Kind }}
+		{{- end }}
 	)
 
 	BeforeEach(func() {
+		{{- if .ExternalAPI }}
+		obj = &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
+		{{- else }}
 		obj = &{{ .Resource.Kind }}{}
+		{{- end }}
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
 
 		// TODO (user): Add any setup logic common to all tests
@@ -106,7 +119,11 @@ Context("When creating {{ .Resource.Kind }} under Conversion Webhook", func() {
 	// TODO (user): Add logic to convert the object to the desired version and verify the conversion
 	// Example:
 	// It("Should convert the object correctly", func() {
+	{{- if .ExternalAPI }}
+	//     convertedObj := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
+	{{- else }}
 	//     convertedObj := &{{ .Resource.Kind }}{}
+	{{- end }}
 	//     Expect(obj.ConvertTo(convertedObj)).To(Succeed())
 	//     Expect(convertedObj).ToNot(BeNil())
 	// })

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -18,6 +18,7 @@ package scaffolds
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -85,11 +86,13 @@ func (s *webhookScaffolder) Scaffold() error {
 		return fmt.Errorf("error updating resource: %w", err)
 	}
 
+	externalAPI := !strings.HasPrefix(s.resource.Path, s.config.GetRepository())
+
 	if err := scaffold.Execute(
-		&api.Webhook{Force: s.force},
+		&api.Webhook{Force: s.force, ExternalAPI: externalAPI},
 		&e2e.WebhookTestUpdater{WireWebhook: true},
-		&templates.MainUpdater{WireWebhook: true},
-		&api.WebhookTest{Force: s.force},
+		&templates.MainUpdater{WireWebhook: true, ExternalAPI: externalAPI},
+		&api.WebhookTest{Force: s.force, ExternalAPI: externalAPI},
 	); err != nil {
 		return err
 	}
@@ -102,7 +105,7 @@ You need to implement the conversion.Hub and conversion.Convertible interfaces f
 	// TODO: Add test suite for conversion webhook after #1664 has been merged & conversion tests supported in envtest.
 	if doDefaulting || doValidation {
 		if err := scaffold.Execute(
-			&api.WebhookSuite{K8SVersion: EnvtestK8SVersion},
+			&api.WebhookSuite{K8SVersion: EnvtestK8SVersion, ExternalAPI: externalAPI},
 		); err != nil {
 			return err
 		}

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -96,11 +96,16 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 			" --programmatic-validation and --conversion to be true", p.commandName)
 	}
 
-	// check if resource exist to create webhook
-	if r, err := p.config.GetResource(p.resource.GVK); err != nil {
-		return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
-	} else if r.Webhooks != nil && !r.Webhooks.IsEmpty() && !p.force {
+	if p.force {
+		return nil
+	}
+
+	r, err := p.config.GetResource(p.resource.GVK)
+	if err == nil && r.Webhooks != nil && !r.Webhooks.IsEmpty() {
 		return fmt.Errorf("webhook resource already exists")
+	}
+	if err == nil && r.API == nil || err != nil && res.Path == "" {
+		return fmt.Errorf("%s create webhook requires a previously created API or a core API", p.commandName)
 	}
 
 	return nil


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

This is a WIP branch. But looking for feedback already.

With this PR scaffolding for core resource types will be added. Addresses #2141.

This will currently only work with core resources, not external resources per se, since a flag to describe the external Go module is missing in this PR as of now.
Currently the changes in this PR rely of this map of groups here to get the external path set if its a core resource: https://github.com/kubernetes-sigs/kubebuilder/blob/662f78fadaef9caa4302f64d71ccba8c019b8140/pkg/plugins/golang/options.go#L118

Adding a flag like `--module` or `resource-pkg-path` would make this work with general external resources.

This flag could be added as part of the Golang plugin flag set or as part of the global kubebuilder flag set.
I am unsure if adding this flag to the global kubebuilder flag set might break some plugins that never assumed they will ever have to deal with external plugins. 
So adding this flag to the global kubebuilder flag set would need further discussion I think.

I also had to change the `SetupWithManager` method that is as of now a receiver method on the resource struct type since one can not define methods on external struct types in Go.
At the moment it looks like this:

```
// SetupWebhookWithManager will setup the manager to manage the webhooks.
func SetupWebhookForJobWithManager(mgr ctrl.Manager) error {
	return ctrl.NewWebhookManagedBy(mgr).
		For(&batchv1.Job{}).
		WithValidator(&JobCustomValidator{}).
		WithDefaulter(&JobCustomDefaulter{}).
		Complete()
}
```

--- 

It seems webhooks are going to be moved to internal/webhook anyway:  #4150
Then the new schema is similiar.

A `--external-api-path` flag is added also in #4171 as part of the Golang plugin flag set.

Feedback welcome.
I would espacially need to know:
- what the plan with the flag for external APIs is (#4171)
- should I rebase my PR on #4150 (probably yes)?
