### PR TITLE
🐛 fix: (helm/v1alpha1) add missing name prefix and namespace to leader-election-role and leader-election-rolebinding

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -292,6 +292,20 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 		contentStr = strings.Replace(contentStr,
 			"name: metrics-reader",
 			fmt.Sprintf("name: %s-metrics-reader", projectName), 1)
+		contentStr = strings.Replace(contentStr,
+			"name: leader-election-role",
+			fmt.Sprintf("name: %s-leader-election-role", projectName), -1)
+		contentStr = strings.Replace(contentStr,
+			"name: leader-election-rolebinding",
+			fmt.Sprintf("name: %s-leader-election-rolebinding", projectName), 1)
+
+		// The generated files do not include the namespace
+		if strings.Contains(contentStr, "leader-election-rolebinding") ||
+			strings.Contains(contentStr, "leader-election-role") {
+			namespace := `
+  namespace: {{ .Release.Namespace }}`
+			contentStr = strings.Replace(contentStr, "metadata:", "metadata:"+namespace, 1)
+		}
 	}
 
 	// Conditionally handle CRD patches and annotations for CRDs

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader_election_role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader_election_role.yaml
@@ -5,7 +5,8 @@ kind: Role
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  name: leader-election-role
+  namespace: {{ .Release.Namespace }}
+  name: project-v4-with-plugins-leader-election-role
 rules:
 - apiGroups:
   - ""

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader_election_role_binding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader_election_role_binding.yaml
@@ -4,11 +4,12 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  name: leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  name: project-v4-with-plugins-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: project-v4-with-plugins-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: project-v4-with-plugins-controller-manager


### PR DESCRIPTION
I'm not sure this is the best approach but since there are already some hardcoded values in there I suppose it's not a terrible idea either.

The [Role](https://github.com/monteiro-renato/kubebuilder/blob/d0765c4eff32891f634183a2ab6487e8693b4c54/testdata/project-v4-with-plugins/config/rbac/leader_election_role.yaml) and [RoleBinding](https://github.com/monteiro-renato/kubebuilder/blob/d0765c4eff32891f634183a2ab6487e8693b4c54/testdata/project-v4-with-plugins/config/rbac/leader_election_role_binding.yaml) do not have a namespace associated with them when the project is `init`ed. I didn't actually try to deploy this but I believe this would actually fail to apply as is (without the namepace on the Role and RoleBinding - [src](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole)).

I added the expected value that a later [instruction](https://github.com/monteiro-renato/kubebuilder/blob/d0765c4eff32891f634183a2ab6487e8693b4c54/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go#L333-L334) is expecting.

There are a few other resources that do not have the prefix either. I can open other PRs to address those individually.