### PR TITLE
🌱 Add lint-config target to validate config and fix issues faced

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,8 +17,6 @@ issues:
         - gosec
 
 linters-settings:
-  govet:
-    enable=fieldalignment: true
   revive:
     rules:
       # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
@@ -28,9 +26,9 @@ linters-settings:
       - name: dot-imports
         arguments:
           # dot import should be ONLY allowed for ginkgo testing packages
-          allowedPackages:
-            - "github.com/onsi/ginkgo/v2"
-            - "github.com/onsi/gomega"
+          - allowedPackages:
+              - "github.com/onsi/ginkgo/v2"
+              - "github.com/onsi/gomega"
       - name: error-return
       - name: error-strings
       - name: error-naming

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ lint: golangci-lint yamllint ## Run golangci-lint linter & yamllint
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+.PHONY: lint-config
+lint-config: golangci-lint ## Verify golangci-lint linter configuration
+	$(GOLANGCI_LINT) config verify
+
 .PHONY: yamllint
 yamllint:
 	@files=$$(find testdata -name '*.yaml' ! -path 'testdata/*/dist/*'); \


### PR DESCRIPTION
Fix golangci-lint config schema errors: corrected invalid govet fieldalignment

This PR add the new target, which is also called in the CI to validate the Lint config for Kubebuilder itself and solve the issues found:

```
make lint-config
/Users/camilam/go/src/sigs.k8s.io/kubebuilder/bin/golangci-lint config verify
jsonschema: "linters-settings.revive.rules.3.arguments" does not validate with "/properties/linters-settings/properties/revive/properties/rules/items/properties/arguments/type": expected array, but got object
jsonschema: "linters-settings.govet" does not validate with "/properties/linters-settings/properties/govet/additionalProperties": additionalProperties 'enable=fieldalignment' not allowed
Failed executing command with error: the configuration contains invalid elements
make: *** [lint-config] Error 3
```

Related to: https://github.com/kubernetes-sigs/kubebuilder/issues/4416