### PR TITLE
🌱 (chore): avoid shadowing of 'err' in CLI options, YAML store, and external plugin helpers

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -203,7 +203,7 @@ func getPluginsRoot(host string) (pluginsRoot string, err error) {
 	// if user provides specific path, return
 	if pluginsPath := os.Getenv("EXTERNAL_PLUGINS_PATH"); pluginsPath != "" {
 		// verify if the path actually exists
-		if _, err := os.Stat(pluginsPath); err != nil {
+		if _, err = os.Stat(pluginsPath); err != nil {
 			if os.IsNotExist(err) {
 				// the path does not exist
 				return "", fmt.Errorf("the specified path %s does not exist", pluginsPath)

--- a/pkg/config/store/yaml/store.go
+++ b/pkg/config/store/yaml/store.go
@@ -89,7 +89,7 @@ func (s *yamlStore) LoadFrom(path string) error {
 
 	// Check the file version
 	var versioned versionedConfig
-	if err := yaml.Unmarshal(in, &versioned); err != nil {
+	if err = yaml.Unmarshal(in, &versioned); err != nil {
 		return store.LoadError{Err: fmt.Errorf("unable to determine config version: %w", err)}
 	}
 

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -127,7 +127,7 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 		}
 
 		defer func() {
-			if err := file.Close(); err != nil {
+			if err = file.Close(); err != nil {
 				return
 			}
 		}()


### PR DESCRIPTION
Replaced short variable declarations with assignments in `pkg/cli/options.go`, `pkg/config/store/yaml/store.go`, and `pkg/plugins/external/helpers.go` to avoid shadowing the `err` variable.