### PR TITLE
🌱 fix GoReleaser by adding permission to write content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,14 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We found an issue to publish the assets when we are trying to publish the release 4.3.0. Therefore, we are adding the content permission to verify if the issue can be solved within. More info: https://kubernetes.slack.com/archives/C01672LSZL0/p1729570852721079

