### PR TITLE
🌱  (chore): refactor unit tests to isolate mutable state with BeforeEach in pkg/config

### DIFF
--- a/pkg/config/errors_test.go
+++ b/pkg/config/errors_test.go
@@ -26,9 +26,13 @@ import (
 )
 
 var _ = Describe("UnsupportedVersionError", func() {
-	err := UnsupportedVersionError{
-		Version: Version{Number: 1},
-	}
+	var err UnsupportedVersionError
+
+	BeforeEach(func() {
+		err = UnsupportedVersionError{
+			Version: Version{Number: 1},
+		}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {
@@ -38,10 +42,14 @@ var _ = Describe("UnsupportedVersionError", func() {
 })
 
 var _ = Describe("UnsupportedFieldError", func() {
-	err := UnsupportedFieldError{
-		Version: Version{Number: 1},
-		Field:   "name",
-	}
+	var err UnsupportedFieldError
+
+	BeforeEach(func() {
+		err = UnsupportedFieldError{
+			Version: Version{Number: 1},
+			Field:   "name",
+		}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {
@@ -51,14 +59,18 @@ var _ = Describe("UnsupportedFieldError", func() {
 })
 
 var _ = Describe("ResourceNotFoundError", func() {
-	err := ResourceNotFoundError{
-		GVK: resource.GVK{
-			Group:   "group",
-			Domain:  "my.domain",
-			Version: "v1",
-			Kind:    "Kind",
-		},
-	}
+	var err ResourceNotFoundError
+
+	BeforeEach(func() {
+		err = ResourceNotFoundError{
+			GVK: resource.GVK{
+				Group:   "group",
+				Domain:  "my.domain",
+				Version: "v1",
+				Kind:    "Kind",
+			},
+		}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {
@@ -68,9 +80,13 @@ var _ = Describe("ResourceNotFoundError", func() {
 })
 
 var _ = Describe("PluginKeyNotFoundError", func() {
-	err := PluginKeyNotFoundError{
-		Key: "go.kubebuilder.io/v1",
-	}
+	var err PluginKeyNotFoundError
+
+	BeforeEach(func() {
+		err = PluginKeyNotFoundError{
+			Key: "go.kubebuilder.io/v1",
+		}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {
@@ -81,9 +97,14 @@ var _ = Describe("PluginKeyNotFoundError", func() {
 
 var _ = Describe("MarshalError", func() {
 	var (
-		wrapped = fmt.Errorf("error message")
-		err     = MarshalError{Err: wrapped}
+		wrapped error
+		err     MarshalError
 	)
+
+	BeforeEach(func() {
+		wrapped = fmt.Errorf("wrapped error")
+		err = MarshalError{Err: wrapped}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {
@@ -100,9 +121,14 @@ var _ = Describe("MarshalError", func() {
 
 var _ = Describe("UnmarshalError", func() {
 	var (
-		wrapped = fmt.Errorf("error message")
-		err     = UnmarshalError{Err: wrapped}
+		wrapped error
+		err     UnmarshalError
 	)
+
+	BeforeEach(func() {
+		wrapped = fmt.Errorf("wrapped error")
+		err = UnmarshalError{Err: wrapped}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -23,9 +23,14 @@ import (
 
 var _ = Describe("registry", func() {
 	var (
-		version = Version{}
-		f       = func() Config { return nil }
+		version Version
+		f       func() Config
 	)
+
+	BeforeEach(func() {
+		version = Version{}
+		f = func() Config { return nil }
+	})
 
 	AfterEach(func() {
 		registry = make(map[Version]func() Config)

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -45,14 +45,15 @@ var _ = Describe("Cfg", func() {
 	)
 
 	var (
-		c Cfg
-
-		pluginChain = []string{"go.kubebuilder.io/v2"}
-
-		otherPluginChain = []string{"go.kubebuilder.io/v3"}
+		c                Cfg
+		pluginChain      []string
+		otherPluginChain []string
 	)
 
 	BeforeEach(func() {
+		pluginChain = []string{"go.kubebuilder.io/v2"}
+		otherPluginChain = []string{"go.kubebuilder.io/v3"}
+
 		c = Cfg{
 			Version:     Version,
 			Domain:      domain,
@@ -136,6 +137,12 @@ var _ = Describe("Cfg", func() {
 
 	Context("Resources", func() {
 		var (
+			res              resource.Resource
+			resWithoutPlural resource.Resource
+			checkResource    func(result, expected resource.Resource)
+		)
+
+		BeforeEach(func() {
 			res = resource.Resource{
 				GVK: resource.GVK{
 					Group:   "group",
@@ -157,35 +164,35 @@ var _ = Describe("Cfg", func() {
 				},
 			}
 			resWithoutPlural = res.Copy()
-		)
 
-		// As some of the tests insert directly into the slice without using the interface methods,
-		// regular plural forms should not be present in here. rsWithoutPlural is used for this purpose.
-		resWithoutPlural.Plural = ""
+			// As some of the tests insert directly into the slice without using the interface methods,
+			// regular plural forms should not be present in here. rsWithoutPlural is used for this purpose.
+			resWithoutPlural.Plural = ""
 
-		// Auxiliary function for GetResource, AddResource and UpdateResource tests
-		checkResource := func(result, expected resource.Resource) {
-			Expect(result.GVK.IsEqualTo(expected.GVK)).To(BeTrue())
-			Expect(result.Plural).To(Equal(expected.Plural))
-			Expect(result.Path).To(Equal(expected.Path))
-			if expected.API == nil {
-				Expect(result.API).To(BeNil())
-			} else {
-				Expect(result.API).NotTo(BeNil())
-				Expect(result.API.CRDVersion).To(Equal(expected.API.CRDVersion))
-				Expect(result.API.Namespaced).To(Equal(expected.API.Namespaced))
+			// Auxiliary function for GetResource, AddResource and UpdateResource tests
+			checkResource = func(result, expected resource.Resource) {
+				Expect(result.GVK.IsEqualTo(expected.GVK)).To(BeTrue())
+				Expect(result.Plural).To(Equal(expected.Plural))
+				Expect(result.Path).To(Equal(expected.Path))
+				if expected.API == nil {
+					Expect(result.API).To(BeNil())
+				} else {
+					Expect(result.API).NotTo(BeNil())
+					Expect(result.API.CRDVersion).To(Equal(expected.API.CRDVersion))
+					Expect(result.API.Namespaced).To(Equal(expected.API.Namespaced))
+				}
+				Expect(result.Controller).To(Equal(expected.Controller))
+				if expected.Webhooks == nil {
+					Expect(result.Webhooks).To(BeNil())
+				} else {
+					Expect(result.Webhooks).NotTo(BeNil())
+					Expect(result.Webhooks.WebhookVersion).To(Equal(expected.Webhooks.WebhookVersion))
+					Expect(result.Webhooks.Defaulting).To(Equal(expected.Webhooks.Defaulting))
+					Expect(result.Webhooks.Validation).To(Equal(expected.Webhooks.Validation))
+					Expect(result.Webhooks.Conversion).To(Equal(expected.Webhooks.Conversion))
+				}
 			}
-			Expect(result.Controller).To(Equal(expected.Controller))
-			if expected.Webhooks == nil {
-				Expect(result.Webhooks).To(BeNil())
-			} else {
-				Expect(result.Webhooks).NotTo(BeNil())
-				Expect(result.Webhooks.WebhookVersion).To(Equal(expected.Webhooks.WebhookVersion))
-				Expect(result.Webhooks.Defaulting).To(Equal(expected.Webhooks.Defaulting))
-				Expect(result.Webhooks.Validation).To(Equal(expected.Webhooks.Validation))
-				Expect(result.Webhooks.Conversion).To(Equal(expected.Webhooks.Conversion))
-			}
-		}
+		})
 
 		DescribeTable("ResourcesLength should return the number of resources",
 			func(n int) {
@@ -354,6 +361,11 @@ var _ = Describe("Cfg", func() {
 		)
 
 		var (
+			c0, c1, c2 Cfg
+			pluginCfg  PluginConfig
+		)
+
+		BeforeEach(func() {
 			c0 = Cfg{
 				Version:     Version,
 				Domain:      domain,
@@ -386,11 +398,11 @@ var _ = Describe("Cfg", func() {
 					},
 				},
 			}
-			pluginConfig = PluginConfig{
+			pluginCfg = PluginConfig{
 				Data1: "plugin value 1",
 				Data2: "plugin value 2",
 			}
-		)
+		})
 
 		It("DecodePluginConfig should fail for no plugin config object", func() {
 			var pluginCfg PluginConfig
@@ -407,24 +419,24 @@ var _ = Describe("Cfg", func() {
 		})
 
 		DescribeTable("DecodePluginConfig should retrieve the plugin data correctly",
-			func(inputConfig Cfg, expectedPluginConfig PluginConfig) {
+			func(getCfg func() Cfg, expected func() PluginConfig) {
 				var pluginCfg PluginConfig
-				Expect(inputConfig.DecodePluginConfig(key, &pluginCfg)).To(Succeed())
-				Expect(pluginCfg).To(Equal(expectedPluginConfig))
+				Expect(getCfg().DecodePluginConfig(key, &pluginCfg)).To(Succeed())
+				Expect(pluginCfg).To(Equal(expected()))
 			},
-			Entry("for an empty plugin config object", c1, PluginConfig{}),
-			Entry("for a full plugin config object", c2, pluginConfig),
+			Entry("for an empty plugin config object", func() Cfg { return c1 }, func() PluginConfig { return PluginConfig{} }),
+			Entry("for a full plugin config object", func() Cfg { return c2 }, func() PluginConfig { return pluginCfg }),
 			// TODO (coverage): add cases where yaml.Marshal returns an error
 			// TODO (coverage): add cases where yaml.Unmarshal returns an error
 		)
 
 		DescribeTable("EncodePluginConfig should encode the plugin data correctly",
-			func(pluginConfig PluginConfig, expectedConfig Cfg) {
-				Expect(c.EncodePluginConfig(key, pluginConfig)).To(Succeed())
-				Expect(c).To(Equal(expectedConfig))
+			func(getPluginCfg func() PluginConfig, expectedCfg func() Cfg) {
+				Expect(c.EncodePluginConfig(key, getPluginCfg())).To(Succeed())
+				Expect(c).To(Equal(expectedCfg()))
 			},
-			Entry("for an empty plugin config object", PluginConfig{}, c1),
-			Entry("for a full plugin config object", pluginConfig, c2),
+			Entry("for an empty plugin config object", func() PluginConfig { return PluginConfig{} }, func() Cfg { return c1 }),
+			Entry("for a full plugin config object", func() PluginConfig { return pluginCfg }, func() Cfg { return c2 }),
 			// TODO (coverage): add cases where yaml.Marshal returns an error
 			// TODO (coverage): add cases where yaml.Unmarshal returns an error
 		)
@@ -432,7 +444,11 @@ var _ = Describe("Cfg", func() {
 
 	Context("Persistence", func() {
 		var (
-			// BeforeEach is called after the entries are evaluated, and therefore, c is not available
+			c1, c2        Cfg
+			s1, s1bis, s2 string
+		)
+
+		BeforeEach(func() {
 			c1 = Cfg{
 				Version:     Version,
 				Domain:      domain,
@@ -472,8 +488,8 @@ var _ = Describe("Cfg", func() {
 							Kind:    "Kind",
 						},
 						Plural:   "kindes",
-						API:      &resource.API{},
-						Webhooks: &resource.Webhooks{},
+						API:      nil,
+						Webhooks: nil,
 					},
 					{
 						GVK: resource.GVK{
@@ -564,22 +580,23 @@ resources:
     webhookVersion: v1
 version: "3"
 `
-		)
+		})
 
 		DescribeTable("MarshalYAML should succeed",
-			func(c Cfg, content string) {
-				b, err := c.MarshalYAML()
+			func(getCfg func() Cfg, getContent func() string) {
+				b, err := getCfg().MarshalYAML()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(b)).To(Equal(content))
+				Expect(string(b)).To(Equal(getContent()))
 			},
-			Entry("for a basic configuration", c1, s1),
-			Entry("for a full configuration", c2, s2),
+			Entry("for a basic configuration", func() Cfg { return c1 }, func() string { return s1 }),
+			Entry("for a full configuration", func() Cfg { return c2 }, func() string { return s2 }),
 		)
 
 		DescribeTable("UnmarshalYAML should succeed",
-			func(content string, c Cfg) {
+			func(getContent func() string, getCfg func() Cfg) {
 				var unmarshalled Cfg
-				Expect(unmarshalled.UnmarshalYAML([]byte(content))).To(Succeed())
+				Expect(unmarshalled.UnmarshalYAML([]byte(getContent()))).To(Succeed())
+				c := getCfg()
 				Expect(unmarshalled.Version.Compare(c.Version)).To(Equal(0))
 				Expect(unmarshalled.Domain).To(Equal(c.Domain))
 				Expect(unmarshalled.Repository).To(Equal(c.Repository))
@@ -590,9 +607,9 @@ version: "3"
 				Expect(unmarshalled.Plugins).To(HaveLen(len(c.Plugins)))
 				// TODO: fully test Plugins field and not on its length
 			},
-			Entry("basic", s1, c1),
-			Entry("full", s2, c2),
-			Entry("string layout", s1bis, c1),
+			Entry("basic", func() string { return s1 }, func() Cfg { return c1 }),
+			Entry("full", func() string { return s2 }, func() Cfg { return c2 }),
+			Entry("string layout", func() string { return s1bis }, func() Cfg { return c1 }),
 		)
 
 		DescribeTable("UnmarshalYAML should fail",

--- a/pkg/config/version_test.go
+++ b/pkg/config/version_test.go
@@ -29,8 +29,13 @@ var _ = Describe("Version", func() {
 	// Parse, String and Validate are tested by MarshalJSON and UnmarshalJSON
 
 	Context("Compare", func() {
-		// Test Compare() by sorting a list.
 		var (
+			versions       []Version
+			sortedVersions []Version
+		)
+
+		BeforeEach(func() {
+			// Test Compare() by sorting a list.
 			versions = []Version{
 				{Number: 2, Stage: stage.Alpha},
 				{Number: 44, Stage: stage.Alpha},
@@ -56,7 +61,7 @@ var _ = Describe("Version", func() {
 				{Number: 44, Stage: stage.Alpha},
 				{Number: 44, Stage: stage.Alpha},
 			}
-		)
+		})
 
 		It("sorts a valid list of versions correctly", func() {
 			sort.Slice(versions, func(i int, j int) bool {


### PR DESCRIPTION
### 🌱 (chore): Move shared test vars to `BeforeEach` to avoid spec pollution

This change refactors multiple Ginkgo test suites to move shared variables into `BeforeEach` blocks, including:

- `pkg/config/errors_test.go`
- `pkg/config/version_test.go`
- `pkg/config/v3/config_test.go`
- `pkg/config/registry_test.go`

By initializing test data in `BeforeEach`, we ensure test isolation and avoid accidental state pollution between specs. This also aligns with best practices and improves test readability and maintainability.