### PR TITLE
🌱 fix: alpha generate command. If the output-dir path is not informed than it should be the current directory

### DIFF
--- a/pkg/cli/alpha/command.go
+++ b/pkg/cli/alpha/command.go
@@ -55,9 +55,11 @@ Then we will re-scaffold the project by Kubebuilder in the directory specified b
 		},
 	}
 	scaffoldCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
-		"path to a Kubebuilder project file if not in the current working directory")
+		"Specifies the full path to a Kubebuilder project file. If not provided, "+
+			"the current working directory is used.")
 	scaffoldCmd.Flags().StringVar(&opts.OutputDir, "output-dir", "",
-		"path to output the scaffolding. defaults a directory in the current working directory")
+		"Specifies the full path where the scaffolded files will be output. "+
+			"Defaults to a directory within the current working directory.")
 
 	return scaffoldCmd
 }

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -68,27 +68,28 @@ var _ = Describe("kubebuilder", func() {
 			kbc.Destroy()
 		})
 
-		It("should regenerate the project with success", func() {
+		It("should regenerate the project in current directory with success", func() {
 			generateProject(kbc)
-			regenerateProject(kbc, projectOutputDir)
-			validateProjectFile(kbc, projectFilePath)
+			regenerateProject(kbc)
+			By("checking that the project file was generated in the current directory")
+			validateProjectFile(kbc, filepath.Join(kbc.Dir, "PROJECT"))
 		})
 
 		It("should regenerate project with grafana plugin with success", func() {
 			generateProjectWithGrafanaPlugin(kbc)
-			regenerateProject(kbc, projectOutputDir)
+			regenerateProjectWith(kbc, projectOutputDir)
 			validateGrafanaPlugin(projectFilePath)
 		})
 
 		It("should regenerate project with DeployImage plugin with success", func() {
 			generateProjectWithDeployImagePlugin(kbc)
-			regenerateProject(kbc, projectOutputDir)
+			regenerateProjectWith(kbc, projectOutputDir)
 			validateDeployImagePlugin(projectFilePath)
 		})
 
 		It("should regenerate project with helm plugin with success", func() {
 			generateProjectWithHelmPlugin(kbc)
-			regenerateProject(kbc, projectOutputDir)
+			regenerateProjectWith(kbc, projectOutputDir)
 			validateHelmPlugin(projectFilePath)
 		})
 	})
@@ -185,7 +186,13 @@ func generateProject(kbc *utils.TestContext) {
 	Expect(err).NotTo(HaveOccurred(), "Failed to scaffold API with external API")
 }
 
-func regenerateProject(kbc *utils.TestContext, projectOutputDir string) {
+func regenerateProject(kbc *utils.TestContext) {
+	By("regenerating the project")
+	err := kbc.Regenerate()
+	Expect(err).NotTo(HaveOccurred(), "Failed to regenerate project")
+}
+
+func regenerateProjectWith(kbc *utils.TestContext, projectOutputDir string) {
 	By("regenerating the project")
 	err := kbc.Regenerate(
 		fmt.Sprintf("--input-dir=%s", kbc.Dir),


### PR DESCRIPTION
If not informed of an input directory and an output directory, then the tool should re-generate the project in the current directory.  