### PR TITLE
:seedling: Enable govet settings and fix issue found

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,11 @@ issues:
         - gosec
 
 linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
   revive:
     rules:
       # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration

--- a/pkg/plugins/golang/v4/scaffolds/edit.go
+++ b/pkg/plugins/golang/v4/scaffolds/edit.go
@@ -56,11 +56,6 @@ func (s *editScaffolder) Scaffold() error {
 	}
 	str := string(bs)
 
-	// Ignore the error encountered, if the file is already in desired format.
-	if err != nil && s.multigroup != s.config.IsMultiGroup() {
-		return err
-	}
-
 	if s.multigroup {
 		_ = s.config.SetMultiGroup()
 	} else {


### PR DESCRIPTION
Fix linter error `nilness: impossible condition: nil != nil (govet)`

```
golangci-lint run
pkg/plugins/golang/v4/scaffolds/edit.go:60:9: nilness: impossible condition: nil != nil (govet)
	if err != nil && s.multigroup != s.config.IsMultiGroup() {
	       ^
make: *** [lint] Error 1
```