### PR TITLE
🌱 (chore): avoid shadowing of 'err' in plugin util and test utilities

### DIFF
--- a/pkg/plugin/util/util.go
+++ b/pkg/plugin/util/util.go
@@ -115,7 +115,7 @@ func AppendCodeAtTheEnd(filename, code string) error {
 		return err
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
+		if err = f.Close(); err != nil {
 			return
 		}
 	}()
@@ -150,15 +150,14 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
 			return err
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
+		if _, err = out.WriteString("\n"); err != nil {
 			return err
 		}
 	}
@@ -197,8 +196,7 @@ func CommentCode(filename, target, prefix string) error {
 	// Add the comment prefix to each line of the target code
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
 	for scanner.Scan() {
-		_, err := out.WriteString(prefix + scanner.Text() + "\n")
-		if err != nil {
+		if _, err = out.WriteString(prefix + scanner.Text() + "\n"); err != nil {
 			return err
 		}
 	}

--- a/pkg/plugin/util/util_test.go
+++ b/pkg/plugin/util/util_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Cover plugin util helpers", func() {
 			err := os.MkdirAll("testdata", 0o755)
 			Expect(err).NotTo(HaveOccurred())
 
-			if _, err := os.Stat(path); os.IsNotExist(err) {
+			if _, err = os.Stat(path); os.IsNotExist(err) {
 				err = os.WriteFile(path, []byte("exampleTarget"), 0o644)
 				Expect(err).NotTo(HaveOccurred())
 			}


### PR DESCRIPTION
Replaced short variable declarations with assignments in `pkg/plugin/util/util.go` and `util_test.go` to avoid shadowing the existing `err` variable. This ensures proper error propagation, improves code readability, and aligns with Go best practices for error handling and scope control.