### PR TITLE
🌱 : Revert Fix `make remove-spaces` for GNU system"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ generate: generate-testdata generate-docs ## Update/generate all mock data. You 
 .PHONY: remove-spaces
 remove-spaces:
 	@echo "Removing trailing spaces"
-	@SED_CMD="sed -i ''" && [ "$$(uname)" != "Darwin" ] && SED_CMD="sed -i"; \
-	find . -type f -name "*.md" -exec $$SED_CMD 's/[[:space:]]*$$//' {} + || true
+	@find . -type f -name "*.md" -exec sed -i '' 's/[[:space:]]*$$//' {} + || true
 
 .PHONY: generate-testdata
 generate-testdata: ## Update/generate the testdata in $GOPATH/src/sigs.k8s.io/kubebuilder


### PR DESCRIPTION
Reverts kubernetes-sigs/kubebuilder#4330
Broke the target (On Mac)

![Screenshot 2024-11-16 at 09 52 35](https://github.com/user-attachments/assets/fabef346-463c-4997-819b-ebb1d8327c69)
