### PR TITLE
🌱 fix: run make generate to fix ci

### DIFF
--- a/testdata/project-v4-multigroup/go.mod
+++ b/testdata/project-v4-multigroup/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup
 go 1.22.0
 
 require (
-	github.com/cert-manager/cert-manager v1.16.1
+	github.com/cert-manager/cert-manager v1.16.2
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	k8s.io/api v0.31.1

--- a/testdata/project-v4/go.mod
+++ b/testdata/project-v4/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/kubebuilder/testdata/project-v4
 go 1.22.0
 
 require (
-	github.com/cert-manager/cert-manager v1.16.1
+	github.com/cert-manager/cert-manager v1.16.2
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	k8s.io/api v0.31.1


### PR DESCRIPTION
There was a release about 2 hours ago
https://github.com/cert-manager/cert-manager/releases/tag/v1.16.2
I guess this issue will eventually occur again if nothing is done to prevent it.