### PR TITLE
🐛 Allow 'kubebuilder alpha generate' rescaffolds work with no longer supported/available plugins ( go/v3 and go/v2 )

### DIFF
--- a/.github/workflows/test-alpha-generate.yml
+++ b/.github/workflows/test-alpha-generate.yml
@@ -1,0 +1,40 @@
+name: Test Alpha Generate
+
+on:
+  push:
+    paths:
+      - 'pkg/cli/alpha/**'
+      - '.github/workflows/test-alpha-generate.yml'
+  pull_request:
+    paths:
+      - 'pkg/cli/alpha/**'
+      - '.github/workflows/test-alpha-generate.yml'
+      
+jobs:
+  unsupported:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install dependencies and generate binary
+        run: make install
+
+      - name: Navigate to testdata/project-v4
+        run: cd testdata/project-v4
+
+      - name: Update PROJECT file
+        run: |
+          sed -i 's#go.kubebuilder.io/v4#go.kubebuilder.io/v3#g' testdata/project-v4/PROJECT
+
+      - name: Run kubebuilder alpha generate
+        run: |
+          cd testdata/project-v4 && kubebuilder alpha generate

--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -256,6 +256,24 @@ func getInputPath(inputPath string) (string, error) {
 func getInitArgs(store store.Store) []string {
 	var args []string
 	plugins := store.Config().GetPluginChain()
+
+	// Define outdated plugin versions that need replacement
+	outdatedPlugins := map[string]string{
+		"go.kubebuilder.io/v3":       "go.kubebuilder.io/v4",
+		"go.kubebuilder.io/v3-alpha": "go.kubebuilder.io/v4",
+		"go.kubebuilder.io/v2":       "go.kubebuilder.io/v4",
+	}
+
+	// Replace outdated plugins and exit after the first replacement
+	for i, plugin := range plugins {
+		if newPlugin, exists := outdatedPlugins[plugin]; exists {
+			log.Warnf("We checked that your PROJECT file is configured with the layout '%s', which is no longer supported.\n"+
+				"However, we will try our best to re-generate the project using '%s'.", plugin, newPlugin)
+			plugins[i] = newPlugin
+			break
+		}
+	}
+
 	if len(plugins) > 0 {
 		args = append(args, "--plugins", strings.Join(plugins, ","))
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -147,6 +147,14 @@ func (c *CLI) buildCmd() error {
 
 	var uve config.UnsupportedVersionError
 
+	// Workaround for kubebuilder alpha generate
+	if len(os.Args) > 2 && os.Args[1] == "alpha" && os.Args[2] == "generate" {
+		err := updateProjectFileForAlphaGenerate()
+		if err != nil {
+			return fmt.Errorf("failed to update PROJECT file: %w", err)
+		}
+	}
+
 	// Get project version and plugin keys.
 	switch err := c.getInfo(); {
 	case err == nil:

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -335,4 +337,41 @@ func (factory *executionHooksFactory) postRunEFunc() func(*cobra.Command, []stri
 
 		return nil
 	}
+}
+
+func updateProjectFileForAlphaGenerate() error {
+	projectFilePath := "PROJECT"
+
+	content, err := os.ReadFile(projectFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read PROJECT file: %w", err)
+	}
+
+	projectStr := string(content)
+
+	// Define outdated plugin versions that need replacement
+	outdatedPlugins := []string{"go.kubebuilder.io/v3", "go.kubebuilder.io/v3-alpha", "go.kubebuilder.io/v2"}
+	updated := false
+
+	for _, oldPlugin := range outdatedPlugins {
+		if strings.Contains(projectStr, oldPlugin) {
+			log.Warnf("Detected '%s' in PROJECT file.", oldPlugin)
+			log.Warnf("Kubebuilder v4 no longer supports this. It will be replaced with 'go.kubebuilder.io/v4'.")
+
+			projectStr = strings.ReplaceAll(projectStr, oldPlugin, "go.kubebuilder.io/v4")
+			updated = true
+			break
+		}
+	}
+
+	// Only update the file if changes were made
+	if updated {
+		err = os.WriteFile(projectFilePath, []byte(projectStr), 0644)
+		if err != nil {
+			return fmt.Errorf("failed to update PROJECT file: %w", err)
+		}
+		log.Infof("PROJECT file updated successfully.")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes: #4433 

- Fixed issue where 'kubebuilder alpha generate' failed if PROJECT contained go.kubebuilder.io/v3.  
- Automatically updates outdated plugin references (v3 → v4) to support scaffolding.  
- Added a warning to notify users before modifying the PROJECT file. 
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
![image](https://github.com/user-attachments/assets/4a28859d-f600-4a4d-bb8e-a68c6dca2fc9)
<br>
![image](https://github.com/user-attachments/assets/0582e906-5396-48d5-ab1b-f46d78892577)
<br>
![image](https://github.com/user-attachments/assets/229d5e31-2290-4234-8d4f-38193582fb0a)
