### PR TITLE
🌱  (chore): refactor unit tests to isolate mutable state with BeforeEach for pkg/config/store

### DIFF
--- a/pkg/config/store/errors_test.go
+++ b/pkg/config/store/errors_test.go
@@ -31,9 +31,14 @@ func TestConfigStore(t *testing.T) {
 
 var _ = Describe("LoadError", func() {
 	var (
-		wrapped = fmt.Errorf("error message")
-		err     = LoadError{Err: wrapped}
+		wrapped error
+		err     LoadError
 	)
+
+	BeforeEach(func() {
+		wrapped = fmt.Errorf("error message")
+		err = LoadError{Err: wrapped}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {
@@ -50,9 +55,14 @@ var _ = Describe("LoadError", func() {
 
 var _ = Describe("SaveError", func() {
 	var (
-		wrapped = fmt.Errorf("error message")
-		err     = SaveError{Err: wrapped}
+		wrapped error
+		err     SaveError
 	)
+
+	BeforeEach(func() {
+		wrapped = fmt.Errorf("error message")
+		err = SaveError{Err: wrapped}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {

--- a/pkg/config/store/yaml/store_test.go
+++ b/pkg/config/store/yaml/store_test.go
@@ -62,13 +62,13 @@ layout: ""
 	)
 
 	var (
-		s *yamlStore
-
-		path = DefaultPath + "2"
+		s    *yamlStore
+		path string
 	)
 
 	BeforeEach(func() {
 		s = New(machinery.Filesystem{FS: afero.NewMemMapFs()}).(*yamlStore)
+		path = DefaultPath + "2"
 	})
 
 	Context("New", func() {


### PR DESCRIPTION
### 🌱 (chore): Move test var initialization into `BeforeEach` in store tests

This change refactors `store_test.go` and `errors_test.go` to move test-specific variable initialization into `BeforeEach` blocks.

This avoids any risk of test state leakage between specs and aligns with best practices for Ginkgo-based tests. Ensures cleaner, more isolated, and maintainable test definitions.
