### PR TITLE
⚠️ 🐛 (API) convert CLI methods to use pointer receivers

### DIFF
--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -26,7 +26,7 @@ import (
 
 const apiErrorMsg = "failed to create API"
 
-func (c CLI) newCreateAPICmd() *cobra.Command {
+func (c *CLI) newCreateAPICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Scaffold a Kubernetes API",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -449,7 +449,7 @@ func (c *CLI) addExtraCommands() error {
 }
 
 // printDeprecationWarnings prints the deprecation warnings of the resolved plugins.
-func (c CLI) printDeprecationWarnings() {
+func (c *CLI) printDeprecationWarnings() {
 	for _, p := range c.resolvedPlugins {
 		if p != nil && p.(plugin.Deprecated) != nil && len(p.(plugin.Deprecated).DeprecationWarning()) > 0 {
 			_, _ = fmt.Fprintf(os.Stderr, noticeColor, fmt.Sprintf(deprecationFmt, p.(plugin.Deprecated).DeprecationWarning()))
@@ -458,7 +458,7 @@ func (c CLI) printDeprecationWarnings() {
 }
 
 // metadata returns CLI's metadata.
-func (c CLI) metadata() plugin.CLIMetadata {
+func (c *CLI) metadata() plugin.CLIMetadata {
 	return plugin.CLIMetadata{
 		CommandName: c.commandName,
 	}
@@ -467,11 +467,18 @@ func (c CLI) metadata() plugin.CLIMetadata {
 // Run executes the CLI utility.
 //
 // If an error is found, command help and examples will be printed.
-func (c CLI) Run() error {
+func (c *CLI) Run() error {
 	return c.cmd.Execute()
 }
 
 // Command returns the underlying root command.
+//
+// Deprecated: Use (c *CLI).CommandPtr() instead.
 func (c CLI) Command() *cobra.Command {
+	return (&c).CommandPtr()
+}
+
+// CommandPtr returns the underlying root command.
+func (c *CLI) CommandPtr() *cobra.Command {
 	return c.cmd
 }

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c CLI) newBashCmd() *cobra.Command {
+func (c *CLI) newBashCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "bash",
 		Short: "Load bash completions",
@@ -42,7 +42,7 @@ MacOS:
 	}
 }
 
-func (c CLI) newZshCmd() *cobra.Command {
+func (c *CLI) newZshCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "zsh",
 		Short: "Load zsh completions",
@@ -61,7 +61,7 @@ $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
 	}
 }
 
-func (c CLI) newFishCmd() *cobra.Command {
+func (c *CLI) newFishCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "fish",
 		Short: "Load fish completions",
@@ -77,7 +77,7 @@ $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
 	}
 }
 
-func (CLI) newPowerShellCmd() *cobra.Command {
+func (c *CLI) newPowerShellCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "powershell",
 		Short: "Load powershell completions",
@@ -87,7 +87,7 @@ func (CLI) newPowerShellCmd() *cobra.Command {
 	}
 }
 
-func (c CLI) newCompletionCmd() *cobra.Command {
+func (c *CLI) newCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion",
 		Short: "Load completions for the specified shell",

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (CLI) newCreateCmd() *cobra.Command {
+func (c *CLI) newCreateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "create",
 		SuggestFor: []string{"new"},

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -26,7 +26,7 @@ import (
 
 const editErrorMsg = "failed to edit project"
 
-func (c CLI) newEditCmd() *cobra.Command {
+func (c *CLI) newEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "Update the project configuration",

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -30,7 +30,7 @@ import (
 
 const initErrorMsg = "failed to initialize project"
 
-func (c CLI) newInitCmd() *cobra.Command {
+func (c *CLI) newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize a new project",
@@ -75,7 +75,7 @@ For further help about a specific plugin, set --plugins.
 	return cmd
 }
 
-func (c CLI) getInitHelpExamples() string {
+func (c *CLI) getInitHelpExamples() string {
 	var sb strings.Builder
 	for _, version := range c.getAvailableProjectVersions() {
 		rendered := fmt.Sprintf(`  # Help for initializing a project with version %[2]s
@@ -88,7 +88,7 @@ func (c CLI) getInitHelpExamples() string {
 	return strings.TrimSuffix(sb.String(), "\n\n")
 }
 
-func (c CLI) getAvailableProjectVersions() (projectVersions []string) {
+func (c *CLI) getAvailableProjectVersions() (projectVersions []string) {
 	versionSet := make(map[config.Version]struct{})
 	for _, p := range c.plugins {
 		// Only return versions of non-deprecated plugins.

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -31,7 +31,7 @@ const (
 
 var supportedPlatforms = []string{"darwin", "linux"}
 
-func (c CLI) newRootCmd() *cobra.Command {
+func (c *CLI) newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     c.commandName,
 		Long:    c.description,
@@ -55,7 +55,7 @@ func (c CLI) newRootCmd() *cobra.Command {
 }
 
 // rootExamples builds the examples string for the root command before resolving plugins
-func (c CLI) rootExamples() string {
+func (c *CLI) rootExamples() string {
 	str := fmt.Sprintf(`The first step is to initialize your project:
     %[1]s init [--plugins=<PLUGIN KEYS> [--project-version=<PROJECT VERSION>]]
 
@@ -84,7 +84,7 @@ configuration please run:
 }
 
 // getPluginTable returns an ASCII table of the available plugins and their supported project versions.
-func (c CLI) getPluginTable() string {
+func (c *CLI) getPluginTable() string {
 	var (
 		maxPluginKeyLength      = len(pluginKeysHeader)
 		pluginKeys              = make([]string, 0, len(c.plugins))

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c CLI) newVersionCmd() *cobra.Command {
+func (c *CLI) newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
 		Short:   fmt.Sprintf("Print the %s version", c.commandName),

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -26,7 +26,7 @@ import (
 
 const webhookErrorMsg = "failed to create webhook"
 
-func (c CLI) newCreateWebhookCmd() *cobra.Command {
+func (c *CLI) newCreateWebhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "webhook",
 		Short: "Scaffold a webhook for an API resource",


### PR DESCRIPTION
Updated all CLI method receivers to use pointer semantics `(*CLI)` instead of value `(CLI)`, ensuring consistent behavior across command setup functions and reducing potential for unintentional value copying.