### PR TITLE
🌱 (chore): avoid shadowing of 'err' and related variables in E2E and external plugin tests

### DIFF
--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Resource", func() {
 			webhookVersion = "v1"
 		)
 
-		res := Resource{
+		res = Resource{
 			GVK:    gvk,
 			Plural: plural,
 			Path:   path,

--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -142,7 +142,8 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 
 		AfterEach(func() {
 			filename := filepath.Join("tmp", "externalPlugin", "LICENSE")
-			fileInfo, err := fs.FS.Stat(filename)
+			var fileInfo os.FileInfo
+			fileInfo, err = fs.FS.Stat(filename)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fileInfo).NotTo(BeNil())
 		})

--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -100,7 +100,8 @@ func Run(kbc *utils.TestContext) {
 	By("validating that the controller-manager pod is running as expected")
 	verifyControllerUp := func(g Gomega) {
 		// Get pod name
-		podOutput, err := kbc.Kubectl.Get(
+		var podOutput string
+		podOutput, err = kbc.Kubectl.Get(
 			true,
 			"pods", "-l", "control-plane=controller-manager",
 			"-o", "go-template={{ range .items }}{{ if not .metadata.deletionTimestamp }}{{ .metadata.name }}"+
@@ -116,8 +117,8 @@ func Run(kbc *utils.TestContext) {
 			To(Equal("Running"), "incorrect controller pod status")
 	}
 	defer func() {
-		out, err := kbc.Kubectl.CommandInNamespace("describe", "all")
-		Expect(err).NotTo(HaveOccurred())
+		out, errDescribe := kbc.Kubectl.CommandInNamespace("describe", "all")
+		Expect(errDescribe).NotTo(HaveOccurred())
 		_, _ = fmt.Fprintln(GinkgoWriter, out)
 	}()
 	Eventually(verifyControllerUp).Should(Succeed())

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -193,7 +193,7 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 
 	By("validating that the Prometheus manager has provisioned the Service")
 	Eventually(func(g Gomega) {
-		_, err := kbc.Kubectl.Get(
+		_, err = kbc.Kubectl.Get(
 			false,
 			"Service", "prometheus-operator")
 		g.Expect(err).NotTo(HaveOccurred())
@@ -207,7 +207,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 
 	if hasNetworkPolicies {
 		By("Checking for Calico pods")
-		outputGet, err := kbc.Kubectl.Get(
+		var outputGet string
+		outputGet, err = kbc.Kubectl.Get(
 			false,
 			"pods",
 			"-n", "kube-system",
@@ -223,7 +224,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 				"metrics=enabled")).Error().NotTo(HaveOccurred())
 
 			By("Ensuring the Allow Metrics Traffic NetworkPolicy exists", func() {
-				output, err := kbc.Kubectl.Get(
+				var output string
+				output, err = kbc.Kubectl.Get(
 					true,
 					"networkpolicy", fmt.Sprintf("e2e-%s-allow-metrics-traffic", kbc.TestSuffix),
 				)
@@ -240,7 +242,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Ensuring the allow-webhook-traffic NetworkPolicy exists", func() {
-				output, err := kbc.Kubectl.Get(
+				var output string
+				output, err = kbc.Kubectl.Get(
 					true,
 					"networkpolicy", fmt.Sprintf("e2e-%s-allow-webhook-traffic", kbc.TestSuffix),
 				)
@@ -255,7 +258,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 		By("validating that cert-manager has provisioned the certificate Secret")
 
 		verifyWebhookCert := func(g Gomega) {
-			output, err := kbc.Kubectl.Get(
+			var output string
+			output, err = kbc.Kubectl.Get(
 				true,
 				"secrets", "webhook-server-cert")
 			g.Expect(err).ToNot(HaveOccurred(), "webhook-server-cert should exist in the namespace")
@@ -266,7 +270,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 
 		By("validating that the mutating|validating webhooks have the CA injected")
 		verifyCAInjection := func(g Gomega) {
-			mwhOutput, err := kbc.Kubectl.Get(
+			var mwhOutput, vwhOutput string
+			mwhOutput, err = kbc.Kubectl.Get(
 				false,
 				"mutatingwebhookconfigurations.admissionregistration.k8s.io",
 				fmt.Sprintf("e2e-%s-mutating-webhook-configuration", kbc.TestSuffix),
@@ -275,7 +280,7 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 			// check that ca should be long enough, because there may be a place holder "\n"
 			g.Expect(len(mwhOutput)).To(BeNumerically(">", 10))
 
-			vwhOutput, err := kbc.Kubectl.Get(
+			vwhOutput, err = kbc.Kubectl.Get(
 				false,
 				"validatingwebhookconfigurations.admissionregistration.k8s.io",
 				fmt.Sprintf("e2e-%s-validating-webhook-configuration", kbc.TestSuffix),
@@ -290,7 +295,8 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 		By("validating that the CA injection is applied for CRD conversion")
 		crdKind := "ConversionTest"
 		verifyCAInjection = func(g Gomega) {
-			crdOutput, err := kbc.Kubectl.Get(
+			var crdOutput string
+			crdOutput, err = kbc.Kubectl.Get(
 				false,
 				"customresourcedefinition.apiextensions.k8s.io",
 				"-o", fmt.Sprintf(
@@ -366,7 +372,7 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 		By("applying the CR in the created namespace")
 
 		applySampleNamespaced := func(g Gomega) {
-			_, err := kbc.Kubectl.Apply(false, "-n", namespace, "-f", sampleFile)
+			_, err = kbc.Kubectl.Apply(false, "-n", namespace, "-f", sampleFile)
 			g.Expect(err).To(Not(HaveOccurred()))
 		}
 		Eventually(applySampleNamespaced, 2*time.Minute, time.Second).Should(Succeed())
@@ -493,7 +499,8 @@ func getMetricsOutput(kbc *utils.TestContext) string {
 
 	By("ensuring the service endpoint is ready")
 	checkServiceEndpoint := func(g Gomega) {
-		output, err := kbc.Kubectl.Get(
+		var output string
+		output, err = kbc.Kubectl.Get(
 			true,
 			"endpoints", fmt.Sprintf("e2e-%s-controller-manager-metrics-service", kbc.TestSuffix),
 			"-o", "jsonpath={.subsets[*].addresses[*].ip}",
@@ -511,7 +518,8 @@ func getMetricsOutput(kbc *utils.TestContext) string {
 
 	By("validating that the curl pod is running as expected")
 	verifyCurlUp := func(g Gomega) {
-		status, err := kbc.Kubectl.Get(
+		var status string
+		status, err = kbc.Kubectl.Get(
 			true,
 			"pods", "curl", "-o", "jsonpath={.status.phase}")
 		g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Replaced short variable declarations with assignments in `test/e2e` and `pkg/plugins/external` to avoid shadowing the `err` variable and other previously declared variables. This includes explicit declarations for variables like `output`, `status`, and `fileInfo` to ensure consistent error handling and improved readability in test logic.
