### PR TITLE
:seedling: Make `make remove-spaces` compatible with GNU and MAC OS X system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,12 @@ generate: generate-testdata generate-docs ## Update/generate all mock data. You 
 .PHONY: remove-spaces
 remove-spaces:
 	@echo "Removing trailing spaces"
-	@find . -type f -name "*.md" -exec sed -i '' 's/[[:space:]]*$$//' {} + || true
+	@bash -c ' \
+		if [[ "$$(uname)" == "Linux" ]]; then \
+			find . -type f -name "*.md" -exec sed -i "s/[[:space:]]*$$//" {} + || true; \
+		else \
+			find . -type f -name "*.md" -exec sed -i "" "s/[[:space:]]*$$//" {} + || true; \
+		fi'
 
 .PHONY: generate-testdata
 generate-testdata: ## Update/generate the testdata in $GOPATH/src/sigs.k8s.io/kubebuilder


### PR DESCRIPTION
## Why this PR does exist

This PR is motivated by this issue: #4327.

It is a fix about the make remove-spaces command that was only working on OS X and not GNU based system. It is because the behavior of the sed -i command is different between these two systems (see [this stack exchange discussion](https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed/131940#131940)).

- On OS X: `sed -i ''`
- On GNU: `sed -i`

So I added a check by using `uname` to use the `sed -i` in the correct way depending if we are on GNU based system or on OS X based system.

This PR follows this one #4330 that was not working. So it got reverted here #4331. This PR should works correctly. I cannot test on a MAC since I only have a linux system.

This PR needs to be tested by someone that has a MAC before merging.

## Quick explanation

The `bash -c` is used because `make` cannot interpret `if` & `else` since it executes each line of the recipe in a separate shell (each command runs in isolation, making the condition ineffective).

Then we check only for "Linux" system and not "Darwin". Why? Because we want the default behavior of the command to be the same as previously (the command that worked for the "Darwin" system).
Thus, if it is a GNU system (uname = Linux), then we execute the modified command. Else, we execute the default behavior -> the previous command.
