### PR TITLE
 📖 Fix path for samples in the Getting Started tutorial

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -129,7 +129,7 @@ To generate all required files:
 
 1. Run `make generate` to create the DeepCopy implementations in `api/v1alpha1/zz_generated.deepcopy.go`.
 
-2. Then, run `make manifests` to generate the CRD manifests under `config/crd/bases` and a sample for it under `config/crd/samples`.
+2. Then, run `make manifests` to generate the CRD manifests under `config/crd/bases` and a sample for it under `config/samples`.
 
 Both commands use [controller-gen][controller-gen] with different flags for code and manifest generation, respectively.
 


### PR DESCRIPTION
Fix incorrect location of the samples folder.

Currently the documentation suggests that the location for the samples is config/crd/samples, but from what I can see when I create my getting-started project it's under config/samples.

![image](https://github.com/user-attachments/assets/c6b7a8f1-3e77-497f-9e39-cad7db45f4cc)
