### PR TITLE
🐛 Fix kubebuild alpha generate when not in GOPATH

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -262,6 +262,9 @@ func getInitArgs(store store.Store) []string {
 	if domain := store.Config().GetDomain(); domain != "" {
 		args = append(args, "--domain", domain)
 	}
+	if repo := store.Config().GetRepository(); repo != "" {
+		args = append(args, "--repo", repo)
+	}
 	return args
 }
 


### PR DESCRIPTION
Ran to an issue when running `kubebuilder alpha generate`, and since my project was not on the GOPATH, there was no implicit call to `go mod init`.

>  If your project is initialized within GOPATH, the implicitly called go mod init will interpolate the module path for you. Otherwise --repo=<module path> must be set.

This change updates `alpha generate` command so that `--repo` is always included when running kubebuilder init to fix issue when not on GOPATH. The value for `repo` is retrieved from the PROJECT file as other kubebuilder init options.
