### PR TITLE
🐛 Update golang version to 1.23.0 in init validation logic

### DIFF
--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -36,7 +36,7 @@ import (
 
 // Variables and function to check Go version requirements.
 var (
-	goVerMin = golang.MustParse("go1.19.0")
+	goVerMin = golang.MustParse("go1.23.0")
 	goVerMax = golang.MustParse("go2.0alpha1")
 )
 


### PR DESCRIPTION
The minimal golang version provided in init operation for validation should be 1.23.0, as embedded go.mod contains this one.

Otherwise, project init will fails on downloading with following log

```shell
[xyz@fedora kbtest]$ kubebuilder init --repo kb --domain bootsman.tech
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO Get controller runtime:
$ go get sigs.k8s.io/controller-runtime@v0.19.4 
go: errors parsing go.mod:
go.mod:5: unknown directive: godebug
Error: failed to initialize project: unable to scaffold with "base.go.kubebuilder.io/v4": exit status 1
FATA failed to initialize project: unable to scaffold with "base.go.kubebuilder.io/v4": exit status 1 
[xyz@fedora kbtest]$ go version
go version go1.22.10 linux/amd64
[xyz@fedora kbtest]$ kubebuilder version
Version: main.version{KubeBuilderVersion:"4.4.0", KubernetesVendor:"1.31.0", GitCommit:"55097d022e2f99ec9df942ab1bee122369612571", BuildDate:"2025-01-12T13:10:24Z", GoOs:"linux", GoArch:"amd64"}
```
