### PR TITLE
🐛 (grafana/v1alpha) avoid shadowing of 'err' in grafana plugin code generating

### DIFF
--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -69,8 +69,11 @@ func loadConfig(configPath string) ([]templates.CustomMetricItem, error) {
 	}
 
 	items, err := configReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config.yaml: %w", err)
+	}
 
-	if err := f.Close(); err != nil {
+	if err = f.Close(); err != nil {
 		return nil, fmt.Errorf("could not close config.yaml: %w", err)
 	}
 


### PR DESCRIPTION
Split the error handling for config reading and file closing in `pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go` to avoid shadowing the `err` variable. This improves error visibility and follows best practices for clarity in error handling and variable reuse.