### PR TITLE
✨ (helm/v1alpha1): Add a step to render the chart in the GitHub Action

### DIFF
--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -73,6 +73,10 @@ jobs:
           kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
           kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
 
+      - name: Render Helm chart for project-v4-with-plugins
+        run: |
+          helm template testdata/project-v4-with-plugins/dist/chart --namespace=project-v4-with-plugins-system
+
       - name: Install Helm chart for project-v4-with-plugins
         run: |
           helm install my-release testdata/project-v4-with-plugins/dist/chart --create-namespace --namespace project-v4-with-plugins-system --set prometheus.enable=true


### PR DESCRIPTION
Related to > https://github.com/kubernetes-sigs/kubebuilder/pull/4377

If you agree it's useful, I can add it to the  test_chart.go as well.

Note for example in the picture below that some resources are not being prefixed (The issue I mentioned here: https://github.com/kubernetes-sigs/kubebuilder/pull/4357)

![bilde](https://github.com/user-attachments/assets/ed8dba72-a817-473d-a426-d4bae9b0a19d)

