### PR TITLE
:seeding: Update dependabot.yml to just raise PRs against project-v4 sample

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,26 +37,6 @@ updates:
     labels:
       - "ok-to-test"
 
-  # Maintain dependencies for go
-  - package-ecosystem: "gomod"
-    directory: "/testdata/project-v4-with-plugins"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
-
-  # Maintain dependencies for go
-  - package-ecosystem: "gomod"
-    directory: "/testdata/project-v4-multigroup"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
-
   # Maintain dependencies for dockerfile scaffold in the projects
   - package-ecosystem: docker
     directory: "testdata/project-v4"


### PR DESCRIPTION
The go.mod check for sample configuration helps us identify potential required bumps. However, note that go.mod is often updated by controller-runtime, so we can't manually change certain dependencies.

Additionally, we only need to check one sample project—there’s no need to duplicate efforts by opening the same PR across all samples.

Follow up of : https://github.com/kubernetes-sigs/kubebuilder/pull/4249
