### PR TITLE
🌱 Upgrade GoReleaser version from v2.1.0 to v2.3.2 used in the GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v2.1.0
+          version: v2.3.2
           args: release -f ./build/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
🌱 Upgrade GoReleaser version from v2.1.0 to v2.3.2 used in the GitHub action