### PR TITLE
🌱 Fix incorrect image reference for DeployImage plugin in test data

### DIFF
--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -86,7 +86,7 @@ function scaffold_test_project {
   if [[ $project =~ multigroup ]] || [[ $project =~ with-plugins ]] ; then
     header_text 'With Optional Plugins ...'
     header_text 'Creating APIs with deploy-image plugin ...'
-    $kb create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:memcached:1.6.26-alpine3.19 --image-container-command="memcached,--memory-limit=64,-o,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha" --make=false
+    $kb create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.26-alpine3.19 --image-container-command="memcached,--memory-limit=64,-o,modern,-v" --image-container-port="11211" --run-as-user="1001" --plugins="deploy-image/v1-alpha" --make=false
     $kb create api --group example.com --version v1alpha1 --kind Busybox --image=busybox:1.36.1 --plugins="deploy-image/v1-alpha" --make=false
     $kb create webhook --group example.com --version v1alpha1 --kind Memcached --programmatic-validation
     header_text 'Editing project with Grafana plugin ...'

--- a/testdata/project-v4-multigroup/PROJECT
+++ b/testdata/project-v4-multigroup/PROJECT
@@ -15,7 +15,7 @@ plugins:
       options:
         containerCommand: memcached,--memory-limit=64,-o,modern,-v
         containerPort: "11211"
-        image: memcached:memcached:1.6.26-alpine3.19
+        image: memcached:1.6.26-alpine3.19
         runAsUser: "1001"
       version: v1alpha1
     - domain: testproject.org

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
         - name: BUSYBOX_IMAGE
           value: busybox:1.36.1
         - name: MEMCACHED_IMAGE
-          value: memcached:memcached:1.6.26-alpine3.19
+          value: memcached:1.6.26-alpine3.19
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -1764,7 +1764,7 @@ spec:
         - name: BUSYBOX_IMAGE
           value: busybox:1.36.1
         - name: MEMCACHED_IMAGE
-          value: memcached:memcached:1.6.26-alpine3.19
+          value: memcached:1.6.26-alpine3.19
         image: controller:latest
         livenessProbe:
           httpGet:

--- a/testdata/project-v4-with-plugins/PROJECT
+++ b/testdata/project-v4-with-plugins/PROJECT
@@ -14,7 +14,7 @@ plugins:
       options:
         containerCommand: memcached,--memory-limit=64,-o,modern,-v
         containerPort: "11211"
-        image: memcached:memcached:1.6.26-alpine3.19
+        image: memcached:1.6.26-alpine3.19
         runAsUser: "1001"
       version: v1alpha1
     - domain: testproject.org

--- a/testdata/project-v4-with-plugins/config/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
         - name: BUSYBOX_IMAGE
           value: busybox:1.36.1
         - name: MEMCACHED_IMAGE
-          value: memcached:memcached:1.6.26-alpine3.19
+          value: memcached:1.6.26-alpine3.19
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -606,7 +606,7 @@ spec:
         - name: BUSYBOX_IMAGE
           value: busybox:1.36.1
         - name: MEMCACHED_IMAGE
-          value: memcached:memcached:1.6.26-alpine3.19
+          value: memcached:1.6.26-alpine3.19
         image: controller:latest
         livenessProbe:
           httpGet:


### PR DESCRIPTION
We generate a sample API in the testdata directory using the DeployImage plugin. However, the flag previously contained incorrect information regarding the image that should be used. This fix ensures the correct image is referenced.
