### PR TITLE
:bug: (go/v4) Fix issue with scaffolding multiple webhooks for the same resource

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
@@ -81,7 +81,7 @@ func (f *Webhook) SetTemplateDefaults() error {
 	if f.Force {
 		f.IfExistsAction = machinery.OverwriteFile
 	} else {
-		f.IfExistsAction = machinery.Error
+		f.IfExistsAction = machinery.SkipFile
 	}
 
 	f.AdmissionReviewVersions = "v1"

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -119,9 +119,12 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 		return err
 	}
 
-	if !p.resource.HasDefaultingWebhook() && !p.resource.HasValidationWebhook() && !p.resource.HasConversionWebhook() {
-		return fmt.Errorf("%s create webhook requires at least one of --defaulting,"+
-			" --programmatic-validation and --conversion to be true", p.commandName)
+	// Ensure at least one webhook type is specified
+	if !p.resource.HasDefaultingWebhook() &&
+		!p.resource.HasValidationWebhook() &&
+		!p.resource.HasConversionWebhook() {
+		return fmt.Errorf("%s create webhook requires at least one of --defaulting, --programmatic-validation, "+
+			"and --conversion to be true", p.commandName)
 	}
 
 	// check if resource exist to create webhook

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -18,6 +18,7 @@ package v4
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -55,6 +56,8 @@ func GenerateV4(kbc *utils.TestContext) {
 	err = utils.ImplementWebhooks(webhookFilePath, strings.ToLower(kbc.Kind))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
+	scaffoldConversionWebhook(kbc)
+
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		"#- ../certmanager", "#")).To(Succeed())
@@ -91,6 +94,8 @@ func GenerateV4WithoutMetrics(kbc *utils.TestContext) {
 		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind)))
 	err = utils.ImplementWebhooks(webhookFilePath, strings.ToLower(kbc.Kind))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	scaffoldConversionWebhook(kbc)
 
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
@@ -152,6 +157,8 @@ func GenerateV4WithNetworkPolicies(kbc *utils.TestContext) {
 		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind)))
 	err = utils.ImplementWebhooks(webhookFilePath, strings.ToLower(kbc.Kind))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	scaffoldConversionWebhook(kbc)
 
 	ExpectWithOffset(1, pluginutil.UncommentCode(
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
@@ -367,4 +374,115 @@ func uncommentPodStandards(kbc *utils.TestContext) {
           type: RuntimeDefault`); err == nil {
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	}
+}
+
+// scaffoldConversionWebhook sets up conversion webhooks for testing the ConversionTest API
+func scaffoldConversionWebhook(kbc *utils.TestContext) {
+	By("scaffolding conversion webhooks for testing ConversionTest v1 to v2 conversion")
+
+	// Create API for v1 (hub) with conversion enabled
+	err := kbc.CreateAPI(
+		"--group", kbc.Group,
+		"--version", "v1",
+		"--kind", "ConversionTest",
+		"--controller=true",
+		"--resource=true",
+		"--make=false",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create v1 API for conversion testing")
+
+	// Create API for v2 (spoke) without a controller
+	err = kbc.CreateAPI(
+		"--group", kbc.Group,
+		"--version", "v2",
+		"--kind", "ConversionTest",
+		"--controller=false",
+		"--resource=true",
+		"--make=false",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create v2 API for conversion testing")
+
+	// Create the conversion webhook for v1
+	By("setting up the conversion webhook for v1")
+	err = kbc.CreateWebhook(
+		"--group", kbc.Group,
+		"--version", "v1",
+		"--kind", "ConversionTest",
+		"--conversion",
+		"--make=false",
+	)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create conversion webhook for v1")
+
+	// Insert Size field in v1
+	By("implementing the size spec in v1")
+	ExpectWithOffset(1, pluginutil.InsertCode(
+		filepath.Join(kbc.Dir, "api", "v1", "conversiontest_types.go"),
+		"Foo string `json:\"foo,omitempty\"`",
+		"\n\tSize int `json:\"size,omitempty\"` // Number of desired instances",
+	)).NotTo(HaveOccurred(), "failed to add size spec to conversiontest_types v1")
+
+	// Insert Replicas field in v2
+	By("implementing the replicas spec in v2")
+	ExpectWithOffset(1, pluginutil.InsertCode(
+		filepath.Join(kbc.Dir, "api", "v2", "conversiontest_types.go"),
+		"Foo string `json:\"foo,omitempty\"`",
+		"\n\tReplicas int `json:\"replicas,omitempty\"` // Number of replicas",
+	)).NotTo(HaveOccurred(), "failed to add replicas spec to conversiontest_types v2")
+
+	// TODO: Remove the code bellow when we have hub and spoke scaffolded by
+	// Kubebuilder. Intead of create the file we will replace the TODO(user)
+	// with the code implementation.
+	By("implementing markers")
+	ExpectWithOffset(1, pluginutil.InsertCode(
+		filepath.Join(kbc.Dir, "api", "v1", "conversiontest_types.go"),
+		"// +kubebuilder:object:root=true\n// +kubebuilder:subresource:status",
+		"\n// +kubebuilder:storageversion\n// +kubebuilder:conversion:hub\n",
+	)).NotTo(HaveOccurred(), "failed to add markers to conversiontest_types v1")
+
+	// Create the hub conversion file in v1
+	By("creating the conversion implementation in v1 as hub")
+	err = os.WriteFile(filepath.Join(kbc.Dir, "api", "v1", "conversiontest_conversion.go"), []byte(`
+package v1
+
+// ConversionTest defines the hub conversion logic.
+// Implement the Hub interface to signal that v1 is the hub version.
+func (*ConversionTest) Hub() {}
+`), 0644)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create hub conversion file in v1")
+
+	// Create the conversion file in v2
+	By("creating the conversion implementation in v2")
+	err = os.WriteFile(filepath.Join(kbc.Dir, "api", "v2", "conversiontest_conversion.go"), []byte(`
+package v2
+
+import (
+	"log"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	v1 "sigs.k8s.io/kubebuilder/v4/api/v1"
+)
+
+// ConvertTo converts this ConversionTest to the Hub version (v1).
+func (src *ConversionTest) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1.ConversionTest)
+	log.Printf("Converting from %T to %T", src.APIVersion, dst.APIVersion)
+
+	// Implement conversion logic from v2 to v1
+	dst.Spec.Size = src.Spec.Replicas // Convert replicas in v2 to size in v1
+
+	return nil
+}
+
+// ConvertFrom converts the Hub version (v1) to this ConversionTest (v2).
+func (dst *ConversionTest) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1.ConversionTest)
+	log.Printf("Converting from %T to %T", src.APIVersion, dst.APIVersion)
+
+	// Implement conversion logic from v1 to v2
+	dst.Spec.Replicas = src.Spec.Size // Convert size in v1 to replicas in v2
+
+	return nil
+}
+`), 0644)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to create conversion file in v2")
 }


### PR DESCRIPTION
Attempting to create multiple webhooks for the same resource with different configurations (e.g., `--defaulting` and `--programmatic-validation`) resulted in an error indicating that the webhook already exists.
    
This update allows multiple webhook types to be scaffolded for a single resource without conflict. Users can scaffold different webhooks for the same GKV afterwards without needing to do so all at once, as expected.

Either we are adding tests to cover the webhook undergo/v4 conversion type.
The tests are scaffolding the conversion webhook after the defaulting and validation were created already.
Therefore, we are validating the fix done in this PR. 

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4146