### PR TITLE
:bug: (kustomize/v2): fix ServiceMonitor with TLS kustomize scaffolding

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -75,6 +75,17 @@ replacements:
          delimiter: '.'
          index: 0
          create: true
+     - select:
+         kind: ServiceMonitor
+         group: monitoring.coreos.com
+         version: v1
+         name: controller-manager-metrics-monitor
+       fieldPaths:
+         - spec.endpoints.0.tlsConfig.serverName
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
 
  - source:
      kind: Service
@@ -90,6 +101,17 @@ replacements:
        fieldPaths:
          - spec.dnsNames.0
          - spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true
+     - select:
+         kind: ServiceMonitor
+         group: monitoring.coreos.com
+         version: v1
+         name: controller-manager-metrics-monitor
+       fieldPaths:
+         - spec.endpoints.0.tlsConfig.serverName
        options:
          delimiter: '.'
          index: 1

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
@@ -1,22 +1,19 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4276,7 +4276,11 @@ metadata:
   namespace: project-system
 spec:
   endpoints:
-  - tlsConfig:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
       ca:
         secret:
           key: ca.crt
@@ -4289,6 +4293,7 @@ spec:
       keySecret:
         key: tls.key
         name: metrics-server-cert
+      serverName: project-controller-manager-metrics-service.project-system.svc
   selector:
     matchLabels:
       app.kubernetes.io/name: project

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -75,6 +75,17 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -90,6 +101,17 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/docs/book/src/getting-started/testdata/project/config/prometheus/monitor_tls_patch.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/prometheus/monitor_tls_patch.yaml
@@ -1,22 +1,19 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -75,6 +75,17 @@ replacements:
          delimiter: '.'
          index: 0
          create: true
+     - select:
+         kind: ServiceMonitor
+         group: monitoring.coreos.com
+         version: v1
+         name: controller-manager-metrics-monitor
+       fieldPaths:
+         - spec.endpoints.0.tlsConfig.serverName
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
 
  - source:
      kind: Service
@@ -90,6 +101,17 @@ replacements:
        fieldPaths:
          - spec.dnsNames.0
          - spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true
+     - select:
+         kind: ServiceMonitor
+         group: monitoring.coreos.com
+         version: v1
+         name: controller-manager-metrics-monitor
+       fieldPaths:
+         - spec.endpoints.0.tlsConfig.serverName
        options:
          delimiter: '.'
          index: 1

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
@@ -1,22 +1,19 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -8122,7 +8122,11 @@ metadata:
   namespace: project-system
 spec:
   endpoints:
-  - tlsConfig:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
       ca:
         secret:
           key: ca.crt
@@ -8135,6 +8139,7 @@ spec:
       keySecret:
         key: tls.key
         name: metrics-server-cert
+      serverName: project-controller-manager-metrics-service.project-system.svc
   selector:
     matchLabels:
       app.kubernetes.io/name: project

--- a/hack/docs/internal/cronjob-tutorial/sample.go
+++ b/hack/docs/internal/cronjob-tutorial/sample.go
@@ -52,6 +52,17 @@ const certManagerForMetricsAndWebhooks = `#replacements:
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -67,6 +78,17 @@ const certManagerForMetricsAndWebhooks = `#replacements:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -120,6 +120,17 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -135,6 +146,17 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor_tls_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor_tls_patch.go
@@ -44,24 +44,21 @@ func (f *ServiceMonitorPatch) SetTemplateDefaults() error {
 
 const serviceMonitorPatchTemplate = `# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key
 `

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -475,6 +475,17 @@ const metricsCertReplaces = `# - source: # Uncomment the following block to enab
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -490,6 +501,17 @@ const metricsCertReplaces = `# - source: # Uncomment the following block to enab
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -75,6 +75,17 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -90,6 +101,17 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4-multigroup/config/prometheus/monitor_tls_patch.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus/monitor_tls_patch.yaml
@@ -1,22 +1,19 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key

--- a/testdata/project-v4-with-plugins/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/default/kustomization.yaml
@@ -75,6 +75,17 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -90,6 +101,17 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4-with-plugins/config/prometheus/monitor_tls_patch.yaml
+++ b/testdata/project-v4-with-plugins/config/prometheus/monitor_tls_patch.yaml
@@ -1,22 +1,19 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -75,6 +75,17 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
+#       options:
+#         delimiter: '.'
+#         index: 0
+#         create: true
 #
 # - source:
 #     kind: Service
@@ -90,6 +101,17 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
+#       options:
+#         delimiter: '.'
+#         index: 1
+#         create: true
+#     - select:
+#         kind: ServiceMonitor
+#         group: monitoring.coreos.com
+#         version: v1
+#         name: controller-manager-metrics-monitor
+#       fieldPaths:
+#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4/config/prometheus/monitor_tls_patch.yaml
+++ b/testdata/project-v4/config/prometheus/monitor_tls_patch.yaml
@@ -1,22 +1,19 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: controller-manager-metrics-monitor
-  namespace: system
-spec:
-  endpoints:
-    - tlsConfig:
-        insecureSkipVerify: false
-        ca:
-          secret:
-            name: metrics-server-cert
-            key: ca.crt
-        cert:
-          secret:
-            name: metrics-server-cert
-            key: tls.crt
-        keySecret:
-          name: metrics-server-cert
-          key: tls.key
+- op: replace
+  path: /spec/endpoints/0/tlsConfig
+  value:
+    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
+    insecureSkipVerify: false
+    ca:
+      secret:
+        name: metrics-server-cert
+        key: ca.crt
+    cert:
+      secret:
+        name: metrics-server-cert
+        key: tls.crt
+    keySecret:
+      name: metrics-server-cert
+      key: tls.key


### PR DESCRIPTION
Fixes #4533 

- Fixed `config/prometheus/monitor_tls_patch.yaml` fiel
- Added `serverName` field in `monitor_tls_patch.yaml` for metric server cert validation