### PR TITLE
🌱 (chore): enable ginkgolinter forbid-focus-container

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,7 +63,8 @@ linters-settings:
       - name: bool-literal-in-expr
       - name: constant-logical-expr
       - name: comment-spacings
-
+  ginkgolinter:
+    forbid-focus-container: true
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
:seedling: enable ginkgolinter forbid-focus-container

This PR adds the following configuration to `.golangci.yml`:

```yaml
linters-settings:
  ginkgolinter:
    forbid-focus-container: true
```

Enabling forbid-focus-container protects the code in the repository against accident committing of debug code. A contributeor may use ginkgo's focus container (e.g. `FIt`, `FContext` etc. or by adding the `Focus` decorator), in order to locally debug a specific test. Merging a ginkgo's focus container will prevent running of all the other tests in CI.

Inspired by #4710 