### PR TITLE
🐛 Fix HasResource pkg method to properly stop when a match is found

### DIFF
--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -160,13 +160,15 @@ func (c Cfg) ResourcesLength() int {
 
 // HasResource implements config.Config
 func (c Cfg) HasResource(gvk resource.GVK) bool {
+	found := false
 	for _, res := range c.Resources {
 		if gvk.IsEqualTo(res.GVK) {
-			return true
+			found = true
+			break
 		}
 	}
 
-	return false
+	return found
 }
 
 // GetResource implements config.Config


### PR DESCRIPTION
- Updated the HasResource method to correctly stop the iteration when a matching GVK is found.
- Replaced the immediate return inside the loop with a boolean flag  and a break statement to ensure the function exits early when a resource is found.
- This resolves the issue where the method was not stopping as expected after finding a matching resource

PS.: This issue was found when I was implementing the e2e tests for generate alpha command: https://github.com/kubernetes-sigs/kubebuilder/pull/4181