### PR TITLE
🌱 (chore): enable ginkgolinter forbid-spec-pollution to enforce isolated test specs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,8 @@ issues:
         - gosec
 
 linters-settings:
+  ginkgolinter:
+    forbid-spec-pollution: true
   govet:
     enable-all: true
     disable:


### PR DESCRIPTION
### 🌱 Enable ginkgolinter forbid-spec-pollution

This PR adds the following configuration to `.golangci.yml`:

```yaml
linters-settings:
  ginkgolinter:
    forbid-spec-pollution: true
```

Enabling forbid-spec-pollution ensures all shared test state is scoped within BeforeEach or similar blocks, helping prevent flaky tests and improving test isolation in Ginkgo test suites.