### PR TITLE
🌱 (chore): rename local 'config' variable to avoid collision with imported package

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -46,7 +46,7 @@ type Generate struct {
 
 // Generate handles the migration and scaffolding process.
 func (opts *Generate) Generate() error {
-	config, err := loadProjectConfig(opts.InputDir)
+	projectConfig, err := loadProjectConfig(opts.InputDir)
 	if err != nil {
 		return err
 	}
@@ -82,28 +82,28 @@ func (opts *Generate) Generate() error {
 		return err
 	}
 
-	if err := kubebuilderInit(config); err != nil {
+	if err := kubebuilderInit(projectConfig); err != nil {
 		return err
 	}
 
-	if err := kubebuilderEdit(config); err != nil {
+	if err := kubebuilderEdit(projectConfig); err != nil {
 		return err
 	}
 
-	if err := kubebuilderCreate(config); err != nil {
+	if err := kubebuilderCreate(projectConfig); err != nil {
 		return err
 	}
 
-	if err := migrateGrafanaPlugin(config, opts.InputDir, opts.OutputDir); err != nil {
+	if err := migrateGrafanaPlugin(projectConfig, opts.InputDir, opts.OutputDir); err != nil {
 		return err
 	}
 
-	if hasHelmPlugin(config) {
+	if hasHelmPlugin(projectConfig) {
 		if err := kubebuilderHelmEdit(); err != nil {
 			return err
 		}
 	}
-	return migrateDeployImagePlugin(config)
+	return migrateDeployImagePlugin(projectConfig)
 }
 
 // Validate ensures the options are valid and kubebuilder is installed.
@@ -124,11 +124,11 @@ func (opts *Generate) Validate() error {
 
 // Helper function to load the project configuration.
 func loadProjectConfig(inputDir string) (store.Store, error) {
-	config := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
-	if err := config.LoadFrom(fmt.Sprintf("%s/%s", inputDir, yaml.DefaultPath)); err != nil {
+	projectConfig := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
+	if err := projectConfig.LoadFrom(fmt.Sprintf("%s/%s", inputDir, yaml.DefaultPath)); err != nil {
 		return nil, fmt.Errorf("failed to load PROJECT file: %w", err)
 	}
-	return config, nil
+	return projectConfig, nil
 }
 
 // Helper function to create the output directory.


### PR DESCRIPTION
The local variable `config` was shadowing the imported `config` package, which could lead to confusion or unexpected behavior. Renamed to `projectConfig` for clarity and to prevent name collision.
