### PR TITLE
✨ feat: (helm/v1alpha1): Allow ServiceAccount annotations to be configurable

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -292,6 +292,19 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 		contentStr = strings.Replace(contentStr,
 			"name: metrics-reader",
 			fmt.Sprintf("name: %s-metrics-reader", projectName), 1)
+		if strings.Contains(contentStr, "-controller-manager") &&
+			strings.Contains(contentStr, "kind: ServiceAccount") &&
+			!strings.Contains(contentStr, "RoleBinding") {
+			// The generated Service Account does not have the annotations field so we must add it.
+			contentStr = strings.Replace(contentStr,
+				"metadata:", `metadata:
+  {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.controllerManager.serviceAccount.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}`, 1)
+		}
 		contentStr = strings.Replace(contentStr,
 			"name: leader-election-role",
 			fmt.Sprintf("name: %s-leader-election-role", projectName), -1)

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/service_account.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/service_account.yaml
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+  {{- if and .Values.controllerManager.serviceAccount .Values.controllerManager.serviceAccount.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.controllerManager.serviceAccount.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
   name: project-v4-with-plugins-controller-manager
   namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
The use case I have in mind is for example [Azure WI configuration](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html#service-account).

Sooner or later I think this way of massaging the yaml files is going to become burdensome.