### PR TITLE
:book: Upgrade controller-gen version used to generate documentation

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -71,7 +71,7 @@ chmod +x /tmp/mdbook
 
 echo "grabbing the latest released controller-gen"
 go version
-go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.1
+go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.4
 
 # make sure we add the go bin directory to our path
 gobin=$(go env GOBIN)


### PR DESCRIPTION
The documenation for the markers are generated automatic. The project currently scaffold solutions using controller-gen 0.16.4 therefore the documentation should either be generated using this version
