### PR TITLE
🌱  (chore): refactor unit tests to isolate mutable state with BeforeEach for pkg/cli

### DIFF
--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -38,14 +38,19 @@ import (
 var _ = Describe("Discover external plugins", func() {
 	Context("with valid plugins root path", func() {
 		var (
-			homePath   string = os.Getenv("HOME")
-			customPath string = "/tmp/myplugins"
+			homePath   string
+			customPath string
 			// store user's original EXTERNAL_PLUGINS_PATH
 			originalPluginPath string
 			xdghome            string
 			// store user's original XDG_CONFIG_HOME
 			originalXdghome string
 		)
+
+		BeforeEach(func() {
+			homePath = os.Getenv("HOME")
+			customPath = "/tmp/myplugins"
+		})
 
 		When("XDG_CONFIG_HOME is not set and using the $HOME environment variable", func() {
 			// store and unset the XDG_CONFIG_HOME
@@ -504,14 +509,24 @@ var _ = Describe("CLI options", func() {
 		c   *CLI
 		err error
 
+		projectVersion config.Version
+
+		p   plugin.Plugin
+		np1 plugin.Plugin
+		np2 mockPlugin
+		np3 plugin.Plugin
+		np4 plugin.Plugin
+	)
+
+	BeforeEach(func() {
 		projectVersion = config.Version{Number: 1}
 
-		p   = newMockPlugin(pluginName, pluginVersion, projectVersion)
+		p = newMockPlugin(pluginName, pluginVersion, projectVersion)
 		np1 = newMockPlugin("Plugin", pluginVersion, projectVersion)
 		np2 = mockPlugin{pluginName, plugin.Version{Number: -1}, []config.Version{projectVersion}}
 		np3 = newMockPlugin(pluginName, pluginVersion)
 		np4 = newMockPlugin(pluginName, pluginVersion, config.Version{})
-	)
+	})
 
 	Context("WithCommandName", func() {
 		It("should use provided command name", func() {

--- a/pkg/cli/resource_test.go
+++ b/pkg/cli/resource_test.go
@@ -32,6 +32,12 @@ var _ = Describe("resourceOptions", func() {
 	)
 
 	var (
+		fullGVK     resource.GVK
+		noDomainGVK resource.GVK
+		noGroupGVK  resource.GVK
+	)
+
+	BeforeEach(func() {
 		fullGVK = resource.GVK{
 			Group:   group,
 			Domain:  domain,
@@ -48,7 +54,7 @@ var _ = Describe("resourceOptions", func() {
 			Version: version,
 			Kind:    kind,
 		}
-	)
+	})
 
 	Context("validate", func() {
 		DescribeTable("should succeed for valid options",
@@ -68,13 +74,14 @@ var _ = Describe("resourceOptions", func() {
 
 	Context("newResource", func() {
 		DescribeTable("should succeed if the Resource is valid",
-			func(options resourceOptions) {
+			func(getOpts func() resourceOptions) {
+				options := getOpts()
+
 				Expect(options.validate()).To(Succeed())
 
 				resource := options.newResource()
 				Expect(resource.Validate()).To(Succeed())
 				Expect(resource.GVK.IsEqualTo(options.GVK)).To(BeTrue())
-				// Plural is checked in the next test
 				Expect(resource.Path).To(Equal(""))
 				Expect(resource.API).NotTo(BeNil())
 				Expect(resource.API.CRDVersion).To(Equal(""))
@@ -86,9 +93,9 @@ var _ = Describe("resourceOptions", func() {
 				Expect(resource.Webhooks.Validation).To(BeFalse())
 				Expect(resource.Webhooks.Conversion).To(BeFalse())
 			},
-			Entry("full GVK", resourceOptions{GVK: fullGVK}),
-			Entry("missing domain", resourceOptions{GVK: noDomainGVK}),
-			Entry("missing group", resourceOptions{GVK: noGroupGVK}),
+			Entry("full GVK", func() resourceOptions { return resourceOptions{GVK: fullGVK} }),
+			Entry("missing domain", func() resourceOptions { return resourceOptions{GVK: noDomainGVK} }),
+			Entry("missing group", func() resourceOptions { return resourceOptions{GVK: noGroupGVK} }),
 		)
 
 		DescribeTable("should default the Plural by pluralizing the Kind",


### PR DESCRIPTION
### 🌱 (chore): Move mutable test declarations into `BeforeEach` to ensure clean test state

This refactors the `options_test.go` spec to define mutable test variables like `projectVersion`, plugin mocks, and env paths inside `BeforeEach` blocks. This avoids potential side effects and improves Ginkgo test isolation.

Previously, some of these variables were declared in outer scopes and could accidentally retain or leak state between examples.

This change improves test clarity and maintainability without impacting behavior.
