### PR TITLE
🐛 fix: (helm/v1alpha1): Add missing prefixes in various k8s resources

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -293,6 +293,14 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 		contentStr = strings.Replace(contentStr,
 			"name: metrics-reader",
 			fmt.Sprintf("name: %s-metrics-reader", projectName), 1)
+
+		contentStr = strings.Replace(contentStr,
+			"name: metrics-auth-role",
+			fmt.Sprintf("name: %s-metrics-auth-role", projectName), -1)
+		contentStr = strings.Replace(contentStr,
+			"name: metrics-auth-rolebinding",
+			fmt.Sprintf("name: %s-metrics-auth-rolebinding", projectName), 1)
+
 		if strings.Contains(contentStr, "-controller-manager") &&
 			strings.Contains(contentStr, "kind: ServiceAccount") &&
 			!strings.Contains(contentStr, "RoleBinding") {
@@ -312,6 +320,12 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 		contentStr = strings.Replace(contentStr,
 			"name: leader-election-rolebinding",
 			fmt.Sprintf("name: %s-leader-election-rolebinding", projectName), 1)
+		contentStr = strings.Replace(contentStr,
+			"name: manager-role",
+			fmt.Sprintf("name: %s-manager-role", projectName), -1)
+		contentStr = strings.Replace(contentStr,
+			"name: manager-rolebinding",
+			fmt.Sprintf("name: %s-manager-rolebinding", projectName), 1)
 
 		// The generated files do not include the namespace
 		if strings.Contains(contentStr, "leader-election-rolebinding") ||

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
@@ -27,6 +27,7 @@ var _ machinery.Template = &ManagerDeployment{}
 // ManagerDeployment scaffolds the manager Deployment for the Helm chart
 type ManagerDeployment struct {
 	machinery.TemplateMixin
+	machinery.ProjectNameMixin
 
 	// DeployImages if true will scaffold the env with the images
 	DeployImages bool
@@ -57,7 +58,7 @@ func (f *ManagerDeployment) SetTemplateDefaults() error {
 const managerDeploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: {{ .ProjectName }}-controller-manager
   namespace: {{ "{{ .Release.Namespace }}" }}
   labels:
     {{ "{{- include \"chart.labels\" . | nindent 4 }}" }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: project-v4-with-plugins-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics_auth_role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics_auth_role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  name: metrics-auth-role
+  name: project-v4-with-plugins-metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics_auth_role_binding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics_auth_role_binding.yaml
@@ -4,11 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  name: metrics-auth-rolebinding
+  name: project-v4-with-plugins-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metrics-auth-role
+  name: project-v4-with-plugins-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: project-v4-with-plugins-controller-manager

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/role.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  name: manager-role
+  name: project-v4-with-plugins-manager-role
 rules:
 - apiGroups:
   - ""

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/role_binding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/role_binding.yaml
@@ -4,11 +4,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-  name: manager-rolebinding
+  name: project-v4-with-plugins-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: project-v4-with-plugins-manager-role
 subjects:
 - kind: ServiceAccount
   name: project-v4-with-plugins-controller-manager


### PR DESCRIPTION
Hey 👋
I've added missing prefixes to k8s resources (except for cert-manager ones)
I've added 4 commits so it's easier to review.
I will delete the [helm-install.yaml](https://github.com/monteiro-renato/kubebuilder/blob/088436bd8f1b63c793a7f81f32301679f8998e8b/testdata/project-v4-with-plugins/dist/helm-install.yaml) file and squash the commits after the review.