### PR TITLE
🌱 fix(docs): correct typo in comments across multiple files

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with Prometheus already installed,
-	// we check for it's presence before execution.
+	// we check for its presence before execution.
 	// Setup Prometheus before the suite if not already installed
 	By("checking if prometheus is installed already")
 	isPrometheusOperatorAlreadyInstalled = utils.IsPrometheusCRDsInstalled()

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with Prometheus already installed,
-	// we check for it's presence before execution.
+	// we check for its presence before execution.
 	// Setup Prometheus before the suite if not already installed
 	By("checking if prometheus is installed already")
 	isPrometheusOperatorAlreadyInstalled = utils.IsPrometheusCRDsInstalled()

--- a/hack/docs/internal/cronjob-tutorial/e2e_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/e2e_implementation.go
@@ -36,7 +36,7 @@ if !isPrometheusOperatorAlreadyInstalled {
 
 const checkPrometheusInstalled = `
 // To prevent errors when tests run in environments with Prometheus already installed,
-// we check for it's presence before execution.
+// we check for its presence before execution.
 // Setup Prometheus before the suite if not already installed
 By("checking if prometheus is installed already")
 isPrometheusOperatorAlreadyInstalled = utils.IsPrometheusCRDsInstalled()


### PR DESCRIPTION
correct "it's" to "its" in comments to ensure grammatical accuracy in e2e test files and cronjob tutorial implementation.