### PR TITLE
✨ feat: (helm/v1alpha1): Allow extra pod labels to be configured

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
@@ -75,6 +75,11 @@ spec:
       labels:
         {{ "{{- include \"chart.labels\" . | nindent 8 }}" }}
         control-plane: controller-manager
+        {{ "{{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}" }}
+        {{ "{{- range $key, $value := .Values.controllerManager.pod.labels }}" }}
+        {{ "{{ $key }}" }}: {{ "{{ $value }}" }}
+        {{ "{{- end }}" }}
+        {{ "{{- end }}" }}
     spec:
       containers:
         - name: manager

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -19,6 +19,11 @@ spec:
       labels:
         {{- include "chart.labels" . | nindent 8 }}
         control-plane: controller-manager
+        {{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}
+        {{- range $key, $value := .Values.controllerManager.pod.labels }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+        {{- end }}
     spec:
       containers:
         - name: manager


### PR DESCRIPTION
The use case I have in mind is for example [Azure WI configuration](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html#pod).