### PR TITLE
📖 fix: correct minor typos in documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,7 +68,7 @@ The releases occur in an account in the Google Cloud (See [here](https://console
 ### To build the Kubebuilder CLI binaries:
 
 A trigger GitHub action [release](.github/workflows/release.yml) is trigged when a new tag is pushed.
-This action will caall the job [./build/.goreleaser.yml](./build/.goreleaser.yml).
+This action will call the job [./build/.goreleaser.yml](./build/.goreleaser.yml).
 
 ###  (Deprecated) - To build the Kubebuilder-tools: (Artifacts required to use ENV TEST)
 
@@ -93,7 +93,7 @@ see: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907
 These images are built from the project [brancz/kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy).
 The projects built with Kubebuilder creates a side container with `kube-rbac-proxy` to protect the Manager.
 
-These images are can be checked in the consolse, see [here](https://console.cloud.google.com/gcr/images/kubebuilder/GLOBAL/kube-rbac-proxy).
+These images can be checked in the console, see [here](https://console.cloud.google.com/gcr/images/kubebuilder/GLOBAL/kube-rbac-proxy).
 
 The project `kube-rbac-proxy` is in the process to be donated to the k8s org. However, it is going on for a long time and then,
 we have no ETA for that to occur. When that occurs we can automate this process. But until there we need to generate these images

--- a/docs/book/src/migration/manually_migration_guide_gov3_to_gov4.md
+++ b/docs/book/src/migration/manually_migration_guide_gov3_to_gov4.md
@@ -198,7 +198,7 @@ controller(s), and webhook(s) in order to compare the generated configuration wi
 
 Also, after all updates you would run the following commands:
 
-- `make manifests` (to re-generate the files using the latest version of the contrller-gen after you update the Makefile)
+- `make manifests` (to re-generate the files using the latest version of the controller-gen after you update the Makefile)
 - `make all` (to ensure that you are able to build and perform all operations)
 
 [v3vsv4]: v3vsv4.md

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -102,7 +102,7 @@ By using this method, you ensure that the endpoint is accessible only to those w
 
 In this way, only Pods using the `ServiceAccount` token are authorized to read the metrics endpoint. For example:
 
-```ymal
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -324,7 +324,7 @@ var (
     goobers = prometheus.NewCounter(
         prometheus.CounterOpts{
             Name: "goobers_total",
-            Help: "Number of goobers proccessed",
+            Help: "Number of goobers processed",
         },
     )
     gooberFailures = prometheus.NewCounter(

--- a/docs/book/src/reference/platform.md
+++ b/docs/book/src/reference/platform.md
@@ -21,7 +21,7 @@ You can inspect the images using a ManifestList of supported platforms using the
 [docker manifest inspect <image>][docker-manifest], i.e.:
 
 ```shell
-$ docker manifest inspect myresgystry/example/myimage:v0.0.1
+$ docker manifest inspect myregistry/example/myimage:v0.0.1
 {
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",

--- a/docs/book/src/reference/pprof-tutorial.md
+++ b/docs/book/src/reference/pprof-tutorial.md
@@ -52,7 +52,7 @@ While [Pprof][github] is an excellent tool for profiling and debugging, it is no
     go tool pprof -http=:8080 ./cpu-profile.out
     ```
 
-    Visualizaion results will vary depending on the deployed workload, and the Controller's behavior.
+    Visualization results will vary depending on the deployed workload, and the Controller's behavior.
     However, you'll see the result on your browser similar to this one:
 
     ![pprof-result-visualization](./images/pprof-result-visualization.png)

--- a/docs/book/src/reference/submodule-layouts.md
+++ b/docs/book/src/reference/submodule-layouts.md
@@ -170,7 +170,7 @@ go.work
 go.work.sum
 ```
 
-When releasing with a present `go.work` file, make sure to set the environment variable `GOWORK=off` (verifiable with `go env GOWORK`) to make sure the release process does not get impeded by a potentially commited `go.work` file.
+When releasing with a present `go.work` file, make sure to set the environment variable `GOWORK=off` (verifiable with `go env GOWORK`) to make sure the release process does not get impeded by a potentially committed `go.work` file.
 
 #### Adjusting the Dockerfile
 
@@ -231,7 +231,7 @@ go mod edit -dropreplace YOUR_GO_PATH/test-operator/api/v1alpha1 # this will dro
 git push origin main v1.0.0 api/v1.0.0
 ```
 
-After this, your modules will be available in VCS and you do not need a local replacement anymore. However if youre making local changes,
+After this, your modules will be available in VCS and you do not need a local replacement anymore. However if you're making local changes,
 make sure to adopt your behavior with `replace` directives accordingly.
 
 ### Reusing your extracted API module

--- a/docs/kubebuilder_annotation.md
+++ b/docs/kubebuilder_annotation.md
@@ -30,7 +30,7 @@ Delimiter symbols are distinguished to work in different levels from top-down fo
 
 - **Equal sign**
 
-  Equal sign `=` is the 3rd level delimiter (to annotation) for identifying key and value. Since the `key=value` parts are splitted from single token (2nd level), its inner delimiter `=` works for next level (3rd level)
+  Equal sign `=` is the 3rd level delimiter (to annotation) for identifying key and value. Since the `key=value` parts are split from single token (2nd level), its inner delimiter `=` works for next level (3rd level)
 
 - **Semicolon sign**
 


### PR DESCRIPTION
This change introduces some fixes to a number of small typos that appear in the Kubebuilder documentation and some other markdown files within the repo.