### PR TITLE
🌱 (chore): normalize error messages and wrap errors using %w

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -421,7 +421,7 @@ func copyFile(src, des string) error {
 func grafanaConfigMigrate(src, des string) error {
 	grafanaConfig := fmt.Sprintf("%s/grafana/custom-metrics/config.yaml", src)
 	if _, err := os.Stat(grafanaConfig); os.IsNotExist(err) {
-		return fmt.Errorf("Grafana config path %s does not exist: %w", grafanaConfig, err)
+		return fmt.Errorf("grafana config path %s does not exist: %w", grafanaConfig, err)
 	}
 	return copyFile(grafanaConfig, fmt.Sprintf("%s/grafana/custom-metrics/config.yaml", des))
 }
@@ -456,7 +456,7 @@ func hasHelmPlugin(cfg store.Store) bool {
 			return false
 		}
 		// Log other errors if needed
-		log.Errorf("Error decoding Helm plugin config: %v", err)
+		log.Errorf("error decoding Helm plugin config: %v", err)
 		return false
 	}
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -352,7 +352,7 @@ func (c *CLI) resolvePlugins() error {
 		if _, version := plugin.SplitKey(pluginKey); version != "" {
 			var ver plugin.Version
 			if err := ver.Parse(version); err != nil {
-				return fmt.Errorf("error parsing input plugin version from key %q: %v", pluginKey, err)
+				return fmt.Errorf("error parsing input plugin version from key %q: %w", pluginKey, err)
 			}
 			if !ver.IsStable() {
 				extraErrMsg += unstablePluginMsg

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -76,7 +76,7 @@ func WithPlugins(plugins ...plugin.Plugin) Option {
 				return fmt.Errorf("two plugins have the same key: %q", key)
 			}
 			if err := plugin.Validate(p); err != nil {
-				return fmt.Errorf("broken pre-set plugin %q: %v", key, err)
+				return fmt.Errorf("broken pre-set plugin %q: %w", key, err)
 			}
 			c.plugins[key] = p
 		}
@@ -97,7 +97,7 @@ func WithDefaultPlugins(projectVersion config.Version, plugins ...plugin.Plugin)
 		}
 		for _, p := range plugins {
 			if err := plugin.Validate(p); err != nil {
-				return fmt.Errorf("broken pre-set default plugin %q: %v", plugin.KeyFor(p), err)
+				return fmt.Errorf("broken pre-set default plugin %q: %w", plugin.KeyFor(p), err)
 			}
 			if !plugin.SupportsVersion(p, projectVersion) {
 				return fmt.Errorf("default plugin %q doesn't support version %q", plugin.KeyFor(p), projectVersion)
@@ -114,7 +114,7 @@ func WithDefaultPlugins(projectVersion config.Version, plugins ...plugin.Plugin)
 func WithDefaultProjectVersion(version config.Version) Option {
 	return func(c *CLI) error {
 		if err := version.Validate(); err != nil {
-			return fmt.Errorf("broken pre-set default project version %q: %v", version, err)
+			return fmt.Errorf("broken pre-set default project version %q: %w", version, err)
 		}
 		c.defaultProjectVersion = version
 		return nil
@@ -209,7 +209,7 @@ func getPluginsRoot(host string) (pluginsRoot string, err error) {
 				return "", fmt.Errorf("the specified path %s does not exist", pluginsPath)
 			}
 			// some other error
-			return "", fmt.Errorf("error checking the path: %v", err)
+			return "", fmt.Errorf("error checking the path: %w", err)
 		}
 		// the path exists
 		return pluginsPath, nil
@@ -232,7 +232,7 @@ func getPluginsRoot(host string) (pluginsRoot string, err error) {
 
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("error retrieving home dir: %v", err)
+		return "", fmt.Errorf("error retrieving home dir: %w", err)
 	}
 
 	return filepath.Join(userHomeDir, pluginsRoot), nil
@@ -294,13 +294,13 @@ func DiscoverExternalPlugins(filesystem afero.Fs) (ps []plugin.Plugin, err error
 				// for example: sample.sh --> sample, externalplugin.py --> externalplugin
 				trimmedPluginName := strings.Split(pluginFile.Name(), ".")
 				if trimmedPluginName[0] == "" {
-					return nil, fmt.Errorf("Invalid plugin name found %q", pluginFile.Name())
+					return nil, fmt.Errorf("invalid plugin name found %q", pluginFile.Name())
 				}
 
 				if pluginFile.Name() == pluginInfo.Name() || trimmedPluginName[0] == pluginInfo.Name() {
 					// check whether the external plugin is an executable.
 					if !isPluginExecutable(pluginFile.Mode()) {
-						return nil, fmt.Errorf("External plugin %q found in path is not an executable", pluginFile.Name())
+						return nil, fmt.Errorf("external plugin %q found in path is not an executable", pluginFile.Name())
 					}
 
 					ep := external.Plugin{

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Discover external plugins", func() {
 
 				plugins, err = DiscoverExternalPlugins(filesystem.FS)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Invalid plugin name found"))
+				Expect(err.Error()).To(ContainSubstring("invalid plugin name found"))
 				Expect(plugins).To(BeEmpty())
 			})
 		})


### PR DESCRIPTION
- Use %w consistently in fmt.Errorf for proper error wrapping
- Normalize error message casing for consistency
- Adjust tests to reflect updated error strings