### PR TITLE
🌱 Revert (kustomize/v2): fix ServiceMonitor with TLS kustomize scaffolding

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -75,17 +75,6 @@ replacements:
          delimiter: '.'
          index: 0
          create: true
-     - select:
-         kind: ServiceMonitor
-         group: monitoring.coreos.com
-         version: v1
-         name: controller-manager-metrics-monitor
-       fieldPaths:
-         - spec.endpoints.0.tlsConfig.serverName
-       options:
-         delimiter: '.'
-         index: 0
-         create: true
 
  - source:
      kind: Service
@@ -101,17 +90,6 @@ replacements:
        fieldPaths:
          - spec.dnsNames.0
          - spec.dnsNames.1
-       options:
-         delimiter: '.'
-         index: 1
-         create: true
-     - select:
-         kind: ServiceMonitor
-         group: monitoring.coreos.com
-         version: v1
-         name: controller-manager-metrics-monitor
-       fieldPaths:
-         - spec.endpoints.0.tlsConfig.serverName
        options:
          delimiter: '.'
          index: 1

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,22 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4276,11 +4276,7 @@ metadata:
   namespace: project-system
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    path: /metrics
-    port: https
-    scheme: https
-    tlsConfig:
+  - tlsConfig:
       ca:
         secret:
           key: ca.crt
@@ -4293,7 +4289,6 @@ spec:
       keySecret:
         key: tls.key
         name: metrics-server-cert
-      serverName: project-controller-manager-metrics-service.project-system.svc
   selector:
     matchLabels:
       app.kubernetes.io/name: project

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -75,17 +75,6 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -101,17 +90,6 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/docs/book/src/getting-started/testdata/project/config/prometheus/monitor_tls_patch.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,22 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -75,17 +75,6 @@ replacements:
          delimiter: '.'
          index: 0
          create: true
-     - select:
-         kind: ServiceMonitor
-         group: monitoring.coreos.com
-         version: v1
-         name: controller-manager-metrics-monitor
-       fieldPaths:
-         - spec.endpoints.0.tlsConfig.serverName
-       options:
-         delimiter: '.'
-         index: 0
-         create: true
 
  - source:
      kind: Service
@@ -101,17 +90,6 @@ replacements:
        fieldPaths:
          - spec.dnsNames.0
          - spec.dnsNames.1
-       options:
-         delimiter: '.'
-         index: 1
-         create: true
-     - select:
-         kind: ServiceMonitor
-         group: monitoring.coreos.com
-         version: v1
-         name: controller-manager-metrics-monitor
-       fieldPaths:
-         - spec.endpoints.0.tlsConfig.serverName
        options:
          delimiter: '.'
          index: 1

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,22 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -8122,11 +8122,7 @@ metadata:
   namespace: project-system
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    path: /metrics
-    port: https
-    scheme: https
-    tlsConfig:
+  - tlsConfig:
       ca:
         secret:
           key: ca.crt
@@ -8139,7 +8135,6 @@ spec:
       keySecret:
         key: tls.key
         name: metrics-server-cert
-      serverName: project-controller-manager-metrics-service.project-system.svc
   selector:
     matchLabels:
       app.kubernetes.io/name: project

--- a/hack/docs/internal/cronjob-tutorial/sample.go
+++ b/hack/docs/internal/cronjob-tutorial/sample.go
@@ -52,17 +52,6 @@ const certManagerForMetricsAndWebhooks = `#replacements:
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -78,17 +67,6 @@ const certManagerForMetricsAndWebhooks = `#replacements:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -120,17 +120,6 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -146,17 +135,6 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor_tls_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus/monitor_tls_patch.go
@@ -44,21 +44,24 @@ func (f *ServiceMonitorPatch) SetTemplateDefaults() error {
 
 const serviceMonitorPatchTemplate = `# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key
 `

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -475,17 +475,6 @@ const metricsCertReplaces = `# - source: # Uncomment the following block to enab
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -501,17 +490,6 @@ const metricsCertReplaces = `# - source: # Uncomment the following block to enab
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -75,17 +75,6 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -101,17 +90,6 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4-multigroup/config/prometheus/monitor_tls_patch.yaml
+++ b/testdata/project-v4-multigroup/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,22 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key

--- a/testdata/project-v4-with-plugins/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/default/kustomization.yaml
@@ -75,17 +75,6 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -101,17 +90,6 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4-with-plugins/config/prometheus/monitor_tls_patch.yaml
+++ b/testdata/project-v4-with-plugins/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,22 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -75,17 +75,6 @@ patches:
 #         delimiter: '.'
 #         index: 0
 #         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
 #
 # - source:
 #     kind: Service
@@ -101,17 +90,6 @@ patches:
 #       fieldPaths:
 #         - spec.dnsNames.0
 #         - spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
-#     - select:
-#         kind: ServiceMonitor
-#         group: monitoring.coreos.com
-#         version: v1
-#         name: controller-manager-metrics-monitor
-#       fieldPaths:
-#         - spec.endpoints.0.tlsConfig.serverName
 #       options:
 #         delimiter: '.'
 #         index: 1

--- a/testdata/project-v4/config/prometheus/monitor_tls_patch.yaml
+++ b/testdata/project-v4/config/prometheus/monitor_tls_patch.yaml
@@ -1,19 +1,22 @@
 # Patch for Prometheus ServiceMonitor to enable secure TLS configuration
 # using certificates managed by cert-manager
-- op: replace
-  path: /spec/endpoints/0/tlsConfig
-  value:
-    # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
-    serverName: SERVICE_NAME.SERVICE_NAMESPACE.svc
-    insecureSkipVerify: false
-    ca:
-      secret:
-        name: metrics-server-cert
-        key: ca.crt
-    cert:
-      secret:
-        name: metrics-server-cert
-        key: tls.crt
-    keySecret:
-      name: metrics-server-cert
-      key: tls.key
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - tlsConfig:
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+          key: tls.key


### PR DESCRIPTION
Reverts kubernetes-sigs/kubebuilder#4536

Those changes broke the project: Example: https://github.com/kubernetes-sigs/kubebuilder/actions/runs/13250335077/job/36986568474?pr=4555

It is strange but seems that the tests were not executed and the PR merged without them
