### PR TITLE
🌱 (chore): fix improper usage of `errors.As` in scaffold tests

### DIFF
--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Scaffold", func() {
 			func(errType interface{}, files ...Builder) {
 				err := s.Execute(files...)
 				Expect(err).To(HaveOccurred())
-				Expect(errors.As(err, errType)).To(BeTrue())
+				Expect(errors.As(err, &errType)).To(BeTrue())
 			},
 			Entry("should fail if unable to validate a file builder",
 				&ValidateError{},
@@ -413,7 +413,7 @@ func init() {
 
 				err := s.Execute(files...)
 				Expect(err).To(HaveOccurred())
-				Expect(errors.As(err, errType)).To(BeTrue())
+				Expect(errors.As(err, &errType)).To(BeTrue())
 			},
 			Entry("should fail if inserting into a model that fails when a file exists and it does exist",
 				&FileAlreadyExistsError{},


### PR DESCRIPTION
This fixes a misuse of `errors.As` where a non-pointer was passed as the second argument. Go requires the second argument to be a pointer to an interface or a type implementing the `error` interface.

The test helper now correctly uses `&errType` to ensure proper error assertion and avoid false negatives or runtime issues.
