### PR TITLE
:book: Fix readme wrong url your-own-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,5 +166,5 @@ Additionally, we can use this channel to demonstrate new features.
 [operator-sdk]: https://github.com/operator-framework/operator-sdk
 [plugin-section]: https://book.kubebuilder.io/plugins/plugins.html
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
-[your-own-plugins]: https://book.kubebuilder.io/plugins/creating-plugins.html
+[your-own-plugins]: https://book.kubebuilder.io/plugins/extending
 [controller-tools]: https://github.com/kubernetes-sigs/controller-tools


### PR DESCRIPTION
Small fix of the README that contains an old url that were working in the [book-v3](https://book-v3.book.kubebuilder.io/plugins/creating-plugins.html) in the [Kubebuilder is also a library](https://github.com/kubernetes-sigs/kubebuilder/tree/master?tab=readme-ov-file#kubebuilder-is-also-a-library) section (how to create your own plugins).

The new url is the following: [https://book.kubebuilder.io/plugins/extending](https://book.kubebuilder.io/plugins/extending)