### PR TITLE
🌱 (chore): clean up var declarations in grafana scaffolder and cronjob doc generator

### DIFF
--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -655,7 +655,7 @@ func (sp *Sample) updateExample() {
 }
 
 func (sp *Sample) addControllerTest() {
-	var fs = afero.NewOsFs()
+	fs := afero.NewOsFs()
 	err := afero.WriteFile(fs, filepath.Join(sp.ctx.Dir, "internal/controller/cronjob_controller_test.go"), []byte(controllerTest), 0600)
 	hackutils.CheckError("adding cronjob_controller_test", err)
 }

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -169,7 +169,7 @@ func (s *editScaffolder) Scaffold() error {
 
 	configPath := string(configFilePath)
 
-	var templatesBuilder = []machinery.Builder{
+	templatesBuilder := []machinery.Builder{
 		&templates.RuntimeManifest{},
 		&templates.ResourcesManifest{},
 		&templates.CustomMetricsConfigManifest{ConfigPath: configPath},


### PR DESCRIPTION
Refactored `var` declarations to use short form where appropriate:
- Replaced `var templatesBuilder =` with `:=` in the Grafana scaffolder.
- Replaced `var fs =` with `:=` in the cronjob tutorial generator. This improves code clarity and aligns with idiomatic Go style.