### PR TITLE
🌱  (chore): refactor unit tests to isolate mutable state with BeforeEach in pkg/machinery tests

### DIFF
--- a/pkg/machinery/errors_test.go
+++ b/pkg/machinery/errors_test.go
@@ -26,23 +26,30 @@ import (
 
 var _ = Describe("Errors", func() {
 	var (
-		path    = filepath.Join("path", "to", "file")
-		testErr = errors.New("test error")
+		path    string
+		testErr error
 	)
 
+	BeforeEach(func() {
+		path = filepath.Join("path", "to", "file")
+		testErr = errors.New("test error")
+	})
+
 	DescribeTable("should contain the wrapped error",
-		func(err error) {
+		func(getErr func() error) {
+			err := getErr()
+			Expect(err).To(HaveOccurred())
 			Expect(errors.Is(err, testErr)).To(BeTrue())
 		},
-		Entry("for validate errors", ValidateError{testErr}),
-		Entry("for set template defaults errors", SetTemplateDefaultsError{testErr}),
-		Entry("for file existence errors", ExistsFileError{testErr}),
-		Entry("for file opening errors", OpenFileError{testErr}),
-		Entry("for directory creation errors", CreateDirectoryError{testErr}),
-		Entry("for file creation errors", CreateFileError{testErr}),
-		Entry("for file reading errors", ReadFileError{testErr}),
-		Entry("for file writing errors", WriteFileError{testErr}),
-		Entry("for file closing errors", CloseFileError{testErr}),
+		Entry("for validate errors", func() error { return ValidateError{testErr} }),
+		Entry("for set template defaults errors", func() error { return SetTemplateDefaultsError{testErr} }),
+		Entry("for file existence errors", func() error { return ExistsFileError{testErr} }),
+		Entry("for file opening errors", func() error { return OpenFileError{testErr} }),
+		Entry("for directory creation errors", func() error { return CreateDirectoryError{testErr} }),
+		Entry("for file creation errors", func() error { return CreateFileError{testErr} }),
+		Entry("for file reading errors", func() error { return ReadFileError{testErr} }),
+		Entry("for file writing errors", func() error { return WriteFileError{testErr} }),
+		Entry("for file closing errors", func() error { return CloseFileError{testErr} }),
 	)
 
 	// NOTE: the following test increases coverage

--- a/pkg/machinery/injector_test.go
+++ b/pkg/machinery/injector_test.go
@@ -93,10 +93,14 @@ func (t *templateWithResource) InjectResource(res *resource.Resource) {
 }
 
 var _ = Describe("injector", func() {
-	tmp := templateBase{
-		path:           "my/path/to/file",
-		ifExistsAction: Error,
-	}
+	var tmp templateBase
+
+	BeforeEach(func() {
+		tmp = templateBase{
+			path:           "my/path/to/file",
+			ifExistsAction: Error,
+		}
+	})
 
 	Context("injectInto", func() {
 		Context("Config", func() {

--- a/pkg/machinery/mixins_test.go
+++ b/pkg/machinery/mixins_test.go
@@ -45,13 +45,17 @@ var _ = Describe("TemplateMixin", func() {
 		body           = "content"
 	)
 
-	tmp := mockTemplate{
-		TemplateMixin: TemplateMixin{
-			PathMixin:           PathMixin{path},
-			IfExistsActionMixin: IfExistsActionMixin{ifExistsAction},
-			TemplateBody:        body,
-		},
-	}
+	var tmp mockTemplate
+
+	BeforeEach(func() {
+		tmp = mockTemplate{
+			TemplateMixin: TemplateMixin{
+				PathMixin:           PathMixin{path},
+				IfExistsActionMixin: IfExistsActionMixin{ifExistsAction},
+				TemplateBody:        body,
+			},
+		}
+	})
 
 	Context("GetPath", func() {
 		It("should return the path", func() {
@@ -75,11 +79,15 @@ var _ = Describe("TemplateMixin", func() {
 var _ = Describe("InserterMixin", func() {
 	const path = "path/to/file.go"
 
-	tmp := mockInserter{
-		InserterMixin: InserterMixin{
-			PathMixin: PathMixin{path},
-		},
-	}
+	var tmp mockInserter
+
+	BeforeEach(func() {
+		tmp = mockInserter{
+			InserterMixin: InserterMixin{
+				PathMixin: PathMixin{path},
+			},
+		}
+	})
 
 	Context("GetPath", func() {
 		It("should return the path", func() {
@@ -97,7 +105,11 @@ var _ = Describe("InserterMixin", func() {
 var _ = Describe("DomainMixin", func() {
 	const domain = "my.domain"
 
-	tmp := mockTemplate{}
+	var tmp mockTemplate
+
+	BeforeEach(func() {
+		tmp = mockTemplate{}
+	})
 
 	Context("InjectDomain", func() {
 		It("should inject the provided domain", func() {
@@ -110,7 +122,11 @@ var _ = Describe("DomainMixin", func() {
 var _ = Describe("RepositoryMixin", func() {
 	const repo = "test"
 
-	tmp := mockTemplate{}
+	var tmp mockTemplate
+
+	BeforeEach(func() {
+		tmp = mockTemplate{}
+	})
 
 	Context("InjectRepository", func() {
 		It("should inject the provided repository", func() {
@@ -123,7 +139,11 @@ var _ = Describe("RepositoryMixin", func() {
 var _ = Describe("ProjectNameMixin", func() {
 	const name = "my project"
 
-	tmp := mockTemplate{}
+	var tmp mockTemplate
+
+	BeforeEach(func() {
+		tmp = mockTemplate{}
+	})
 
 	Context("InjectProjectName", func() {
 		It("should inject the provided project name", func() {
@@ -134,7 +154,11 @@ var _ = Describe("ProjectNameMixin", func() {
 })
 
 var _ = Describe("MultiGroupMixin", func() {
-	tmp := mockTemplate{}
+	var tmp mockTemplate
+
+	BeforeEach(func() {
+		tmp = mockTemplate{}
+	})
 
 	Context("InjectMultiGroup", func() {
 		It("should inject the provided multi group flag", func() {
@@ -147,7 +171,11 @@ var _ = Describe("MultiGroupMixin", func() {
 var _ = Describe("BoilerplateMixin", func() {
 	const boilerplate = "Copyright"
 
-	tmp := mockTemplate{}
+	var tmp mockTemplate
+
+	BeforeEach(func() {
+		tmp = mockTemplate{}
+	})
 
 	Context("InjectBoilerplate", func() {
 		It("should inject the provided boilerplate", func() {
@@ -158,14 +186,21 @@ var _ = Describe("BoilerplateMixin", func() {
 })
 
 var _ = Describe("ResourceMixin", func() {
-	res := &resource.Resource{GVK: resource.GVK{
-		Group:   "group",
-		Domain:  "my.domain",
-		Version: "v1",
-		Kind:    "Kind",
-	}}
+	var (
+		res *resource.Resource
+		tmp mockTemplate
+	)
 
-	tmp := mockTemplate{}
+	BeforeEach(func() {
+		res = &resource.Resource{GVK: resource.GVK{
+			Group:   "group",
+			Domain:  "my.domain",
+			Version: "v1",
+			Kind:    "Kind",
+		}}
+
+		tmp = mockTemplate{}
+	})
 
 	Context("InjectResource", func() {
 		It("should inject the provided resource", func() {

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -115,12 +115,12 @@ var _ = Describe("Scaffold", func() {
 		)
 
 		var (
-			testErr = errors.New("error text")
-
-			s *Scaffold
+			testErr error
+			s       *Scaffold
 		)
 
 		BeforeEach(func() {
+			testErr = errors.New("error text")
 			s = &Scaffold{fs: afero.NewMemMapFs()}
 		})
 
@@ -168,29 +168,36 @@ var _ = Describe("Scaffold", func() {
 		)
 
 		DescribeTable("file builders related errors",
-			func(errType interface{}, files ...Builder) {
+			func(setup func() (interface{}, []Builder)) {
+				errType, files := setup()
+
 				err := s.Execute(files...)
+
 				Expect(err).To(HaveOccurred())
 				Expect(errors.As(err, &errType)).To(BeTrue())
 			},
-			Entry("should fail if unable to validate a file builder",
-				&ValidateError{},
-				fakeRequiresValidation{validateErr: testErr},
-			),
-			Entry("should fail if unable to set default values for a template",
-				&SetTemplateDefaultsError{},
-				&fakeTemplate{err: testErr},
-			),
-			Entry("should fail if an unexpected previous model is found",
-				&ModelAlreadyExistsError{},
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: path}},
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: path, ifExistsAction: Error}},
-			),
-			Entry("should fail if behavior if-exists-action is not defined",
-				&UnknownIfExistsActionError{},
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: path}},
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: path, ifExistsAction: -1}},
-			),
+			Entry("should fail if unable to validate a file builder", func() (interface{}, []Builder) {
+				return &ValidateError{}, []Builder{
+					fakeRequiresValidation{validateErr: testErr},
+				}
+			}),
+			Entry("should fail if unable to set default values for a template", func() (interface{}, []Builder) {
+				return &SetTemplateDefaultsError{}, []Builder{
+					&fakeTemplate{err: testErr},
+				}
+			}),
+			Entry("should fail if an unexpected previous model is found", func() (interface{}, []Builder) {
+				return &ModelAlreadyExistsError{}, []Builder{
+					&fakeTemplate{fakeBuilder: fakeBuilder{path: path}},
+					&fakeTemplate{fakeBuilder: fakeBuilder{path: path, ifExistsAction: Error}},
+				}
+			}),
+			Entry("should fail if behavior if-exists-action is not defined", func() (interface{}, []Builder) {
+				return &UnknownIfExistsActionError{}, []Builder{
+					&fakeTemplate{fakeBuilder: fakeBuilder{path: path}},
+					&fakeTemplate{fakeBuilder: fakeBuilder{path: path, ifExistsAction: -1}},
+				}
+			}),
 		)
 
 		// Following errors are unwrapped, so we need to check for substrings


### PR DESCRIPTION
### 🌱 (chore): Move mutable test declarations into `BeforeEach` to ensure clean test state

This refactors multiple test files to move mutable test variables into `BeforeEach` blocks. This prevents unintended state sharing across tests and improves isolation and readability.

#### Affected test files:
- `pkg/machinery/errors_test.go`
- `pkg/machinery/injector_test.go`
- `pkg/machinery/mixins_test.go`
- `pkg/machinery/scaffold_test.go`

This aligns with Ginkgo best practices and avoids potential side effects from shared variables in nested contexts or table-driven specs.