### PR TITLE
🌱 (chore): wrap error with %w in test_context.go for improved diagnostics

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -307,7 +307,7 @@ func (cc *CmdContext) Run(cmd *exec.Cmd) ([]byte, error) {
 	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
+		return output, fmt.Errorf("%q failed with error %q: %w", command, string(output), err)
 	}
 
 	return output, nil


### PR DESCRIPTION
- Updated error formatting to use `%w` in `fmt.Errorf` for proper error chaining
- Affects command execution error reporting in test context