### PR TITLE
📖 Add link to Watching Secondary Resources Owned by the Controller

### DIFF
--- a/docs/book/src/reference/watching-resources.md
+++ b/docs/book/src/reference/watching-resources.md
@@ -130,6 +130,8 @@ Here are the key reasons why it's important to watch them:
     - Watching non-owned secondary resources lets the controller respond to lifecycle events (create, update, delete)
     that might affect the primary resource, ensuring consistent behavior across the system.
 
+See [Watching Secondary Resources That Are Not Owned](./watching-resources/secondary-resources-not-owned.md#configuration-example) for an example.
+
 ## Why not use `RequeueAfter X` for all scenarios instead of watching resources?
 
 Kubernetes controllers are fundamentally **event-driven**. When creating a controller,


### PR DESCRIPTION
This PR adds a hyperlink to [Watching Secondary Resources That Are Not Owned](https://book.kubebuilder.io/reference/watching-resources/secondary-resources-not-owned.html?highlight=BackupBusyboxReconciler#configuration-example).

I think that is useful to better understand the text.