### PR TITLE
🐛 (helm/v1alpha1): using a more precise pod selector in NetworkPolicy

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -359,6 +359,17 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string) error 
 		contentStr = injectAnnotations(contentStr, hasWebhookPatch)
 	}
 
+	// Apply NetworkPolicy-specific replacements
+	if subDir == "networkPolicy" {
+		contentStr = strings.Replace(contentStr,
+			"matchLabels:",
+			`matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+      {{- with .Values.controllerManager.pod.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}`, 1)
+	}
+
 	// Remove existing labels if necessary
 	contentStr = removeLabels(contentStr)
 

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
@@ -76,10 +76,8 @@ spec:
       labels:
         {{ "{{- include \"chart.labels\" . | nindent 8 }}" }}
         control-plane: controller-manager
-        {{ "{{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}" }}
-        {{ "{{- range $key, $value := .Values.controllerManager.pod.labels }}" }}
-        {{ "{{ $key }}" }}: {{ "{{ $value }}" }}
-        {{ "{{- end }}" }}
+        {{ "{{- with .Values.controllerManager.pod.labels }}" }}
+        {{ "{{- toYaml . | indent 8 }}" }}
         {{ "{{- end }}" }}
     spec:
       containers:

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/values.go
@@ -58,6 +58,8 @@ func (f *HelmValues) SetTemplateDefaults() error {
 const helmValuesTemplate = `# [MANAGER]: Manager Deployment Configurations
 controllerManager:
   replicas: 1
+  pod:
+    labels: {}
   container:
     image:
       repository: controller

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -19,10 +19,8 @@ spec:
       labels:
         {{- include "chart.labels" . | nindent 8 }}
         control-plane: controller-manager
-        {{- if and .Values.controllerManager.pod .Values.controllerManager.pod.labels }}
-        {{- range $key, $value := .Values.controllerManager.pod.labels }}
-        {{ $key }}: {{ $value }}
-        {{- end }}
+        {{- with .Values.controllerManager.pod.labels }}
+        {{- toYaml . | indent 8 }}
         {{- end }}
     spec:
       containers:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   podSelector:
     matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+      {{- with .Values.controllerManager.pod.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       control-plane: controller-manager
   policyTypes:
     - Ingress

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -12,6 +12,10 @@ metadata:
 spec:
   podSelector:
     matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+      {{- with .Values.controllerManager.pod.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       control-plane: controller-manager
   policyTypes:
     - Ingress

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -1,6 +1,8 @@
 # [MANAGER]: Manager Deployment Configurations
 controllerManager:
   replicas: 1
+  pod:
+    labels: {}
   container:
     image:
       repository: controller


### PR DESCRIPTION
PR's key content:

1. The `podSelector` in `NetworkPolicy` should use more precise labels.
2. Add default values for `controllerManager.pod.labels` in values.yaml, this helps the user to visualize what options are available (there are quite a few more of these issues in this plugin, do they need to be changed together now?)
