### PR TITLE
🐛 (helm/alpha-v1): fix yaml lint in the ServiceMonitor file

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/prometheus/monitor.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/prometheus/monitor.go
@@ -48,7 +48,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-	{{ "{{- include \"chart.labels\" . | nindent 4 }}" }}
+    {{ "{{- include \"chart.labels\" . | nindent 4 }}" }}
   name: {{ .ProjectName }}-controller-manager-metrics-monitor
   namespace: {{ "{{ .Release.Namespace }}" }}
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/monitor.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-	{{- include "chart.labels" . | nindent 4 }}
+    {{- include "chart.labels" . | nindent 4 }}
   name: project-v4-with-plugins-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/4490
