### PR TITLE
🌱 (chore): avoid shadowing of 'config', 'resource', and 'err' in kustomize/v2 scaffolds

### DIFF
--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -48,9 +48,9 @@ type apiScaffolder struct {
 }
 
 // NewAPIScaffolder returns a new Scaffolder for API/controller creation operations
-func NewAPIScaffolder(config config.Config, res resource.Resource, force bool) plugins.Scaffolder {
+func NewAPIScaffolder(cfg config.Config, res resource.Resource, force bool) plugins.Scaffolder {
 	return &apiScaffolder{
-		config:   config,
+		config:   cfg,
 		resource: res,
 		force:    force,
 	}
@@ -95,8 +95,8 @@ func (s *apiScaffolder) Scaffold() error {
 		kustomizeFilePath := "config/default/kustomization.yaml"
 		err := pluginutil.UncommentCode(kustomizeFilePath, "#- ../crd", `#`)
 		if err != nil {
-			hasCRUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../crd")
-			if !hasCRUncommented || err != nil {
+			hasCRUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../crd")
+			if !hasCRUncommented || errCheck != nil {
 				log.Errorf("Unable to find the target #- ../crd to uncomment in the file "+
 					"%s.", kustomizeFilePath)
 			}

--- a/pkg/plugins/common/kustomize/v2/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/init.go
@@ -43,9 +43,9 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(config config.Config) plugins.Scaffolder {
+func NewInitScaffolder(cfg config.Config) plugins.Scaffolder {
 	return &initScaffolder{
-		config: config,
+		config: cfg,
 	}
 }
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -47,10 +47,10 @@ type webhookScaffolder struct {
 }
 
 // NewWebhookScaffolder returns a new Scaffolder for v2 webhook creation operations
-func NewWebhookScaffolder(config config.Config, resource resource.Resource, force bool) plugins.Scaffolder {
+func NewWebhookScaffolder(cfg config.Config, res resource.Resource, force bool) plugins.Scaffolder {
 	return &webhookScaffolder{
-		config:   config,
-		resource: resource,
+		config:   cfg,
+		resource: res,
 		force:    force,
 	}
 }
@@ -116,8 +116,8 @@ func (s *webhookScaffolder) Scaffold() error {
 	kustomizeFilePath := "config/default/kustomization.yaml"
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#- ../webhook", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../webhook")
-		if !hasWebHookUncommented || err != nil {
+		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../webhook")
+		if !hasWebHookUncommented || errCheck != nil {
 			log.Errorf("Unable to find the target #- ../webhook to uncomment in the file "+
 				"%s.", kustomizeFilePath)
 		}
@@ -125,8 +125,8 @@ func (s *webhookScaffolder) Scaffold() error {
 
 	err = pluginutil.UncommentCode(kustomizeFilePath, "#patches:", `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "patches:")
-		if !hasWebHookUncommented || err != nil {
+		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath, "patches:")
+		if !hasWebHookUncommented || errCheck != nil {
 			log.Errorf("Unable to find the line '#patches:' to uncomment in the file "+
 				"%s.", kustomizeFilePath)
 		}
@@ -136,8 +136,9 @@ func (s *webhookScaffolder) Scaffold() error {
 #  target:
 #    kind: Deployment`, `#`)
 	if err != nil {
-		hasWebHookUncommented, err := pluginutil.HasFileContentWith(kustomizeFilePath, "- path: manager_webhook_patch.yaml")
-		if !hasWebHookUncommented || err != nil {
+		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath,
+			"- path: manager_webhook_patch.yaml")
+		if !hasWebHookUncommented || errCheck != nil {
 			log.Errorf("Unable to find the target #- path: manager_webhook_patch.yaml to uncomment in the file "+
 				"%s.", kustomizeFilePath)
 		}


### PR DESCRIPTION
Renamed variables and function parameters in `pkg/plugins/common/kustomize/v2` scaffolds to avoid shadowing imported packages and previously declared variables. Specifically, `config` → `cfg`, `resource` → `res`, and inner `err` → `errCheck`. This improves code readability and avoids confusion or bugs caused by variable shadowing.