### PR TITLE
🌱 Use dynamic controller-runtime version in doc generator to make easier update the version

### DIFF
--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cronjob
 
 import (
+	"fmt"
 	"os/exec"
 	"path/filepath"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/spf13/afero"
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
@@ -288,7 +290,8 @@ func (sp *Sample) updateController() {
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/cronjob_controller.go"),
-		`// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile`, skipGoCycloLint)
+		fmt.Sprintf(`// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@%s/pkg/reconcile`,
+			scaffolds.ControllerRuntimeVersion), skipGoCycloLint)
 	hackutils.CheckError("fixing cronjob_controller.go", err)
 
 	err = pluginutil.ReplaceInFile(


### PR DESCRIPTION
# 🐛 Fix hardcoded controller-runtime version in docs generation

Replace hardcoded controller-runtime version in `hack/docs/internal/cronjob-tutorial/generate_cronjob.go` with a reference to the `ControllerRuntimeVersion` constant from the scaffolding package.
This prevents the docs generation from breaking when the controller-runtime version is updated in the scaffolding logic, ensuring that `make generate-docs` remains stable across version bumps.

## Changes

- Import the scaffolds/init package to access the ControllerRuntimeVersion constant
- Replace the hardcoded version string with a dynamic reference using fmt.Sprintf
This change adheres to the DRY principle by having a single source of truth for the controller-runtime version, preventing future breakages when dependencies are updated.

## Fixed Issue
Fixes the issue where make generate-docs fails when controller-runtime is updated in only one location.
Fixes #4679


I'm open to any feedback or suggestions on how to improve this approach if there's a cleaner way to handle it!