### PR TITLE
🌱 Add kubernetesVendorVersion for binary builds with LD_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,11 @@ help: ## Display this help
 
 ##@ Build
 
+K8S_VERSION ?= $(shell go list -m -modfile=./testdata/project-v4/go.mod -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d.%d", $$3, $$4}')
+
 LD_FLAGS=-ldflags " \
     -X sigs.k8s.io/kubebuilder/v4/cmd.kubeBuilderVersion=$(shell git describe --tags --dirty --broken) \
+    -X sigs.k8s.io/kubebuilder/v4/cmd.kubernetesVendorVersion=$(K8S_VERSION) \
     -X sigs.k8s.io/kubebuilder/v4/cmd.goos=$(shell go env GOOS) \
     -X sigs.k8s.io/kubebuilder/v4/cmd.goarch=$(shell go env GOARCH) \
     -X sigs.k8s.io/kubebuilder/v4/cmd.gitCommit=$(shell git rev-parse HEAD) \
@@ -201,7 +204,6 @@ install-helm: ## Install the latest version of Helm locally
 helm-lint: install-helm ## Lint the Helm chart in testdata
 	helm lint testdata/project-v4-with-plugins/dist/chart
 
-K8S_VERSION ?= $(shell go list -m -modfile=./testdata/project-v4/go.mod -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d.%d", $$3, $$4}')
 .PHONY: update-k8s-version
 update-k8s-version: ## Update Kubernetes API version in version.go and .goreleaser.yml
 	@if [ -z "$(K8S_VERSION)" ]; then echo "Error: K8S_VERSION is empty"; exit 1; fi


### PR DESCRIPTION
This commit changes how the Makefile handles updating Kubernetes version in `cmd/version.go` when running `make generate`.

Rely on ldflags to set `kubernetesVendorVersion`, similarly to the other variables in `cmd/version.go.`

Use a single variable to define `K8S_VERSION` for both ldflags and the `goreleaser` configuration.

This makes our version handling more consistent and avoids unnecessary diffs in version control when only generating docs or other build artifacts.

Closes: #4611 