### PR TITLE
:bug: revert the changes done in the PR #4286

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
@@ -81,7 +81,7 @@ func (f *Webhook) SetTemplateDefaults() error {
 	if f.Force {
 		f.IfExistsAction = machinery.OverwriteFile
 	} else {
-		f.IfExistsAction = machinery.SkipFile
+		f.IfExistsAction = machinery.Error
 	}
 
 	f.AdmissionReviewVersions = "v1"

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -119,12 +119,9 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 		return err
 	}
 
-	// Ensure at least one webhook type is specified
-	if !p.resource.HasDefaultingWebhook() &&
-		!p.resource.HasValidationWebhook() &&
-		!p.resource.HasConversionWebhook() {
-		return fmt.Errorf("%s create webhook requires at least one of --defaulting, --programmatic-validation, "+
-			"and --conversion to be true", p.commandName)
+	if !p.resource.HasDefaultingWebhook() && !p.resource.HasValidationWebhook() && !p.resource.HasConversionWebhook() {
+		return fmt.Errorf("%s create webhook requires at least one of --defaulting,"+
+			" --programmatic-validation and --conversion to be true", p.commandName)
 	}
 
 	// check if resource exist to create webhook


### PR DESCRIPTION
We are reverting the changes done in the PR #4286. We are just keeping the e2e tests improvements.
We will not able to solve the issue https://github.com/kubernetes-sigs/kubebuilder/issues/4146 without add new markers.

We cannot skip the action to write an webhook since it will result in incomplete inplementation in the <kind>_webhook.go as in the <kind>_webhook_test.go