### PR TITLE
🌱 Fix golangci-lint wrong configurations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ issues:
 
 linters-settings:
   ginkgolinter:
+    forbid-focus-container: true
     forbid-spec-pollution: true
   govet:
     enable-all: true
@@ -65,8 +66,6 @@ linters-settings:
       - name: bool-literal-in-expr
       - name: constant-logical-expr
       - name: comment-spacings
-  ginkgolinter:
-    forbid-focus-container: true
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
The current file is wrong with duplicated key: the `linters-settings.ginkgolinter` key, appears twice, as result of merging two PRs: #4710 and #4714.

This is breaking golangci-lint.

This PR fixes this issue by merging the duplicated keys into one.