### PR TITLE
🌱 (chore): Enable wrapcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - wrapcheck
     - whitespace
   settings:
     ginkgolinter:


### PR DESCRIPTION
🌱 Enable `wrapcheck` linter

This change improves code quality by enforcing two new linting rule:

- `wrapcheck` ensures wrapped errors are properly handled and not silently ignored.

The motivation is to promote modern Go practices and ensure consistent error wrapping and checking across the codebase.