### PR TITLE
 📖 improve docs of rescaffold

### DIFF
--- a/docs/book/src/reference/rescaffold.md
+++ b/docs/book/src/reference/rescaffold.md
@@ -29,7 +29,7 @@ Currently, it supports two optional params, `input-dir` and `output-dir`.
 
 `input-dir` is the path to the existing project that you want to re-scaffold. Default is the current working directory.
 
-`output-dir` is the path to the directory where you want to generate the new project. Default is a subdirectory in the current working directory.
+`output-dir` is the path to the directory where you want to generate the new project. Default is a directory named "output-dir" in the current working directory.
 
 ```sh
 kubebuilder alpha generate --input-dir=/path/to/existing/project --output-dir=/path/to/new/project
@@ -39,7 +39,7 @@ kubebuilder alpha generate --input-dir=/path/to/existing/project --output-dir=/p
 <h1>Regarding `input-dir` and `output-dir`:</h1>
 
 If neither `input-dir` nor `output-dir` are specified, the project will be regenerated in the current directory.
-This approach facilitates comparison between your current local branch and the version stored upstream (e.g., GitHub main branch).
+This approach facilitates comparison between your code and regenerated files in `output-dir`.
 This way, you can easily overlay your project's code changes atop the new scaffold.
 
 </aside>

--- a/pkg/cli/alpha/command.go
+++ b/pkg/cli/alpha/command.go
@@ -16,6 +16,7 @@ package alpha
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal"
 )
 
@@ -57,7 +58,7 @@ Then we will re-scaffold the project by Kubebuilder in the directory specified b
 	scaffoldCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
 		"path to a Kubebuilder project file if not in the current working directory")
 	scaffoldCmd.Flags().StringVar(&opts.OutputDir, "output-dir", "",
-		"path to output the scaffolding. defaults a directory in the current working directory")
+		"path to output the scaffolding. defaults to a directory named `output-dir` in the current working directory")
 
 	return scaffoldCmd
 }


### PR DESCRIPTION
So I was irritated by reading the documentation and also the CLI --help output.

I was surprised that the `output-dir` actually defaults to `output-dir`. I also did not understand how I could use git to diff the files with upstream if they are created in a sub directory. I would understand how this works if the files would be regenerated in place.

I've adjusted the docs & command to be more explicit about the default value `output-dir`.
Furthermore, I've adjusted the note to explain that you can diff the local files against the `output-dir` (the folder that was configured by the user).


relates #4478 