### PR TITLE
🐛 Use explicit docker.io prefix for Docker Hub images

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/getting-started/testdata/project/Dockerfile
+++ b/docs/book/src/getting-started/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/migration/legacy/manually_migration_guide_v2_v3.md
+++ b/docs/book/src/migration/legacy/manually_migration_guide_v2_v3.md
@@ -372,13 +372,13 @@ In the Dockerfile, replace:
 
 ```
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM docker.io/golang:1.13 as builder
 ```
 
 With:
 ```
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM docker.io/golang:1.16 as builder
 ```
 
 ####  Update your Makefile

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/reference/submodule-layouts.md
+++ b/docs/book/src/reference/submodule-layouts.md
@@ -179,7 +179,7 @@ You will have to manually add the new API module into the download of dependenci
 
 ```dockerfile
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM docker.io/golang:1.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -22,7 +22,7 @@ import (
 
 const devContainerTemplate = `{
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-with-plugins/Dockerfile
+++ b/testdata/project-v4-with-plugins/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.23",
+  "image": "docker.io/golang:1.23",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM docker.io/golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Fixes build failure with non-docker builders like buildah in docs and scaffolding. Initially reported in my operator that closely aligns to scaffolding, so I figured I'd upstream the fix.

Docker's builder uses `docker.io` by default if no prefix is provided, but buildah doesn't, and I don't think it's part of the spec.