### PR TITLE
(WIP - TODO Address change agreed on review)✨ (helm/v1alpha): add samples manifests

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -236,6 +236,7 @@ func (s *initScaffolder) copyConfigFiles() error {
 	}{
 		{"config/rbac", "dist/chart/templates/rbac", "rbac"},
 		{"config/crd/bases", "dist/chart/templates/crd", "crd"},
+		{"config/samples", "dist/chart/templates/samples", "samples"},
 		{"config/network-policy", "dist/chart/templates/network-policy", "networkPolicy"},
 	}
 

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/values.go
@@ -120,6 +120,10 @@ crd:
   # (Certificates, Issuers, ...) due to garbage collection.
   keep: true
 
+# [SAMPLES]: To apply the sample(s) manifests set true
+samples:
+  enable: false
+
 # [METRICS]: Set to true to generate manifests for exporting metrics.
 # To disable metrics export set false, and ensure that the
 # ControllerManager argument "--metrics-bind-address=:8443" is removed.

--- a/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v1_wordpress.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v1_wordpress.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.samples.enable }}
+apiVersion: example.com.testproject.org/v1
+kind: Wordpress
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: wordpress-sample
+spec:
+  # TODO(user): Add fields here
+{{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v1alpha1_busybox.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v1alpha1_busybox.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.samples.enable }}
+apiVersion: example.com.testproject.org/v1alpha1
+kind: Busybox
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: busybox-sample
+spec:
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
+  size: 1
+{{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v1alpha1_memcached.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v1alpha1_memcached.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.samples.enable }}
+apiVersion: example.com.testproject.org/v1alpha1
+kind: Memcached
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: memcached-sample
+spec:
+  # TODO(user): edit the following value to ensure the number
+  # of Pods/Instances your Operand must have on cluster
+  size: 1
+
+  # TODO(user): edit the following value to ensure the container has the right port to be initialized
+  containerPort: 11211
+{{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v2_wordpress.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/samples/example.com_v2_wordpress.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.samples.enable }}
+apiVersion: example.com.testproject.org/v2
+kind: Wordpress
+metadata:
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  name: wordpress-sample
+spec:
+  # TODO(user): Add fields here
+{{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -60,6 +60,10 @@ crd:
   # (Certificates, Issuers, ...) due to garbage collection.
   keep: true
 
+# [SAMPLES]: To apply the sample(s) manifests set true
+samples:
+  enable: false
+
 # [METRICS]: Set to true to generate manifests for exporting metrics.
 # To disable metrics export set false, and ensure that the
 # ControllerManager argument "--metrics-bind-address=:8443" is removed.


### PR DESCRIPTION
Add samples to the helm chart so that consumers and developers can decide if should provide good samples configurations and enable them for the chart be installed within

**motivation**

The inclusion of sample CRs in Helm charts is motivated by the need to improve user experience and ease of use. By providing default configurations and ready-to-use examples, we reduce the setup time for users, guide them in customizing their CRs, and ensure the Operator is functional right after installation. This approach not only simplifies onboarding but also allows users to quickly verify the Operator’s deployment, making the setup process more intuitive and productive.