### PR TITLE
🌱 (chore): fix formatting for multi-line function signatures

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -56,7 +56,8 @@ type webhookScaffolder struct {
 
 // NewWebhookScaffolder returns a new Scaffolder for v2 webhook creation operations
 func NewWebhookScaffolder(config config.Config, resource resource.Resource,
-	force bool, isLegacy bool) plugins.Scaffolder {
+	force bool, isLegacy bool,
+) plugins.Scaffolder {
 	return &webhookScaffolder{
 		config:   config,
 		resource: resource,

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -152,7 +152,8 @@ func (s *initScaffolder) getDeployImagesEnvVars() map[string]string {
 // config/webhooks and created Mutating and Validating helper structures to
 // generate the webhook manifest for the helm-chart
 func (s *initScaffolder) extractWebhooksFromGeneratedFiles() (mutatingWebhooks []templateswebhooks.DataWebhook,
-	validatingWebhooks []templateswebhooks.DataWebhook, err error) {
+	validatingWebhooks []templateswebhooks.DataWebhook, err error,
+) {
 	manifestFile := "config/webhook/manifests.yaml"
 
 	if _, err := os.Stat(manifestFile); os.IsNotExist(err) {

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -106,7 +106,8 @@ var _ = Describe("kubebuilder", func() {
 
 // Run runs a set of e2e tests for a scaffolded project defined by a TestContext.
 func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart, hasMetrics bool,
-	hasNetworkPolicies bool) {
+	hasNetworkPolicies bool,
+) {
 	var controllerPodName string
 	var err error
 


### PR DESCRIPTION
Added trailing commas in multi-line function declarations in `webhook.go`, `plugin_cluster_test.go`, and helm init scaffolder to align with Go formatting conventions and avoid formatting diffs from `gofmt`.
