### PR TITLE
🐛 fix: kubebuilder alpha generate command to allow re-create projects with webhooks for external-apis

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -361,6 +361,10 @@ func createWebhook(resource resource.Resource) error {
 // Gets flags for webhook creation.
 func getWebhookResourceFlags(resource resource.Resource) []string {
 	var args []string
+	if resource.IsExternal() {
+		args = append(args, "--external-api-path", resource.Path)
+		args = append(args, "--external-api-domain", resource.Domain)
+	}
 	if resource.HasValidationWebhook() {
 		args = append(args, "--programmatic-validation")
 	}


### PR DESCRIPTION
Allow re-generate projects which were previously scaffolded with an external API; a webhook was created for those. 

The issue is encountered when using the command before this Pull Request to re-generate the scaffold under test data, for example.