### PR TITLE
🌱 Add bundle installer for sample projects in docs

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -110,37 +110,37 @@ replacements:
          index: 1
          create: true
 
- - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
-     kind: Certificate
-     group: cert-manager.io
-     version: v1
-     name: serving-cert # This name should match the one in certificate.yaml
-     fieldPath: .metadata.namespace # Namespace of the certificate CR
-   targets:
-     - select:
-         kind: CustomResourceDefinition
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 0
-         create: true
- - source:
-     kind: Certificate
-     group: cert-manager.io
-     version: v1
-     name: serving-cert # This name should match the one in certificate.yaml
-     fieldPath: .metadata.name
-   targets:
-     - select:
-         kind: CustomResourceDefinition
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 1
-         create: true
-
+# - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # This name should match the one in certificate.yaml
+#     fieldPath: .metadata.namespace # Namespace of the certificate CR
+#   targets:
+#     - select:
+#         kind: CustomResourceDefinition
+#       fieldPaths:
+#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#       options:
+#         delimiter: '/'
+#         index: 0
+#         create: true
+# - source:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # This name should match the one in certificate.yaml
+#     fieldPath: .metadata.name
+#   targets:
+#     - select:
+#         kind: CustomResourceDefinition
+#       fieldPaths:
+#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#       options:
+#         delimiter: '/'
+#         index: 1
+#         create: true
+#
  - source: # Uncomment the following block if you enable cert-manager
      kind: Service
      version: v1

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -1,0 +1,4206 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: cronjobs.batch.tutorial.kubebuilder.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: project-webhook-service
+          namespace: project-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: batch.tutorial.kubebuilder.io
+  names:
+    kind: CronJob
+    listKind: CronJobList
+    plural: cronjobs
+    singular: cronjob
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              concurrencyPolicy:
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
+              failedJobsHistoryLimit:
+                format: int32
+                minimum: 0
+                type: integer
+              jobTemplate:
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    properties:
+                      activeDeadlineSeconds:
+                        format: int64
+                        type: integer
+                      backoffLimit:
+                        format: int32
+                        type: integer
+                      backoffLimitPerIndex:
+                        format: int32
+                        type: integer
+                      completionMode:
+                        type: string
+                      completions:
+                        format: int32
+                        type: integer
+                      managedBy:
+                        type: string
+                      manualSelector:
+                        type: boolean
+                      maxFailedIndexes:
+                        format: int32
+                        type: integer
+                      parallelism:
+                        format: int32
+                        type: integer
+                      podFailurePolicy:
+                        properties:
+                          rules:
+                            items:
+                              properties:
+                                action:
+                                  type: string
+                                onExitCodes:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                  - operator
+                                  - values
+                                  type: object
+                                onPodConditions:
+                                  items:
+                                    properties:
+                                      status:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - status
+                                    - type
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      podReplacementPolicy:
+                        type: string
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      successPolicy:
+                        properties:
+                          rules:
+                            items:
+                              properties:
+                                succeededCount:
+                                  format: int32
+                                  type: integer
+                                succeededIndexes:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      suspend:
+                        type: boolean
+                      template:
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              affinity:
+                                properties:
+                                  nodeAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            preference:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        properties:
+                                          nodeSelectorTerms:
+                                            items:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              dnsConfig:
+                                properties:
+                                  nameservers:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  options:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  searches:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              hostAliases:
+                                items:
+                                  properties:
+                                    hostnames:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ip:
+                                      type: string
+                                  required:
+                                  - ip
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostUsers:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              initContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                items:
+                                  properties:
+                                    conditionType:
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resourceClaims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resourceClaimName:
+                                      type: string
+                                    resourceClaimTemplateName:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              schedulingGates:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              securityContext:
+                                properties:
+                                  appArmorProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  fsGroup:
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    type: string
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  supplementalGroupsPolicy:
+                                    type: string
+                                  sysctls:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              setHostnameAsFQDN:
+                                type: boolean
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                format: int64
+                                type: integer
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologySpreadConstraints:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      type: string
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                items:
+                                  properties:
+                                    awsElasticBlockStore:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          default: ext4
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          default: false
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      properties:
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    emptyDir:
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      properties:
+                                        volumeClaimTemplate:
+                                          properties:
+                                            metadata:
+                                              type: object
+                                            spec:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        wwids:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    flexVolume:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    image:
+                                      properties:
+                                        pullPolicy:
+                                          type: string
+                                        reference:
+                                          type: string
+                                      type: object
+                                    iscsi:
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          default: default
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      type: string
+                                    nfs:
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          items:
+                                            properties:
+                                              clusterTrustBundle:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  signerName:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              configMap:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              secret:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    quobyte:
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          default: /etc/ceph/keyring
+                                          type: string
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        pool:
+                                          default: rbd
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          default: admin
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      properties:
+                                        fsType:
+                                          default: xfs
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          default: ThinProvisioned
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      ttlSecondsAfterFinished:
+                        format: int32
+                        type: integer
+                    required:
+                    - template
+                    type: object
+                type: object
+              schedule:
+                minLength: 0
+                type: string
+              startingDeadlineSeconds:
+                format: int64
+                minimum: 0
+                type: integer
+              successfulJobsHistoryLimit:
+                format: int32
+                minimum: 0
+                type: integer
+              suspend:
+                type: boolean
+            required:
+            - jobTemplate
+            - schedule
+            type: object
+          status:
+            properties:
+              active:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    fieldPath:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    resourceVersion:
+                      type: string
+                    uid:
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              lastScheduleTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-leader-election-role
+  namespace: project-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-editor-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-viewer-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-manager-role
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-leader-election-rolebinding
+  namespace: project-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: project-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: project-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager-metrics-service
+  namespace: project-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-webhook-service
+  namespace: project-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager
+  namespace: project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: controller:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: project-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: project-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: project-webhook-service
+      namespace: project-system
+      path: /mutate-batch-tutorial-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: mcronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: project-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: project-webhook-service
+      namespace: project-system
+      path: /validate-batch-tutorial-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: vcronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.

--- a/docs/book/src/getting-started/testdata/project/config/manager/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -1,0 +1,455 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Memcached is the Schema for the memcacheds API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MemcachedSpec defines the desired state of Memcached.
+            properties:
+              size:
+                description: |-
+                  Size defines the number of Memcached instances
+                  The following markers will use OpenAPI v3 schema to validate the value
+                  More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
+                format: int32
+                maximum: 3
+                minimum: 1
+                type: integer
+            type: object
+          status:
+            description: MemcachedStatus defines the observed state of Memcached.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-leader-election-role
+  namespace: project-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-memcached-editor-role
+rules:
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-memcached-viewer-role
+rules:
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-leader-election-rolebinding
+  namespace: project-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: project-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: project-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager-metrics-service
+  namespace: project-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager
+  namespace: project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: controller:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: project-controller-manager
+      terminationGracePeriodSeconds: 10
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager-metrics-monitor
+  namespace: project-system
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/manager/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -1,0 +1,8104 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: project-system/project-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: cronjobs.batch.tutorial.kubebuilder.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: project-webhook-service
+          namespace: project-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: batch.tutorial.kubebuilder.io
+  names:
+    kind: CronJob
+    listKind: CronJobList
+    plural: cronjobs
+    singular: cronjob
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              concurrencyPolicy:
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
+              failedJobsHistoryLimit:
+                format: int32
+                minimum: 0
+                type: integer
+              jobTemplate:
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    properties:
+                      activeDeadlineSeconds:
+                        format: int64
+                        type: integer
+                      backoffLimit:
+                        format: int32
+                        type: integer
+                      backoffLimitPerIndex:
+                        format: int32
+                        type: integer
+                      completionMode:
+                        type: string
+                      completions:
+                        format: int32
+                        type: integer
+                      managedBy:
+                        type: string
+                      manualSelector:
+                        type: boolean
+                      maxFailedIndexes:
+                        format: int32
+                        type: integer
+                      parallelism:
+                        format: int32
+                        type: integer
+                      podFailurePolicy:
+                        properties:
+                          rules:
+                            items:
+                              properties:
+                                action:
+                                  type: string
+                                onExitCodes:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                  - operator
+                                  - values
+                                  type: object
+                                onPodConditions:
+                                  items:
+                                    properties:
+                                      status:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - status
+                                    - type
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      podReplacementPolicy:
+                        type: string
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      successPolicy:
+                        properties:
+                          rules:
+                            items:
+                              properties:
+                                succeededCount:
+                                  format: int32
+                                  type: integer
+                                succeededIndexes:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      suspend:
+                        type: boolean
+                      template:
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              affinity:
+                                properties:
+                                  nodeAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            preference:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        properties:
+                                          nodeSelectorTerms:
+                                            items:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              dnsConfig:
+                                properties:
+                                  nameservers:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  options:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  searches:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              hostAliases:
+                                items:
+                                  properties:
+                                    hostnames:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ip:
+                                      type: string
+                                  required:
+                                  - ip
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostUsers:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              initContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                items:
+                                  properties:
+                                    conditionType:
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resourceClaims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resourceClaimName:
+                                      type: string
+                                    resourceClaimTemplateName:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              schedulingGates:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              securityContext:
+                                properties:
+                                  appArmorProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  fsGroup:
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    type: string
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  supplementalGroupsPolicy:
+                                    type: string
+                                  sysctls:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              setHostnameAsFQDN:
+                                type: boolean
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                format: int64
+                                type: integer
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologySpreadConstraints:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      type: string
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                items:
+                                  properties:
+                                    awsElasticBlockStore:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          default: ext4
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          default: false
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      properties:
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    emptyDir:
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      properties:
+                                        volumeClaimTemplate:
+                                          properties:
+                                            metadata:
+                                              type: object
+                                            spec:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        wwids:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    flexVolume:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    image:
+                                      properties:
+                                        pullPolicy:
+                                          type: string
+                                        reference:
+                                          type: string
+                                      type: object
+                                    iscsi:
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          default: default
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      type: string
+                                    nfs:
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          items:
+                                            properties:
+                                              clusterTrustBundle:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  signerName:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              configMap:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              secret:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    quobyte:
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          default: /etc/ceph/keyring
+                                          type: string
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        pool:
+                                          default: rbd
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          default: admin
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      properties:
+                                        fsType:
+                                          default: xfs
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          default: ThinProvisioned
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      ttlSecondsAfterFinished:
+                        format: int32
+                        type: integer
+                    required:
+                    - template
+                    type: object
+                type: object
+              schedule:
+                minLength: 0
+                type: string
+              startingDeadlineSeconds:
+                format: int64
+                minimum: 0
+                type: integer
+              successfulJobsHistoryLimit:
+                format: int32
+                minimum: 0
+                type: integer
+              suspend:
+                type: boolean
+            required:
+            - jobTemplate
+            - schedule
+            type: object
+          status:
+            properties:
+              active:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    fieldPath:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    resourceVersion:
+                      type: string
+                    uid:
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              lastScheduleTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              concurrencyPolicy:
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
+              failedJobsHistoryLimit:
+                format: int32
+                minimum: 0
+                type: integer
+              jobTemplate:
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    properties:
+                      activeDeadlineSeconds:
+                        format: int64
+                        type: integer
+                      backoffLimit:
+                        format: int32
+                        type: integer
+                      backoffLimitPerIndex:
+                        format: int32
+                        type: integer
+                      completionMode:
+                        type: string
+                      completions:
+                        format: int32
+                        type: integer
+                      managedBy:
+                        type: string
+                      manualSelector:
+                        type: boolean
+                      maxFailedIndexes:
+                        format: int32
+                        type: integer
+                      parallelism:
+                        format: int32
+                        type: integer
+                      podFailurePolicy:
+                        properties:
+                          rules:
+                            items:
+                              properties:
+                                action:
+                                  type: string
+                                onExitCodes:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                  - operator
+                                  - values
+                                  type: object
+                                onPodConditions:
+                                  items:
+                                    properties:
+                                      status:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - status
+                                    - type
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      podReplacementPolicy:
+                        type: string
+                      selector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      successPolicy:
+                        properties:
+                          rules:
+                            items:
+                              properties:
+                                succeededCount:
+                                  format: int32
+                                  type: integer
+                                succeededIndexes:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      suspend:
+                        type: boolean
+                      template:
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            properties:
+                              activeDeadlineSeconds:
+                                format: int64
+                                type: integer
+                              affinity:
+                                properties:
+                                  nodeAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            preference:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        properties:
+                                          nodeSelectorTerms:
+                                            items:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  podAntiAffinity:
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            podAffinityTerm:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        items:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                type: boolean
+                              containers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              dnsConfig:
+                                properties:
+                                  nameservers:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  options:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  searches:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              dnsPolicy:
+                                type: string
+                              enableServiceLinks:
+                                type: boolean
+                              ephemeralContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    targetContainerName:
+                                      type: string
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              hostAliases:
+                                items:
+                                  properties:
+                                    hostnames:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ip:
+                                      type: string
+                                  required:
+                                  - ip
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
+                              hostIPC:
+                                type: boolean
+                              hostNetwork:
+                                type: boolean
+                              hostPID:
+                                type: boolean
+                              hostUsers:
+                                type: boolean
+                              hostname:
+                                type: string
+                              imagePullSecrets:
+                                items:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              initContainers:
+                                items:
+                                  properties:
+                                    args:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                          valueFrom:
+                                            properties:
+                                              configMapKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      type: string
+                                    imagePullPolicy:
+                                      type: string
+                                    lifecycle:
+                                      properties:
+                                        postStart:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              properties:
+                                                seconds:
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      type: string
+                                    ports:
+                                      items:
+                                        properties:
+                                          containerPort:
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            type: string
+                                          hostPort:
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      items:
+                                        properties:
+                                          resourceName:
+                                            type: string
+                                          restartPolicy:
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    securityContext:
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          type: boolean
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          properties:
+                                            add:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          type: boolean
+                                        procMount:
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          type: boolean
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          properties:
+                                            port:
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      type: boolean
+                                    stdinOnce:
+                                      type: boolean
+                                    terminationMessagePath:
+                                      type: string
+                                    terminationMessagePolicy:
+                                      type: string
+                                    tty:
+                                      type: boolean
+                                    volumeDevices:
+                                      items:
+                                        properties:
+                                          devicePath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      items:
+                                        properties:
+                                          mountPath:
+                                            type: string
+                                          mountPropagation:
+                                            type: string
+                                          name:
+                                            type: string
+                                          readOnly:
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            type: string
+                                          subPath:
+                                            type: string
+                                          subPathExpr:
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              nodeName:
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              preemptionPolicy:
+                                type: string
+                              priority:
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                type: string
+                              readinessGates:
+                                items:
+                                  properties:
+                                    conditionType:
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resourceClaims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    resourceClaimName:
+                                      type: string
+                                    resourceClaimTemplateName:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              restartPolicy:
+                                type: string
+                              runtimeClassName:
+                                type: string
+                              schedulerName:
+                                type: string
+                              schedulingGates:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              securityContext:
+                                properties:
+                                  appArmorProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  fsGroup:
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    type: string
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    properties:
+                                      localhostProfile:
+                                        type: string
+                                      type:
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  supplementalGroupsPolicy:
+                                    type: string
+                                  sysctls:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      hostProcess:
+                                        type: boolean
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                type: string
+                              serviceAccountName:
+                                type: string
+                              setHostnameAsFQDN:
+                                type: boolean
+                              shareProcessNamespace:
+                                type: boolean
+                              subdomain:
+                                type: string
+                              terminationGracePeriodSeconds:
+                                format: int64
+                                type: integer
+                              tolerations:
+                                items:
+                                  properties:
+                                    effect:
+                                      type: string
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    tolerationSeconds:
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologySpreadConstraints:
+                                items:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      type: string
+                                    topologyKey:
+                                      type: string
+                                    whenUnsatisfiable:
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                items:
+                                  properties:
+                                    awsElasticBlockStore:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      properties:
+                                        cachingMode:
+                                          type: string
+                                        diskName:
+                                          type: string
+                                        diskURI:
+                                          type: string
+                                        fsType:
+                                          default: ext4
+                                          type: string
+                                        kind:
+                                          type: string
+                                        readOnly:
+                                          default: false
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      properties:
+                                        readOnly:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                        shareName:
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      properties:
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretFile:
+                                          type: string
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        nodePublishSecretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    emptyDir:
+                                      properties:
+                                        medium:
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      properties:
+                                        volumeClaimTemplate:
+                                          properties:
+                                            metadata:
+                                              type: object
+                                            spec:
+                                              properties:
+                                                accessModes:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                dataSource:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  properties:
+                                                    apiGroup:
+                                                      type: string
+                                                    kind:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  type: string
+                                                volumeMode:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          type: boolean
+                                        targetWWNs:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        wwids:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    flexVolume:
+                                      properties:
+                                        driver:
+                                          type: string
+                                        fsType:
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      properties:
+                                        datasetName:
+                                          type: string
+                                        datasetUUID:
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        partition:
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      properties:
+                                        directory:
+                                          type: string
+                                        repository:
+                                          type: string
+                                        revision:
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      properties:
+                                        endpoints:
+                                          type: string
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      properties:
+                                        path:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    image:
+                                      properties:
+                                        pullPolicy:
+                                          type: string
+                                        reference:
+                                          type: string
+                                      type: object
+                                    iscsi:
+                                      properties:
+                                        chapAuthDiscovery:
+                                          type: boolean
+                                        chapAuthSession:
+                                          type: boolean
+                                        fsType:
+                                          type: string
+                                        initiatorName:
+                                          type: string
+                                        iqn:
+                                          type: string
+                                        iscsiInterface:
+                                          default: default
+                                          type: string
+                                        lun:
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      type: string
+                                    nfs:
+                                      properties:
+                                        path:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        server:
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      properties:
+                                        claimName:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        pdID:
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        volumeID:
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          items:
+                                            properties:
+                                              clusterTrustBundle:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  signerName:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              configMap:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              secret:
+                                                properties:
+                                                  items:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        mode:
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                properties:
+                                                  audience:
+                                                    type: string
+                                                  expirationSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    quobyte:
+                                      properties:
+                                        group:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        registry:
+                                          type: string
+                                        tenant:
+                                          type: string
+                                        user:
+                                          type: string
+                                        volume:
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        image:
+                                          type: string
+                                        keyring:
+                                          default: /etc/ceph/keyring
+                                          type: string
+                                        monitors:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        pool:
+                                          default: rbd
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          default: admin
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      properties:
+                                        fsType:
+                                          default: xfs
+                                          type: string
+                                        gateway:
+                                          type: string
+                                        protectionDomain:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          type: boolean
+                                        storageMode:
+                                          default: ThinProvisioned
+                                          type: string
+                                        storagePool:
+                                          type: string
+                                        system:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      properties:
+                                        defaultMode:
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        optional:
+                                          type: boolean
+                                        secretName:
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        readOnly:
+                                          type: boolean
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              default: ""
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          type: string
+                                        volumeNamespace:
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      properties:
+                                        fsType:
+                                          type: string
+                                        storagePolicyID:
+                                          type: string
+                                        storagePolicyName:
+                                          type: string
+                                        volumePath:
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      ttlSecondsAfterFinished:
+                        format: int32
+                        type: integer
+                    required:
+                    - template
+                    type: object
+                type: object
+              schedule:
+                properties:
+                  dayOfMonth:
+                    type: string
+                  dayOfWeek:
+                    type: string
+                  hour:
+                    type: string
+                  minute:
+                    type: string
+                  month:
+                    type: string
+                type: object
+              startingDeadlineSeconds:
+                format: int64
+                minimum: 0
+                type: integer
+              successfulJobsHistoryLimit:
+                format: int32
+                minimum: 0
+                type: integer
+              suspend:
+                type: boolean
+            required:
+            - jobTemplate
+            - schedule
+            type: object
+          status:
+            properties:
+              active:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    fieldPath:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    resourceVersion:
+                      type: string
+                    uid:
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              lastScheduleTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-leader-election-role
+  namespace: project-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-editor-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-viewer-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-manager-role
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-leader-election-rolebinding
+  namespace: project-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: project-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: project-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: project-controller-manager
+  namespace: project-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager-metrics-service
+  namespace: project-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-webhook-service
+  namespace: project-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager
+  namespace: project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        command:
+        - /manager
+        image: controller:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: project-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: project
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/part-of: project
+  name: project-serving-cert
+  namespace: project-system
+spec:
+  dnsNames:
+  - project-webhook-service.project-system.svc
+  - project-webhook-service.project-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: project-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-selfsigned-issuer
+  namespace: project-system
+spec:
+  selfSigned: {}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+    control-plane: controller-manager
+  name: project-controller-manager-metrics-monitor
+  namespace: project-system
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: project-system/project-serving-cert
+  name: project-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: project-webhook-service
+      namespace: project-system
+      path: /mutate-batch-tutorial-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: mcronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: project-webhook-service
+      namespace: project-system
+      path: /mutate-batch-tutorial-kubebuilder-io-v2-cronjob
+  failurePolicy: Fail
+  name: mcronjob-v2.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: project-system/project-serving-cert
+  name: project-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: project-webhook-service
+      namespace: project-system
+      path: /validate-batch-tutorial-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: vcronjob-v1.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: project-webhook-service
+      namespace: project-system
+      path: /validate-batch-tutorial-kubebuilder-io-v2-cronjob
+  failurePolicy: Fail
+  name: vcronjob-v2.kb.io
+  rules:
+  - apiGroups:
+    - batch.tutorial.kubebuilder.io
+    apiVersions:
+    - v2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -116,21 +116,22 @@ func (sp *Sample) UpdateTutorial() {
 func (sp *Sample) CodeGen() {}
 
 func (sp *Sample) codeGen() {
-	cmd := exec.Command("go", "get", "github.com/robfig/cron")
+	cmd := exec.Command("go", "mod", "tidy")
 	_, err := sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to get package robfig/cron", err)
+	hackutils.CheckError("Failed to run go mod tidy for cronjob tutorial", err)
 
-	cmd = exec.Command("make", "manifests")
+	cmd = exec.Command("go", "get", "github.com/robfig/cron")
 	_, err = sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to run make manifests for cronjob tutorial", err)
+	hackutils.CheckError("Failed to get package robfig/cron", err)
 
 	cmd = exec.Command("make", "all")
 	_, err = sp.ctx.Run(cmd)
 	hackutils.CheckError("Failed to run make all for cronjob tutorial", err)
 
-	cmd = exec.Command("go", "mod", "tidy")
+	cmd = exec.Command("make", "build-installer")
 	_, err = sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to run go mod tidy for cronjob tutorial", err)
+	hackutils.CheckError("Failed to run make build-installer for cronjob tutorial", err)
+
 }
 
 // insert code to fix docs
@@ -592,7 +593,12 @@ func (sp *Sample) updateKustomization() {
 
 	err = pluginutil.UncommentCode(
 		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
-		DefaultKustomization, `#`)
+		certmanagerForWebhooks, `#`)
+	hackutils.CheckError("fixing default/kustomization", err)
+
+	err = pluginutil.UncommentCode(
+		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
+		webhookServiceDefaultKustomize, `#`)
 	hackutils.CheckError("fixing default/kustomization", err)
 
 	err = pluginutil.UncommentCode(

--- a/hack/docs/internal/cronjob-tutorial/sample.go
+++ b/hack/docs/internal/cronjob-tutorial/sample.go
@@ -33,7 +33,7 @@ const CronjobSample = `
             - date; echo Hello from the Kubernetes cluster
           restartPolicy: OnFailure`
 
-const DefaultKustomization = `#replacements:
+const certmanagerForWebhooks = `#replacements:
 # - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
 #     kind: Certificate
 #     group: cert-manager.io
@@ -95,39 +95,9 @@ const DefaultKustomization = `#replacements:
 #         delimiter: '/'
 #         index: 1
 #         create: true
-#
-# - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # This name should match the one in certificate.yaml
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # This name should match the one in certificate.yaml
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
-#
-# - source: # Uncomment the following block if you enable cert-manager
+#`
+
+const webhookServiceDefaultKustomize = `# - source: # Uncomment the following block if you enable cert-manager
 #     kind: Service
 #     version: v1
 #     name: webhook-service

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -43,6 +43,14 @@ func (sp *Sample) UpdateTutorial() {
 	sp.updateSample()
 	sp.updateController()
 	sp.updateControllerTest()
+	sp.updateDefaultKustomize()
+}
+
+func (sp *Sample) updateDefaultKustomize() {
+	err := pluginutil.UncommentCode(
+		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
+		`#- ../prometheus`, `#`)
+	hackutils.CheckError("fixing default/kustomization", err)
 }
 
 func (sp *Sample) updateControllerTest() {
@@ -221,17 +229,17 @@ func (sp *Sample) GenerateSampleProject() {
 }
 
 func (sp *Sample) CodeGen() {
-	cmd := exec.Command("make", "manifests")
+	cmd := exec.Command("go", "mod", "tidy")
 	_, err := sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to run make manifests for getting started tutorial", err)
+	hackutils.CheckError("Failed to run go mod tidy all for getting started tutorial", err)
 
 	cmd = exec.Command("make", "all")
 	_, err = sp.ctx.Run(cmd)
 	hackutils.CheckError("Failed to run make all for getting started tutorial", err)
 
-	cmd = exec.Command("go", "mod", "tidy")
+	cmd = exec.Command("make", "build-installer")
 	_, err = sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to run go mod tidy all for getting started tutorial", err)
+	hackutils.CheckError("Failed to run make build-installer for getting started tutorial", err)
 }
 
 const oldSpecApi = "// Foo is an example field of Memcached. Edit memcached_types.go to remove/update\n\tFoo string `json:\"foo,omitempty\"`"

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -80,6 +80,15 @@ func (sp *Sample) UpdateTutorial() {
 	sp.createHubFiles()
 	sp.updateSampleV2()
 	sp.updateMain()
+	sp.updateDefaultKustomize()
+}
+
+func (sp *Sample) updateDefaultKustomize() {
+	// Enable CA for Conversion Webhook
+	err := pluginutil.UncommentCode(
+		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
+		caConversionCRDDefaultKustomize, `#`)
+	hackutils.CheckError("fixing default/kustomization", err)
 }
 
 func (sp *Sample) updateWebhookV1() {
@@ -487,19 +496,11 @@ type CronJobStatus struct {
 }
 
 func (sp *Sample) CodeGen() {
-	cmd := exec.Command("go", "get", "github.com/robfig/cron")
+	cmd := exec.Command("make", "all")
 	_, err := sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to get package robfig/cron", err)
-
-	cmd = exec.Command("make", "manifests")
-	_, err = sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to run make manifests for cronjob tutorial", err)
-
-	cmd = exec.Command("make", "all")
-	_, err = sp.ctx.Run(cmd)
 	hackutils.CheckError("Failed to run make all for cronjob tutorial", err)
 
-	cmd = exec.Command("go", "mod", "tidy")
+	cmd = exec.Command("make", "build-installer")
 	_, err = sp.ctx.Run(cmd)
-	hackutils.CheckError("Failed to run go mod tidy for cronjob tutorial", err)
+	hackutils.CheckError("Failed to run make build-installer for  multiversion cronjob tutorial", err)
 }

--- a/hack/docs/internal/multiversion-tutorial/kustomize.go
+++ b/hack/docs/internal/multiversion-tutorial/kustomize.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiversion
+
+const caConversionCRDDefaultKustomize = `# - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # This name should match the one in certificate.yaml
+#     fieldPath: .metadata.namespace # Namespace of the certificate CR
+#   targets:
+#     - select:
+#         kind: CustomResourceDefinition
+#       fieldPaths:
+#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#       options:
+#         delimiter: '/'
+#         index: 0
+#         create: true
+# - source:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # This name should match the one in certificate.yaml
+#     fieldPath: .metadata.name
+#   targets:
+#     - select:
+#         kind: CustomResourceDefinition
+#       fieldPaths:
+#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#       options:
+#         delimiter: '/'
+#         index: 1
+#         create: true
+#`


### PR DESCRIPTION
Introduces a bundle installer for sample projects, with config/default/kustomization.yaml settings uncommented to ensure complete bundle generation. This enhances review visibility by showing the final state of patches and Kustomize configurations directly in the generated bundle.

Motivation: Makes reviews more efficient by displaying final configurations directly in the bundle, with only relevant settings uncommented in config/default/kustomization.yaml for each sample.