### PR TITLE
🌱 (chore): avoid shadowing of 'resource' and 'err' in machinery scaffold

### DIFF
--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -110,9 +110,9 @@ func WithBoilerplate(boilerplate string) ScaffoldOption {
 }
 
 // WithResource provides the resource to the Scaffold
-func WithResource(resource *resource.Resource) ScaffoldOption {
+func WithResource(res *resource.Resource) ScaffoldOption {
 	return func(s *Scaffold) {
-		s.injector.resource = resource
+		s.injector.resource = res
 	}
 }
 
@@ -492,7 +492,7 @@ func (s Scaffold) writeFile(f *File) (err error) {
 	}
 
 	// Create the directory if needed
-	if err := s.fs.MkdirAll(filepath.Dir(f.Path), s.dirPerm); err != nil {
+	if err = s.fs.MkdirAll(filepath.Dir(f.Path), s.dirPerm); err != nil {
 		return CreateDirectoryError{err}
 	}
 


### PR DESCRIPTION
Renamed the parameter `resource` to `res` in the `WithResource` function to avoid shadowing the imported package. Also replaced `:=` with `=` when assigning to `err` to prevent redeclaration and shadowing of the existing error variable.