### PR TITLE
🐛 (kustomize/v2, go/v4):  Fix ca injection for conversion webhooks

### DIFF
--- a/.github/workflows/test-e2e-samples.yml
+++ b/.github/workflows/test-e2e-samples.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           KUSTOMIZATION_FILE_PATH="testdata/project-v4/config/default/kustomization.yaml"
           sed -i '25s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '55,182s/^#//' $KUSTOMIZATION_FILE_PATH
+          # Uncomment all cert-manager injections
+          sed -i '55,168s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '170,185s/^#//' $KUSTOMIZATION_FILE_PATH
           cd testdata/project-v4/
           go mod tidy
 
@@ -81,9 +83,12 @@ jobs:
           KUSTOMIZATION_FILE_PATH="testdata/project-v4-with-plugins/config/default/kustomization.yaml"
           sed -i '25s/^#//' $KUSTOMIZATION_FILE_PATH
           # Uncomment only ValidatingWebhookConfiguration
-          # from cert-manager replaces
+          # from cert-manager replaces; we are leaving defaulting uncommented
+          # since this sample has no defaulting webhooks
           sed -i '55,121s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '153,182s/^#//' $KUSTOMIZATION_FILE_PATH
+          # Uncomment only --conversion webhooks CA injection
+          sed -i '153,168s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '170,185s/^#//' $KUSTOMIZATION_FILE_PATH
           cd testdata/project-v4-with-plugins/
           go mod tidy
 
@@ -122,7 +127,9 @@ jobs:
         run: |
           KUSTOMIZATION_FILE_PATH="testdata/project-v4-multigroup/config/default/kustomization.yaml"
           sed -i '25s/^#//' $KUSTOMIZATION_FILE_PATH
-          sed -i '55,182s/^#//' $KUSTOMIZATION_FILE_PATH
+          # Uncomment all cert-manager injections
+          sed -i '55,168s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '170,185s/^#//' $KUSTOMIZATION_FILE_PATH
           cd testdata/project-v4-multigroup
           go mod tidy
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -10,10 +10,6 @@ patches:
 # patches here are for enabling the conversion webhook for each CRD
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 #configurations:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -156,27 +156,13 @@ replacements:
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+# +kubebuilder:scaffold:crdkustomizecainjectionns
 # - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+# +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/docs/book/src/getting-started/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/crd/kustomization.yaml
@@ -10,10 +10,6 @@ patches:
 # patches here are for enabling the conversion webhook for each CRD
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 #configurations:

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -156,27 +156,13 @@ patches:
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+# +kubebuilder:scaffold:crdkustomizecainjectionns
 # - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+# +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/kustomization.yaml
@@ -11,11 +11,6 @@ patches:
 - path: patches/webhook_in_cronjobs.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-#- path: patches/cainjection_in_cronjobs.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/cainjection_in_cronjobs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/crd/patches/cainjection_in_cronjobs.yaml
@@ -1,7 +1,0 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: cronjobs.batch.tutorial.kubebuilder.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -156,27 +156,31 @@ replacements:
      version: v1
      name: serving-cert # This name should match the one in certificate.yaml
      fieldPath: .metadata.namespace # Namespace of the certificate CR
-   targets:
+   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
      - select:
          kind: CustomResourceDefinition
+         name: cronjobs.batch.tutorial.kubebuilder.io
        fieldPaths:
          - .metadata.annotations.[cert-manager.io/inject-ca-from]
        options:
          delimiter: '/'
          index: 0
          create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionns
  - source:
      kind: Certificate
      group: cert-manager.io
      version: v1
      name: serving-cert # This name should match the one in certificate.yaml
      fieldPath: .metadata.name
-   targets:
+   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
      - select:
          kind: CustomResourceDefinition
+         name: cronjobs.batch.tutorial.kubebuilder.io
        fieldPaths:
          - .metadata.annotations.[cert-manager.io/inject-ca-from]
        options:
          delimiter: '/'
          index: 1
          create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -279,7 +279,13 @@ func (sp *Sample) updateDefaultKustomize() {
 	// Enable CA for Conversion Webhook
 	err := pluginutil.UncommentCode(
 		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
-		caConversionCRDDefaultKustomize, `#`)
+		caInjectionNamespace, `#`)
+	hackutils.CheckError("fixing default/kustomization", err)
+
+	// Enable CA for Conversion Webhook
+	err = pluginutil.UncommentCode(
+		filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml"),
+		caInjectionCert, `#`)
 	hackutils.CheckError("fixing default/kustomization", err)
 }
 

--- a/hack/docs/internal/multiversion-tutorial/kustomize.go
+++ b/hack/docs/internal/multiversion-tutorial/kustomize.go
@@ -16,31 +16,34 @@ limitations under the License.
 
 package multiversion
 
-const caConversionCRDDefaultKustomize = `#
+const caInjectionNamespace = `#
 # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: cronjobs.batch.tutorial.kubebuilder.io
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 0
-#         create: true
-# - source:
+#         create: true`
+
+const caInjectionCert = `# - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: cronjobs.batch.tutorial.kubebuilder.io
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -91,6 +91,7 @@ func (s *apiScaffolder) Scaffold() error {
 			}
 		}
 
+		// nolint:goconst
 		kustomizeFilePath := "config/default/kustomization.yaml"
 		err := pluginutil.UncommentCode(kustomizeFilePath, "#- ../crd", `#`)
 		if err != nil {

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -45,7 +45,6 @@ func (f *Kustomization) SetTemplateDefaults() error {
 	f.TemplateBody = fmt.Sprintf(kustomizationTemplate,
 		machinery.NewMarkerFor(f.Path, resourceMarker),
 		machinery.NewMarkerFor(f.Path, webhookPatchMarker),
-		machinery.NewMarkerFor(f.Path, caInjectionPatchMarker),
 	)
 
 	return nil
@@ -53,9 +52,8 @@ func (f *Kustomization) SetTemplateDefaults() error {
 
 //nolint:gosec to ignore false complain G101: Potential hardcoded credentials (gosec)
 const (
-	resourceMarker         = "crdkustomizeresource"
-	webhookPatchMarker     = "crdkustomizewebhookpatch"
-	caInjectionPatchMarker = "crdkustomizecainjectionpatch"
+	resourceMarker     = "crdkustomizeresource"
+	webhookPatchMarker = "crdkustomizewebhookpatch"
 )
 
 // GetMarkers implements file.Inserter
@@ -63,7 +61,6 @@ func (f *Kustomization) GetMarkers() []machinery.Marker {
 	return []machinery.Marker{
 		machinery.NewMarkerFor(f.Path, resourceMarker),
 		machinery.NewMarkerFor(f.Path, webhookPatchMarker),
-		machinery.NewMarkerFor(f.Path, caInjectionPatchMarker),
 	}
 }
 
@@ -72,13 +69,11 @@ const (
 `
 	webhookPatchCodeFragment = `- path: patches/webhook_in_%s.yaml
 `
-	caInjectionPatchCodeFragment = `#- path: patches/cainjection_in_%s.yaml
-`
 )
 
 // GetCodeFragments implements file.Inserter
 func (f *Kustomization) GetCodeFragments() machinery.CodeFragmentsMap {
-	fragments := make(machinery.CodeFragmentsMap, 3)
+	fragments := make(machinery.CodeFragmentsMap, 2)
 
 	// Generate resource code fragments
 	res := make([]string, 0)
@@ -98,19 +93,9 @@ func (f *Kustomization) GetCodeFragments() machinery.CodeFragmentsMap {
 		}
 	}
 
-	// Generate resource code fragments
-	caInjectionPatch := make([]string, 0)
-	if !f.Resource.Webhooks.IsEmpty() && f.Resource.Webhooks.Conversion {
-		caInjectionPatch = append(caInjectionPatch, fmt.Sprintf(caInjectionPatchCodeFragment, suffix))
-	}
-
 	// Only store code fragments in the map if the slices are non-empty
 	if len(res) != 0 {
 		fragments[machinery.NewMarkerFor(f.Path, resourceMarker)] = res
-	}
-
-	if len(caInjectionPatch) != 0 {
-		fragments[machinery.NewMarkerFor(f.Path, caInjectionPatchMarker)] = caInjectionPatch
 	}
 
 	return fragments
@@ -125,10 +110,6 @@ resources:
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-%s
-
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
 %s
 
 # [WEBHOOK] To enable webhook, uncomment the following section

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -201,28 +201,14 @@ patches:
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+# +kubebuilder:scaffold:crdkustomizecainjectionns
 # - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: CustomResourceDefinition
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+# +kubebuilder:scaffold:crdkustomizecainjectionname
 `

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization_conversion_updater.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization_conversion_updater.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kdefault
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+const caNamespace = "crdkustomizecainjectionns"
+const caName = "crdkustomizecainjectionname"
+
+// KustomizationCAConversionUpdater appends CA injection targets for CRDs with --conversion
+type KustomizationCAConversionUpdater struct {
+	machinery.TemplateMixin
+	machinery.ResourceMixin
+}
+
+// SetTemplateDefaults defines the file path and behavior for existing files
+func (f *KustomizationCAConversionUpdater) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "default", "kustomization.yaml")
+	}
+	f.IfExistsAction = machinery.SkipFile // Only append to the existing file, don’t overwrite it
+	return nil
+}
+
+// GetMarkers provides the markers where the CA injection targets will be appended
+func (f *KustomizationCAConversionUpdater) GetMarkers() []machinery.Marker {
+
+	return []machinery.Marker{
+		machinery.NewMarkerFor(f.Path, caNamespace),
+		machinery.NewMarkerFor(f.Path, caName),
+	}
+}
+
+// GetCodeFragments appends CA injection targets for the CRD with --conversion as comments
+func (f *KustomizationCAConversionUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
+	fragments := make(machinery.CodeFragmentsMap)
+
+	// Obtain the formatted CRD name as Plural.Group.Domain (e.g., cronjobs.batch.tutorial.kubebuilder.io)
+	crdName := fmt.Sprintf("%s.%s", f.Resource.Plural, f.Resource.QualifiedGroup())
+
+	if !f.Resource.Webhooks.IsEmpty() && f.Resource.Webhooks.Conversion {
+		// Commented CA injection configuration for the namespace part
+		caInjectionNamespace := fmt.Sprintf(`#     - select:
+#         kind: CustomResourceDefinition
+#         name: %s
+#       fieldPaths:
+#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#       options:
+#         delimiter: '/'
+#         index: 0
+#         create: true
+`, crdName)
+
+		// Commented CA injection configuration for the name part
+		caInjectionName := fmt.Sprintf(`#     - select:
+#         kind: CustomResourceDefinition
+#         name: %s
+#       fieldPaths:
+#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#       options:
+#         delimiter: '/'
+#         index: 1
+#         create: true
+`, crdName)
+
+		// Append to the correct markers to prevent duplication
+		namespaceMarker := machinery.NewMarkerFor(f.Path, caNamespace)
+		certificateMarker := machinery.NewMarkerFor(f.Path, caName)
+
+		// Check if the fragments already exist before adding them
+		if _, exists := fragments[namespaceMarker]; !exists {
+			fragments[namespaceMarker] = []string{caInjectionNamespace}
+		}
+		if _, exists := fragments[certificateMarker]; !exists {
+			fragments[certificateMarker] = []string{caInjectionName}
+		}
+	}
+
+	return fragments
+}

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -62,6 +62,12 @@ func (s *webhookScaffolder) InjectFS(fs machinery.Filesystem) { s.fs = fs }
 func (s *webhookScaffolder) Scaffold() error {
 	log.Println("Writing kustomize manifests for you to edit...")
 
+	// Will validate the scaffold
+	// Users that scaffolded the project previously
+	// with the bugs will receive a message to help
+	// them out fix their scaffold.
+	validateScaffoldedProject()
+
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs,
 		machinery.WithConfig(s.config),
@@ -86,7 +92,7 @@ func (s *webhookScaffolder) Scaffold() error {
 	// Only scaffold the following patches if is a conversion webhook
 	if s.resource.Webhooks.Conversion {
 		buildScaffold = append(buildScaffold, &patches.EnableWebhookPatch{})
-		buildScaffold = append(buildScaffold, &patches.EnableCAInjectionPatch{})
+		buildScaffold = append(buildScaffold, &kdefault.KustomizationCAConversionUpdater{})
 	}
 
 	if !s.resource.External && !s.resource.Core {
@@ -105,6 +111,7 @@ func (s *webhookScaffolder) Scaffold() error {
 			"%s to allow webhook traffic.", policyKustomizeFilePath)
 	}
 
+	// nolint:goconst
 	kustomizeFilePath := "config/default/kustomization.yaml"
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#- ../webhook", `#`)
 	if err != nil {
@@ -148,6 +155,70 @@ func (s *webhookScaffolder) Scaffold() error {
 	}
 
 	return nil
+}
+
+// Deprecated: remove it when go/v4 and/or kustomize/v2 be removed
+// validateScaffoldedProject will output a message to help users fix their scaffold
+func validateScaffoldedProject() {
+	// nolint:goconst
+	kustomizeFilePath := "config/default/kustomization.yaml"
+	hasCertManagerPatch, _ := pluginutil.HasFileContentWith(kustomizeFilePath,
+		"crdkustomizecainjectionpatch")
+
+	if hasCertManagerPatch {
+		log.Warning(`
+
+1. **Remove the CERTMANAGER Section from config/crd/kustomization.yaml:**
+
+   Delete the CERTMANAGER section to prevent unintended CA injection patches for CRDs.
+   Ensure the following lines are removed or commented out:
+
+   # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+   # patches here are for enabling the CA injection for each CRD
+   #- path: patches/cainjection_in_firstmates.yaml
+   # +kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+2. **Ensure CA Injection Configuration in config/default/kustomization.yaml:**
+
+   Under the [CERTMANAGER] replacement in config/default/kustomization.yaml,
+   add the following code for proper CA injection generation:
+
+   **NOTE:** You must ensure that the code contains the following target markers:
+   - +kubebuilder:scaffold:crdkustomizecainjectionns
+   - +kubebuilder:scaffold:crdkustomizecainjectioname
+
+   # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
+   #     kind: Certificate
+   #     group: cert-manager.io
+   #     version: v1
+   #     name: serving-cert # This name should match the one in certificate.yaml
+   #     fieldPath: .metadata.namespace # Namespace of the certificate CR
+   #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+   # +kubebuilder:scaffold:crdkustomizecainjectionns
+   # - source:
+   #     kind: Certificate
+   #     group: cert-manager.io
+   #     version: v1
+   #     name: serving-cert # This name should match the one in certificate.yaml
+   #     fieldPath: .metadata.name
+   #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
+   # +kubebuilder:scaffold:crdkustomizecainjectioname
+
+3. **Ensure Only Conversion Webhook Patches in config/crd/patches:**
+
+   The config/crd/patches directory and the corresponding entries in config/crd/kustomization.yaml should only 
+   contain files for conversion webhooks. Previously, a bug caused the patch file to be generated for any webhook, 
+   but only patches for webhooks created with the --conversion option should be included.
+
+For further guidance, you can refer to examples in the testdata/ directory in the Kubebuilder repository.
+
+**Alternatively**: You can use the 'alpha generate' command to re-generate the project from scratch using the latest
+release available. Afterward, you can re-add only your code implementation on top to ensure your project includes all
+the latest bug fixes and enhancements.
+
+`)
+
+	}
 }
 
 const allowWebhookTrafficFragment = `

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -101,7 +101,7 @@ function scaffold_test_project {
     $kb create api --group example.com --version v1 --kind Wordpress --controller=true --resource=true  --make=false
     $kb create api --group example.com --version v2 --kind Wordpress --controller=false --resource=true  --make=false
     $kb create webhook --group example.com --version v1 --kind Wordpress --conversion --make=false --spoke v2
-    
+
     header_text 'Editing project with Grafana plugin ...'
     $kb edit --plugins=grafana.kubebuilder.io/v1-alpha
   fi

--- a/testdata/project-v4-multigroup/config/crd/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/crd/kustomization.yaml
@@ -22,11 +22,6 @@ patches:
 - path: patches/webhook_in_example.com_wordpresses.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-#- path: patches/cainjection_in_example.com_wordpresses.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v4-multigroup/config/crd/patches/cainjection_in_example.com_wordpresses.yaml
+++ b/testdata/project-v4-multigroup/config/crd/patches/cainjection_in_example.com_wordpresses.yaml
@@ -1,7 +1,0 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: wordpresses.example.com.testproject.org

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -156,27 +156,31 @@ patches:
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: wordpresses.example.com.testproject.org
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 0
 #         create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionns
 # - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: wordpresses.example.com.testproject.org
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 1
 #         create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/testdata/project-v4-with-plugins/config/crd/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/crd/kustomization.yaml
@@ -13,11 +13,6 @@ patches:
 - path: patches/webhook_in_wordpresses.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-#- path: patches/cainjection_in_wordpresses.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v4-with-plugins/config/crd/patches/cainjection_in_wordpresses.yaml
+++ b/testdata/project-v4-with-plugins/config/crd/patches/cainjection_in_wordpresses.yaml
@@ -1,7 +1,0 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: wordpresses.example.com.testproject.org

--- a/testdata/project-v4-with-plugins/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/default/kustomization.yaml
@@ -156,27 +156,31 @@ patches:
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: wordpresses.example.com.testproject.org
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 0
 #         create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionns
 # - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: wordpresses.example.com.testproject.org
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 1
 #         create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionname

--- a/testdata/project-v4/config/crd/kustomization.yaml
+++ b/testdata/project-v4/config/crd/kustomization.yaml
@@ -13,11 +13,6 @@ patches:
 - path: patches/webhook_in_firstmates.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
-# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
-# patches here are for enabling the CA injection for each CRD
-#- path: patches/cainjection_in_firstmates.yaml
-# +kubebuilder:scaffold:crdkustomizecainjectionpatch
-
 # [WEBHOOK] To enable webhook, uncomment the following section
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:

--- a/testdata/project-v4/config/crd/patches/cainjection_in_firstmates.yaml
+++ b/testdata/project-v4/config/crd/patches/cainjection_in_firstmates.yaml
@@ -1,7 +1,0 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
-  name: firstmates.crew.testproject.org

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -156,27 +156,31 @@ patches:
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: firstmates.crew.testproject.org
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 0
 #         create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionns
 # - source:
 #     kind: Certificate
 #     group: cert-manager.io
 #     version: v1
 #     name: serving-cert # This name should match the one in certificate.yaml
 #     fieldPath: .metadata.name
-#   targets:
+#   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
 #     - select:
 #         kind: CustomResourceDefinition
+#         name: firstmates.crew.testproject.org
 #       fieldPaths:
 #         - .metadata.annotations.[cert-manager.io/inject-ca-from]
 #       options:
 #         delimiter: '/'
 #         index: 1
 #         create: true
+# +kubebuilder:scaffold:crdkustomizecainjectionname


### PR DESCRIPTION
### PR Description

The CA injection patch has **not** worked for `go/v4` and `kustomize/v2` (release `3.5.0`) due to the need to replace `vars` with `replacements`, as `vars` are no longer supported in the latest major versions of Kustomize. 

However, since webhook `--conversion` was an incomplete feature until the upcoming Kubebuilder future release `v4.4.0` (where [PR #4254](https://github.com/kubernetes-sigs/kubebuilder/pull/4254) is expected to be merged), users likely didn’t encounter this issue or addressed it manually by fixing the scaffold.

**Note:** This change only affects projects that require a **conversion webhook**. 

To better understand the issue and context please see: https://github.com/kubernetes-sigs/kubebuilder/issues/4285

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4285

### To manually fix projects scaffolded with previous versions, users can:

1. **Remove the CERTMANAGER Section from `config/crd/kustomization.yaml`:**

   Delete the `CERTMANAGER` section to avoid unintended CA injection patches for CRDs. Ensure the following lines are removed or commented out:

   ```yaml
   # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
   # patches here are for enabling the CA injection for each CRD
   #- path: patches/cainjection_in_firstmates.yaml
   # +kubebuilder:scaffold:crdkustomizecainjectionpatch
   ```

2. **Add CA Injection Configuration in `config/default/kustomization.yaml`:**

   In `config/default/kustomization.yaml`, add the following code under `[CERTMANAGER]` for CA injection:

   **Important:** Ensure that these scaffold markers are included:
   - `+kubebuilder:scaffold:crdkustomizecainjectionns`
   - `+kubebuilder:scaffold:crdkustomizecainjectioname`

   ```yaml
   # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
   #     kind: Certificate
   #     group: cert-manager.io
   #     version: v1
   #     name: serving-cert # This name should match the one in certificate.yaml
   #     fieldPath: .metadata.namespace # Namespace of the certificate CR
   #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
   # +kubebuilder:scaffold:crdkustomizecainjectionns
   # - source:
   #     kind: Certificate
   #     group: cert-manager.io
   #     version: v1
   #     name: serving-cert # This name should match the one in certificate.yaml
   #     fieldPath: .metadata.name
   #   targets: # Do not remove or uncomment the following scaffold marker; required to generate code for target CRD.
   # +kubebuilder:scaffold:crdkustomizecainjectioname
   ```
3. **Ensure Only Conversion Webhook Patches in config/crd/patches:**

   The `config/crd/patches` directory and the corresponding entries in `config/crd/kustomization.yaml` should only 
   contain files for conversion webhooks. Previously, a bug (https://github.com/kubernetes-sigs/kubebuilder/pull/4280) caused the patch file to be generated for any webhook, 
   but only patches for webhooks created with the `--conversion` option should be included.

For further guidance, you can refer to examples in the `testdata/` directory in the Kubebuilder repository.

> **Alternatively**: You can use the 'alpha generate' command to re-generate the project from scratch using the latest
> release available. Afterward, you can re-add only your code implementation on top to ensure your project includes all
> the latest bug fixes and enhancements.