### PR TITLE
🌱 (chore): simplify variable declarations by removing unnecessary var blocks

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -29,9 +29,7 @@ const (
 	projectVersionsHeader = "Supported project versions"
 )
 
-var (
-	supportedPlatforms = []string{"darwin", "linux"}
-)
+var supportedPlatforms = []string{"darwin", "linux"}
 
 func (c CLI) newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package config
 
-var (
-	registry = make(map[Version]func() Config)
-)
+var registry = make(map[Version]func() Config)
 
 // Register allows implementations of Config to register themselves so that they can be created with New
 func Register(version Version, constructor func() Config) {

--- a/pkg/plugins/golang/go_version.go
+++ b/pkg/plugins/golang/go_version.go
@@ -28,9 +28,7 @@ const (
 	goVerPattern = `^go(?P<major>[0-9]+)\.(?P<minor>[0-9]+)(?:\.(?P<patch>[0-9]+)|(?P<pre>(?:alpha|beta|rc)[0-9]+))?$`
 )
 
-var (
-	goVerRegexp = regexp.MustCompile(goVerPattern)
-)
+var goVerRegexp = regexp.MustCompile(goVerPattern)
 
 // GoVersion describes a Go version.
 type GoVersion struct {

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -23,33 +23,31 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
-var (
-	coreGroups = map[string]string{
-		"admission":             "k8s.io",
-		"admissionregistration": "k8s.io",
-		"apps":                  "",
-		"auditregistration":     "k8s.io",
-		"apiextensions":         "k8s.io",
-		"authentication":        "k8s.io",
-		"authorization":         "k8s.io",
-		"autoscaling":           "",
-		"batch":                 "",
-		"certificates":          "k8s.io",
-		"coordination":          "k8s.io",
-		"core":                  "",
-		"events":                "k8s.io",
-		"extensions":            "",
-		"imagepolicy":           "k8s.io",
-		"networking":            "k8s.io",
-		"node":                  "k8s.io",
-		"metrics":               "k8s.io",
-		"policy":                "",
-		"rbac.authorization":    "k8s.io",
-		"scheduling":            "k8s.io",
-		"setting":               "k8s.io",
-		"storage":               "k8s.io",
-	}
-)
+var coreGroups = map[string]string{
+	"admission":             "k8s.io",
+	"admissionregistration": "k8s.io",
+	"apps":                  "",
+	"auditregistration":     "k8s.io",
+	"apiextensions":         "k8s.io",
+	"authentication":        "k8s.io",
+	"authorization":         "k8s.io",
+	"autoscaling":           "",
+	"batch":                 "",
+	"certificates":          "k8s.io",
+	"coordination":          "k8s.io",
+	"core":                  "",
+	"events":                "k8s.io",
+	"extensions":            "",
+	"imagepolicy":           "k8s.io",
+	"networking":            "k8s.io",
+	"node":                  "k8s.io",
+	"metrics":               "k8s.io",
+	"policy":                "",
+	"rbac.authorization":    "k8s.io",
+	"scheduling":            "k8s.io",
+	"setting":               "k8s.io",
+	"storage":               "k8s.io",
+}
 
 // Options contains the information required to build a new resource.Resource.
 type Options struct {

--- a/pkg/plugins/optional/grafana/v1alpha/plugin.go
+++ b/pkg/plugins/optional/grafana/v1alpha/plugin.go
@@ -38,9 +38,7 @@ type Plugin struct {
 	editSubcommand
 }
 
-var (
-	_ plugin.Init = Plugin{}
-)
+var _ plugin.Init = Plugin{}
 
 // Name returns the name of the plugin
 func (Plugin) Name() string { return pluginName }

--- a/test/e2e/grafana/generate_test.go
+++ b/test/e2e/grafana/generate_test.go
@@ -30,9 +30,7 @@ import (
 
 var _ = Describe("kubebuilder", func() {
 	Context("plugin grafana/v1-alpha", func() {
-		var (
-			kbc *utils.TestContext
-		)
+		var kbc *utils.TestContext
 
 		BeforeEach(func() {
 			var err error


### PR DESCRIPTION
Converted single-variable `var (...)` blocks to direct `var` declarations in various packages such as `golang/options.go`, `cli/root.go`, `config/registry.go`, and test files. This makes the code more concise and aligns with idiomatic Go style.