### PR TITLE
:sparkles: Include admin ClusterRole and add it to the scaffold

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_admin_role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over batch.tutorial.kubebuilder.io.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
+  name: cronjob-admin-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_editor_role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit cronjobs.
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the batch.tutorial.kubebuilder.io.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_viewer_role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/cronjob_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view cronjobs.
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to batch.tutorial.kubebuilder.io resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/rbac/kustomization.yaml
@@ -18,10 +18,11 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+- cronjob_admin_role.yaml
 - cronjob_editor_role.yaml
 - cronjob_viewer_role.yaml
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -3869,6 +3869,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project
+  name: project-cronjob-admin-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
   name: project-cronjob-editor-role
 rules:
 - apiGroups:

--- a/docs/book/src/getting-started/testdata/project/config/rbac/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/kustomization.yaml
@@ -18,10 +18,11 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+- memcached_admin_role.yaml
 - memcached_editor_role.yaml
 - memcached_viewer_role.yaml
 

--- a/docs/book/src/getting-started/testdata/project/config/rbac/memcached_admin_role.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/memcached_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over cache.example.com.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
+  name: memcached-admin-role
+rules:
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds
+  verbs:
+  - '*'
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds/status
+  verbs:
+  - get

--- a/docs/book/src/getting-started/testdata/project/config/rbac/memcached_editor_role.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/memcached_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit memcacheds.
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the cache.example.com.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/getting-started/testdata/project/config/rbac/memcached_viewer_role.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/rbac/memcached_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view memcacheds.
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to cache.example.com resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -238,6 +238,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project
+  name: project-memcached-admin-role
+rules:
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds
+  verbs:
+  - '*'
+- apiGroups:
+  - cache.example.com
+  resources:
+  - memcacheds/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
   name: project-memcached-editor-role
 rules:
 - apiGroups:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/cronjob_admin_role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/cronjob_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over batch.tutorial.kubebuilder.io.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project
+    app.kubernetes.io/managed-by: kustomize
+  name: cronjob-admin-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/cronjob_editor_role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/cronjob_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit cronjobs.
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the batch.tutorial.kubebuilder.io.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/cronjob_viewer_role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/cronjob_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view cronjobs.
+# This rule is not used by the project project itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to batch.tutorial.kubebuilder.io resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/rbac/kustomization.yaml
@@ -18,10 +18,11 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+- cronjob_admin_role.yaml
 - cronjob_editor_role.yaml
 - cronjob_viewer_role.yaml
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -7680,6 +7680,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project
+  name: project-cronjob-admin-role
+rules:
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - batch.tutorial.kubebuilder.io
+  resources:
+  - cronjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
   name: project-cronjob-editor-role
 rules:
 - apiGroups:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -75,6 +75,7 @@ func (s *apiScaffolder) Scaffold() error {
 	if s.resource.HasAPI() {
 		if err := scaffold.Execute(
 			&samples.CRDSample{Force: s.force},
+			&rbac.CRDAdminRole{},
 			&rbac.CRDEditorRole{},
 			&rbac.CRDViewerRole{},
 			&crd.Kustomization{},
@@ -100,22 +101,22 @@ func (s *apiScaffolder) Scaffold() error {
 			}
 		}
 
-		// Add scaffolded CRD Editor and Viewer roles in config/rbac/kustomization.yaml
+		// Add scaffolded CRD Admin, Editor and Viewer roles in config/rbac/kustomization.yaml
 		rbacKustomizeFilePath := "config/rbac/kustomization.yaml"
 		err = pluginutil.AppendCodeIfNotExist(rbacKustomizeFilePath,
-			editViewRulesCommentFragment)
+			adminEditViewRulesCommentFragment)
 		if err != nil {
-			log.Errorf("Unable to append the edit/view roles comment in the file "+
+			log.Errorf("Unable to append the admin/edit/view roles comment in the file "+
 				"%s.", rbacKustomizeFilePath)
 		}
 		crdName := strings.ToLower(s.resource.Kind)
 		if s.config.IsMultiGroup() && s.resource.Group != "" {
 			crdName = strings.ToLower(s.resource.Group) + "_" + crdName
 		}
-		err = pluginutil.InsertCodeIfNotExist(rbacKustomizeFilePath, editViewRulesCommentFragment,
-			fmt.Sprintf("\n- %[1]s_editor_role.yaml\n- %[1]s_viewer_role.yaml", crdName))
+		err = pluginutil.InsertCodeIfNotExist(rbacKustomizeFilePath, adminEditViewRulesCommentFragment,
+			fmt.Sprintf("\n- %[1]s_admin_role.yaml\n- %[1]s_editor_role.yaml\n- %[1]s_viewer_role.yaml", crdName))
 		if err != nil {
-			log.Errorf("Unable to add Editor and Viewer roles in the file "+
+			log.Errorf("Unable to add Admin, Editor and Viewer roles in the file "+
 				"%s.", rbacKustomizeFilePath)
 		}
 		// Add an empty line at the end of the file
@@ -132,7 +133,7 @@ func (s *apiScaffolder) Scaffold() error {
 	return nil
 }
 
-const editViewRulesCommentFragment = `# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+const adminEditViewRulesCommentFragment = `# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.`

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_admin_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_admin_role.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:dupl
+package rbac
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &CRDAdminRole{}
+
+// CRDAdminRole scaffolds a file that defines the role that allows full control over plurals
+type CRDAdminRole struct {
+	machinery.TemplateMixin
+	machinery.MultiGroupMixin
+	machinery.ResourceMixin
+	machinery.ProjectNameMixin
+
+	RoleName string
+}
+
+// SetTemplateDefaults implements file.Template
+func (f *CRDAdminRole) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup && f.Resource.Group != "" {
+			f.Path = filepath.Join("config", "rbac", "%[group]_%[kind]_admin_role.yaml")
+		} else {
+			f.Path = filepath.Join("config", "rbac", "%[kind]_admin_role.yaml")
+		}
+
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	if f.RoleName == "" {
+		if f.MultiGroup && f.Resource.Group != "" {
+			f.RoleName = fmt.Sprintf("%s-%s-admin-role",
+				strings.ToLower(f.Resource.Group),
+				strings.ToLower(f.Resource.Kind))
+		} else {
+			f.RoleName = fmt.Sprintf("%s-admin-role",
+				strings.ToLower(f.Resource.Kind))
+		}
+	}
+
+	f.TemplateBody = crdRoleAdminTemplate
+
+	return nil
+}
+
+const crdRoleAdminTemplate = `# This rule is not used by the project {{ .ProjectName }} itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over {{ .Resource.QualifiedGroup }}.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .ProjectName }}
+    app.kubernetes.io/managed-by: kustomize
+  name: {{ .RoleName }}
+rules:
+- apiGroups:
+  - {{ .Resource.QualifiedGroup }}
+  resources:
+  - {{ .Resource.Plural }}
+  verbs:
+  - '*'
+- apiGroups:
+  - {{ .Resource.QualifiedGroup }}
+  resources:
+  - {{ .Resource.Plural }}/status
+  verbs:
+  - get
+`

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
@@ -65,7 +65,13 @@ func (f *CRDEditorRole) SetTemplateDefaults() error {
 	return nil
 }
 
-const crdRoleEditorTemplate = `# permissions for end users to edit {{ .Resource.Plural }}.
+const crdRoleEditorTemplate = `# This rule is not used by the project {{ .ProjectName }} itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the {{ .Resource.QualifiedGroup }}.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
@@ -65,7 +65,13 @@ func (f *CRDViewerRole) SetTemplateDefaults() error {
 	return nil
 }
 
-const crdRoleViewerTemplate = `# permissions for end users to view {{ .Resource.Plural }}.
+const crdRoleViewerTemplate = `# This rule is not used by the project {{ .ProjectName }} itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to {{ .Resource.QualifiedGroup }} resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/crew_captain_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/crew_captain_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over crew.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: crew-captain-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/crew_captain_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/crew_captain_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit captains.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the crew.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/crew_captain_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/crew_captain_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view captains.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to crew.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/example.com_busybox_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_busybox_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over example.com.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: example.com-busybox-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/example.com_busybox_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_busybox_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit busyboxes.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the example.com.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/example.com_busybox_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_busybox_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view busyboxes.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to example.com.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/example.com_memcached_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_memcached_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over example.com.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: example.com-memcached-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/example.com_memcached_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_memcached_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit memcacheds.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the example.com.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/example.com_memcached_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_memcached_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view memcacheds.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to example.com.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/example.com_wordpress_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_wordpress_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over example.com.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: example.com-wordpress-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/example.com_wordpress_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_wordpress_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit wordpresses.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the example.com.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/example.com_wordpress_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/example.com_wordpress_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view wordpresses.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to example.com.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/fiz_bar_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/fiz_bar_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over fiz.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: fiz-bar-admin-role
+rules:
+- apiGroups:
+  - fiz.testproject.org
+  resources:
+  - bars
+  verbs:
+  - '*'
+- apiGroups:
+  - fiz.testproject.org
+  resources:
+  - bars/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/fiz_bar_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/fiz_bar_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit bars.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the fiz.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/fiz_bar_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/fiz_bar_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view bars.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to fiz.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over foo.policy.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: foo.policy-healthcheckpolicy-admin-role
+rules:
+- apiGroups:
+  - foo.policy.testproject.org
+  resources:
+  - healthcheckpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - foo.policy.testproject.org
+  resources:
+  - healthcheckpolicies/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit healthcheckpolicies.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the foo.policy.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo.policy_healthcheckpolicy_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view healthcheckpolicies.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to foo.policy.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/foo_bar_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo_bar_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over foo.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: foo-bar-admin-role
+rules:
+- apiGroups:
+  - foo.testproject.org
+  resources:
+  - bars
+  verbs:
+  - '*'
+- apiGroups:
+  - foo.testproject.org
+  resources:
+  - bars/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/foo_bar_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo_bar_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit bars.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the foo.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/foo_bar_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/foo_bar_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view bars.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to foo.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/kustomization.yaml
@@ -18,32 +18,44 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+- example.com_wordpress_admin_role.yaml
 - example.com_wordpress_editor_role.yaml
 - example.com_wordpress_viewer_role.yaml
+- example.com_busybox_admin_role.yaml
 - example.com_busybox_editor_role.yaml
 - example.com_busybox_viewer_role.yaml
+- example.com_memcached_admin_role.yaml
 - example.com_memcached_editor_role.yaml
 - example.com_memcached_viewer_role.yaml
+- fiz_bar_admin_role.yaml
 - fiz_bar_editor_role.yaml
 - fiz_bar_viewer_role.yaml
+- foo_bar_admin_role.yaml
 - foo_bar_editor_role.yaml
 - foo_bar_viewer_role.yaml
+- foo.policy_healthcheckpolicy_admin_role.yaml
 - foo.policy_healthcheckpolicy_editor_role.yaml
 - foo.policy_healthcheckpolicy_viewer_role.yaml
+- sea-creatures_leviathan_admin_role.yaml
 - sea-creatures_leviathan_editor_role.yaml
 - sea-creatures_leviathan_viewer_role.yaml
+- sea-creatures_kraken_admin_role.yaml
 - sea-creatures_kraken_editor_role.yaml
 - sea-creatures_kraken_viewer_role.yaml
+- ship_cruiser_admin_role.yaml
 - ship_cruiser_editor_role.yaml
 - ship_cruiser_viewer_role.yaml
+- ship_destroyer_admin_role.yaml
 - ship_destroyer_editor_role.yaml
 - ship_destroyer_viewer_role.yaml
+- ship_frigate_admin_role.yaml
 - ship_frigate_editor_role.yaml
 - ship_frigate_viewer_role.yaml
+- crew_captain_admin_role.yaml
 - crew_captain_editor_role.yaml
 - crew_captain_viewer_role.yaml
 

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over sea-creatures.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: sea-creatures-kraken-admin-role
+rules:
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - krakens
+  verbs:
+  - '*'
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - krakens/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit krakens.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the sea-creatures.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_kraken_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view krakens.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to sea-creatures.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over sea-creatures.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: sea-creatures-leviathan-admin-role
+rules:
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - leviathans
+  verbs:
+  - '*'
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - leviathans/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit leviathans.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the sea-creatures.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/sea-creatures_leviathan_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view leviathans.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to sea-creatures.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/ship_cruiser_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_cruiser_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over ship.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: ship-cruiser-admin-role
+rules:
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - cruisers
+  verbs:
+  - '*'
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - cruisers/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_cruiser_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_cruiser_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit cruisers.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the ship.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/ship_cruiser_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_cruiser_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view cruisers.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to ship.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/ship_destroyer_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_destroyer_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over ship.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: ship-destroyer-admin-role
+rules:
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - destroyers
+  verbs:
+  - '*'
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - destroyers/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_destroyer_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_destroyer_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit destroyers.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the ship.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/ship_destroyer_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_destroyer_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view destroyers.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to ship.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/ship_frigate_admin_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_frigate_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over ship.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-multigroup
+    app.kubernetes.io/managed-by: kustomize
+  name: ship-frigate-admin-role
+rules:
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - frigates
+  verbs:
+  - '*'
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - frigates/status
+  verbs:
+  - get

--- a/testdata/project-v4-multigroup/config/rbac/ship_frigate_editor_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_frigate_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit frigates.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the ship.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/config/rbac/ship_frigate_viewer_role.yaml
+++ b/testdata/project-v4-multigroup/config/rbac/ship_frigate_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view frigates.
+# This rule is not used by the project project-v4-multigroup itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to ship.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -888,6 +888,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-crew-captain-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
   name: project-v4-multigroup-crew-captain-editor-role
 rules:
 - apiGroups:
@@ -929,6 +950,27 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-example.com-busybox-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes/status
   verbs:
   - get
 ---
@@ -988,6 +1030,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-example.com-memcached-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
   name: project-v4-multigroup-example.com-memcached-editor-role
 rules:
 - apiGroups:
@@ -1029,6 +1092,27 @@ rules:
   - example.com.testproject.org
   resources:
   - memcacheds/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-example.com-wordpress-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses/status
   verbs:
   - get
 ---
@@ -1088,6 +1172,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-fiz-bar-admin-role
+rules:
+- apiGroups:
+  - fiz.testproject.org
+  resources:
+  - bars
+  verbs:
+  - '*'
+- apiGroups:
+  - fiz.testproject.org
+  resources:
+  - bars/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
   name: project-v4-multigroup-fiz-bar-editor-role
 rules:
 - apiGroups:
@@ -1127,6 +1232,27 @@ rules:
   - watch
 - apiGroups:
   - fiz.testproject.org
+  resources:
+  - bars/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-foo-bar-admin-role
+rules:
+- apiGroups:
+  - foo.testproject.org
+  resources:
+  - bars
+  verbs:
+  - '*'
+- apiGroups:
+  - foo.testproject.org
   resources:
   - bars/status
   verbs:
@@ -1179,6 +1305,27 @@ rules:
   - foo.testproject.org
   resources:
   - bars/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-foo.policy-healthcheckpolicy-admin-role
+rules:
+- apiGroups:
+  - foo.policy.testproject.org
+  resources:
+  - healthcheckpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - foo.policy.testproject.org
+  resources:
+  - healthcheckpolicies/status
   verbs:
   - get
 ---
@@ -1513,6 +1660,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-sea-creatures-kraken-admin-role
+rules:
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - krakens
+  verbs:
+  - '*'
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - krakens/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
   name: project-v4-multigroup-sea-creatures-kraken-editor-role
 rules:
 - apiGroups:
@@ -1554,6 +1722,27 @@ rules:
   - sea-creatures.testproject.org
   resources:
   - krakens/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-sea-creatures-leviathan-admin-role
+rules:
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - leviathans
+  verbs:
+  - '*'
+- apiGroups:
+  - sea-creatures.testproject.org
+  resources:
+  - leviathans/status
   verbs:
   - get
 ---
@@ -1613,6 +1802,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-ship-cruiser-admin-role
+rules:
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - cruisers
+  verbs:
+  - '*'
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - cruisers/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
   name: project-v4-multigroup-ship-cruiser-editor-role
 rules:
 - apiGroups:
@@ -1663,6 +1873,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-ship-destroyer-admin-role
+rules:
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - destroyers
+  verbs:
+  - '*'
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - destroyers/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
   name: project-v4-multigroup-ship-destroyer-editor-role
 rules:
 - apiGroups:
@@ -1704,6 +1935,27 @@ rules:
   - ship.testproject.org
   resources:
   - destroyers/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-multigroup
+  name: project-v4-multigroup-ship-frigate-admin-role
+rules:
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - frigates
+  verbs:
+  - '*'
+- apiGroups:
+  - ship.testproject.org
+  resources:
+  - frigates/status
   verbs:
   - get
 ---

--- a/testdata/project-v4-with-plugins/config/rbac/busybox_admin_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/busybox_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over example.com.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-plugins
+    app.kubernetes.io/managed-by: kustomize
+  name: busybox-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes/status
+  verbs:
+  - get

--- a/testdata/project-v4-with-plugins/config/rbac/busybox_editor_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/busybox_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit busyboxes.
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the example.com.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/config/rbac/busybox_viewer_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/busybox_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view busyboxes.
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to example.com.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/config/rbac/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/kustomization.yaml
@@ -18,14 +18,17 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+- wordpress_admin_role.yaml
 - wordpress_editor_role.yaml
 - wordpress_viewer_role.yaml
+- busybox_admin_role.yaml
 - busybox_editor_role.yaml
 - busybox_viewer_role.yaml
+- memcached_admin_role.yaml
 - memcached_editor_role.yaml
 - memcached_viewer_role.yaml
 

--- a/testdata/project-v4-with-plugins/config/rbac/memcached_admin_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/memcached_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over example.com.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-plugins
+    app.kubernetes.io/managed-by: kustomize
+  name: memcached-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds/status
+  verbs:
+  - get

--- a/testdata/project-v4-with-plugins/config/rbac/memcached_editor_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/memcached_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit memcacheds.
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the example.com.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/config/rbac/memcached_viewer_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/memcached_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view memcacheds.
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to example.com.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/config/rbac/wordpress_admin_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/wordpress_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over example.com.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4-with-plugins
+    app.kubernetes.io/managed-by: kustomize
+  name: wordpress-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses/status
+  verbs:
+  - get

--- a/testdata/project-v4-with-plugins/config/rbac/wordpress_editor_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/wordpress_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit wordpresses.
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the example.com.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/config/rbac/wordpress_viewer_role.yaml
+++ b/testdata/project-v4-with-plugins/config/rbac/wordpress_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view wordpresses.
+# This rule is not used by the project project-v4-with-plugins itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to example.com.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -402,6 +402,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-with-plugins
+  name: project-v4-with-plugins-busybox-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - busyboxes/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-with-plugins
   name: project-v4-with-plugins-busybox-editor-role
 rules:
 - apiGroups:
@@ -517,6 +538,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4-with-plugins
+  name: project-v4-with-plugins-memcached-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - memcacheds/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-with-plugins
   name: project-v4-with-plugins-memcached-editor-role
 rules:
 - apiGroups:
@@ -586,6 +628,27 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4-with-plugins
+  name: project-v4-with-plugins-wordpress-admin-role
+rules:
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses
+  verbs:
+  - '*'
+- apiGroups:
+  - example.com.testproject.org
+  resources:
+  - wordpresses/status
   verbs:
   - get
 ---

--- a/testdata/project-v4/config/rbac/admiral_admin_role.yaml
+++ b/testdata/project-v4/config/rbac/admiral_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over crew.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
+  name: admiral-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - admirales
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - admirales/status
+  verbs:
+  - get

--- a/testdata/project-v4/config/rbac/admiral_editor_role.yaml
+++ b/testdata/project-v4/config/rbac/admiral_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit admirales.
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the crew.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4/config/rbac/admiral_viewer_role.yaml
+++ b/testdata/project-v4/config/rbac/admiral_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view admirales.
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to crew.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4/config/rbac/captain_admin_role.yaml
+++ b/testdata/project-v4/config/rbac/captain_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over crew.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
+  name: captain-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains/status
+  verbs:
+  - get

--- a/testdata/project-v4/config/rbac/captain_editor_role.yaml
+++ b/testdata/project-v4/config/rbac/captain_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit captains.
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the crew.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4/config/rbac/captain_viewer_role.yaml
+++ b/testdata/project-v4/config/rbac/captain_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view captains.
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to crew.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4/config/rbac/firstmate_admin_role.yaml
+++ b/testdata/project-v4/config/rbac/firstmate_admin_role.yaml
@@ -1,0 +1,27 @@
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants full permissions ('*') over crew.testproject.org.
+# This role is intended for users authorized to modify roles and bindings within the cluster,
+# enabling them to delegate specific permissions to other users or groups as needed.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
+  name: firstmate-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - firstmates
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - firstmates/status
+  verbs:
+  - get

--- a/testdata/project-v4/config/rbac/firstmate_editor_role.yaml
+++ b/testdata/project-v4/config/rbac/firstmate_editor_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to edit firstmates.
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants permissions to create, update, and delete resources within the crew.testproject.org.
+# This role is intended for users who need to manage these resources
+# but should not control RBAC or manage permissions for others.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4/config/rbac/firstmate_viewer_role.yaml
+++ b/testdata/project-v4/config/rbac/firstmate_viewer_role.yaml
@@ -1,4 +1,10 @@
-# permissions for end users to view firstmates.
+# This rule is not used by the project project-v4 itself.
+# It is provided to allow the cluster admin to help manage permissions for users.
+#
+# Grants read-only access to crew.testproject.org resources.
+# This role is intended for users who need visibility into these resources
+# without permissions to modify them. It is ideal for monitoring purposes and limited-access viewing.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4/config/rbac/kustomization.yaml
+++ b/testdata/project-v4/config/rbac/kustomization.yaml
@@ -18,14 +18,17 @@ resources:
 - metrics_auth_role.yaml
 - metrics_auth_role_binding.yaml
 - metrics_reader_role.yaml
-# For each CRD, "Editor" and "Viewer" roles are scaffolded by
+# For each CRD, "Admin", "Editor" and "Viewer" roles are scaffolded by
 # default, aiding admins in cluster management. Those roles are
-# not used by the Project itself. You can comment the following lines
+# not used by the {{ .ProjectName }} itself. You can comment the following lines
 # if you do not want those helpers be installed with your Project.
+- admiral_admin_role.yaml
 - admiral_editor_role.yaml
 - admiral_viewer_role.yaml
+- firstmate_admin_role.yaml
 - firstmate_editor_role.yaml
 - firstmate_viewer_role.yaml
+- captain_admin_role.yaml
 - captain_editor_role.yaml
 - captain_viewer_role.yaml
 

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -273,6 +273,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4
+  name: project-v4-admiral-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - admirales
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - admirales/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4
   name: project-v4-admiral-editor-role
 rules:
 - apiGroups:
@@ -323,6 +344,27 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: project-v4
+  name: project-v4-captain-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - captains/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4
   name: project-v4-captain-editor-role
 rules:
 - apiGroups:
@@ -364,6 +406,27 @@ rules:
   - crew.testproject.org
   resources:
   - captains/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project-v4
+  name: project-v4-firstmate-admin-role
+rules:
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - firstmates
+  verbs:
+  - '*'
+- apiGroups:
+  - crew.testproject.org
+  resources:
+  - firstmates/status
   verbs:
   - get
 ---


### PR DESCRIPTION
This PR solve this issue #4294 by adding a new `admin` role. This role allows the user to have full control (`verb: '*'`) over the CRs and the RBAC.

It is defined in this form:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    app.kubernetes.io/name: {{ .ProjectName }}
    app.kubernetes.io/managed-by: kustomize
  name: {{ .RoleName }}
rules:
- apiGroups:
  - {{ .Resource.QualifiedGroup }}
  resources:
  - {{ .Resource.Plural }}
  verbs:
  - '*'
- apiGroups:
  - {{ .Resource.QualifiedGroup }}
  resources:
  - {{ .Resource.Plural }}/status
  verbs:
  - get
```
It can be found under this path [`pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_admin_role.go`](https://github.com/damsien/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_admin_role.go).

Moreover, the comment on top of each role (`admin`, `editor` and `viewer`) has been changed to be more explicit.