### PR TITLE
📖 (doc) remove from menu Appendix: The TODO Landing Page

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -135,6 +135,4 @@
 
 [FAQ](./faq.md)
 
-[Appendix: The TODO Landing Page](./TODO.md)
-
 [plugins]: ./plugins/plugins.md


### PR DESCRIPTION
It does not bring value for the docs. Therefore, we are removing it