### PR TITLE
:sparkles:  (go/v4): Enable `seccompProfile.type: RuntimeDefault` by default in scaffolded projects

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
@@ -49,14 +49,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4135,6 +4135,8 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: project-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
@@ -49,14 +49,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -430,6 +430,8 @@ spec:
             - ALL
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: project-controller-manager
       terminationGracePeriodSeconds: 10
 ---

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
@@ -49,14 +49,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -7949,6 +7949,8 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: project-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -95,14 +95,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -75,11 +75,6 @@ func GenerateV4(kbc *utils.TestContext) {
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "cmd", "main.go"),
 		tlsConfigManager, "// ")).To(Succeed())
-
-	if kbc.IsRestricted {
-		By("uncomment kustomize files to ensure that pods are restricted")
-		uncommentPodStandards(kbc)
-	}
 }
 
 // GenerateV4WithoutMetrics implements a go/v4 plugin project defined by a TestContext.
@@ -121,11 +116,6 @@ func GenerateV4WithoutMetrics(kbc *utils.TestContext) {
 	ExpectWithOffset(1, pluginutil.CommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		metricsTarget, "#")).To(Succeed())
-
-	if kbc.IsRestricted {
-		By("uncomment kustomize files to ensure that pods are restricted")
-		uncommentPodStandards(kbc)
-	}
 }
 
 // GenerateV4WithoutMetrics implements a go/v4 plugin project defined by a TestContext.
@@ -204,11 +194,6 @@ func GenerateV4WithoutWebhooks(kbc *utils.TestContext) {
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- ../prometheus", "#")).To(Succeed())
-
-	if kbc.IsRestricted {
-		By("uncomment kustomize files to ensure that pods are restricted")
-		uncommentPodStandards(kbc)
-	}
 }
 
 func creatingAPI(kbc *utils.TestContext) {
@@ -377,22 +362,6 @@ const certManagerTarget = `#replacements:
 #         delimiter: '/'
 #         index: 1
 #         create: true`
-
-func uncommentPodStandards(kbc *utils.TestContext) {
-	configManager := filepath.Join(kbc.Dir, "config", "manager", "manager.yaml")
-
-	//nolint:lll
-	if err := pluginutil.ReplaceInFile(configManager, `# TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault`, `seccompProfile:
-          type: RuntimeDefault`); err == nil {
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	}
-}
 
 // scaffoldConversionWebhook sets up conversion webhooks for testing the ConversionTest API
 func scaffoldConversionWebhook(kbc *utils.TestContext) {

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -67,33 +67,27 @@ var _ = Describe("kubebuilder", func() {
 			kbc.Destroy()
 		})
 		It("should generate a runnable project", func() {
-			kbc.IsRestricted = false
 			GenerateV4(kbc)
 			Run(kbc, true, false, true, false)
 		})
 		It("should generate a runnable project with the Installer", func() {
-			kbc.IsRestricted = false
 			GenerateV4(kbc)
 			Run(kbc, true, true, true, false)
 		})
 		It("should generate a runnable project without metrics exposed", func() {
-			kbc.IsRestricted = false
 			GenerateV4WithoutMetrics(kbc)
 			Run(kbc, true, false, false, false)
 		})
 		It("should generate a runnable project with metrics protected by network policies", func() {
-			kbc.IsRestricted = false
 			GenerateV4WithNetworkPoliciesWithoutWebhooks(kbc)
 			Run(kbc, false, false, true, true)
 		})
 		It("should generate a runnable project with webhooks and metrics protected by network policies", func() {
-			kbc.IsRestricted = false
 			GenerateV4WithNetworkPolicies(kbc)
 			Run(kbc, true, false, true, true)
 		})
 		It("should generate a runnable project with the manager running "+
 			"as restricted and without webhooks", func() {
-			kbc.IsRestricted = true
 			GenerateV4WithoutWebhooks(kbc)
 			Run(kbc, false, false, true, false)
 		})
@@ -110,11 +104,9 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, hasMetrics bool, 
 	err = kbc.CreateManagerNamespace()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	if kbc.IsRestricted {
-		By("labeling all namespaces to warn about restricted")
-		err = kbc.LabelNamespacesToWarnAboutRestricted()
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	}
+	By("labeling all namespaces to warn about restricted")
+	err = kbc.LabelNamespacesToWarnAboutRestricted()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	By("updating the go.mod")
 	err = kbc.Tidy()
@@ -149,10 +141,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, hasMetrics bool, 
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	}
 
-	if kbc.IsRestricted {
-		By("validating that manager Pod/container(s) are restricted")
-		ExpectWithOffset(1, output).NotTo(ContainSubstring("Warning: would violate PodSecurity"))
-	}
+	By("validating that manager Pod/container(s) are restricted")
+	ExpectWithOffset(1, output).NotTo(ContainSubstring("Warning: would violate PodSecurity"))
 
 	By("Checking controllerManager and getting the name of the Pod")
 	controllerPodName = getControllerName(kbc)

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -49,14 +49,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -1906,6 +1906,8 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: project-v4-multigroup-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/testdata/project-v4-with-plugins/config/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/config/manager/manager.yaml
@@ -49,14 +49,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -788,6 +788,8 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: project-v4-with-plugins-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -49,14 +49,12 @@ spec:
       #             values:
       #               - linux
       securityContext:
+        # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
+        # This ensures that deployments meet the highest security requirements for Kubernetes.
+        # For more details, see: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -653,6 +653,8 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: project-v4-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
- Removed the comment about `seccompProfile` as `type: RuntimeDefault` is now set by default.
- Updated to reflect that Kubebuilder only tests and supports the latest three Kubernetes releases.
- Given that we’re currently using Kubernetes 1.31, there’s no longer a reason to keep this line commented, ensuring projects adhere to `restricted` Pod Security Standards by default.
- Either OCP 4.10 is in EOL already: https://endoflife.date/red-hat-openshift
