### PR TITLE
🌱 (chore): group const declarations into blocks for clarity

### DIFF
--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -242,14 +242,16 @@ func (sp *Sample) CodeGen() {
 	hackutils.CheckError("Failed to enable helm plugin", err)
 }
 
-const oldSpecAPI = "// Foo is an example field of Memcached. Edit memcached_types.go to remove/update\n\tFoo string `json:\"foo,omitempty\"`"
-const newSpecAPI = `// Size defines the number of Memcached instances
+const (
+	oldSpecAPI = "// Foo is an example field of Memcached. Edit memcached_types.go to remove/update\n\tFoo string `json:\"foo,omitempty\"`"
+	newSpecAPI = `// Size defines the number of Memcached instances
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=3
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 ` + "`json:\"size,omitempty\"`"
+)
 
 const oldStatusAPI = `// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file`

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization_conversion_updater.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization_conversion_updater.go
@@ -23,8 +23,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
-const caNamespace = "crdkustomizecainjectionns"
-const caName = "crdkustomizecainjectionname"
+const (
+	caNamespace = "crdkustomizecainjectionns"
+	caName      = "crdkustomizecainjectionname"
+)
 
 // KustomizationCAConversionUpdater appends CA injection targets for CRDs with --conversion
 type KustomizationCAConversionUpdater struct {


### PR DESCRIPTION
Refactored standalone `const` declarations into grouped blocks in `kustomization_conversion_updater.go` and `generate_getting_started.go` to improve readability and align with Go style conventions.
