### PR TITLE
📖 Update roadmap_2024.md - Complete goal to align webhook scaffold with the latest changes in controller-runtime

### DIFF
--- a/roadmap/roadmap_2024.md
+++ b/roadmap/roadmap_2024.md
@@ -2,7 +2,7 @@
 
 ### Updating Scaffolding to Align with the Latest changes of controller-runtime
 
-**Status:** :raised_hands: Seeking help from the contributors
+**Status:** ✅ Complete (Changes available from release `4.3.0`)
 
 **Objective:** Update Kubebuilder's controller scaffolding to align with the latest changes
 in controller-runtime, focusing on compatibility and addressing recent updates and deprecations


### PR DESCRIPTION
The current scaffold is using the new interfaces and no longer the methods which are not supported.

See that the changes were done in the following PRs:

- (go/v4): Replaced the deprecated webhook.Validator and webhook.Defaulter interfaces with CustomValidator and CustomDefaulter. Projects using the old interfaces must migrate to ensure compatibility with future versions. (https://github.com/kubernetes-sigs/kubebuilder/pull/4060)
- (go/v4): Webhooks are now decoupled from the API directory. Webhook files should be moved from api/<version> or api/<group>/<version> to internal/webhook/<version> or internal/webhook/<group>/<version>. This restructuring improves project organization. (https://github.com/kubernetes-sigs/kubebuilder/pull/4150)