### PR TITLE
🌱 (chore): remove unnecessary blank lines across plugin configuration and options

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -317,11 +317,9 @@ func DiscoverExternalPlugins(filesystem afero.Fs) (ps []plugin.Plugin, err error
 					logrus.Printf("Adding external plugin: %s", ep.Name())
 
 					ps = append(ps, ep)
-
 				}
 			}
 		}
-
 	}
 
 	return ps, nil

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -88,7 +88,6 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 			CRDVersion: "v1",
 			Namespaced: opts.Namespaced,
 		}
-
 	}
 
 	if opts.DoController {

--- a/pkg/plugins/optional/grafana/v1alpha/commons.go
+++ b/pkg/plugins/optional/grafana/v1alpha/commons.go
@@ -26,7 +26,6 @@ import (
 func InsertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
 	err := target.DecodePluginConfig(pluginKey, cfg)
 	if !errors.As(err, &config.UnsupportedFieldError{}) {
-
 		if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
 			return err
 		}
@@ -34,7 +33,6 @@ func InsertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
 		if err = target.EncodePluginConfig(pluginKey, cfg); err != nil {
 			return err
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
- Removed stray empty lines in `grafana`, `golang`, and CLI plugin logic
- Keeps code formatting consistent and clean
