### PR TITLE
🌱 (chore): avoid shadowing of 'config' and 'resource' in golang/v4 plugins

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -49,9 +49,9 @@ type apiScaffolder struct {
 }
 
 // NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
-func NewAPIScaffolder(config config.Config, res resource.Resource, force bool) plugins.Scaffolder {
+func NewAPIScaffolder(cfg config.Config, res resource.Resource, force bool) plugins.Scaffolder {
 	return &apiScaffolder{
-		config:   config,
+		config:   cfg,
 		resource: res,
 		force:    force,
 	}

--- a/pkg/plugins/golang/v4/scaffolds/edit.go
+++ b/pkg/plugins/golang/v4/scaffolds/edit.go
@@ -35,9 +35,9 @@ type editScaffolder struct {
 }
 
 // NewEditScaffolder returns a new Scaffolder for configuration edit operations
-func NewEditScaffolder(config config.Config, multigroup bool) plugins.Scaffolder {
+func NewEditScaffolder(cfg config.Config, multigroup bool) plugins.Scaffolder {
 	return &editScaffolder{
-		config:     config,
+		config:     cfg,
 		multigroup: multigroup,
 	}
 }

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -63,9 +63,9 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config config.Config, license, owner, commandName string) plugins.Scaffolder {
+func NewInitScaffolder(cfg config.Config, license, owner, commandName string) plugins.Scaffolder {
 	return &initScaffolder{
-		config:          config,
+		config:          cfg,
 		boilerplatePath: hack.DefaultBoilerplatePath,
 		license:         license,
 		owner:           owner,

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -55,12 +55,10 @@ type webhookScaffolder struct {
 }
 
 // NewWebhookScaffolder returns a new Scaffolder for v2 webhook creation operations
-func NewWebhookScaffolder(config config.Config, resource resource.Resource,
-	force bool, isLegacy bool,
-) plugins.Scaffolder {
+func NewWebhookScaffolder(cfg config.Config, res resource.Resource, force bool, isLegacy bool) plugins.Scaffolder {
 	return &webhookScaffolder{
-		config:   config,
-		resource: resource,
+		config:   cfg,
+		resource: res,
 		force:    force,
 		isLegacy: isLegacy,
 	}
@@ -102,11 +100,11 @@ func (s *webhookScaffolder) Scaffold() error {
 	doValidation := s.resource.HasValidationWebhook()
 	doConversion := s.resource.HasConversionWebhook()
 
-	if err := s.config.UpdateResource(s.resource); err != nil {
+	if err = s.config.UpdateResource(s.resource); err != nil {
 		return fmt.Errorf("error updating resource: %w", err)
 	}
 
-	if err := scaffold.Execute(
+	if err = scaffold.Execute(
 		&webhooks.Webhook{Force: s.force, IsLegacyPath: s.isLegacy},
 		&e2e.WebhookTestUpdater{WireWebhook: true},
 		&cmd.MainUpdater{WireWebhook: true, IsLegacyPath: s.isLegacy},

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -179,9 +179,9 @@ func (p *createWebhookSubcommand) PostScaffold() error {
 }
 
 // Helper function to validate spoke versions
-func isValidVersion(version string, res *resource.Resource, config config.Config) bool {
+func isValidVersion(version string, res *resource.Resource, cfg config.Config) bool {
 	// Fetch all resources in the config
-	resources, err := config.GetResources()
+	resources, err := cfg.GetResources()
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Renamed variables and function parameters in `pkg/plugins/golang/v4` to avoid shadowing imported packages: `config` → `cfg`, and `resource` → `res`. This includes updates to the webhook, scaffolds (api, edit, init, webhook), and internal validation logic. These changes improve code readability and prevent potential issues when using package-level identifiers within the same scope.
