### PR TITLE
✨ (go/v4): Follow cert-manager org name changes

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -33,7 +33,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -33,7 +33,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
@@ -33,7 +33,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -60,7 +60,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -33,7 +33,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {

--- a/testdata/project-v4-with-plugins/test/utils/utils.go
+++ b/testdata/project-v4-with-plugins/test/utils/utils.go
@@ -33,7 +33,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -33,7 +33,7 @@ const (
 		"releases/download/%s/bundle.yaml"
 
 	certmanagerVersion = "v1.16.3"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 )
 
 func warnError(err error) {


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

The `cert-manager` project has been transferred to the `cert-manager` organization from the jetstack.

Fix the `certmanagerURLTmpl` value to follow them.