### PR TITLE
:seedling: fix: use Go version from go.mod file in CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
 
       - name: Build and install Kubebuilder CLI
         run: make install


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kubebuilder/pull/4446#discussion_r1898664394

Make go version updates easier, as less files must be updated
