### PR TITLE
📖 refactor: finalizer in CronJob example 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -67,7 +67,12 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(cronJob, myFinalizerName) {
-			controllerutil.AddFinalizer(cronJob, myFinalizerName)
+			log.Info("Adding Finalizer for CronJob")
+			if ok := controllerutil.AddFinalizer(cronJob, myFinalizerName); !ok {
+				log.Error(err, "Failed to add finalizer into the custom resource")
+				return ctrl.Result{Requeue: true}, nil
+			}
+
 			if err := r.Update(ctx, cronJob); err != nil {
 				return ctrl.Result{}, err
 			}

--- a/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
+++ b/docs/book/src/cronjob-tutorial/testdata/finalizer_example.go
@@ -76,6 +76,14 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			if err := r.Update(ctx, cronJob); err != nil {
 				return ctrl.Result{}, err
 			}
+
+			// we re-fetch after having updated the CronJob, so that we have the latest
+			// state of the resource, and avoid the error "the object has been modified,
+			// please apply your changes to the latest version and try again".
+			if err := r.Get(ctx, req.NamespacedName, cronJob); err != nil {
+				log.Error(err, "unable to fetch CronJob")
+				return ctrl.Result{}, client.IgnoreNotFound(err)
+			}
 		}
 	} else {
 		// The object is being deleted

--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -144,8 +144,11 @@ const (
 
 // CronJobStatus defines the observed state of CronJob.
 type CronJobStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// Represents the observations of a CronJob's current state.
+	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	// A list of pointers to currently running jobs.
 	// +optional

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -291,7 +291,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		The status subresource ignores changes to spec, so it's less likely to conflict
 		with any other updates, and can have separate permissions.
 	*/
-	if err := r.Status().Update(ctx, &cronJob); err != nil {
+	if err := r.Status().Update(ctx, cronJob); err != nil {
 		log.Error(err, "unable to update CronJob status")
 		return ctrl.Result{}, err
 	}
@@ -432,7 +432,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// figure out the next times that we need to create
 	// jobs at (or anything we missed).
-	missedRun, nextRun, err := getNextSchedule(&cronJob, r.Now())
+	missedRun, nextRun, err := getNextSchedule(cronJob, r.Now())
 	if err != nil {
 		log.Error(err, "unable to figure out CronJob schedule")
 		// we don't really care about requeuing until we get an update that
@@ -536,7 +536,7 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// +kubebuilder:docs-gen:collapse=constructJobForCronJob
 
 	// actually make the job...
-	job, err := constructJobForCronJob(&cronJob, missedRun)
+	job, err := constructJobForCronJob(cronJob, missedRun)
 	if err != nil {
 		log.Error(err, "unable to construct job from template")
 		// don't bother requeuing until we get a change to the spec


### PR DESCRIPTION
## Description
Refactor `CronJob` sample code to follow the structure and best practices introduced by the [`DeployImage` plugin](https://book.kubebuilder.io/plugins/available/deploy-image-plugin-v1-alpha).

## Motivation
Follow best practices, and provide an example that works without incurring in errors like trying to do a second update without re-fetching the resource.

## References
- #4291.