### PR TITLE
:seedling: fix: remove unused nolint comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,8 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+  nolintlint:
+    allow-unused: false
   revive:
     rules:
       # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
@@ -78,6 +80,7 @@ linters:
     - ineffassign
     - lll
     - misspell
+    - nolintlint
     - nakedret
     - prealloc
     - revive

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,8 +25,6 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	kustomizecommonv2 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
-
-	//nolint:staticcheck
 	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
 	grafanav1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cli //nolint:dupl
+package cli
 
 import (
 	"fmt"

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -60,7 +60,6 @@ func setBoolFlag(flag string) {
 	os.Args = append(os.Args, "subcommand", "--"+flag)
 }
 
-// nolint:unparam
 func setProjectVersionFlag(value string) {
 	setFlag(projectVersionFlag, value)
 }

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -285,7 +285,7 @@ func (factory *executionHooksFactory) preRunEFunc(
 		}
 
 		// Pre-scaffold hook.
-		// nolint:revive
+		//nolint:revive
 		if err := factory.forEach(func(subcommand plugin.Subcommand) error {
 			if subcommand, hasPreScaffold := subcommand.(plugin.HasPreScaffold); hasPreScaffold {
 				return subcommand.PreScaffold(factory.fs)
@@ -303,7 +303,7 @@ func (factory *executionHooksFactory) preRunEFunc(
 func (factory *executionHooksFactory) runEFunc() func(*cobra.Command, []string) error {
 	return func(*cobra.Command, []string) error {
 		// Scaffold hook.
-		// nolint:revive
+		//nolint:revive
 		if err := factory.forEach(func(subcommand plugin.Subcommand) error {
 			return subcommand.Scaffold(factory.fs)
 		}, "unable to scaffold with"); err != nil {
@@ -323,7 +323,7 @@ func (factory *executionHooksFactory) postRunEFunc() func(*cobra.Command, []stri
 		}
 
 		// Post-scaffold hook.
-		// nolint:revive
+		//nolint:revive
 		if err := factory.forEach(func(subcommand plugin.Subcommand) error {
 			if subcommand, hasPostScaffold := subcommand.(plugin.HasPostScaffold); hasPostScaffold {
 				return subcommand.PostScaffold()

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cli //nolint:dupl
+package cli
 
 import (
 	"fmt"

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cli //nolint:dupl
+package cli
 
 import (
 	"fmt"

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-//nolint:dupl
 var _ = Describe("Resource", func() {
 	const (
 		group   = "group"

--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -64,8 +64,7 @@ func GetNonEmptyLines(output string) []string {
 
 // InsertCode searches target content in the file and insert `toInsert` after the target.
 func InsertCode(filename, target, code string) error {
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -75,15 +74,13 @@ func InsertCode(filename, target, code string) error {
 		return fmt.Errorf("string %s not found in %s", target, string(contents))
 	}
 	out := string(contents[:idx+len(target)]) + code + string(contents[idx+len(target):])
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	return os.WriteFile(filename, []byte(out), 0644)
 }
 
 // InsertCodeIfNotExist insert code if it does not already exists
 func InsertCodeIfNotExist(filename, target, code string) error {
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -130,8 +127,7 @@ func AppendCodeAtTheEnd(filename, code string) error {
 // UncommentCode searches for target in the file and remove the comment prefix
 // of the target content. The target content may span multiple lines.
 func UncommentCode(filename, target, prefix string) error {
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -171,8 +167,7 @@ func UncommentCode(filename, target, prefix string) error {
 	if err != nil {
 		return err
 	}
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	return os.WriteFile(filename, out.Bytes(), 0644)
 }
 
@@ -232,8 +227,7 @@ func ReplaceInFile(path, oldValue, newValue string) error {
 	if err != nil {
 		return err
 	}
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -260,8 +254,7 @@ func ReplaceRegexInFile(path, match, replace string) error {
 	if err != nil {
 		return err
 	}
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
@@ -279,7 +272,7 @@ func ReplaceRegexInFile(path, match, replace string) error {
 
 // HasFileContentWith check if given `text` can be found in file
 func HasFileContentWith(path, text string) (bool, error) {
-	// nolint:gosec
+	//nolint:gosec
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return false, err

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -91,7 +91,7 @@ func (s *apiScaffolder) Scaffold() error {
 			}
 		}
 
-		// nolint:goconst
+		//nolint:goconst
 		kustomizeFilePath := "config/default/kustomization.yaml"
 		err := pluginutil.UncommentCode(kustomizeFilePath, "#- ../crd", `#`)
 		if err != nil {

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/certmanager/certificate_metrics.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/certmanager/certificate_metrics.go
@@ -44,7 +44,7 @@ func (f *MetricsCertificate) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
+//nolint:lll
 const metricsCertManagerTemplate = `# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
 # More document can be found at https://docs.cert-manager.io
 apiVersion: cert-manager.io/v1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/certmanager/kustomizeconfig.go
@@ -43,7 +43,6 @@ func (f *KustomizeConfig) SetTemplateDefaults() error {
 	return nil
 }
 
-//nolint:lll
 const kustomizeConfigTemplate = `# This configuration is for teaching kustomize how to update name ref substitution
 nameReference:
 - kind: Issuer

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/kustomization.go
@@ -50,7 +50,7 @@ func (f *Kustomization) SetTemplateDefaults() error {
 	return nil
 }
 
-//nolint:gosec to ignore false complain G101: Potential hardcoded credentials (gosec)
+//nolint:gosec // to ignore false complain G101: Potential hardcoded credentials (gosec)
 const (
 	resourceMarker     = "crdkustomizeresource"
 	webhookPatchMarker = "crdkustomizewebhookpatch"

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/patches/enablecainjection_patch.go
@@ -47,7 +47,6 @@ func (f *EnableCAInjectionPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-//nolint:lll
 const enableCAInjectionPatchTemplate = `# The following patch adds a directive for certmanager to inject CA into the CRD
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/cert_metrics_manager_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/cert_metrics_manager_patch.go
@@ -50,7 +50,7 @@ func (f *CertManagerMetricsPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
+//nolint:lll
 const metricsManagerPatchTemplate = `# This patch adds the args, volumes, and ports to allow the manager to use the metrics-server certs.
 
 # Add the volumeMount for the metrics-server certs

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
@@ -50,8 +50,7 @@ func (f *ManagerWebhookPatch) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
-// nolint:lll
+//nolint:lll
 const managerWebhookPatchTemplate = `# This patch ensures the webhook certificates are properly mounted in the manager container.
 # It configures the necessary arguments, volumes, volume mounts, and container ports.
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor.go
@@ -41,7 +41,7 @@ func (f *Monitor) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
+//nolint:lll
 const serviceMonitorTemplate = `# Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -113,7 +113,6 @@ func (s *webhookScaffolder) Scaffold() error {
 			"%s to allow webhook traffic.", policyKustomizeFilePath)
 	}
 
-	// nolint:goconst
 	kustomizeFilePath := "config/default/kustomization.yaml"
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#- ../webhook", `#`)
 	if err != nil {
@@ -164,7 +163,6 @@ func (s *webhookScaffolder) Scaffold() error {
 // Deprecated: remove it when go/v4 and/or kustomize/v2 be removed
 // validateScaffoldedProject will output a message to help users fix their scaffold
 func validateScaffoldedProject() {
-	// nolint:goconst
 	kustomizeFilePath := "config/default/kustomization.yaml"
 	hasCertManagerPatch, _ := pluginutil.HasFileContentWith(kustomizeFilePath,
 		"crdkustomizecainjectionpatch")

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -63,14 +63,14 @@ type createAPISubcommand struct {
 }
 
 func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
-	// nolint: lll
+	//nolint:lll
 	subcmdMeta.Description = `Scaffold the code implementation to deploy and manage your Operand which is represented by the API informed and will be reconciled by its controller. This plugin will generate the code implementation to help you out.
 
 	Note: In general, it’s recommended to have one controller responsible for managing each API created for the project to properly follow the design goals set by Controller Runtime(https://github.com/kubernetes-sigs/controller-runtime).
 
 	This plugin will work as the common behaviour of the flag --force and will scaffold the API and controller always. Use core types or external APIs is not officially support by default with.
 `
-	// nolint: lll
+	//nolint:lll
 	subcmdMeta.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1, Kind: Frigate to represent the
 	Image: example.com/frigate:v0.0.1 and its controller with a code to deploy and manage this Operand.
 

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -53,7 +53,6 @@ type apiScaffolder struct {
 }
 
 // NewDeployImageScaffolder returns a new Scaffolder for declarative
-// nolint: lll
 func NewDeployImageScaffolder(config config.Config, res resource.Resource, image,
 	command, port, runAsUser string,
 ) plugins.Scaffolder {

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &Types{}
 
 // Types scaffolds the file that defines the schema for a CRD
-// nolint:maligned
+//
+//nolint:maligned
 type Types struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &ControllerTest{}
 
 // ControllerTest scaffolds the file that defines tests for the controller for a CRD or a builtin resource
-// nolint:maligned
+//
+//nolint:maligned
 type ControllerTest struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin
@@ -59,7 +60,6 @@ func (f *ControllerTest) SetTemplateDefaults() error {
 	return nil
 }
 
-//nolint:lll
 const controllerTestTemplate = `{{ .Boilerplate }}
 
 package {{ if and .MultiGroup .Resource.Group }}{{ .Resource.PackageName }}{{ else }}{{ .PackageName }}{{ end }}

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &Controller{}
 
 // Controller scaffolds the file that defines the controller for a CRD or a builtin resource
-// nolint:maligned
+//
+//nolint:maligned
 type Controller struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -84,7 +84,6 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 
 	if opts.DoAPI {
-		//nolint:staticcheck
 		res.Path = resource.APIPackagePath(c.GetRepository(), res.Group, res.Version, c.IsMultiGroup())
 
 		res.API = &resource.API{
@@ -99,7 +98,6 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 
 	if opts.DoDefaulting || opts.DoValidation || opts.DoConversion {
-		//nolint:staticcheck
 		res.Path = resource.APIPackagePath(c.GetRepository(), res.Group, res.Version, c.IsMultiGroup())
 
 		res.Webhooks.WebhookVersion = "v1"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/hub.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/hub.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &Hub{}
 
 // Hub scaffolds the file that defines hub
-// nolint:maligned
+//
+//nolint:maligned
 type Hub struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/spoke.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/spoke.go
@@ -62,7 +62,7 @@ func (f *Spoke) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
+//nolint:lll
 const spokeTemplate = `{{ .Boilerplate }}
 
 package {{ .SpokeVersion }}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &Types{}
 
 // Types scaffolds the file that defines the schema for a CRD
-// nolint:maligned
+//
+//nolint:maligned
 type Types struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
@@ -217,7 +217,7 @@ func (f *MainUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
 	return fragments
 }
 
-// nolint:lll
+//nolint:lll
 var mainTemplate = `{{ .Boilerplate }}
 
 package main

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &Controller{}
 
 // Controller scaffolds the file that defines the controller for a CRD or a builtin resource
-// nolint:maligned
+//
+//nolint:maligned
 type Controller struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -29,7 +29,8 @@ var _ machinery.Template = &SuiteTest{}
 var _ machinery.Inserter = &SuiteTest{}
 
 // SuiteTest scaffolds the file that sets up the controller tests
-// nolint:maligned
+//
+//nolint:maligned
 type SuiteTest struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
@@ -27,7 +27,8 @@ import (
 var _ machinery.Template = &ControllerTest{}
 
 // ControllerTest scaffolds the file that sets up the controller unit tests
-// nolint:maligned
+//
+//nolint:maligned
 type ControllerTest struct {
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -41,7 +41,6 @@ func (f *Golangci) SetTemplateDefaults() error {
 	return nil
 }
 
-//nolint:lll
 const golangciTemplate = `run:
   timeout: 5m
   allow-parallel-runners: true

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -64,7 +64,6 @@ func (f *Readme) SetTemplateDefaults() error {
 	return nil
 }
 
-//nolint:lll
 const readmeFileTemplate = `# {{ .ProjectName }}
 // TODO(user): Add simple overview of use/purpose
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -143,7 +143,6 @@ const mutatingWebhookChecksFragment = `It("should have CA injection for mutating
 
 `
 
-// nolint:lll
 const validatingWebhookChecksFragment = `It("should have CA injection for validating webhooks", func() {
 	By("checking CA injection for validating webhooks")
 	verifyCAInjection := func(g Gomega) {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
@@ -28,7 +28,7 @@ import (
 var _ machinery.Template = &Webhook{}
 
 // Webhook scaffolds the file that defines a webhook for a CRD or a builtin resource
-type Webhook struct { // nolint:maligned
+type Webhook struct { //nolint:maligned
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin
 	machinery.BoilerplateMixin
@@ -53,7 +53,7 @@ type Webhook struct { // nolint:maligned
 func (f *Webhook) SetTemplateDefaults() error {
 	if f.Path == "" {
 		// Deprecated: Remove me when remove go/v4
-		// nolint:goconst
+		//nolint:goconst
 		baseDir := "api"
 		if !f.IsLegacyPath {
 			baseDir = filepath.Join("internal", "webhook")

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -56,7 +56,6 @@ type WebhookSuite struct { //nolint:maligned
 func (f *WebhookSuite) SetTemplateDefaults() error {
 	if f.Path == "" {
 		// Deprecated: Remove me when remove go/v4
-		// nolint:goconst
 		baseDir := "api"
 		if !f.IsLegacyPath {
 			baseDir = filepath.Join("internal", "webhook")

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_template.go
@@ -29,7 +29,7 @@ import (
 var _ machinery.Template = &WebhookTest{}
 
 // WebhookTest scaffolds the file that sets up the webhook unit tests
-type WebhookTest struct { // nolint:maligned
+type WebhookTest struct { //nolint:maligned
 	machinery.TemplateMixin
 	machinery.MultiGroupMixin
 	machinery.BoilerplateMixin
@@ -48,7 +48,6 @@ type WebhookTest struct { // nolint:maligned
 func (f *WebhookTest) SetTemplateDefaults() error {
 	if f.Path == "" {
 		// Deprecated: Remove me when remove go/v4
-		// nolint:goconst
 		baseDir := "api"
 		if !f.IsLegacyPath {
 			baseDir = filepath.Join("internal", "webhook")

--- a/pkg/plugins/optional/grafana/v1alpha/constants.go
+++ b/pkg/plugins/optional/grafana/v1alpha/constants.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package v1alpha
 
-// nolint: lll
+//nolint:lll
 const metaDataDescription = `This command will add Grafana manifests to the project:
   - A JSON file includes dashboard manifest that can be directly copied to Grafana Web UI.
 	('grafana/controller-runtime-metrics.json')

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -62,7 +62,7 @@ func loadConfig(configPath string) ([]templates.CustomMetricItem, error) {
 		return nil, nil
 	}
 
-	// nolint:gosec
+	//nolint:gosec
 	f, err := os.Open(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("error loading plugin config: %w", err)
@@ -136,7 +136,7 @@ func fillMissingExpr(item templates.CustomMetricItem) templates.CustomMetricItem
 		case "counter":
 			item.Expr = "sum(rate(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, pod)`
 		case "histogram":
-			// nolint: lll
+			//nolint:lll
 			item.Expr = "histogram_quantile(0.90, sum by(instance, le) (rate(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}[5m])))`
 		default: // gauge
 			item.Expr = item.Metric

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom.go
@@ -39,7 +39,6 @@ func (f *CustomMetricsConfigManifest) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint: lll
 const customMetricsConfigTemplate = `---
 customMetrics:
 #  - metric: # Raw custom metric (required)

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom_metrics.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/custom_metrics.go
@@ -84,7 +84,6 @@ func (f *CustomMetricsDashManifest) createTemplate() (string, error) {
 	return outputTmpl.String(), nil
 }
 
-// nolint: lll
 const customMetricsDashTemplate = `{
   "__inputs": [
     {

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/resources.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/resources.go
@@ -45,7 +45,6 @@ func (f *ResourcesManifest) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint: lll
 const controllerResourcesTemplate = `{
   "__inputs": [
     {

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/runtime.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates/runtime.go
@@ -44,7 +44,7 @@ func (f *RuntimeManifest) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint: lll
+//nolint:lll
 const controllerRuntimeTemplate = `{
   "__inputs": [
     {

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -33,7 +33,7 @@ type editSubcommand struct {
 	force  bool
 }
 
-// nolint:lll
+//nolint:lll
 func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	subcmdMeta.Description = `Initialize or update a Helm chart to distribute the project under the dist/ directory.
 

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -43,7 +43,6 @@ func (f *HelmHelpers) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
 const helmHelpersTemplate = `{{` + "`" + `{{- define "chart.name" -}}` + "`" + `}}
 {{` + "`" + `{{- if .Chart }}` + "`" + `}}
   {{` + "`" + `{{- if .Chart.Name }}` + "`" + `}}

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/manager/manager.go
@@ -54,7 +54,7 @@ func (f *Deployment) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
+//nolint:lll
 const managerDeploymentTemplate = `apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
@@ -43,7 +43,7 @@ func (f *HelmChartCI) SetTemplateDefaults() error {
 	return nil
 }
 
-// nolint:lll
+//nolint:lll
 const testChartTemplate = `name: Test Chart
 
 on:

--- a/test/e2e/deployimage/generate_test.go
+++ b/test/e2e/deployimage/generate_test.go
@@ -20,10 +20,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	//nolint:golint
-	// nolint:revive
-	//nolint:golint
-	// nolint:revive
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 

--- a/test/e2e/utils/webhooks.go
+++ b/test/e2e/utils/webhooks.go
@@ -25,8 +25,7 @@ import (
 
 // ImplementWebhooks will mock an webhook data
 func ImplementWebhooks(filename, lowerKind string) error {
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	bs, err := os.ReadFile(filename)
 	if err != nil {
 		return err
@@ -74,7 +73,6 @@ func ImplementWebhooks(filename, lowerKind string) error {
 	if err != nil {
 		return err
 	}
-	// false positive
-	// nolint:gosec
+	//nolint:gosec // false positive
 	return os.WriteFile(filename, []byte(str), 0644)
 }

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -25,11 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-
-	//nolint:golint
-	// nolint:revive
-	//nolint:golint
-	// nolint:revive
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
@@ -248,7 +243,6 @@ const metricsTarget = `- path: manager_metrics_patch.yaml
   target:
     kind: Deployment`
 
-//nolint:lll
 const certManagerTarget = `# - source: # Uncomment the following block if you have any webhook
 #     kind: Service
 #     version: v1

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -568,7 +568,7 @@ func metricsShouldBeUnavailable(kbc *utils.TestContext) {
 }
 
 func cmdOptsToCreateCurlPod(kbc *utils.TestContext, token string) []string {
-	// nolint:lll
+	//nolint:lll
 	cmdOpts := []string{
 		"run", "curl",
 		"--restart=Never",


### PR DESCRIPTION
There are unnecessary `//nolint` comments in project code

This PR removes these unnecessary comments and enforces that no new `//nolint` unnecessary comments are added to the code