### PR TITLE
🐛 cleanup: remove func APIPackagePathLegacy which is no longer used since release 4.0.0

### DIFF
--- a/pkg/model/resource/utils.go
+++ b/pkg/model/resource/utils.go
@@ -56,17 +56,6 @@ func APIPackagePath(repo, group, version string, multiGroup bool) string {
 	return path.Join(repo, "api", version)
 }
 
-// APIPackagePathLegacy returns the default path
-func APIPackagePathLegacy(repo, group, version string, multiGroup bool) string {
-	if multiGroup {
-		if group != "" {
-			return path.Join(repo, "apis", group, version)
-		}
-		return path.Join(repo, "apis", version)
-	}
-	return path.Join(repo, "api", version)
-}
-
 // RegularPlural returns a default plural form when none was specified
 func RegularPlural(singular string) string {
 	return flect.Pluralize(strings.ToLower(singular))

--- a/pkg/model/resource/utils_test.go
+++ b/pkg/model/resource/utils_test.go
@@ -50,23 +50,6 @@ var _ = Describe("APIPackagePath", func() {
 	)
 })
 
-var _ = Describe("APIPackagePathLegacy", func() {
-	const (
-		repo    = "github.com/kubernetes-sigs/kubebuilder"
-		group   = "group"
-		version = "v1"
-	)
-
-	DescribeTable("should work",
-		func(repo, group, version string, multiGroup bool, p string) {
-			Expect(APIPackagePathLegacy(repo, group, version, multiGroup)).To(Equal(p))
-		},
-		Entry("single group setup", repo, group, version, false, path.Join(repo, "api", version)),
-		Entry("multiple group setup", repo, group, version, true, path.Join(repo, "apis", group, version)),
-		Entry("multiple group setup with empty group", repo, "", version, true, path.Join(repo, "apis", version)),
-	)
-})
-
 var _ = DescribeTable("RegularPlural should return the regular plural form",
 	func(singular, plural string) { Expect(RegularPlural(singular)).To(Equal(plural)) },
 	Entry("basic singular", "firstmate", "firstmates"),

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -126,8 +126,7 @@ func (t *TestContext) makePrometheusOperatorURL() string {
 	return fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
 }
 
-// InstallCertManager installs the cert manager bundle. If hasv1beta1CRs is true,
-// the legacy version (which uses v1alpha2 CRs) is installed.
+// InstallCertManager installs the cert manager bundle.
 func (t *TestContext) InstallCertManager() error {
 	url := t.makeCertManagerURL()
 	if _, err := t.Kubectl.Apply(false, "-f", url, "--validate=false"); err != nil {


### PR DESCRIPTION
The APIPackagePathLegacy function was useful in older scaffolds to ensure backward compatibility. However, with the release of version 4.0.0, all deprecated features have been removed. As a result, this function should no longer be present