### PR TITLE
✨ (go/v4): enable 'import-shadowing' linter

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -45,3 +45,4 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -45,3 +45,4 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing

--- a/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
@@ -45,3 +45,4 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -88,4 +88,5 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing
 `

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -45,3 +45,4 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing

--- a/testdata/project-v4-with-plugins/.golangci.yml
+++ b/testdata/project-v4-with-plugins/.golangci.yml
@@ -45,3 +45,4 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -45,3 +45,4 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+      - name: import-shadowing


### PR DESCRIPTION
### Summary

This PR adds the `import-shadowing` linter to all `.golangci.yml` configuration files across test projects and templates.  
The `import-shadowing` linter detects cases where a package import shadows an existing variable, which can lead to subtle bugs.

### Motivation

Adding this linter helps maintain cleaner and more maintainable code by avoiding accidental name collisions.  
This change aligns the lint configuration across the codebase and ensures new code follows the same checks.

### Changes

- Added `import-shadowing` to:
  - `testdata/project-v4*/.golangci.yml`
  - test projects in `docs/book/src/**/testdata`
  - generated linter config in `pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go`

No functional code changes were made—this is purely a tooling/linting update.
