### PR TITLE
📖 Improve error format in the design docs for API Versioning in Kubebuilder

### DIFF
--- a/designs/crd_version_conversion.md
+++ b/designs/crd_version_conversion.md
@@ -158,12 +158,12 @@ func (ch *conversionHandler) convertObject(src, dst runtime.Object) error {
 
     err = src.(conversion.Convertible).ConvertTo(hub)
     if err != nil {
-        return fmt.Errorf("%T failed to convert to hub version %T : %v", src, hub, err)
+        return fmt.Errorf("%T failed to convert to hub version %T : %w", src, hub, err)
     }
 
     err = dst.(conversion.Convertible).ConvertFrom(hub)
     if err != nil {
-        return fmt.Errorf("%T failed to convert from hub version %T : %v", dst, hub, err)
+        return fmt.Errorf("%T failed to convert from hub version %T : %w", dst, hub, err)
     }
     return nil
 }


### PR DESCRIPTION
- Updated `fmt.Errorf` to use `%w` for proper error wrapping in code snippets
- Improves consistency and error traceability in example code