### PR TITLE
🐛 fix: (helm/alpha-v1): Fix rendered value for app.kubernetes.io/name

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -47,7 +47,7 @@ func (f *HelmHelpers) SetTemplateDefaults() error {
 const helmHelpersTemplate = `{{` + "`" + `{{- define "chart.name" -}}` + "`" + `}}
 {{` + "`" + `{{- if .Chart }}` + "`" + `}}
   {{` + "`" + `{{- if .Chart.Name }}` + "`" + `}}
-    {{` + "`" + `{{ .Chart.Name | trunc 63 | trimSuffix "-" }}` + "`" + `}}
+    {{` + "`" + `{{- .Chart.Name | trunc 63 | trimSuffix "-" }}` + "`" + `}}
   {{` + "`" + `{{- else if .Values.nameOverride }}` + "`" + `}}
     {{` + "`" + `{{ .Values.nameOverride | trunc 63 | trimSuffix "-" }}` + "`" + `}}
   {{` + "`" + `{{- else }}` + "`" + `}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "chart.name" -}}
 {{- if .Chart }}
   {{- if .Chart.Name }}
-    {{ .Chart.Name | trunc 63 | trimSuffix "-" }}
+    {{- .Chart.Name | trunc 63 | trimSuffix "-" }}
   {{- else if .Values.nameOverride }}
     {{ .Values.nameOverride | trunc 63 | trimSuffix "-" }}
   {{- else }}


### PR DESCRIPTION
![bilde](https://github.com/user-attachments/assets/dd25a1c3-4d15-4317-9f73-f5254495ebc5)

The fix for the extra line after "**_labels:_**" is being fixed in this PR: https://github.com/kubernetes-sigs/kubebuilder/pull/4350