### PR TITLE
chore: improve readability of test case for alternative delimiters

### DIFF
--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -158,8 +158,12 @@ var _ = Describe("Scaffold", func() {
 
 			Entry("should render actions with alternative delimiters correctly",
 				path, "package testValue",
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: path, TestField: "testValue"},
-					body: "package [[.TestField]]", parseDelimLeft: "[[", parseDelimRight: "]]"},
+				&fakeTemplate{
+					fakeBuilder:     fakeBuilder{path: path, TestField: "testValue"},
+					body:            "package [[.TestField]]",
+					parseDelimLeft:  "[[",
+					parseDelimRight: "]]",
+				},
 			),
 		)
 


### PR DESCRIPTION
Reformatted the inline struct definition in `scaffold_test.go` to a multi-line layout.
