### PR TITLE
:seedling: Upgrade Goreleaser + fix deprecation on release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v2.3.2
+          version: v2.7.0
           args: release -f ./build/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -51,7 +51,7 @@ builds:
 
 # Only binaries of the form "kubebuilder_${goos}_${goarch}" will be released.
 archives:
-  - format: binary
+  - formats: ['binary']
     # Setting name_template correctly maps checksums to binary names.
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
 


### PR DESCRIPTION
The current used GoReleaser is v2.3.2 from Sept/2024.

This PR upgrades it t othe latest release v2.7.0 and also adds a fix for a small deprecation on `goreleaser.yml`.

![image](https://github.com/user-attachments/assets/8c6c50e7-a475-4ceb-830e-6797f0fecb65)

Docs: https://goreleaser.com/deprecations/

Before:
![Screenshot from 2025-03-01 14-31-43](https://github.com/user-attachments/assets/cb3b3f81-760d-48d3-8aa2-5fcd22c61408)

After:
![Screenshot from 2025-03-01 14-31-53](https://github.com/user-attachments/assets/a3c58178-d0e6-4914-8bbd-9cf2892272a5)
