### PR TITLE
 ✨ (go/v4): Update actions to use go.mod for Go version management

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.22"
+          go-version-file: go.mod
       - name: Execute go-apidiff
         uses: joelanford/go-apidiff@v0.8.2
         with:

--- a/.github/workflows/external-plugin.yml
+++ b/.github/workflows/external-plugin.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.3'
+          go-version-file: docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
 
       - name: Build Sample External Plugin
         working-directory: docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1

--- a/.github/workflows/legacy-webhook-path.yml
+++ b/.github/workflows/legacy-webhook-path.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.3'
+          go-version-file: go.mod
       - name: Run make test-legacy
         run: make test-legacy
 

--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,12 @@ jobs:
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
-      - name: Clone the code
-        uses: actions/checkout@v4
+          go-version-file: go.mod
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
       - name: Clean dist directory
         run: rm -rf dist || true
       - name: Install Syft to generate SBOMs

--- a/.github/workflows/test-devcontainer.yaml
+++ b/.github/workflows/test-devcontainer.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go 1.22.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.x"
+          go-version-file: go.mod
 
       - name: Setup NodeJS 20.x
         uses: actions/setup-node@v4

--- a/.github/workflows/test-e2e-book.yml
+++ b/.github/workflows/test-e2e-book.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/.github/workflows/test-e2e-samples.yml
+++ b/.github/workflows/test-e2e-samples.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.22"
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/.github/workflows/testdata.yml
+++ b/.github/workflows/testdata.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.3'
+          go-version-file: go.mod
       - name: Remove pre-installed kustomize
         # This step is needed as the following one tries to remove
         # kustomize for each test but has no permission to do so

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
       # This step is needed as the following one tries to remove
       # kustomize for each test but has no permission to do so
       - name: Remove pre-installed kustomize
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
       - name: Generate the coverage output
         run: make test-coverage
       - name: Send the coverage output

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-e2e.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test-e2e.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-e2e.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/kubebuilder/v4
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.22.3
 
 require (
 	github.com/gobuffalo/flect v1.0.3

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test-e2e.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test-e2e.go
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/test.go
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/testdata/project-v4-multigroup/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/testdata/project-v4-multigroup/.github/workflows/test-e2e.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/testdata/project-v4-multigroup/.github/workflows/test.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/testdata/project-v4-with-plugins/.github/workflows/test-e2e.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/testdata/project-v4-with-plugins/.github/workflows/test.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/testdata/project-v4/.github/workflows/test-e2e.yml
+++ b/testdata/project-v4/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Install the latest version of kind
         run: |

--- a/testdata/project-v4/.github/workflows/test.yml
+++ b/testdata/project-v4/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: go.mod
 
       - name: Running Tests
         run: |


### PR DESCRIPTION
This commit changes all GitHub Actions to use the go.mod file for specifying the Go version instead of pinning the version directly. This reduces the burden of maintaining the Go version across multiple workflows.