### PR TITLE
🌱 (chore): add gofumpt to golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,6 +74,7 @@ linters:
     - goconst
     - gocyclo
     - gofmt
+    - gofumpt
     - goimports
     - gosimple
     - govet


### PR DESCRIPTION
Enabled the `gofumpt` linter in `.golangci.yml` to enforce stricter formatting rules and ensure consistency with gofumpt standards across the codebase.