### PR TITLE
🐛 fixed Duplicate Webhook Patch Entries when Creating Multiple Ver…

### DIFF
--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -91,7 +91,11 @@ func (f *Kustomization) GetCodeFragments() machinery.CodeFragmentsMap {
 
 	if !f.Resource.Webhooks.IsEmpty() {
 		webhookPatch := fmt.Sprintf(webhookPatchCodeFragment, suffix)
-		fragments[machinery.NewMarkerFor(f.Path, webhookPatchMarker)] = []string{webhookPatch}
+
+		marker := machinery.NewMarkerFor(f.Path, webhookPatchMarker)
+		if _, exists := fragments[marker]; !exists {
+			fragments[marker] = []string{webhookPatch}
+		}
 	}
 
 	// Generate resource code fragments


### PR DESCRIPTION
fixes #4143 

Hey @camilamacedo86 I gave it a try and used the approach that-

1. created marker and stored the marker in a variable.
2. checked if the marker already exists ignoring the value part only checking key
3. If the marker doesn't exist in fragments add the webhookPatch to the fragments. If it already exists, we skip adding it.