### PR TITLE
📖 (doc): remove section in the platform documentation which says that kube-rbac-proxy is an image provided by default

### DIFF
--- a/docs/book/src/reference/platform.md
+++ b/docs/book/src/reference/platform.md
@@ -218,20 +218,7 @@ end up labeled with ` kubernetes.io/os=linux`
 
 </aside>
 
-### Kube RBAC Proxy
-
-A workload will be created to run the image [gcr.io/kubebuilder/kube-rbac-proxy:<tag>][proxy-images] which is
-configured in the `config/default/manager_auth_proxy_patch.yaml` manifest. It is a side-car proxy whose purpose
-is to protect the manager from malicious attacks. You can learn more about its motivations by looking at
-the README of this project [github.com/brancz/kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy).
-
-Kubebuilder has been building this image with support for multiple architectures by default.( Check it [here][proxy-images] ).
-If you need to address any edge case scenario where you want to produce a project that
-only provides support for a specific architecture platform, you can customize your
-configuration manifests to use the specific architecture types built for this image.
-
 [node-affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 [docker-manifest]: https://docs.docker.com/engine/reference/commandline/manifest/
-[proxy-images]: https://console.cloud.google.com/gcr/images/kubebuilder/GLOBAL/kube-rbac-proxy
 [buildx]: https://docs.docker.com/build/buildx/
 [goreleaser-buildx]: https://goreleaser.com/customization/docker/#use-a-specific-builder-with-docker-buildx


### PR DESCRIPTION
The usage of kube-rbac-proxy was discontinue and the image is no longer build or promoted by the project. Therefore, this section needs to be removed to avoid misleadings. More info: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907
