### PR TITLE
🐛 fix: (helm/v1-alpha): Remove extra space before the labels section

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -62,7 +62,7 @@ const helmHelpersTemplate = `{{` + "`" + `{{- define "chart.name" -}}` + "`" + `
 Common labels for the chart.
 */}}
 {{` + "`" + `{{- define "chart.labels" -}}` + "`" + `}}
-{{` + "`" + `{{- if .Chart.AppVersion }}` + "`" + `}}
+{{` + "`" + `{{- if .Chart.AppVersion -}}` + "`" + `}}
 app.kubernetes.io/version: {{` + "`" + `{{ .Chart.AppVersion | quote }}` + "`" + `}}
 {{` + "`" + `{{- end }}` + "`" + `}}
 {{` + "`" + `{{- if .Chart.Version }}` + "`" + `}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -14,7 +14,7 @@
 
 
 {{- define "chart.labels" -}}
-{{- if .Chart.AppVersion }}
+{{- if .Chart.AppVersion -}}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 {{- if .Chart.Version }}


### PR DESCRIPTION
![bilde](https://github.com/user-attachments/assets/3ce253b8-90bd-433f-9d4a-d264a8008bf5)
Looks like the value for "**_app.kubernetes.io/name:_**" is also not rendering properly. Can I add that fix in this PR as well? Or should I open a second one?
Edit: I created a new PR: https://github.com/kubernetes-sigs/kubebuilder/pull/4351