### PR TITLE
🌱 : Ensure that golangci-lint CI version is passed for the templates

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.61.0

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.61.0

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.61.0

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -36,6 +36,8 @@ import (
 )
 
 const (
+	// GolangciLintVersion is the golangci-lint version to be used in the project
+	GolangciLintVersion = "v1.61.0"
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
 	ControllerRuntimeVersion = "v0.19.1"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project
@@ -154,6 +156,7 @@ func (s *initScaffolder) Scaffold() error {
 			BoilerplatePath:          s.boilerplatePath,
 			ControllerToolsVersion:   ControllerToolsVersion,
 			KustomizeVersion:         kustomizeVersion,
+			GolangciLintVersion:      GolangciLintVersion,
 			ControllerRuntimeVersion: ControllerRuntimeVersion,
 			EnvtestVersion:           getControllerRuntimeReleaseBranch(),
 		},
@@ -166,7 +169,9 @@ func (s *initScaffolder) Scaffold() error {
 		&e2e.SuiteTest{},
 		&github.E2eTestCi{},
 		&github.TestCi{},
-		&github.LintCi{},
+		&github.LintCi{
+			GolangciLintVersion: GolangciLintVersion,
+		},
 		&utils.Utils{},
 		&templates.DevContainer{},
 		&templates.DevContainerPostInstallScript{},

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -28,6 +28,9 @@ var _ machinery.Template = &TestCi{}
 type LintCi struct {
 	machinery.TemplateMixin
 	machinery.BoilerplateMixin
+
+	// golangci-lint version to use in the project
+	GolangciLintVersion string
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -65,5 +68,5 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: {{ .GolangciLintVersion }}
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -35,6 +35,8 @@ type Makefile struct {
 	ControllerToolsVersion string
 	// Kustomize version to use in the project
 	KustomizeVersion string
+	// golangci-lint version to use in the project
+	GolangciLintVersion string
 	// ControllerRuntimeVersion version to be used to download the envtest setup script
 	ControllerRuntimeVersion string
 	// EnvtestVersion store the name of the verions to be used to install setup-envtest
@@ -251,7 +253,7 @@ CONTROLLER_TOOLS_VERSION ?= {{ .ControllerToolsVersion }}
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ "{{ .Version }}" }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ "{{ .Version }}" }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v1.61.0
+GOLANGCI_LINT_VERSION ?= {{ .GolangciLintVersion }}
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/testdata/project-v4-multigroup/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.61.0

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.61.0

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.61.0


### PR DESCRIPTION
Noted while working on https://github.com/kubernetes-sigs/kubebuilder/pull/4425 that scaffold GitHub action and Makefile have different `golangci-lint` version
