### PR TITLE
🌱 (chore): refactor stage unit tests with Ginkgo conventions and simplify logic in stage_test.go

### DIFF
--- a/pkg/model/stage/stage_test.go
+++ b/pkg/model/stage/stage_test.go
@@ -20,76 +20,81 @@ import (
 	"sort"
 	"testing"
 
-	g "github.com/onsi/ginkgo/v2" // An alias is required because Context is defined elsewhere in this package.
+	. "github.com/onsi/ginkgo/v2" // An alias is required because Context is defined elsewhere in this package.
 	. "github.com/onsi/gomega"
 )
 
 func TestStage(t *testing.T) {
-	RegisterFailHandler(g.Fail)
-	g.RunSpecs(t, "Stage Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Stage Suite")
 }
 
-var _ = g.Describe("ParseStage", func() {
-	g.DescribeTable("should be correctly parsed for valid stage strings",
+var _ = Describe("ParseStage", func() {
+	DescribeTable("should be correctly parsed for valid stage strings",
 		func(str string, stage Stage) {
 			s, err := ParseStage(str)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s).To(Equal(stage))
 		},
-		g.Entry("for alpha stage", "alpha", Alpha),
-		g.Entry("for beta stage", "beta", Beta),
-		g.Entry("for stable stage", "", Stable),
+		Entry("for alpha stage", "alpha", Alpha),
+		Entry("for beta stage", "beta", Beta),
+		Entry("for stable stage", "", Stable),
 	)
 
-	g.DescribeTable("should error when parsing invalid stage strings",
+	DescribeTable("should error when parsing invalid stage strings",
 		func(str string) {
 			_, err := ParseStage(str)
 			Expect(err).To(HaveOccurred())
 		},
-		g.Entry("passing a number as the stage string", "1"),
-		g.Entry("passing `gamma` as the stage string", "gamma"),
-		g.Entry("passing a dash-prefixed stage string", "-alpha"),
+		Entry("passing a number as the stage string", "1"),
+		Entry("passing `gamma` as the stage string", "gamma"),
+		Entry("passing a dash-prefixed stage string", "-alpha"),
 	)
 })
 
-var _ = g.Describe("Stage", func() {
-	g.Context("String", func() {
-		g.DescribeTable("should return the correct string value",
+var _ = Describe("Stage", func() {
+	Context("String", func() {
+		DescribeTable("should return the correct string value",
 			func(stage Stage, str string) { Expect(stage.String()).To(Equal(str)) },
-			g.Entry("for alpha stage", Alpha, "alpha"),
-			g.Entry("for beta stage", Beta, "beta"),
-			g.Entry("for stable stage", Stable, ""),
+			Entry("for alpha stage", Alpha, "alpha"),
+			Entry("for beta stage", Beta, "beta"),
+			Entry("for stable stage", Stable, ""),
 		)
 
-		g.DescribeTable("should panic",
+		DescribeTable("should panic",
 			func(stage Stage) { Expect(func() { _ = stage.String() }).To(Panic()) },
-			g.Entry("for stage 34", Stage(34)),
-			g.Entry("for stage 75", Stage(75)),
-			g.Entry("for stage 123", Stage(123)),
-			g.Entry("for stage 255", Stage(255)),
+			Entry("for stage 34", Stage(34)),
+			Entry("for stage 75", Stage(75)),
+			Entry("for stage 123", Stage(123)),
+			Entry("for stage 255", Stage(255)),
 		)
 	})
 
-	g.Context("Validate", func() {
-		g.DescribeTable("should validate existing stages",
+	Context("Validate", func() {
+		DescribeTable("should validate existing stages",
 			func(stage Stage) { Expect(stage.Validate()).To(Succeed()) },
-			g.Entry("for alpha stage", Alpha),
-			g.Entry("for beta stage", Beta),
-			g.Entry("for stable stage", Stable),
+			Entry("for alpha stage", Alpha),
+			Entry("for beta stage", Beta),
+			Entry("for stable stage", Stable),
 		)
 
-		g.DescribeTable("should fail for non-existing stages",
+		DescribeTable("should fail for non-existing stages",
 			func(stage Stage) { Expect(stage.Validate()).NotTo(Succeed()) },
-			g.Entry("for stage 34", Stage(34)),
-			g.Entry("for stage 75", Stage(75)),
-			g.Entry("for stage 123", Stage(123)),
-			g.Entry("for stage 255", Stage(255)),
+			Entry("for stage 34", Stage(34)),
+			Entry("for stage 75", Stage(75)),
+			Entry("for stage 123", Stage(123)),
+			Entry("for stage 255", Stage(255)),
 		)
 	})
 
-	g.Context("Compare", func() {
+	Context("Compare", func() {
 		// Test Stage.Compare by sorting a list
 		var (
+			stages       []Stage
+			sortedStages []Stage
+		)
+
+		BeforeEach(func() {
 			stages = []Stage{
 				Stable,
 				Alpha,
@@ -107,9 +112,9 @@ var _ = g.Describe("Stage", func() {
 				Stable,
 				Stable,
 			}
-		)
+		})
 
-		g.It("sorts stages correctly", func() {
+		It("sorts stages correctly", func() {
 			sort.Slice(stages, func(i int, j int) bool {
 				return stages[i].Compare(stages[j]) == -1
 			})
@@ -117,15 +122,15 @@ var _ = g.Describe("Stage", func() {
 		})
 	})
 
-	g.Context("IsStable", func() {
-		g.It("should return true for stable stage", func() {
+	Context("IsStable", func() {
+		It("should return true for stable stage", func() {
 			Expect(Stable.IsStable()).To(BeTrue())
 		})
 
-		g.DescribeTable("should return false for any unstable stage",
+		DescribeTable("should return false for any unstable stage",
 			func(stage Stage) { Expect(stage.IsStable()).To(BeFalse()) },
-			g.Entry("for alpha stage", Alpha),
-			g.Entry("for beta stage", Beta),
+			Entry("for alpha stage", Alpha),
+			Entry("for beta stage", Beta),
 		)
 	})
 })


### PR DESCRIPTION
### 🌱 (chore): Align `stage_test.go` suite with Ginkgo conventions and clean up

This PR refactors the `stage_test.go` file to:

- Replace alias-based import (`g.`) with standard Ginkgo imports for clarity and consistency
- Move shared variables into `BeforeEach` to isolate test state
- Improve naming consistency and indentation

This keeps the test style aligned with the rest of the project and prevents potential side effects or shared mutable state across test cases.