### PR TITLE
✨ (kustomize/v2) feat: add app.kubernetes.io/name label to allow more precise configurations 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/metrics_service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: project
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   policyTypes:
     - Ingress
   ingress:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   policyTypes:
     - Ingress
   ingress:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/webhook/service.yaml
@@ -13,3 +13,4 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4074,6 +4074,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: project
     control-plane: controller-manager
 ---
 apiVersion: v1
@@ -4090,6 +4091,7 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/name: project
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -4105,12 +4107,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: project
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: project
         control-plane: controller-manager
     spec:
       containers:
@@ -4252,6 +4256,7 @@ spec:
         name: metrics-server-cert
   selector:
     matchLabels:
+      app.kubernetes.io/name: project
       control-plane: controller-manager
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/docs/book/src/getting-started/testdata/project/config/default/metrics_service.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project

--- a/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: project
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/docs/book/src/getting-started/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   policyTypes:
     - Ingress
   ingress:

--- a/docs/book/src/getting-started/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -393,6 +393,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: project
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -408,12 +409,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: project
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: project
         control-plane: controller-manager
     spec:
       containers:
@@ -478,4 +481,5 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/name: project
       control-plane: controller-manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/metrics_service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: project
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   policyTypes:
     - Ingress
   ingress:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project
   policyTypes:
     - Ingress
   ingress:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/webhook/service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/webhook/service.yaml
@@ -13,3 +13,4 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -7885,6 +7885,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: project
     control-plane: controller-manager
 ---
 apiVersion: v1
@@ -7901,6 +7902,7 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/name: project
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -7916,12 +7918,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: project
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: project
         control-plane: controller-manager
     spec:
       containers:
@@ -8063,6 +8067,7 @@ spec:
         name: metrics-server-cert
   selector:
     matchLabels:
+      app.kubernetes.io/name: project
       control-plane: controller-manager
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/metrics_service.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/metrics_service.go
@@ -58,4 +58,5 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: {{ .ProjectName }}
 `

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -66,6 +66,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: {{ .ProjectName }}
   replicas: 1
   template:
     metadata:
@@ -73,6 +74,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: {{ .ProjectName }}
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-metrics-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-metrics-traffic.go
@@ -57,6 +57,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: {{ .ProjectName }}
   policyTypes:
     - Ingress
   ingress:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
@@ -57,6 +57,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: {{ .ProjectName }}
   policyTypes:
     - Ingress
   ingress:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -68,4 +68,5 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: {{ .ProjectName }}
 `

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook/service.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook/service.go
@@ -59,4 +59,5 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: {{ .ProjectName }}
 `

--- a/testdata/project-v4-multigroup/config/default/metrics_service.yaml
+++ b/testdata/project-v4-multigroup/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project-v4-multigroup

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-multigroup
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: project-v4-multigroup
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/testdata/project-v4-multigroup/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-multigroup
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-multigroup
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4-multigroup/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-multigroup

--- a/testdata/project-v4-multigroup/config/webhook/service.yaml
+++ b/testdata/project-v4-multigroup/config/webhook/service.yaml
@@ -13,3 +13,4 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project-v4-multigroup

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -2071,6 +2071,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: project-v4-multigroup
     control-plane: controller-manager
 ---
 apiVersion: v1
@@ -2087,6 +2088,7 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/name: project-v4-multigroup
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -2102,12 +2104,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: project-v4-multigroup
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: project-v4-multigroup
         control-plane: controller-manager
     spec:
       containers:

--- a/testdata/project-v4-with-plugins/config/default/metrics_service.yaml
+++ b/testdata/project-v4-with-plugins/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project-v4-with-plugins

--- a/testdata/project-v4-with-plugins/config/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-with-plugins
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: project-v4-with-plugins
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/testdata/project-v4-with-plugins/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/config/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-with-plugins
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4-with-plugins/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/config/network-policy/allow-webhook-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-with-plugins
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4-with-plugins/config/prometheus/monitor.yaml
+++ b/testdata/project-v4-with-plugins/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-with-plugins

--- a/testdata/project-v4-with-plugins/config/webhook/service.yaml
+++ b/testdata/project-v4-with-plugins/config/webhook/service.yaml
@@ -13,3 +13,4 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project-v4-with-plugins

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-with-plugins
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4-with-plugins
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -764,6 +764,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: project-v4-with-plugins
     control-plane: controller-manager
 ---
 apiVersion: v1
@@ -780,6 +781,7 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/name: project-v4-with-plugins
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -795,12 +797,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: project-v4-with-plugins
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: project-v4-with-plugins
         control-plane: controller-manager
     spec:
       containers:

--- a/testdata/project-v4/config/default/metrics_service.yaml
+++ b/testdata/project-v4/config/default/metrics_service.yaml
@@ -15,3 +15,4 @@ spec:
     targetPort: 8443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project-v4

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4
   replicas: 1
   template:
     metadata:
@@ -27,6 +28,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: project-v4
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/testdata/project-v4/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-metrics-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
@@ -13,6 +13,7 @@ spec:
   podSelector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4
   policyTypes:
     - Ingress
   ingress:

--- a/testdata/project-v4/config/prometheus/monitor.yaml
+++ b/testdata/project-v4/config/prometheus/monitor.yaml
@@ -24,3 +24,4 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+      app.kubernetes.io/name: project-v4

--- a/testdata/project-v4/config/webhook/service.yaml
+++ b/testdata/project-v4/config/webhook/service.yaml
@@ -13,3 +13,4 @@ spec:
       targetPort: 9443
   selector:
     control-plane: controller-manager
+    app.kubernetes.io/name: project-v4

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -634,6 +634,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: project-v4
     control-plane: controller-manager
 ---
 apiVersion: v1
@@ -650,6 +651,7 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/name: project-v4
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -665,12 +667,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: project-v4
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: project-v4
         control-plane: controller-manager
     spec:
       containers:


### PR DESCRIPTION
Key Changes:
  * Add `app.kubernetes.io/name` to the controller's pod labels for easy targeting by other resources
  * Associated Service, NetworkPolicy, ServiceMonitor add `app.kubernetes.io/name` selector to match changes to the pod labels