### PR TITLE
🌱 (chore): replace errors.As() with MatchError() in error assertions

### DIFF
--- a/pkg/config/store/yaml/store_test.go
+++ b/pkg/config/store/yaml/store_test.go
@@ -18,6 +18,7 @@ package yaml
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -91,7 +92,13 @@ layout: ""
 		It("should fail if no file exists at the default path", func() {
 			err := s.Load()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to read %q file: %w", DefaultPath, &os.PathError{
+					Err:  os.ErrNotExist,
+					Path: DefaultPath,
+					Op:   "open",
+				}),
+			}))
 		})
 
 		It("should fail if unable to identify the version of the file at the default path", func() {
@@ -99,7 +106,13 @@ layout: ""
 
 			err := s.Load()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to determine config version: %w",
+					fmt.Errorf("error unmarshaling JSON: %w",
+						errors.New("while decoding JSON: project version is empty"),
+					),
+				),
+			}))
 		})
 
 		It("should fail if unable to create a Config for the version of the file at the default path", func() {
@@ -107,7 +120,11 @@ layout: ""
 
 			err := s.Load()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to create config for version %q: %w", "1-alpha", config.UnsupportedVersionError{
+					Version: config.Version{Number: 1, Stage: 2},
+				}),
+			}))
 		})
 
 		It("should fail if unable to unmarshal the file at the default path", func() {
@@ -115,7 +132,14 @@ layout: ""
 
 			err := s.Load()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to create config for version %q: %w", "2", config.UnsupportedVersionError{
+					Version: config.Version{
+						Number: 2,
+						Stage:  0,
+					},
+				}),
+			}))
 		})
 	})
 
@@ -133,7 +157,13 @@ layout: ""
 		It("should fail if no file exists at the specified path", func() {
 			err := s.LoadFrom(path)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to read %q file: %w", path, &os.PathError{
+					Err:  os.ErrNotExist,
+					Path: path,
+					Op:   "open",
+				}),
+			}))
 		})
 
 		It("should fail if unable to identify the version of the file at the specified path", func() {
@@ -141,7 +171,13 @@ layout: ""
 
 			err := s.LoadFrom(path)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to determine config version: %w",
+					fmt.Errorf("error unmarshaling JSON: %w",
+						errors.New("while decoding JSON: project version is empty"),
+					),
+				),
+			}))
 		})
 
 		It("should fail if unable to create a Config for the version of the file at the specified path", func() {
@@ -149,7 +185,11 @@ layout: ""
 
 			err := s.LoadFrom(path)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to create config for version %q: %w", "1-alpha", config.UnsupportedVersionError{
+					Version: config.Version{Number: 1, Stage: 2},
+				}),
+			}))
 		})
 
 		It("should fail if unable to unmarshal the file at the specified path", func() {
@@ -157,7 +197,13 @@ layout: ""
 
 			err := s.LoadFrom(path)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.LoadError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("unable to create config for version %q: %w", "2", config.UnsupportedVersionError{
+					Version: config.Version{
+						Number: 2,
+					},
+				}),
+			}))
 		})
 	})
 
@@ -184,7 +230,9 @@ layout: ""
 		It("should fail for an empty config", func() {
 			err := s.Save()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.SaveError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.SaveError{
+				Err: errors.New("undefined config, use one of the initializers: New, Load, LoadFrom"),
+			}))
 		})
 
 		It("should fail for a pre-existent file that must not exist", func() {
@@ -194,7 +242,9 @@ layout: ""
 
 			err := s.Save()
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.SaveError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("configuration already exists in %q", DefaultPath),
+			}))
 		})
 	})
 
@@ -221,7 +271,9 @@ layout: ""
 		It("should fail for an empty config", func() {
 			err := s.SaveTo(path)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.SaveError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.SaveError{
+				Err: errors.New("undefined config, use one of the initializers: New, Load, LoadFrom"),
+			}))
 		})
 
 		It("should fail for a pre-existent file that must not exist", func() {
@@ -231,7 +283,9 @@ layout: ""
 
 			err := s.SaveTo(path)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &store.SaveError{})).To(BeTrue())
+			Expect(err).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("configuration already exists in %q", path),
+			}))
 		})
 	})
 })

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v3
 
 import (
-	"errors"
 	"sort"
 	"testing"
 
@@ -407,13 +406,13 @@ var _ = Describe("Cfg", func() {
 		It("DecodePluginConfig should fail for no plugin config object", func() {
 			err := c0.DecodePluginConfig(key, &pluginCfg)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &config.PluginKeyNotFoundError{})).To(BeTrue())
+			Expect(err).To(MatchError(config.PluginKeyNotFoundError{Key: key}))
 		})
 
 		It("DecodePluginConfig should fail to retrieve data from a non-existent plugin", func() {
 			err := c1.DecodePluginConfig("plugin-y", &pluginCfg)
 			Expect(err).To(HaveOccurred())
-			Expect(errors.As(err, &config.PluginKeyNotFoundError{})).To(BeTrue())
+			Expect(err).To(MatchError(config.PluginKeyNotFoundError{Key: "plugin-y"}))
 		})
 
 		DescribeTable("DecodePluginConfig should retrieve the plugin data correctly",


### PR DESCRIPTION
This update improves Gomega assertions by replacing `errors.As()` with `MatchError()` where the test intends to match specific error types rather than extract them.

This change simplifies the assertions and improves readability, aligning with idiomatic Gomega style.