### PR TITLE
🌱 (chore): unify import alias for network-policy

### DIFF
--- a/pkg/plugins/common/kustomize/v2/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/init.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager"
-	network_policy "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy"
+	networkpolicy "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/prometheus"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac"
 )
@@ -81,8 +81,8 @@ func (s *initScaffolder) Scaffold() error {
 		&kdefault.CertManagerMetricsPatch{},
 		&manager.Config{Image: imageName},
 		&kdefault.Kustomization{},
-		&network_policy.Kustomization{},
-		&network_policy.PolicyAllowMetrics{},
+		&networkpolicy.Kustomization{},
+		&networkpolicy.PolicyAllowMetrics{},
 		&prometheus.Kustomization{},
 		&prometheus.Monitor{},
 		&prometheus.ServiceMonitorPatch{},

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd/patches"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault"
-	network_policy "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy"
+	networkpolicy "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/webhook"
 )
 
@@ -88,7 +88,7 @@ func (s *webhookScaffolder) Scaffold() error {
 		&certmanager.MetricsCertificate{},
 		&certmanager.Kustomization{},
 		&certmanager.KustomizeConfig{},
-		&network_policy.PolicyAllowWebhooks{},
+		&networkpolicy.PolicyAllowWebhooks{},
 	}
 
 	// Only scaffold the following patches if is a conversion webhook


### PR DESCRIPTION
Replaces import alias `network_policy` with `networkpolicy` to follow Go naming conventions.