### PR TITLE
:warning: container friendly commands

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -58,8 +58,8 @@ COPY internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# was called. For example, if we call make container-build in a local env which has the Apple Silicon M1 SO
+# the BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -178,12 +178,12 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: docker-build
-docker-build: ## Build docker image with the manager.
+.PHONY: container-build
+container-build: ## Build container image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
+.PHONY: container-push
+container-push: ## Push container image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
@@ -194,7 +194,7 @@ docker-push: ## Push docker image with the manager.
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
-docker-buildx: ## Build and push docker image for the manager for cross-platform support
+docker-buildx: ## Build and push container image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name {{ .ProjectName }}-builder

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -45,7 +45,7 @@ func (f *Readme) SetTemplateDefaults() error {
 		"*/", "", 1)
 
 	f.TemplateBody = fmt.Sprintf(readmeFileTemplate,
-		codeFence("make docker-build docker-push IMG=<some-registry>/{{ .ProjectName }}:tag"),
+		codeFence("make container-build container-push IMG=<some-registry>/{{ .ProjectName }}:tag"),
 		codeFence("make install"),
 		codeFence("make deploy IMG=<some-registry>/{{ .ProjectName }}:tag"),
 		codeFence("kubectl apply -k config/samples/"),
@@ -71,9 +71,9 @@ const readmeFileTemplate = `# {{ .ProjectName }}
 
 ### Prerequisites
 - go version v1.22.0+
-- docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+- a container tool (Docker, Podman, Buildah, etc)
+- kubectl version v1.11.3+
+- Access to a Kubernetes v1.11.3+ cluster
 
 ### To Deploy on the cluster
 **Build and push your image to the location specified by ` + "`IMG`" + `:**

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to run make manifests")
 
 	By("building the manager(Operator) image")
-	cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectImage))
+	cmd = exec.Command("make", "container-build", fmt.Sprintf("IMG=%s", projectImage))
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 


### PR DESCRIPTION
## Why the changes were made

Replace `docker` with `container` from command names that do not necessarily need Docker to be used, but should work with any container tool (Podman, Buildah, etc).

> **Note:** I use these commands with Podman, so I validated them with this tool, but not with any other container tool.

## How the changes were made

Checked places that mentions `docker` with the command 
```sh
grep -Inr "docker" ./pkg/plugins/golang/v4/scaffolds/internal/templates/
```
and changed them to a container friendly wording.

> **Note:** Still have to run `make generate` and change `docker` appearances/references in documentation. Waiting to see if community wants this change before doing more changes.

## How to test the changes made

Run new `container-build` and `container-push` commands, and confirm they work as `docker-build` and `docker-push` used to work.
