### PR TITLE
🌱 fix: avoid variable shadowing by renaming loop variable 'plugin'

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -265,10 +265,10 @@ func getInitArgs(store store.Store) []string {
 	}
 
 	// Replace outdated plugins and exit after the first replacement
-	for i, plugin := range plugins {
-		if newPlugin, exists := outdatedPlugins[plugin]; exists {
+	for i, plg := range plugins {
+		if newPlugin, exists := outdatedPlugins[plg]; exists {
 			log.Warnf("We checked that your PROJECT file is configured with the layout '%s', which is no longer supported.\n"+
-				"However, we will try our best to re-generate the project using '%s'.", plugin, newPlugin)
+				"However, we will try our best to re-generate the project using '%s'.", plg, newPlugin)
 			plugins[i] = newPlugin
 			break
 		}


### PR DESCRIPTION
The loop variable `plugin` was shadowing the imported `plugin` package from sigs.k8s.io/kubebuilder. Renamed it to `plg` to improve clarity and prevent potential confusion or unintended behavior.
