### PR TITLE
✨ Follow-up to PR #4243: Limit permissions to access the metrics-server-cert secret

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/certmanager_metrics_manager_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/certmanager_metrics_manager_patch.yaml
@@ -18,5 +18,4 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert

--- a/docs/book/src/getting-started/testdata/project/config/default/certmanager_metrics_manager_patch.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/certmanager_metrics_manager_patch.yaml
@@ -18,5 +18,4 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/certmanager_metrics_manager_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/certmanager_metrics_manager_patch.yaml
@@ -18,5 +18,4 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -7981,7 +7981,6 @@ spec:
           secretName: webhook-server-cert
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert
 ---
 apiVersion: cert-manager.io/v1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/certmanager_metrics_manager_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/certmanager_metrics_manager_patch.go
@@ -70,6 +70,5 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert
 `

--- a/testdata/project-v4-multigroup/config/default/certmanager_metrics_manager_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/certmanager_metrics_manager_patch.yaml
@@ -18,5 +18,4 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert

--- a/testdata/project-v4-with-plugins/config/default/certmanager_metrics_manager_patch.yaml
+++ b/testdata/project-v4-with-plugins/config/default/certmanager_metrics_manager_patch.yaml
@@ -18,5 +18,4 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert

--- a/testdata/project-v4/config/default/certmanager_metrics_manager_patch.yaml
+++ b/testdata/project-v4/config/default/certmanager_metrics_manager_patch.yaml
@@ -18,5 +18,4 @@ spec:
       volumes:
       - name: metrics-certs
         secret:
-          defaultMode: 420
           secretName: metrics-server-cert


### PR DESCRIPTION
This change ensures that only the necessary permissions are granted for accessing the metrics-server-cert secret. Note that setting defaultMode: 420 is not required.
