### PR TITLE
🌱 (chore): avoid variable shadowing by renaming local 'errors' variable

### DIFF
--- a/pkg/model/resource/gvk.go
+++ b/pkg/model/resource/gvk.go
@@ -56,8 +56,7 @@ func (gvk GVK) Validate() error {
 	if gvk.Version == "" {
 		return errors.New(versionRequired)
 	}
-	errs := validation.IsDNS1123Subdomain(gvk.Version)
-	if len(errs) > 0 && gvk.Version != versionInternal {
+	if errs := validation.IsDNS1123Subdomain(gvk.Version); len(errs) > 0 && gvk.Version != versionInternal {
 		return fmt.Errorf("Version must respect DNS-1123 (was %s)", gvk.Version)
 	}
 
@@ -65,9 +64,9 @@ func (gvk GVK) Validate() error {
 	if gvk.Kind == "" {
 		return errors.New(kindRequired)
 	}
-	if errors := validation.IsDNS1035Label(strings.ToLower(gvk.Kind)); len(errors) != 0 {
+	if errs := validation.IsDNS1035Label(strings.ToLower(gvk.Kind)); len(errs) != 0 {
 		// NOTE: IsDNS1035Label returns a slice of strings instead of an error, so no wrapping
-		return fmt.Errorf("invalid Kind: %#v", errors)
+		return fmt.Errorf("invalid Kind: %#v", errs)
 	}
 
 	// Require kind to start with an uppercase character


### PR DESCRIPTION
The local variable `errors` was shadowing the standard library `errors` package, which can lead to confusion and potential issues when calling package functions. Renamed the variable to `errs` to clarify intent and resolve the name collision.