### PR TITLE
🌱 (chore): remove unnecessary trailing newlines and redundant blank lines

### DIFF
--- a/hack/docs/internal/cronjob-tutorial/controller_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/controller_implementation.go
@@ -536,6 +536,7 @@ var (
 	apiGVStr    = batchv1.GroupVersion.String()
 )
 `
+
 const controllerSetupWithManager = `
 	// set up a real clock, since we're not in a test
 	if r.Clock == nil {

--- a/hack/docs/internal/cronjob-tutorial/e2e_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/e2e_implementation.go
@@ -47,6 +47,7 @@ if !isPrometheusOperatorAlreadyInstalled {
 	_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Prometheus Operator is already installed. Skipping installation...\n")
 }
 `
+
 const serviceMonitorE2e = `
 
 By("validating that the ServiceMonitor for Prometheus is applied in the namespace")

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -387,7 +387,6 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 `
 	err := pluginutil.ReplaceInFile(filepath.Join(sp.ctx.Dir, "Makefile"), originalManifestTarget, changedManifestTarget)
 	hackutils.CheckError("updating makefile to use maxDescLen=0 in make manifest target", err)
-
 }
 
 func (sp *Sample) updateWebhookTests() {

--- a/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
@@ -313,6 +313,7 @@ const webhookTestsVars = `var (
 		validator CronJobCustomValidator
 		defaulter CronJobCustomDefaulter
 	)`
+
 const webhookTestsConstants = `	var (
 		obj       *batchv1.CronJob
 		oldObj    *batchv1.CronJob
@@ -322,6 +323,7 @@ const webhookTestsConstants = `	var (
 
 	const validCronJobName = "valid-cronjob-name"
 	const schedule = "*/5 * * * *"`
+
 const webhookTestsBeforeEachOriginal = `obj = &batchv1.CronJob{}
 		oldObj = &batchv1.CronJob{}
 		validator = CronJobCustomValidator{}

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -428,6 +428,7 @@ const controllerReconcileImplementation = `// Fetch the Memcached instance
 		log.Error(err, "Failed to update Memcached status")
 		return ctrl.Result{}, err
 	}`
+
 const controllerDeploymentFunc = `// deploymentForMemcached returns a Memcached Deployment object
 func (r *MemcachedReconciler) deploymentForMemcached(
 	memcached *cachev1alpha1.Memcached) (*appsv1.Deployment, error) {

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -658,7 +658,6 @@ CronJob controller's `+"`SetupWithManager`"+` method.
 		`// +kubebuilder:docs-gen:collapse=existing setup`,
 	)
 	hackutils.CheckError("replace +kubebuilder:docs-gen:collapse=old stuff main.go", err)
-
 }
 
 func (sp *Sample) updateAPIV2() {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -467,7 +467,6 @@ plugins:
 				printed, _ := io.ReadAll(r)
 				Expect(string(printed)).To(Equal(
 					fmt.Sprintf("%s\n", version)))
-
 			})
 		})
 

--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -78,6 +78,5 @@ var _ = Describe("Completion", func() {
 			Expect(cmd.Short).NotTo(Equal(""))
 			Expect(cmd.Short).To(ContainSubstring("Load powershell completions"))
 		})
-
 	})
 })

--- a/pkg/plugin/bundle.go
+++ b/pkg/plugin/bundle.go
@@ -60,7 +60,6 @@ func WithDeprecationMessage(msg string) BundleOption {
 	return func(opts *bundle) {
 		opts.deprecateWarning = msg
 	}
-
 }
 
 // NewBundleWithOptions creates a new Bundle with the provided BundleOptions.

--- a/pkg/plugins/common/kustomize/v2/create.go
+++ b/pkg/plugins/common/kustomize/v2/create.go
@@ -52,7 +52,6 @@ func (p *createSubcommand) configure() (err error) {
 		if p.force, err = strconv.ParseBool(forceFlag.Value.String()); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/patches/enablewebhook_patch.go
@@ -39,7 +39,6 @@ func (f *EnableWebhookPatch) SetTemplateDefaults() error {
 		} else {
 			f.Path = filepath.Join("config", "crd", "patches", "webhook_in_%[plural].yaml")
 		}
-
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization_conversion_updater.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization_conversion_updater.go
@@ -43,7 +43,6 @@ func (f *KustomizationCAConversionUpdater) SetTemplateDefaults() error {
 
 // GetMarkers provides the markers where the CA injection targets will be appended
 func (f *KustomizationCAConversionUpdater) GetMarkers() []machinery.Marker {
-
 	return []machinery.Marker{
 		machinery.NewMarkerFor(f.Path, caNamespace),
 		machinery.NewMarkerFor(f.Path, caName),

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_admin_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_admin_role.go
@@ -45,7 +45,6 @@ func (f *CRDAdminRole) SetTemplateDefaults() error {
 		} else {
 			f.Path = filepath.Join("config", "rbac", "%[kind]_admin_role.yaml")
 		}
-
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_editor_role.go
@@ -45,7 +45,6 @@ func (f *CRDEditorRole) SetTemplateDefaults() error {
 		} else {
 			f.Path = filepath.Join("config", "rbac", "%[kind]_editor_role.yaml")
 		}
-
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac/crd_viewer_role.go
@@ -45,7 +45,6 @@ func (f *CRDViewerRole) SetTemplateDefaults() error {
 		} else {
 			f.Path = filepath.Join("config", "rbac", "%[kind]_viewer_role.yaml")
 		}
-
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples/kustomization.go
@@ -63,7 +63,6 @@ func (f Kustomization) makeCRFileName() string {
 		return f.Resource.Replacer().Replace("%[group]_%[version]_%[kind].yaml")
 	}
 	return f.Resource.Replacer().Replace("%[version]_%[kind].yaml")
-
 }
 
 // GetCodeFragments implements file.Inserter

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -219,7 +219,6 @@ release available. Afterward, you can re-add only your code implementation on to
 the latest bug fixes and enhancements.
 
 `)
-
 	}
 }
 

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -141,7 +141,6 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -116,7 +116,6 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&p.options.ExternalAPIDomain, "external-api-domain", "",
 		"Specify the domain name for the external API. This domain is used to generate accurate RBAC "+
 			"markers and permissions for the external resources (e.g., cert-manager.io).")
-
 }
 
 func (p *createAPISubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
@@ -53,5 +53,4 @@ func (s *initScaffolder) Scaffold() error {
 		&templates.ResourcesManifest{},
 		&templates.CustomMetricsConfigManifest{ConfigPath: string(configFilePath)},
 	)
-
 }

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -36,7 +36,6 @@ import (
 
 var _ = Describe("kubebuilder", func() {
 	Context("alpha generate", func() {
-
 		var (
 			kbc              *utils.TestContext
 			projectOutputDir string

--- a/test/e2e/alphagenerate/generate_v4_multigroup_test.go
+++ b/test/e2e/alphagenerate/generate_v4_multigroup_test.go
@@ -32,7 +32,6 @@ const testProjectDomain = "testproject.org"
 
 var _ = Describe("kubebuilder", func() {
 	Context("alpha generate", func() {
-
 		var (
 			kbc              *utils.TestContext
 			projectOutputDir string
@@ -67,7 +66,6 @@ var _ = Describe("kubebuilder", func() {
 			By("checking that the project file was generated in the current directory")
 			validateV4MultigroupProjectFile(kbc, projectFilePath)
 		})
-
 	})
 })
 
@@ -436,5 +434,4 @@ func validateV4MultigroupProjectFile(kbc *utils.TestContext, projectFile string)
 
 	// Validate the resource configuration
 	Expect(grafanaConfig.Resources).To(BeEmpty(), "Expected zero resource for the Grafana plugin")
-
 }

--- a/test/e2e/alphagenerate/generate_v4_test.go
+++ b/test/e2e/alphagenerate/generate_v4_test.go
@@ -29,7 +29,6 @@ import (
 
 var _ = Describe("kubebuilder", func() {
 	Context("alpha generate", func() {
-
 		var (
 			kbc              *utils.TestContext
 			projectOutputDir string
@@ -51,7 +50,6 @@ var _ = Describe("kubebuilder", func() {
 
 			projectOutputDir = filepath.Join(kbc.Dir, outputDir)
 			projectFilePath = filepath.Join(projectOutputDir, "PROJECT")
-
 		})
 
 		AfterEach(func() {
@@ -63,7 +61,6 @@ var _ = Describe("kubebuilder", func() {
 		It("should regenerate the project in project-v4 directory with success", func() {
 			regenerateAndValidate(kbc, projectOutputDir, projectFilePath)
 		})
-
 	})
 })
 
@@ -237,5 +234,4 @@ func validateV4ProjectFile(kbc *utils.TestContext, projectFile string) {
 	Expect(deploymentResource.Webhooks.Defaulting).To(BeTrue(), "Deployment API should have a defaulting webhook")
 	Expect(deploymentResource.Webhooks.Validation).To(BeTrue(), "Deployment API should have a defaulting webhook")
 	Expect(deploymentResource.Webhooks.WebhookVersion).To(Equal("v1"), "Deployment API should have webhook version v1")
-
 }

--- a/test/e2e/alphagenerate/generate_v4_with_plugins_test.go
+++ b/test/e2e/alphagenerate/generate_v4_with_plugins_test.go
@@ -30,7 +30,6 @@ import (
 
 var _ = Describe("kubebuilder", func() {
 	Context("alpha generate", func() {
-
 		var (
 			kbc              *utils.TestContext
 			projectOutputDir string
@@ -65,7 +64,6 @@ var _ = Describe("kubebuilder", func() {
 			By("checking that the project file was generated in the current directory")
 			validateV4WithPluginsProjectFile(kbc, projectFilePath)
 		})
-
 	})
 })
 
@@ -196,5 +194,4 @@ func validateV4WithPluginsProjectFile(kbc *utils.TestContext, projectFile string
 
 	// Validate the resource configuration
 	Expect(helmConfig.Resources).To(BeEmpty(), "Expected zero resource for the Helm plugin")
-
 }

--- a/test/e2e/grafana/generate_test.go
+++ b/test/e2e/grafana/generate_test.go
@@ -48,7 +48,6 @@ var _ = Describe("kubebuilder", func() {
 		It("should generate a runnable project with grafana plugin", func() {
 			GenerateProject(kbc)
 		})
-
 	})
 })
 

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -239,7 +239,6 @@ func (t *TestContext) Destroy() {
 				warnError(err)
 			}
 		}
-
 	}
 	if err := os.RemoveAll(t.Dir); err != nil {
 		warnError(err)

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -73,7 +73,6 @@ func GenerateV4(kbc *utils.TestContext) {
 		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
 		metricsCertReplaces, "#")).To(Succeed())
 	uncommentKustomizeCoversion(kbc)
-
 }
 
 // GenerateV4WithoutMetrics implements a go/v4 plugin project defined by a TestContext.


### PR DESCRIPTION
Cleaned up redundant blank lines and unnecessary trailing newlines across various files, including test suites, scaffolds, plugin templates, and documentation scripts. This improves code consistency and reduces visual noise, particularly in generated and test-related files.
