### PR TITLE
🐛  (go/v4): fix indentation of imports in test files

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -69,9 +69,9 @@ import (
 	"os"
 	"time"
 
-	//nolint:golint
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -138,8 +138,8 @@ import (
 	"path/filepath"
 	"testing"
 
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -50,8 +50,8 @@ import (
 	"os"
 	"os/exec"
 
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"{{ .Repo }}/test/utils"
 )

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -190,8 +190,8 @@ import (
 	"testing"
 	"time"
 
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller_test.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"time"
 
-	//nolint:golint
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller_test.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"time"
 
-	//nolint:golint
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller_test.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"time"
 
-	//nolint:golint
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller_test.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"time"
 
-	//nolint:golint
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Correct indentation for imported packages in the e2e test suite to maintain consistent code formatting.