### PR TITLE
🌱 (chore): enable 'whitespace' linter in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,4 +90,5 @@ linters:
     - unconvert
     - unparam
     - unused
+    - whitespace
 


### PR DESCRIPTION
Adds `whitespace` to the list of active linters in `.golangci.yml` to enforce consistent formatting and improve code cleanliness.