### PR TITLE
📖 Upgrade mdBook version used to generate docs from v0.4.34 t0 v0.4.40

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -63,9 +63,9 @@ esac
 
 # grab mdbook
 # we hardcode linux/amd64 since rust uses a different naming scheme and it's a pain to tran
-echo "downloading mdBook-v0.4.34-${arch}-${target}.${ext}"
+echo "downloading mdBook-v0.4.40-${arch}-${target}.${ext}"
 set -x
-curl -sL -o /tmp/mdbook.${ext} https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdBook-v0.4.34-${arch}-${target}.${ext}
+curl -sL -o /tmp/mdbook.${ext} https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdBook-v0.4.40-${arch}-${target}.${ext}
 ${cmd} /tmp/mdbook.${ext}
 chmod +x /tmp/mdbook
 


### PR DESCRIPTION
We use mdBook to generate the docs
This PR just keep the project in the edge.