### PR TITLE
Fix: setup.sh to delete resources properly

### DIFF
--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -54,7 +54,6 @@ function create_cluster {
 #   delete_cluster
 function delete_cluster {
   : ${KIND_CLUSTER:?"KIND_CLUSTER must be set"}
-  kind delete cluster --name $KIND_CLUSTER
   echo "Deleting cert-manager resources..."
   kubectl delete --ignore-not-found=true -n kube-system deployment cert-manager-cainjector
   kubectl delete --ignore-not-found=true -n kube-system deployment cert-manager-controller

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -55,6 +55,21 @@ function create_cluster {
 function delete_cluster {
   : ${KIND_CLUSTER:?"KIND_CLUSTER must be set"}
   kind delete cluster --name $KIND_CLUSTER
+  echo "Deleting cert-manager resources..."
+  kubectl delete --ignore-not-found=true -n kube-system deployment cert-manager-cainjector
+  kubectl delete --ignore-not-found=true -n kube-system deployment cert-manager-controller
+  kubectl delete --ignore-not-found=true -n kube-system deployment cert-manager-webhook
+
+  # Delete the cert-manager namespace itself (if it exists)
+  kubectl delete --ignore-not-found=true namespace cert-manager
+
+   # Delete Calico
+  echo "Deleting Calico..."
+  kubectl delete --ignore-not-found=true -f https://docs.projectcalico.org/manifests/calico.yaml
+
+  # Finally, delete the Kind cluster
+  echo "Deleting Kind cluster..."
+  kind delete cluster --name $KIND_CLUSTER
 }
 
 function test_cluster {


### PR DESCRIPTION
Fix: Clean up cert-manager leases after E2E tests [Fixes #4712 ] 

This PR addresses an issue where cert-manager related resources (specifically, leases) were not being properly cleaned up after running the end-to-end (E2E) tests. 

The delete_cluster function in test/e2e/setup.sh was only deleting the Kind cluster itself, but not the resources deployed within the cluster, such as cert-manager's deployments and associated resources.

The `delete_cluster` function in `test/e2e/setup.sh` has been modified to explicitly delete the following resources before deleting the Kind cluster

