### PR TITLE
:bug: Make kubebuilder go install-able

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,15 @@ help: ## Display this help
 ##@ Build
 
 LD_FLAGS=-ldflags " \
-    -X main.kubeBuilderVersion=$(shell git describe --tags --dirty --broken) \
-    -X main.goos=$(shell go env GOOS) \
-    -X main.goarch=$(shell go env GOARCH) \
-    -X main.gitCommit=$(shell git rev-parse HEAD) \
-    -X main.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
+    -X cmd.kubeBuilderVersion=$(shell git describe --tags --dirty --broken) \
+    -X cmd.goos=$(shell go env GOOS) \
+    -X cmd.goarch=$(shell go env GOARCH) \
+    -X cmd.gitCommit=$(shell git rev-parse HEAD) \
+    -X cmd.buildDate=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ') \
     "
 .PHONY: build
 build: ## Build the project locally
-	go build $(LD_FLAGS) -o bin/kubebuilder ./cmd
+	go build $(LD_FLAGS) -o bin/kubebuilder
 
 .PHONY: install
 install: build ## Build and install the binary with the current source code. Use it to test your changes locally.

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -29,16 +29,15 @@ before:
 # Build a binary for each target in targets.
 builds:
   - id: kubebuilder
-    main: ./cmd
     binary: kubebuilder
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags:
-      - -X main.kubeBuilderVersion={{ .Version }}
-      - -X main.goos={{ .Os }}
-      - -X main.goarch={{ .Arch }}
-      - -X main.gitCommit={{ .Commit }}
-      - -X main.buildDate={{ .Date }}
-      - -X main.kubernetesVendorVersion={{ .Env.KUBERNETES_VERSION }}
+      - -X cmd.kubeBuilderVersion={{ .Version }}
+      - -X cmd.goos={{ .Os }}
+      - -X cmd.goarch={{ .Arch }}
+      - -X cmd.gitCommit={{ .Commit }}
+      - -X cmd.buildDate={{ .Date }}
+      - -X cmd.kubernetesVendorVersion={{ .Env.KUBERNETES_VERSION }}
     targets:
       - linux_amd64
       - linux_arm64

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cmd
 
 import (
 	"github.com/sirupsen/logrus"
@@ -36,7 +36,8 @@ func init() {
 	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
 }
 
-func main() {
+// Run bootstraps & runs the CLI
+func Run() {
 	// Bundle plugin which built the golang projects scaffold with base.go/v4 and kustomize/v2 plugins
 	gov4Bundle, _ := plugin.NewBundleWithOptions(plugin.WithName(golang.DefaultNameQualifier),
 		plugin.WithVersion(plugin.Version{Number: 4}),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,19 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 )
+
+const unknown = "unknown"
 
 // var needs to be used instead of const as ldflags is used to fill this
 // information in the release process
 var (
-	kubeBuilderVersion      = "unknown"
-	kubernetesVendorVersion = "unknown"
-	goos                    = "unknown"
-	goarch                  = "unknown"
+	kubeBuilderVersion      = unknown
+	kubernetesVendorVersion = unknown
+	goos                    = unknown
+	goarch                  = unknown
 	gitCommit               = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 
 	buildDate = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -44,6 +47,12 @@ type version struct {
 
 // versionString returns the CLI version
 func versionString() string {
+	if kubeBuilderVersion == unknown {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+			kubeBuilderVersion = info.Main.Version
+		}
+	}
+
 	return fmt.Sprintf("Version: %#v", version{
 		kubeBuilderVersion,
 		kubernetesVendorVersion,

--- a/main.go
+++ b/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "sigs.k8s.io/kubebuilder/v4/cmd"
+
+func main() {
+	cmd.Run()
+}

--- a/test/common.sh
+++ b/test/common.sh
@@ -108,7 +108,7 @@ SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
 function build_kb {
   header_text "Building kubebuilder"
 
-  go build -o "${kb_root_dir}/bin/kubebuilder" ./cmd
+  go build -o "${kb_root_dir}/bin/kubebuilder"
   kb="${kb_root_dir}/bin/kubebuilder"
 }
 


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/kubebuilder/issues/4079

This PR makes `kubebuilder` go installable.

Changes:

- Renamed `main` package originally from `cmd/` to `cmd`
- Renamed `main` function previously inside `cmd/cmg.go` to `Run` - following Go Cobra's pattern
- Created new main file at the root of the project
- Renamed package on `doc.go` to `main`
- Fixed building `make build` target
- Fixed GoReleaser config
