### PR TITLE
🌱 : Fix `make remove-spaces` for GNU system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,8 @@ generate: generate-testdata generate-docs ## Update/generate all mock data. You 
 .PHONY: remove-spaces
 remove-spaces:
 	@echo "Removing trailing spaces"
-	@find . -type f -name "*.md" -exec sed -i '' 's/[[:space:]]*$$//' {} + || true
+	@SED_CMD="sed -i ''" && [ "$$(uname)" != "Darwin" ] && SED_CMD="sed -i"; \
+	find . -type f -name "*.md" -exec $$SED_CMD 's/[[:space:]]*$$//' {} + || true
 
 .PHONY: generate-testdata
 generate-testdata: ## Update/generate the testdata in $GOPATH/src/sigs.k8s.io/kubebuilder


### PR DESCRIPTION
This PR is motivated by this issue: #4327.

It is a fix about the `make remove-spaces` command that was only working on OS X and not GNU based system. It is because the behavior of the `sed -i` command is different between these two systems (see [this stack exchange discussion](https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed/131940#131940)).

- On OS X: `sed -i ''`
- On GNU: `sed -i`

So I added a check by using `uname` to use the `sed -i` in the correct way depending if we are on GNU based system or on OS X based system.