### PR TITLE
✨ Upgrade scaffolds to use go 1.23

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - name: Build and install Kubebuilder CLI
         run: make install

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/cronjob-tutorial/testdata/project/go.mod
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.mod
@@ -1,6 +1,8 @@
 module tutorial.kubebuilder.io/project
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/getting-started/testdata/project/Dockerfile
+++ b/docs/book/src/getting-started/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/getting-started/testdata/project/README.md
+++ b/docs/book/src/getting-started/testdata/project/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/getting-started/testdata/project/go.mod
+++ b/docs/book/src/getting-started/testdata/project/go.mod
@@ -1,6 +1,8 @@
 module example.com/memcached
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/README.md
+++ b/docs/book/src/multiversion-tutorial/testdata/project/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.mod
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.mod
@@ -1,6 +1,8 @@
 module tutorial.kubebuilder.io/project
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/kubebuilder/v4
 
-go 1.22.3
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/gobuffalo/flect v1.0.3

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -200,6 +200,7 @@ var _ = Describe("checkGoVersion", func() {
 		Entry("for go.1.20", "go1.20"),
 		Entry("for go.1.21", "go1.21"),
 		Entry("for go.1.22", "go1.22"),
+		Entry("for go.1.23", "go1.23"),
 	)
 
 	DescribeTable("should return an error for non-supported go versions",

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -22,7 +22,7 @@ import (
 
 const devContainerTemplate = `{
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
@@ -45,7 +45,9 @@ func (f *GoMod) SetTemplateDefaults() error {
 
 const goModTemplate = `module {{ .Repo }}
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -74,7 +74,7 @@ const readmeFileTemplate = `# {{ .ProjectName }}
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup/README.md
+++ b/testdata/project-v4-multigroup/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4-multigroup/go.mod
+++ b/testdata/project-v4-multigroup/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/cert-manager/cert-manager v1.16.2

--- a/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-with-plugins/Dockerfile
+++ b/testdata/project-v4-with-plugins/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-plugins/README.md
+++ b/testdata/project-v4-with-plugins/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4-with-plugins/go.mod
+++ b/testdata/project-v4-with-plugins/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v4-with-plugins
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4/README.md
+++ b/testdata/project-v4/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4/go.mod
+++ b/testdata/project-v4/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v4
 
-go 1.22.0
+go 1.23.0
+
+godebug default=go1.23
 
 require (
 	github.com/cert-manager/cert-manager v1.16.2


### PR DESCRIPTION
Upgrade scaffolds from go version 1.22 to 1.23