### PR TITLE
📖 Fix broken plugin URL in getting-started.md

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -439,6 +439,6 @@ implemented for your controller.
 [quick-start]: ./quick-start.md
 [best-practices]: ./reference/good-practices.md
 [cronjob-tutorial]: https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html
-[deploy-image]: ./plugins/deploy-image-plugin-v1-alpha.md
+[deploy-image]: ./plugins/available/deploy-image-plugin-v1-alpha.md
 [GOPATH-golang-docs]: https://golang.org/doc/code.html#GOPATH
 [go-modules-blogpost]: https://blog.golang.org/using-go-modules


### PR DESCRIPTION
Fix a broken URL in [Getting Started](https://book.kubebuilder.io/getting-started#getting-started) related to the deploy plugin: 
[plugins/deploy-image-plugin-v1-alpha.html](https://book.kubebuilder.io/plugins/deploy-image-plugin-v1-alpha.html)   ->  
[plugins/available/deploy-image-plugin-v1-alpha](https://book.kubebuilder.io/plugins/available/deploy-image-plugin-v1-alpha)

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
