### PR TITLE
🌱 (chore): avoid shadowing of 'err' in version parsing for plugin and config packages

### DIFF
--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -51,7 +51,7 @@ func (v *Version) Parse(version string) error {
 	var err error
 	if v.Number, err = strconv.Atoi(substrings[0]); err != nil {
 		// Let's check if the `-` belonged to a negative number
-		if n, err := strconv.Atoi(version); err == nil && n < 0 {
+		if n, errParse := strconv.Atoi(version); errParse == nil && n < 0 {
 			return errNonPositive
 		}
 		return err

--- a/pkg/plugin/version.go
+++ b/pkg/plugin/version.go
@@ -51,7 +51,7 @@ func (v *Version) Parse(version string) error {
 	var err error
 	if v.Number, err = strconv.Atoi(substrings[0]); err != nil {
 		// Let's check if the `-` belonged to a negative number
-		if n, err := strconv.Atoi(version); err == nil && n < 0 {
+		if n, errParse := strconv.Atoi(version); errParse == nil && n < 0 {
 			return errNegative
 		}
 		return err


### PR DESCRIPTION
Renamed inner error variables in version parsing logic in `pkg/plugin/version.go` and `pkg/config/version.go` from `err` to `errParse` to avoid shadowing the outer `err` variable. This improves clarity in control flow and prevents potential confusion in error handling.
