### PR TITLE
✨ add helper function to the command alpha generate

### DIFF
--- a/pkg/cli/alpha/command.go
+++ b/pkg/cli/alpha/command.go
@@ -31,12 +31,9 @@ using the current version of KubeBuilder binary available.
 $ kubebuilder alpha generate --input-dir="./test" --output-dir="./my-output"
 Then we will re-scaffold the project by Kubebuilder in the directory specified by 'output-dir'.
 		`,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			return opts.Validate()
-		},
 		Run: func(_ *cobra.Command, _ []string) {
-			if err := opts.Generate(); err != nil {
-				log.Fatalf("Failed to command %s", err)
+			if err := internal.RunGenerate(&opts); err != nil {
+				log.Fatalf("Failed to generate: %v", err)
 			}
 		},
 	}

--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -392,3 +392,44 @@ func kubebuilderGrafanaEdit() error {
 	}
 	return nil
 }
+
+func RunGenerate(opts *Generate) error {
+	if err := opts.Validate(); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	config, err := loadProjectConfig(opts.InputDir)
+	if err != nil {
+		return fmt.Errorf("failed to load project config: %w", err)
+	}
+
+	if err := createDirectory(opts.OutputDir); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	if err := changeWorkingDirectory(opts.OutputDir); err != nil {
+		return fmt.Errorf("failed to change working directory: %w", err)
+	}
+
+	if err := kubebuilderInit(config); err != nil {
+		return fmt.Errorf("failed to initialize kubebuilder: %w", err)
+	}
+
+	if err := kubebuilderEdit(config); err != nil {
+		return fmt.Errorf("failed to edit Kubebuilder config: %w", err)
+	}
+
+	if err := kubebuilderCreate(config); err != nil {
+		return fmt.Errorf("failed to create Kubebuilder resources: %w", err)
+	}
+
+	if err := migrateGrafanaPlugin(config, opts.InputDir, opts.OutputDir); err != nil {
+		return fmt.Errorf("failed to migrate Grafana plugin: %w", err)
+	}
+
+	if err := migrateDeployImagePlugin(config); err != nil {
+		return fmt.Errorf("failed to migrate Deploy Image plugin: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### what
Introduce help to the command kubebuilder alpha generate. created a helper function named as RunGenerate which has all the logic of alpha Generate function.

when running kubebuilder alpha generate --help it gives-
```sh
It's an experimental feature that has the purpose of re-scaffolding the whole project from the scratch 
using the current version of KubeBuilder binary available.
# make sure the PROJECT file is in the 'input-dir' argument, the default is the current directory.
$ kubebuilder alpha generate --input-dir="./test" --output-dir="./my-output"
Then we will re-scaffold the project by Kubebuilder in the directory specified by 'output-dir'.

Usage:
  kubebuilder alpha generate [flags]

Flags:
  -h, --help                help for generate
      --input-dir string    path to a Kubebuilder project file if not in the current working directory
      --output-dir string   path to output the scaffolding. defaults a directory in the current working directory

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution
```

Closes: #4192 
