### PR TITLE
:sparkles: feat: enforce restricted Pod Security Context Compliance in testing

### DIFF
--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -113,7 +113,7 @@ spec:
   serviceAccountName: controller-manager
   containers:
   - name: metrics-consumer
-    image: curlimages/curl:7.78.0
+    image: curlimages/curl:latest
     command: ["/bin/sh"]
     args:
       - "-c"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -207,12 +207,19 @@ var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
 	// Before running the tests, set up the environment by creating the namespace,
-	// installing CRDs, and deploying the controller.
+	// enforce the restricted security policy to the namespace, installing CRDs,
+	// and deploying the controller.
 	BeforeAll(func() {
 		By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", namespace)
 		_, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+		By("labeling the namespace to enforce the restricted security policy")
+		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
+			"pod-security.kubernetes.io/enforce=restricted")
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
 
 		By("installing CRDs")
 		cmd = exec.Command("make", "install")
@@ -370,10 +377,30 @@ var _ = Describe("Manager", Ordered, func() {
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,
-				"--image=curlimages/curl:7.78.0",
-				"--", "/bin/sh", "-c", fmt.Sprintf(
-					"curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics",
-					token, metricsServiceName, namespace))
+				"--image=curlimages/curl:latest",
+				"--overrides",
+				fmt.Sprintf(` + "`" + `{
+					"spec": {
+						"containers": [{
+							"name": "curl",
+							"image": "curlimages/curl:latest",
+							"command": ["/bin/sh", "-c"],
+							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
+							"securityContext": {
+								"allowPrivilegeEscalation": false,
+								"capabilities": {
+									"drop": ["ALL"]
+								},
+								"runAsNonRoot": true,
+								"runAsUser": 1000,
+								"seccompProfile": {
+									"type": "RuntimeDefault"
+								}
+							}
+						}],
+						"serviceAccount": "%s"
+					}
+				}` + "`" + `, token, metricsServiceName, namespace, serviceAccountName))
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
 

--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -93,7 +93,8 @@ func Run(kbc *utils.TestContext) {
 
 	By("deploying the controller-manager")
 	cmd := exec.Command("make", "deploy", "IMG="+kbc.ImageName)
-	Expect(kbc.Run(cmd)).NotTo(ContainSubstring("Warning: would violate PodSecurity"))
+	out, _ := kbc.Run(cmd)
+	Expect(string(out)).NotTo(ContainSubstring("Warning: would violate PodSecurity"))
 
 	By("validating that the controller-manager pod is running as expected")
 	verifyControllerUp := func(g Gomega) {

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -252,18 +252,18 @@ func (t *TestContext) CreateManagerNamespace() error {
 	return err
 }
 
-// LabelNamespacesToWarnAboutRestricted will label all namespaces so that we can verify
-// if a warning with `Warning: would violate PodSecurity` will be raised when the manifests are applied
-func (t *TestContext) LabelNamespacesToWarnAboutRestricted() error {
+// LabelNamespacesToEnforceRestricted will label specified namespaces so that we can verify
+// if the manifests can be applied in restricted environments with strict security policy enforced
+func (t *TestContext) LabelNamespacesToEnforceRestricted() error {
 	_, err := t.Kubectl.Command("label", "--overwrite", "ns", t.Kubectl.Namespace,
-		"pod-security.kubernetes.io/warn=restricted")
+		"pod-security.kubernetes.io/enforce=restricted")
 	return err
 }
 
-// RemoveNamespaceLabelToWarnAboutRestricted will remove the `pod-security.kubernetes.io/warn` label
+// RemoveNamespaceLabelToEnforceRestricted will remove the `pod-security.kubernetes.io/enforce` label
 // from the specified namespace
-func (t *TestContext) RemoveNamespaceLabelToWarnAboutRestricted() error {
-	_, err := t.Kubectl.Command("label", "ns", t.Kubectl.Namespace, "pod-security.kubernetes.io/warn-")
+func (t *TestContext) RemoveNamespaceLabelToEnforceRestricted() error {
+	_, err := t.Kubectl.Command("label", "ns", t.Kubectl.Namespace, "pod-security.kubernetes.io/enforce-")
 	return err
 }
 


### PR DESCRIPTION
## Description

Closes #4423 

Main changes:

- Updated the test scaffolds to enforce the restricted security policy:
  - Labeled the manager namespace with `pod-security.kubernetes.io/enforce=restricted`.
  - Changed the curl Pod creation command to adhere the `securityContext` Pod spec fields
- Updated the tests under test/e2e:
  - Changed the utils func `LabelNamespacesToWarnAboutRestricted()`, `RemoveNamespaceLabelToWarnAboutRestricted()` to `LabelNamespacesToEnforceRestricted()`, `RemoveNamespaceLabelToEnforceRestricted()`.
  - Made adjustments to ensure compatibility with the strict security policy enforced.
- Changed to use `curlimages/curl:latest` instead of pinning a version.
