### PR TITLE
🌱 (chore): wrap errors with '%w' and normalize formatting in 'kustomize/v2'

### DIFF
--- a/pkg/plugins/common/kustomize/v2/init.go
+++ b/pkg/plugins/common/kustomize/v2/init.go
@@ -72,13 +72,13 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 	if p.name == "" {
 		dir, err := os.Getwd()
 		if err != nil {
-			return fmt.Errorf("error getting current directory: %v", err)
+			return fmt.Errorf("error getting current directory: %w", err)
 		}
 		p.name = strings.ToLower(filepath.Base(dir))
 	}
 	// Check if the project name is a valid k8s namespace (DNS 1123 label).
 	if err := validation.IsDNS1123Label(p.name); err != nil {
-		return fmt.Errorf("project name (%s) is invalid: %v", p.name, err)
+		return fmt.Errorf("project name %q is invalid: %v", p.name, err)
 	}
 	return p.config.SetProjectName(p.name)
 }

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -81,13 +81,13 @@ func (s *apiScaffolder) Scaffold() error {
 			&crd.Kustomization{},
 			&crd.KustomizeConfig{},
 		); err != nil {
-			return fmt.Errorf("error scaffolding kustomize API manifests: %v", err)
+			return fmt.Errorf("error scaffolding kustomize API manifests: %w", err)
 		}
 
 		// If the gvk is non-empty
 		if s.resource.Group != "" || s.resource.Version != "" || s.resource.Kind != "" {
 			if err := scaffold.Execute(&samples.Kustomization{}); err != nil {
-				return fmt.Errorf("error scaffolding manifests: %v", err)
+				return fmt.Errorf("error scaffolding manifests: %w", err)
 			}
 		}
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -102,7 +102,7 @@ func (s *webhookScaffolder) Scaffold() error {
 	}
 
 	if err := scaffold.Execute(buildScaffold...); err != nil {
-		return fmt.Errorf("error scaffolding kustomize webhook manifests: %v", err)
+		return fmt.Errorf("error scaffolding kustomize webhook manifests: %w", err)
 	}
 
 	policyKustomizeFilePath := "config/network-policy/kustomization.yaml"


### PR DESCRIPTION
Replaced uses of `%v` with `%w` in `fmt.Errorf` to support proper error wrapping. Standardized formatting style, e.g. quoting strings with `%q` where appropriate.