### PR TITLE
Revert "Merge pull request #4512 from sarthaksarthak9/lint"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,9 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 
 .PHONY: yamllint
 yamllint:
-	@files=$$(find testdata -name '*.yaml' ! -path 'testdata/*/dist/chart/install.yaml'); \
-	docker run --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest $$files -d "{extends: relaxed, rules: {line-length: {max: 120}}}" --no-warnings
-		
+	@files=$$(find testdata -name '*.yaml' ! -path 'testdata/*/dist/*'); \
+    	docker run --rm $$(tty -s && echo "-it" || echo) -v $(PWD):/data cytopia/yamllint:latest $$files -d "{extends: relaxed, rules: {line-length: {max: 120}}}" --no-warnings
+
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \


### PR DESCRIPTION
We must revert this change as it is not working well for the Helm Charts.
We are already using Helm Lint to validate Helm YAML files.

However, we will need to see if we can find another one to prevent scenarios like https://github.com/kubernetes-sigs/kubebuilder/pull/4490. Maybe, why it is not falling in the Helm Lint. 

