### PR TITLE
⚠️ 🐛fix: remove duplicate HasFragment method, replaced by HasFileContentWith

### DIFF
--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -226,25 +226,6 @@ func EnsureExistAndReplace(input, match, replace string) (string, error) {
 	return strings.Replace(input, match, replace, -1), nil
 }
 
-func HasFragment(path, target string) (bool, error) {
-	_, err := os.Stat(path)
-	if err != nil {
-		return false, err
-	}
-
-	// false positive
-	// nolint:gosec
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return false, err
-	}
-
-	if !strings.Contains(string(b), target) {
-		return false, nil
-	}
-	return true, nil
-}
-
 // ReplaceInFile replaces all instances of old with new in the file at path.
 func ReplaceInFile(path, old, new string) error {
 	info, err := os.Stat(path)

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -93,7 +93,7 @@ func (s *apiScaffolder) Scaffold() error {
 		kustomizeFilePath := "config/default/kustomization.yaml"
 		err := pluginutil.UncommentCode(kustomizeFilePath, "#- ../crd", `#`)
 		if err != nil {
-			hasCRUncommented, err := pluginutil.HasFragment(kustomizeFilePath, "- ../crd")
+			hasCRUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../crd")
 			if !hasCRUncommented || err != nil {
 				log.Errorf("Unable to find the target #- ../crd to uncomment in the file "+
 					"%s.", kustomizeFilePath)

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -101,7 +101,7 @@ func (s *webhookScaffolder) Scaffold() error {
 	kustomizeFilePath := "config/default/kustomization.yaml"
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#- ../webhook", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFragment(kustomizeFilePath, "- ../webhook")
+		hasWebHookUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../webhook")
 		if !hasWebHookUncommented || err != nil {
 			log.Errorf("Unable to find the target #- ../webhook to uncomment in the file "+
 				"%s.", kustomizeFilePath)
@@ -110,7 +110,7 @@ func (s *webhookScaffolder) Scaffold() error {
 
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#patches:", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFragment(kustomizeFilePath, "patches:")
+		hasWebHookUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "patches:")
 		if !hasWebHookUncommented || err != nil {
 			log.Errorf("Unable to find the line '#patches:' to uncomment in the file "+
 				"%s.", kustomizeFilePath)
@@ -119,7 +119,7 @@ func (s *webhookScaffolder) Scaffold() error {
 
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#- path: manager_webhook_patch.yaml", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFragment(kustomizeFilePath, "- path: manager_webhook_patch.yaml")
+		hasWebHookUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "- path: manager_webhook_patch.yaml")
 		if !hasWebHookUncommented || err != nil {
 			log.Errorf("Unable to find the target #- path: manager_webhook_patch.yaml to uncomment in the file "+
 				"%s.", kustomizeFilePath)
@@ -129,7 +129,7 @@ func (s *webhookScaffolder) Scaffold() error {
 	crdKustomizationsFilePath := "config/crd/kustomization.yaml"
 	err = pluginutil.UncommentCode(crdKustomizationsFilePath, "#- path: patches/webhook", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFragment(crdKustomizationsFilePath, "- path: patches/webhook")
+		hasWebHookUncommented, err := pluginutil.HasFileContentWith(crdKustomizationsFilePath, "- path: patches/webhook")
 		if !hasWebHookUncommented || err != nil {
 			log.Errorf("Unable to find the target(s) #- path: patches/webhook/* to uncomment in the file "+
 				"%s.", crdKustomizationsFilePath)
@@ -138,7 +138,7 @@ func (s *webhookScaffolder) Scaffold() error {
 
 	err = pluginutil.UncommentCode(crdKustomizationsFilePath, "#configurations:\n#- kustomizeconfig.yaml", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFragment(crdKustomizationsFilePath, "- kustomizeconfig.yaml")
+		hasWebHookUncommented, err := pluginutil.HasFileContentWith(crdKustomizationsFilePath, "- kustomizeconfig.yaml")
 		if !hasWebHookUncommented || err != nil {
 			log.Errorf("Unable to find the target(s) #configurations:\n#- kustomizeconfig.yaml to uncomment in the file "+
 				"%s.", crdKustomizationsFilePath)


### PR DESCRIPTION
The HasFragment method was mistakenly added, leading to code duplication. The existing HasFileContentWith method already handles the same functionality, so HasFragment has been removed to avoid redundancy.