### PR TITLE
🌱Build the kubebuilder binary before and use it to regenerate the helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,9 @@ generate-docs: ## Update/generate the docs
 	./hack/docs/generate.sh
 
 .PHONY: generate-charts
-generate-charts: ## Re-generate the helm chart testdata only
+generate-charts: build ## Re-generate the helm chart testdata only
 	rm -rf testdata/project-v4-with-plugins/dist/chart
-	(cd testdata/project-v4-with-plugins && kubebuilder edit --plugins=helm/v1-alpha)
+	(cd testdata/project-v4-with-plugins && ../../bin/kubebuilder edit --plugins=helm/v1-alpha)
 
 .PHONY: check-docs
 check-docs: ## Run the script to ensure that the docs are updated


### PR DESCRIPTION
I believe this way is better? Specially now that the helm plugin is not yet available in any released version of kubebuilder?
For me, it also makes testing easier as I can make changes to the code and see it reflected in the generated chart without having to remember to `make install` beforehand.