### PR TITLE
📖 Update documentation for non-owned resources

### DIFF
--- a/docs/book/src/reference/watching-resources/predicates-with-watch.md
+++ b/docs/book/src/reference/watching-resources/predicates-with-watch.md
@@ -88,7 +88,7 @@ func (r *BackupBusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
         For(&examplecomv1alpha1.BackupBusybox{}).  // Watch the primary resource (BackupBusybox)
         Watches(
             &source.Kind{Type: &examplecomv1alpha1.Busybox{}},  // Watch the Busybox CR
-            handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+            handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
                 return []reconcile.Request{
                     {
                         NamespacedName: types.NamespacedName{

--- a/docs/book/src/reference/watching-resources/secondary-resources-not-owned.md
+++ b/docs/book/src/reference/watching-resources/secondary-resources-not-owned.md
@@ -40,7 +40,7 @@ func (r *BackupBusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
         For(&examplecomv1alpha1.BackupBusybox{}).  // Watch the primary resource (BackupBusybox)
         Watches(
             &source.Kind{Type: &examplecomv1alpha1.Busybox{}},  // Watch the Busybox CR
-            handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+            handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
                 // Trigger reconciliation for the BackupBusybox in the same namespace
                 return []reconcile.Request{
                     {
@@ -67,7 +67,7 @@ func (r *BackupBusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
         For(&examplecomv1alpha1.BackupBusybox{}).  // Watch the primary resource (BackupBusybox)
         Watches(
             &source.Kind{Type: &examplecomv1alpha1.Busybox{}},  // Watch the Busybox CR
-            handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+            handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
                 // Check if the Busybox resource has the label 'backup-needed: "true"'
                 if val, ok := obj.GetLabels()["backup-enable"]; ok && val == "true" {
                     // If the label is present and set to "true", trigger reconciliation for BackupBusybox


### PR DESCRIPTION
When following the docs for watching a non-owned resource (like `corev1.Pod{}`) the function `handler.EnqueueRequestsFromMapFunc` now requires a `context.Context` argument that is not supplied in the docs.

This PR updates the documentation to match the function signature.

Reference: https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/handler/enqueue_mapped.go#L36
