### PR TITLE
🌱 (chore): refactor shared setup logic in plugin into BeforeEach to isolate test state

### DIFF
--- a/pkg/plugin/bundle_test.go
+++ b/pkg/plugin/bundle_test.go
@@ -32,7 +32,16 @@ var _ = Describe("Bundle", func() {
 	)
 
 	var (
-		version = Version{Number: 1}
+		v Version
+
+		p1 mockPlugin
+		p2 mockPlugin
+		p3 mockPlugin
+		p4 mockPlugin
+	)
+
+	BeforeEach(func() {
+		v = Version{Number: 1}
 
 		p1 = mockPlugin{supportedProjectVersions: []config.Version{
 			{Number: 1},
@@ -53,7 +62,7 @@ var _ = Describe("Bundle", func() {
 			{Number: 2},
 			{Number: 3},
 		}}
-	)
+	})
 
 	Context("NewBundle", func() {
 		It("should succeed for plugins with common supported project versions", func() {
@@ -69,11 +78,11 @@ var _ = Describe("Bundle", func() {
 			} {
 
 				b, err := NewBundleWithOptions(WithName(name),
-					WithVersion(version),
+					WithVersion(v),
 					WithPlugins(plugins...))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(b.Name()).To(Equal(name))
-				Expect(b.Version().Compare(version)).To(Equal(0))
+				Expect(b.Version().Compare(v)).To(Equal(0))
 				versions := b.SupportedProjectVersions()
 				sort.Slice(versions, func(i int, j int) bool {
 					return versions[i].Compare(versions[j]) == -1
@@ -92,11 +101,11 @@ var _ = Describe("Bundle", func() {
 			var err error
 			plugins := []Plugin{p1, p2, p3}
 			a, err = NewBundleWithOptions(WithName("a"),
-				WithVersion(version),
+				WithVersion(v),
 				WithPlugins(p1, p2))
 			Expect(err).NotTo(HaveOccurred())
 			b, err = NewBundleWithOptions(WithName("b"),
-				WithVersion(version),
+				WithVersion(v),
 				WithPlugins(a, p3))
 			Expect(err).NotTo(HaveOccurred())
 			versions := b.SupportedProjectVersions()
@@ -121,7 +130,7 @@ var _ = Describe("Bundle", func() {
 				{p1, p2, p3, p4},
 			} {
 				_, err := NewBundleWithOptions(WithName(name),
-					WithVersion(version),
+					WithVersion(v),
 					WithPlugins(plugins...))
 
 				Expect(err).To(HaveOccurred())
@@ -142,13 +151,13 @@ var _ = Describe("Bundle", func() {
 				{p1, p3, p4},
 			} {
 				b, err := NewBundleWithOptions(WithName(name),
-					WithVersion(version),
+					WithVersion(v),
 					WithDeprecationMessage(""),
 					WithPlugins(plugins...),
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(b.Name()).To(Equal(name))
-				Expect(b.Version().Compare(version)).To(Equal(0))
+				Expect(b.Version().Compare(v)).To(Equal(0))
 				versions := b.SupportedProjectVersions()
 				sort.Slice(versions, func(i int, j int) bool {
 					return versions[i].Compare(versions[j]) == -1
@@ -167,13 +176,13 @@ var _ = Describe("Bundle", func() {
 			var err error
 			plugins := []Plugin{p1, p2, p3}
 			a, err = NewBundleWithOptions(WithName("a"),
-				WithVersion(version),
+				WithVersion(v),
 				WithDeprecationMessage(""),
 				WithPlugins(p1, p2),
 			)
 			Expect(err).NotTo(HaveOccurred())
 			b, err = NewBundleWithOptions(WithName("b"),
-				WithVersion(version),
+				WithVersion(v),
 				WithDeprecationMessage(""),
 				WithPlugins(a, p3),
 			)
@@ -200,7 +209,7 @@ var _ = Describe("Bundle", func() {
 				{p1, p2, p3, p4},
 			} {
 				_, err := NewBundleWithOptions(WithName(name),
-					WithVersion(version),
+					WithVersion(v),
 					WithDeprecationMessage(""),
 					WithPlugins(plugins...),
 				)

--- a/pkg/plugin/errors_test.go
+++ b/pkg/plugin/errors_test.go
@@ -22,10 +22,14 @@ import (
 )
 
 var _ = Describe("PluginKeyNotFoundError", func() {
-	err := ExitError{
-		Plugin: "go.kubebuilder.io/v1",
-		Reason: "skipping plugin",
-	}
+	var err ExitError
+
+	BeforeEach(func() {
+		err = ExitError{
+			Plugin: "go.kubebuilder.io/v1",
+			Reason: "skipping plugin",
+		}
+	})
 
 	Context("Error", func() {
 		It("should return the correct error message", func() {

--- a/pkg/plugin/filter_test.go
+++ b/pkg/plugin/filter_test.go
@@ -23,61 +23,68 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 )
 
-var (
-	p1 = mockPlugin{
-		name:                     "go.kubebuilder.io",
-		version:                  Version{Number: 2},
-		supportedProjectVersions: []config.Version{{Number: 2}, {Number: 3}},
-	}
-	p2 = mockPlugin{
-		name:                     "go.kubebuilder.io",
-		version:                  Version{Number: 3},
-		supportedProjectVersions: []config.Version{{Number: 3}},
-	}
-	p3 = mockPlugin{
-		name:                     "example.kubebuilder.io",
-		version:                  Version{Number: 1},
-		supportedProjectVersions: []config.Version{{Number: 2}},
-	}
-	p4 = mockPlugin{
-		name:                     "test.kubebuilder.io",
-		version:                  Version{Number: 1},
-		supportedProjectVersions: []config.Version{{Number: 3}},
-	}
-	p5 = mockPlugin{
-		name:                     "go.test.domain",
-		version:                  Version{Number: 2},
-		supportedProjectVersions: []config.Version{{Number: 2}},
-	}
+var _ = Describe("FilterPlugins", func() {
+	var (
+		p1         mockPlugin
+		p2         mockPlugin
+		p3         mockPlugin
+		p4         mockPlugin
+		p5         mockPlugin
+		allPlugins []Plugin
+	)
 
-	allPlugins = []Plugin{p1, p2, p3, p4, p5}
-)
+	BeforeEach(func() {
+		p1 = mockPlugin{
+			name:                     "go.kubebuilder.io",
+			version:                  Version{Number: 2},
+			supportedProjectVersions: []config.Version{{Number: 2}, {Number: 3}},
+		}
+		p2 = mockPlugin{
+			name:                     "go.kubebuilder.io",
+			version:                  Version{Number: 3},
+			supportedProjectVersions: []config.Version{{Number: 3}},
+		}
+		p3 = mockPlugin{
+			name:                     "example.kubebuilder.io",
+			version:                  Version{Number: 1},
+			supportedProjectVersions: []config.Version{{Number: 2}},
+		}
+		p4 = mockPlugin{
+			name:                     "test.kubebuilder.io",
+			version:                  Version{Number: 1},
+			supportedProjectVersions: []config.Version{{Number: 3}},
+		}
+		p5 = mockPlugin{
+			name:                     "go.test.domain",
+			version:                  Version{Number: 2},
+			supportedProjectVersions: []config.Version{{Number: 2}},
+		}
 
-var _ = Describe("FilterPluginsByKey", func() {
-	DescribeTable("should filter",
-		func(key string, plugins []Plugin) {
+		allPlugins = []Plugin{p1, p2, p3, p4, p5}
+	})
+
+	DescribeTable("should filter by key",
+		func(key string, expectedPlugins func() []Plugin) {
 			filtered, err := FilterPluginsByKey(allPlugins, key)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(filtered).To(Equal(plugins))
+			Expect(filtered).To(Equal(expectedPlugins()))
 		},
-		Entry("go plugins", "go", []Plugin{p1, p2, p5}),
-		Entry("go plugins (kubebuilder domain)", "go.kubebuilder", []Plugin{p1, p2}),
-		Entry("go v2 plugins", "go/v2", []Plugin{p1, p5}),
-		Entry("go v2 plugins (kubebuilder domain)", "go.kubebuilder/v2", []Plugin{p1}),
+		Entry("go plugins", "go", func() []Plugin { return []Plugin{p1, p2, p5} }),
+		Entry("go plugins (kubebuilder domain)", "go.kubebuilder", func() []Plugin { return []Plugin{p1, p2} }),
+		Entry("go v2 plugins", "go/v2", func() []Plugin { return []Plugin{p1, p5} }),
+		Entry("go v2 plugins (kubebuilder domain)", "go.kubebuilder/v2", func() []Plugin { return []Plugin{p1} }),
 	)
 
 	It("should fail for invalid versions", func() {
 		_, err := FilterPluginsByKey(allPlugins, "go/a")
 		Expect(err).To(HaveOccurred())
 	})
-})
 
-var _ = Describe("FilterPluginsByKey", func() {
-	DescribeTable("should filter",
-		func(projectVersion config.Version, plugins []Plugin) {
-			Expect(FilterPluginsByProjectVersion(allPlugins, projectVersion)).To(Equal(plugins))
+	DescribeTable("should filter by project version",
+		func(projectVersion config.Version, expectedPlugins func() []Plugin) {
+			Expect(FilterPluginsByProjectVersion(allPlugins, projectVersion)).To(Equal(expectedPlugins()))
 		},
-		Entry("project v2 plugins", config.Version{Number: 2}, []Plugin{p1, p3, p5}),
-		Entry("project v3 plugins", config.Version{Number: 3}, []Plugin{p1, p2, p4}),
+		Entry("project v2 plugins", config.Version{Number: 2}, func() []Plugin { return []Plugin{p1, p3, p5} }),
+		Entry("project v3 plugins", config.Version{Number: 3}, func() []Plugin { return []Plugin{p1, p2, p4} }),
 	)
 })

--- a/pkg/plugin/helpers_test.go
+++ b/pkg/plugin/helpers_test.go
@@ -116,9 +116,13 @@ var _ = Describe("ValidateKey", func() {
 })
 
 var _ = Describe("SupportsVersion", func() {
-	plugin := mockPlugin{
-		supportedProjectVersions: supportedProjectVersions,
-	}
+	var plugin mockPlugin
+
+	BeforeEach(func() {
+		plugin = mockPlugin{
+			supportedProjectVersions: supportedProjectVersions,
+		}
+	})
 
 	It("should return true for supported versions", func() {
 		Expect(SupportsVersion(plugin, config.Version{Number: 2})).To(BeTrue())

--- a/pkg/plugin/util/util_test.go
+++ b/pkg/plugin/util/util_test.go
@@ -26,10 +26,14 @@ import (
 
 var _ = Describe("Cover plugin util helpers", func() {
 	Describe("InsertCode", Ordered, func() {
-		path := filepath.Join("testdata", "exampleFile.txt")
-		var content []byte
+		var (
+			content []byte
+			path    string
+		)
 
 		BeforeAll(func() {
+			path = filepath.Join("testdata", "exampleFile.txt")
+
 			err := os.MkdirAll("testdata", 0o755)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/plugin/version_test.go
+++ b/pkg/plugin/version_test.go
@@ -121,6 +121,11 @@ var _ = Describe("Version", func() {
 	Context("Compare", func() {
 		// Test Compare() by sorting a list.
 		var (
+			versions       []Version
+			sortedVersions []Version
+		)
+
+		BeforeEach(func() {
 			versions = []Version{
 				{Number: 2, Stage: stage.Alpha},
 				{Number: 44, Stage: stage.Alpha},
@@ -146,7 +151,7 @@ var _ = Describe("Version", func() {
 				{Number: 44, Stage: stage.Alpha},
 				{Number: 44, Stage: stage.Alpha},
 			}
-		)
+		})
 
 		It("sorts a valid list of versions correctly", func() {
 			sort.Slice(versions, func(i int, j int) bool {


### PR DESCRIPTION
### 🌱 (chore): refactor shared test data into `BeforeEach` in plugin-related test suites

This PR ensures better test isolation and avoids spec pollution by refactoring test files to initialize shared variables inside `BeforeEach` blocks.

Refactored files include:

- `pkg/plugin/filter_test.go`
- `pkg/plugin/bundle_test.go`
- `pkg/plugin/errors_test.go`
- `pkg/plugin/version_test.go`
- `pkg/plugin/util/util_test.go`
- `pkg/plugin/helpers_test.go`

This aligns with Ginkgo best practices for clean and deterministic tests.
