### PR TITLE
🌱 (chore): simplify variable declarations by adding var blocks

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -25,8 +25,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
-var _ machinery.Template = &SuiteTest{}
-var _ machinery.Inserter = &SuiteTest{}
+var (
+	_ machinery.Template = &SuiteTest{}
+	_ machinery.Inserter = &SuiteTest{}
+)
 
 // SuiteTest scaffolds the file that sets up the controller tests
 //

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -72,8 +72,10 @@ go version
 kubectl version --client
 `
 
-var _ machinery.Template = &DevContainer{}
-var _ machinery.Template = &DevContainerPostInstallScript{}
+var (
+	_ machinery.Template = &DevContainer{}
+	_ machinery.Template = &DevContainerPostInstallScript{}
+)
 
 // DevContainer scaffoldds a `devcontainer.json` configurations file for creating Kubebuilder & Kind based DevContainer.
 type DevContainer struct {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -23,8 +23,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
-var _ machinery.Template = &Test{}
-var _ machinery.Inserter = &WebhookTestUpdater{}
+var (
+	_ machinery.Template = &Test{}
+	_ machinery.Inserter = &WebhookTestUpdater{}
+)
 
 const webhookChecksMarker = "e2e-webhooks-checks"
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -25,8 +25,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
-var _ machinery.Template = &WebhookSuite{}
-var _ machinery.Inserter = &WebhookSuite{}
+var (
+	_ machinery.Template = &WebhookSuite{}
+	_ machinery.Inserter = &WebhookSuite{}
+)
 
 // WebhookSuite scaffolds the file that sets up the webhook tests
 type WebhookSuite struct { //nolint:maligned


### PR DESCRIPTION
Converted single-variable `var` to blocks `var(...)` declarations
in `controller_suitetest.go`, `devcontainer.go`, `webhook_suitetest.go`, and `test.go`.