### PR TITLE
:seedling: fix: centralize plugin key declaration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func main() {
-	// Bundle plugin which built the golang projects scaffold by Kubebuilder go/v4 with kustomize v2
+	// Bundle plugin which built the golang projects scaffold with base.go/v4 and kustomize/v2 plugins
 	gov4Bundle, _ := plugin.NewBundleWithOptions(plugin.WithName(golang.DefaultNameQualifier),
 		plugin.WithVersion(plugin.Version{Number: 4}),
 		plugin.WithPlugins(kustomizecommonv2.Plugin{}, golangv4.Plugin{}),

--- a/pkg/plugins/common/kustomize/v2/init.go
+++ b/pkg/plugins/common/kustomize/v2/init.go
@@ -49,11 +49,11 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 NOTE: This plugin requires kustomize version v5 and kubectl >= 1.22.
 `
 	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a common project with your domain and name in copyright
-  %[1]s init --plugins common/v3 --domain example.org
+  %[1]s init --plugins %[2]s --domain example.org
 
   # Initialize a common project defining a specific project version
-  %[1]s init --plugins common/v3 --project-version 3
-`, cliMeta.CommandName)
+  %[1]s init --plugins %[2]s --project-version 3
+`, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }
 
 func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -65,31 +65,31 @@ type createAPISubcommand struct {
 func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	// nolint: lll
 	subcmdMeta.Description = `Scaffold the code implementation to deploy and manage your Operand which is represented by the API informed and will be reconciled by its controller. This plugin will generate the code implementation to help you out.
-	
+
 	Note: In general, it’s recommended to have one controller responsible for managing each API created for the project to properly follow the design goals set by Controller Runtime(https://github.com/kubernetes-sigs/controller-runtime).
 
 	This plugin will work as the common behaviour of the flag --force and will scaffold the API and controller always. Use core types or external APIs is not officially support by default with.
 `
 	// nolint: lll
-	subcmdMeta.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1, Kind: Frigate to represent the 
+	subcmdMeta.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1, Kind: Frigate to represent the
 	Image: example.com/frigate:v0.0.1 and its controller with a code to deploy and manage this Operand.
-	
+
 	Note that in the following example we are also adding the optional options to let you inform the command which should be used to create the container and initialize itvia the flag --image-container-command as the Port that should be used
 
 	- By informing the command (--image-container-command="memcached,--memory-limit=64,-o,modern,-v") your deployment will be scaffold with, i.e.:
 
 		Command: []string{"memcached","--memory-limit=64","-o","modern","-v"},
 
-	- By informing the Port (--image-container-port) will deployment will be scaffold with, i.e: 
+	- By informing the Port (--image-container-port) will deployment will be scaffold with, i.e:
 
 		Ports: []corev1.ContainerPort{
 			ContainerPort: Memcached.Spec.ContainerPort,
 			Name:          "Memcached",
 		},
 
-	Therefore, the default values informed will be used to scaffold specs for the API. 
+	Therefore, the default values informed will be used to scaffold specs for the API.
 
-  %[1]s create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached --memory-limit=64 modern -v" --image-container-port="11211" --plugins="deploy-image/v1-alpha" --make=false --namespaced=false
+  %[1]s create api --group example.com --version v1alpha1 --kind Memcached --image=memcached:1.6.15-alpine --image-container-command="memcached --memory-limit=64 modern -v" --image-container-port="11211" --plugins="%[2]s" --make=false --namespaced=false
 
   # Generate the manifests
   make manifests
@@ -99,7 +99,7 @@ func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdM
 
   # Regenerate code and run against the Kubernetes cluster configured by ~/.kube/config
   make run
-`, cliMeta.CommandName)
+`, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }
 
 func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/optional/grafana/v1alpha/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/edit.go
@@ -35,8 +35,8 @@ func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Description = MetaDataDescription
 
 	subcmdMeta.Examples = fmt.Sprintf(`  # Edit a common project with this plugin
-  %[1]s edit --plugins=grafana.kubebuilder.io/v1-alpha
-`, cliMeta.CommandName)
+  %[1]s edit --plugins=%[2]s
+`, cliMeta.CommandName, pluginKey)
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/grafana/v1alpha/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/init.go
@@ -35,8 +35,8 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Description = MetaDataDescription
 
 	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a common project with this plugin
-  %[1]s init --plugins=grafana.kubebuilder.io/v1-alpha
-`, cliMeta.CommandName)
+  %[1]s init --plugins=%[2]s
+`, cliMeta.CommandName, pluginKey)
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -37,14 +37,14 @@ type editSubcommand struct {
 func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	subcmdMeta.Description = `Initialize or update a Helm chart to distribute the project under the dist/ directory.
 
-**NOTE** Before running the edit command, ensure you first execute 'make manifests' to regenerate 
+**NOTE** Before running the edit command, ensure you first execute 'make manifests' to regenerate
 the latest Helm chart with your most recent changes.`
 
 	subcmdMeta.Examples = fmt.Sprintf(`# Initialize or update a Helm chart to distribute the project under the dist/ directory
-  %[1]s edit --plugins=helm/v1-alpha
+  %[1]s edit --plugins=%[2]s
 
 # Update the Helm chart under the dist/ directory and overwrite all files
-  %[1]s edit --plugins=helm/v1-alpha --force
+  %[1]s edit --plugins=%[2]s --force
 
 **IMPORTANT**: If the "--force" flag is not used, the following files will not be updated to preserve your customizations:
 dist/chart/
@@ -58,10 +58,10 @@ The following files are never updated after their initial creation:
   - chart/templates/_helpers.tpl
   - chart/.helmignore
 
-All other files are updated without the usage of the '--force=true' flag 
-when the edit option is used to ensure that the 
+All other files are updated without the usage of the '--force=true' flag
+when the edit option is used to ensure that the
 manifests in the chart align with the latest changes.
-`, cliMeta.CommandName)
+`, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/plugins/optional/helm/v1alpha/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/init.go
@@ -35,10 +35,10 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Description = `Initialize a helm chart to distribute the project under dist/
 `
 	subcmdMeta.Examples = fmt.Sprintf(`# Initialize a helm chart to distribute the project under dist/
-  %[1]s init --plugins=helm/v1-alpha
+  %[1]s init --plugins=%[2]s
 
-**IMPORTANT** You must use %[1]s edit --plugins=helm/v1-alpha to update the chart when changes are made.
-`, cliMeta.CommandName)
+**IMPORTANT** You must use %[1]s edit --plugins=%[2]s to update the chart when changes are made.
+`, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -29,7 +29,9 @@ import (
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates"
 	chart_templates "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates"
@@ -132,8 +134,7 @@ func (s *initScaffolder) getDeployImagesEnvVars() map[string]string {
 		} `json:"resources"`
 	}{}
 
-	const deployImageKey = "deploy-image.go.kubebuilder.io/v1-alpha"
-	err := s.config.DecodePluginConfig(deployImageKey, &pluginConfig)
+	err := s.config.DecodePluginConfig(plugin.KeyFor(v1alpha1.Plugin{}), &pluginConfig)
 	if err == nil {
 		for _, res := range pluginConfig.Resources {
 			image, ok := res.Options["image"]


### PR DESCRIPTION
## Why the changes were made

Fix https://github.com/kubernetes-sigs/kubebuilder/issues/4309

## How the changes were made

Ran these commands to find occurrences 
```sh
grep -Inr "base.go.kubebuilder.io" . --exclude=\*.{md,sh,toml}
grep -Inr "base/v4" . --exclude=\*.{md,sh,toml}
grep -Inr "deploy-image.go.kubebuilder.io" . --exclude=\*.{md,sh,toml}
grep -Inr "deploy-image/v1-alpha" . --exclude=\*.{md,sh,toml}
grep -Inr "grafana.kubebuilder.io" . --exclude=\*.{md,sh,toml}
grep -Inr "grafana/v1-alpha" . --exclude=\*.{md,sh,toml}
grep -Inr "helm.kubebuilder.io" . --exclude=\*.{md,sh,toml}
grep -Inr "helm/v1-alpha" . --exclude=\*.{md,sh,toml}
grep -Inr "kustomize.common.kubebuilder.io" . --exclude=\*.{md,sh,toml}
grep -Inr "kustomize/v2" . --exclude=\*.{md,sh,toml}
grep -Inr "sampleexternalplugin" . --exclude=\*.{md,sh,toml}
grep -Inr "sampleexternalplugin/v1" . --exclude=\*.{md,sh,toml}
grep -Inr "go.kubebuilder.io" . --exclude=\*.{md,sh,toml}
grep -Inr "go/v4" . --exclude=\*.{md,sh,toml}
```
ignoring test files.

> **Note:** `go.kubebuilder.io` plugin is defined in `cmd/main.go` and could not change here because of import cycle https://github.com/kubernetes-sigs/kubebuilder/blob/19237b5aff74056a6729f3584ec2ce878694f503/pkg/plugins/golang/v4/scaffolds/init.go#L136

> **Note:** could not change here because of import cycle https://github.com/kubernetes-sigs/kubebuilder/blob/c32f9714456f7e5e7cc6c790bb87c7e5956e710b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go#L61

> **Note:** did not find where `sampleexternalplugin/v1` plugin key is defined to dynamically inject here https://github.com/kubernetes-sigs/kubebuilder/tree/c32f9714456f7e5e7cc6c790bb87c7e5956e710b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/scaffolds

> **Note:** did not change here https://github.com/kubernetes-sigs/kubebuilder/blob/c32f9714456f7e5e7cc6c790bb87c7e5956e710b/pkg/plugins/golang/v4/init.go#L73 https://github.com/kubernetes-sigs/kubebuilder/blob/c32f9714456f7e5e7cc6c790bb87c7e5956e710b/pkg/plugins/golang/v4/init.go#L76 because of https://github.com/kubernetes-sigs/kubebuilder/issues/4395