### PR TITLE
:seedling: fix: remaining Go upgrades

### DIFF
--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Go 1.22.x
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please see https://git.k8s.io/community/CLA.md for more info.
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.22+.
+- [go](https://golang.org/dl/) version v1.23+.
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/site/content/en/docs/Getting%20started/installation.md) v3.1.0+

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -17,8 +17,8 @@ command = "./litgo.sh"
 command = "./markerdocs.sh"
 
 [context.environment]
-  environment = { GO_VERSION = "1.22" }
+  environment = { GO_VERSION = "1.23" }
 
 [context.deploy-preview.environment]
-  environment = { GO_VERSION = "1.22" }
+  environment = { GO_VERSION = "1.23" }
 

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,7 +9,7 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://go.dev/dl/) version v1.22.0+
+- [go](https://go.dev/dl/) version v1.23.0+
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
@@ -1,8 +1,8 @@
 module v1
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+godebug default=go1.23
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
     base = "docs/book"
-    command = "GO_VERSION=1.22.0 ./install-and-build.sh"
+    command = "GO_VERSION=1.23.0 ./install-and-build.sh"
     publish = "docs/book/book"
     functions = "docs/book/functions"
 


### PR DESCRIPTION
Upgrade remaining Go versions from 1.22 to 1.23, after https://github.com/kubernetes-sigs/kubebuilder/pull/4446

Used `grep -Inr "1\.22" .` ouput to help me find occurrences 