### PR TITLE
🌱 Update codeql.yml to run the workflow once per week only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,10 +5,6 @@ on:
   # - `master` represents the latest development work.
   # - `book-v4` is the latest stable release branch, which contains the latest published code,
   #   ensuring that any issues in production are identified and addressed promptly.
-  push:
-    branches: ["master", "book-v4"]
-  pull_request:
-    branches: ["master", "book-v4"]
   schedule:
     - cron: '30 20 * * 1'  # Runs every Monday at 8:30 PM
 


### PR DESCRIPTION
Follow up of : https://github.com/kubernetes-sigs/kubebuilder/pull/4252

We do not want to run for each Pull Request.
Execute it once per week is more than enough
