### PR TITLE
✨ Upgrade Prometheus Operator version used on the tests from v0.72.0 to 0.77.1

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -53,7 +53,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -33,9 +33,9 @@ import (
 const (
 	certmanagerVersion        = "v1.16.0"
 	certmanagerURLTmpl        = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
-	prometheusOperatorVersion = "0.51"
-	prometheusOperatorURL     = "https://raw.githubusercontent.com/prometheus-operator/" +
-		"prometheus-operator/release-%s/bundle.yaml"
+	prometheusOperatorVersion = "v0.77.1"
+	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
+		"releases/download/%s/bundle.yaml"
 )
 
 // TestContext specified to run e2e tests
@@ -153,7 +153,7 @@ func (t *TestContext) UninstallCertManager() {
 // InstallPrometheusOperManager installs the prometheus manager bundle.
 func (t *TestContext) InstallPrometheusOperManager() error {
 	url := t.makePrometheusOperatorURL()
-	_, err := t.Kubectl.Apply(false, "-f", url)
+	_, err := t.Kubectl.Command("create", "-f", url)
 	return err
 }
 

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4-with-plugins/test/utils/utils.go
+++ b/testdata/project-v4-with-plugins/test/utils/utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	prometheusOperatorVersion = "v0.72.0"
+	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/%s/bundle.yaml"
 


### PR DESCRIPTION
Upgrade Prometheus Operator version used on the tests from v0.72.0 to 0.77.1