### PR TITLE
🐛 (helm/v1-alpha): Skip empty directories in chart generation

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -231,14 +231,25 @@ func (s *initScaffolder) copyConfigFiles() error {
 	}
 
 	for _, dir := range configDirs {
-		// Ensure destination directory exists
-		if err := os.MkdirAll(dir.DestDir, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create directory %s: %v", dir.DestDir, err)
+		// Check if the source directory exists
+		if _, err := os.Stat(dir.SrcDir); os.IsNotExist(err) {
+			// Skip if the source directory does not exist
+			continue
 		}
 
 		files, err := filepath.Glob(filepath.Join(dir.SrcDir, "*.yaml"))
 		if err != nil {
 			return err
+		}
+
+		// Skip processing if the directory is empty (no matching files)
+		if len(files) == 0 {
+			continue
+		}
+
+		// Ensure destination directory exists
+		if err := os.MkdirAll(dir.DestDir, os.ModePerm); err != nil {
+			return fmt.Errorf("failed to create directory %s: %v", dir.DestDir, err)
 		}
 
 		for _, srcFile := range files {


### PR DESCRIPTION
Previously, the scaffolding process would create empty directories in the Helm chart even when the corresponding source directory was missing or contained no YAML files. This commit updates the logic to check for the existence of the source directory and its contents before attempting to copy files.

Changes:
- Skip processing if the source directory does not exist.
- Skip creating destination directories if no YAML files are found.
- Ensure only relevant directories and files are included in the chart.

**Motivation**

If a user removes, for example, the network-policy directory from a project scaffolded with an old version, we do not create an empty directory.




