### PR TITLE
🌱 (chore): enable shadow checks via import-shadowing linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters-settings:
     enable-all: true
     disable:
       - fieldalignment
-      - shadow
   nolintlint:
     allow-unused: false
   revive:
@@ -41,6 +40,7 @@ linters-settings:
       - name: error-naming
       - name: exported
       - name: if-return
+      - name: import-shadowing
       - name: increment-decrement
       - name: var-naming
       - name: var-declaration


### PR DESCRIPTION
Now that all variable shadowing issues have been resolved in previous commits, the `shadow` linter in govet is enabled and `import-shadowing` rule from revive is activated, to ensure consistent detection of future shadowing problems.
