### PR TITLE
🌱 (chore): avoid shadowing of 'pluginConfig' in config v3 implementation and tests

### DIFF
--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -299,8 +299,8 @@ func (c Cfg) DecodePluginConfig(key string, configObj interface{}) error {
 	}
 
 	// Get the object blob by key and unmarshal into the object.
-	if pluginConfig, hasKey := c.Plugins[key]; hasKey {
-		b, err := yaml.Marshal(pluginConfig)
+	if pluginCfg, hasKey := c.Plugins[key]; hasKey {
+		b, err := yaml.Marshal(pluginCfg)
 		if err != nil {
 			return fmt.Errorf("failed to convert extra fields object to bytes: %w", err)
 		}

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -393,24 +393,24 @@ var _ = Describe("Cfg", func() {
 		)
 
 		It("DecodePluginConfig should fail for no plugin config object", func() {
-			var pluginConfig PluginConfig
-			err := c0.DecodePluginConfig(key, &pluginConfig)
+			var pluginCfg PluginConfig
+			err := c0.DecodePluginConfig(key, &pluginCfg)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.As(err, &config.PluginKeyNotFoundError{})).To(BeTrue())
 		})
 
 		It("DecodePluginConfig should fail to retrieve data from a non-existent plugin", func() {
-			var pluginConfig PluginConfig
-			err := c1.DecodePluginConfig("plugin-y", &pluginConfig)
+			var pluginCfg PluginConfig
+			err := c1.DecodePluginConfig("plugin-y", &pluginCfg)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.As(err, &config.PluginKeyNotFoundError{})).To(BeTrue())
 		})
 
 		DescribeTable("DecodePluginConfig should retrieve the plugin data correctly",
 			func(inputConfig Cfg, expectedPluginConfig PluginConfig) {
-				var pluginConfig PluginConfig
-				Expect(inputConfig.DecodePluginConfig(key, &pluginConfig)).To(Succeed())
-				Expect(pluginConfig).To(Equal(expectedPluginConfig))
+				var pluginCfg PluginConfig
+				Expect(inputConfig.DecodePluginConfig(key, &pluginCfg)).To(Succeed())
+				Expect(pluginCfg).To(Equal(expectedPluginConfig))
 			},
 			Entry("for an empty plugin config object", c1, PluginConfig{}),
 			Entry("for a full plugin config object", c2, pluginConfig),


### PR DESCRIPTION
Renamed local variables in `pkg/config/v3/config.go` and `config_test.go` to avoid shadowing the `pluginConfig` package identifier and improve clarity. Updated `pluginConfig` → `pluginCfg` consistently across both implementation and unit tests. This helps prevent confusion and potential misuses, especially when debugging or working with similarly named types or packages.
