### PR TITLE
🌱 (chore): normalize error messages and wrap errors using %w

### DIFF
--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -318,11 +318,11 @@ func (c *Cfg) EncodePluginConfig(key string, configObj interface{}) error {
 	// Get object's bytes and set them under key in extra fields.
 	b, err := yaml.Marshal(configObj)
 	if err != nil {
-		return fmt.Errorf("failed to convert %T object to bytes: %s", configObj, err)
+		return fmt.Errorf("failed to convert %T object to bytes: %w", configObj, err)
 	}
 	var fields map[string]interface{}
 	if err := yaml.Unmarshal(b, &fields); err != nil {
-		return fmt.Errorf("failed to unmarshal %T object bytes: %s", configObj, err)
+		return fmt.Errorf("failed to unmarshal %T object bytes: %w", configObj, err)
 	}
 	if c.Plugins == nil {
 		c.Plugins = make(map[string]pluginConfig)


### PR DESCRIPTION
- Use %w consistently in fmt.Errorf for proper error wrapping