### PR TITLE
🌱 (chore): rename local 'resource' variable to avoid shadowing import

### DIFF
--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -344,11 +344,11 @@ func validateDeployImagePlugin(projectFile string) {
 	// Validate the resource configuration
 	Expect(deployImageConfig.Resources).ToNot(BeEmpty(), "Expected at least one resource for the DeployImage plugin")
 
-	resource := deployImageConfig.Resources[0]
-	Expect(resource.Group).To(Equal("crew"), "Expected group to be 'crew'")
-	Expect(resource.Kind).To(Equal("Memcached"), "Expected kind to be 'Memcached'")
+	resourceData := deployImageConfig.Resources[0]
+	Expect(resourceData.Group).To(Equal("crew"), "Expected group to be 'crew'")
+	Expect(resourceData.Kind).To(Equal("Memcached"), "Expected kind to be 'Memcached'")
 
-	options := resource.Options
+	options := resourceData.Options
 	Expect(options.Image).To(Equal("memcached:1.6.15-alpine"), "Expected image to match")
 	Expect(options.ContainerCommand).To(Equal("memcached,--memory-limit=64,modern,-v"),
 		"Expected container command to match")


### PR DESCRIPTION
The local variable 'resource' in the e2e test was shadowing the imported 'resource' package, which could cause confusion or conflicts. Renamed to 'resourceData' to clarify intent and eliminate the naming collision.
