### PR TITLE
🌱 (chore): enable 'asciicheck' and 'bidichk' for improved code safety and clarity

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,8 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - asciicheck
+    - bidichk
     - dupl
     - errcheck
     - copyloopvar


### PR DESCRIPTION
- Added `asciicheck` to detect non-ASCII characters in identifiers and strings. Helps prevent hidden bugs and improves readability across systems.

- Added `bidichk` to catch Unicode bidirectional control characters. Protects against visual code obfuscation and potential security vulnerabilities.

These linters help enforce safer and more maintainable Go code, especially in kubebuilders collaborative environment with many contributors.