### PR TITLE
🌱 (chore): refactor shared setup logic in plugins into BeforeEach to isolate test state

### DIFF
--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -287,10 +287,11 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			flagset        *pflag.FlagSet
 
 			// Make an array of flags to represent the ones that should be returned in these tests
-			flags = getFlags()
+			flags []external.Flag
 
 			checkFlagset func()
 		)
+
 		BeforeEach(func() {
 			outputGetter = &mockValidFlagOutputGetter{}
 			currentDirGetter = &mockValidOsWdGetter{}
@@ -298,6 +299,8 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			pluginFileName = externalPlugin
 			args = []string{"--captain", "black-beard", "--sail"}
 			flagset = pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			flags = getFlags()
 
 			checkFlagset = func() {
 				Expect(flagset.HasFlags()).To(BeTrue())
@@ -369,6 +372,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			usage          string
 			checkFlagset   func()
 		)
+
 		BeforeEach(func() {
 			outputGetter = &mockInValidOutputGetter{}
 			currentDirGetter = &mockValidOsWdGetter{}
@@ -463,7 +467,15 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 
 	Context("Flag Parsing Helper Functions", func() {
 		var (
-			fs   *pflag.FlagSet
+			fs                  *pflag.FlagSet
+			args                []string
+			forbidden           []string
+			flags               []external.Flag
+			argFilters          []argFilterFunc
+			externalFlagFilters []externalFlagFilterFunc
+		)
+
+		BeforeEach(func() {
 			args = []string{
 				"--domain", "something.com",
 				"--boolean",
@@ -476,12 +488,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			forbidden = []string{
 				"help", "group", "kind", "version",
 			}
-			flags               []external.Flag
-			argFilters          []argFilterFunc
-			externalFlagFilters []externalFlagFilterFunc
-		)
 
-		BeforeEach(func() {
 			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
 
 			flagsToAppend := getFlags()
@@ -559,6 +566,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			metadata       *plugin.SubcommandMetadata
 			checkMetadata  func()
 		)
+
 		BeforeEach(func() {
 			outputGetter = &mockValidMEOutputGetter{}
 			currentDirGetter = &mockValidOsWdGetter{}
@@ -623,6 +631,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			metadata       *plugin.SubcommandMetadata
 			checkMetadata  func()
 		)
+
 		BeforeEach(func() {
 			outputGetter = &mockInValidOutputGetter{}
 			currentDirGetter = &mockValidOsWdGetter{}

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -80,6 +80,11 @@ var _ = Describe("GoVersion", func() {
 	Context("Compare", func() {
 		// Test Compare() by sorting a list.
 		var (
+			versions       []GoVersion
+			sortedVersions []GoVersion
+		)
+
+		BeforeEach(func() {
 			versions = []GoVersion{
 				{major: 1, minor: 15, prerelease: "rc2"},
 				{major: 1, minor: 15, patch: 1},
@@ -113,7 +118,7 @@ var _ = Describe("GoVersion", func() {
 				{major: 1, minor: 16},
 				{major: 2, minor: 0},
 			}
-		)
+		})
 
 		It("sorts a valid list of versions correctly", func() {
 			sort.Slice(versions, func(i int, j int) bool {
@@ -125,8 +130,15 @@ var _ = Describe("GoVersion", func() {
 })
 
 var _ = Describe("checkGoVersion", func() {
-	goVerMin := MustParse("go1.13")
-	goVerMax := MustParse("go2.0alpha1")
+	var (
+		goVerMin GoVersion
+		goVerMax GoVersion
+	)
+
+	BeforeEach(func() {
+		goVerMin = MustParse("go1.13")
+		goVerMax = MustParse("go2.0alpha1")
+	})
 
 	DescribeTable("should return no error for supported go versions",
 		func(version string) { Expect(checkGoVersion(version, goVerMin, goVerMax)).To(Succeed()) },

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -35,7 +35,13 @@ var _ = Describe("Options", func() {
 			version = "v1"
 			kind    = "FirstMate"
 		)
+
 		var (
+			gvk resource.GVK
+			cfg config.Config
+		)
+
+		BeforeEach(func() {
 			gvk = resource.GVK{
 				Group:   group,
 				Domain:  domain,
@@ -43,10 +49,6 @@ var _ = Describe("Options", func() {
 				Kind:    kind,
 			}
 
-			cfg config.Config
-		)
-
-		BeforeEach(func() {
 			cfg = cfgv3.New()
 			_ = cfg.SetRepository("test")
 		})


### PR DESCRIPTION
### 🌱 (chore): refactor shared setup logic in plugins into `BeforeEach` to isolate test state

This PR ensures test isolation by moving mutable shared variables and initialization logic into `BeforeEach` blocks across multiple test suites, including:

- `pkg/plugins/golang/go_version_test.go`
- `pkg/plugins/golang/options_test.go`
- `pkg/plugins/external/external_test.go`

This approach prevents side effects between test cases and aligns with best practices for Ginkgo-style testing. The changes:

- Avoid spec pollution
- Enable safer use of `DescribeTable`
- Improve maintainability and clarity
