### PR TITLE
🐛 fix: (helm/v1alpha1): Use the ServiceAccount name defined in the values.yaml

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -290,7 +290,7 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 	if subDir == "rbac" {
 		contentStr = strings.Replace(contentStr,
 			"name: controller-manager",
-			fmt.Sprintf("name: %s-controller-manager", projectName), -1)
+			"name: {{ .Values.controllerManager.serviceAccountName }}", -1)
 		contentStr = strings.Replace(contentStr,
 			"name: metrics-reader",
 			fmt.Sprintf("name: %s-metrics-reader", projectName), 1)
@@ -302,7 +302,7 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 			"name: metrics-auth-rolebinding",
 			fmt.Sprintf("name: %s-metrics-auth-rolebinding", projectName), 1)
 
-		if strings.Contains(contentStr, "-controller-manager") &&
+		if strings.Contains(contentStr, ".Values.controllerManager.serviceAccountName") &&
 			strings.Contains(contentStr, "kind: ServiceAccount") &&
 			!strings.Contains(contentStr, "RoleBinding") {
 			// The generated Service Account does not have the annotations field so we must add it.

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader_election_role_binding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader_election_role_binding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: project-v4-with-plugins-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: project-v4-with-plugins-controller-manager
+  name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics_auth_role_binding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics_auth_role_binding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: project-v4-with-plugins-metrics-auth-role
 subjects:
 - kind: ServiceAccount
-  name: project-v4-with-plugins-controller-manager
+  name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/role_binding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/role_binding.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: project-v4-with-plugins-manager-role
 subjects:
 - kind: ServiceAccount
-  name: project-v4-with-plugins-controller-manager
+  name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/service_account.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/service_account.yaml
@@ -10,6 +10,6 @@ metadata:
     {{ $key }}: {{ $value }}
     {{- end }}
   {{- end }}
-  name: project-v4-with-plugins-controller-manager
+  name: {{ .Values.controllerManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}


### PR DESCRIPTION
The ServiceAccount and RoleBinding currently generated in dist/chart/rbac do not reference the controllerManager.serviceAccountName defined in values.yaml.