### PR TITLE
📖 : Improve sample external plugin by adding error handling for flag parsing failures.

### DIFF
--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/cmd/flags.go
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/cmd/flags.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"v1/scaffolds"
 
 	"github.com/spf13/pflag"
@@ -43,7 +45,13 @@ func flagsCmd(pr *external.PluginRequest) external.PluginResponse {
 	flagsToParse.Bool("api", false, "sets the api flag to true")
 	flagsToParse.Bool("webhook", false, "sets the webhook flag to true")
 
-	flagsToParse.Parse(pr.Args)
+	if err := flagsToParse.Parse(pr.Args); err != nil {
+		pluginResponse.Error = true
+		pluginResponse.ErrorMsgs = []string{
+			fmt.Sprintf("failed to parse flags: %s", err.Error()),
+		}
+		return pluginResponse
+	}
 
 	initFlag, _ := flagsToParse.GetBool("init")
 	apiFlag, _ := flagsToParse.GetBool("api")

--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/cmd/metadata.go
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/cmd/metadata.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"v1/scaffolds"
 
 	"github.com/spf13/pflag"
@@ -41,7 +43,13 @@ func metadataCmd(pr *external.PluginRequest) external.PluginResponse {
 	flagsToParse.Bool("api", false, "sets the api flag to true")
 	flagsToParse.Bool("webhook", false, "sets the webhook flag to true")
 
-	flagsToParse.Parse(pr.Args)
+	if err := flagsToParse.Parse(pr.Args); err != nil {
+		pluginResponse.Error = true
+		pluginResponse.ErrorMsgs = []string{
+			fmt.Sprintf("failed to parse flags: %s", err.Error()),
+		}
+		return pluginResponse
+	}
 
 	initFlag, _ := flagsToParse.GetBool("init")
 	apiFlag, _ := flagsToParse.GetBool("api")

--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/scaffolds/init.go
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/scaffolds/init.go
@@ -16,6 +16,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"fmt"
+
 	"v1/scaffolds/internal/templates"
 
 	"github.com/spf13/pflag"
@@ -55,7 +57,13 @@ func InitCmd(pr *external.PluginRequest) external.PluginResponse {
 	// Here is an example of parsing a flag from a Kubebuilder external plugin request
 	flags := pflag.NewFlagSet("initFlags", pflag.ContinueOnError)
 	flags.String("domain", "example.domain.com", "sets the domain added in the scaffolded initFile.txt")
-	flags.Parse(pr.Args)
+	if err := flags.Parse(pr.Args); err != nil {
+		pluginResponse.Error = true
+		pluginResponse.ErrorMsgs = []string{
+			fmt.Sprintf("failed to parse flags: %s", err.Error()),
+		}
+		return pluginResponse
+	}
 	domain, _ := flags.GetString("domain")
 
 	initFile := templates.NewInitFile(templates.WithDomain(domain))

--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/scaffolds/webhook.go
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/scaffolds/webhook.go
@@ -16,6 +16,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"
@@ -52,7 +54,13 @@ func WebhookCmd(pr *external.PluginRequest) external.PluginResponse {
 	// Here is an example of parsing a flag from a Kubebuilder external plugin request
 	flags := pflag.NewFlagSet("apiFlags", pflag.ContinueOnError)
 	flags.Bool("hooked", false, "add the word `hooked` to the end of the scaffolded webhookFile.txt")
-	flags.Parse(pr.Args)
+	if err := flags.Parse(pr.Args); err != nil {
+		pluginResponse.Error = true
+		pluginResponse.ErrorMsgs = []string{
+			fmt.Sprintf("failed to parse flags: %s", err.Error()),
+		}
+		return pluginResponse
+	}
 	hooked, _ := flags.GetBool("hooked")
 
 	msg := "A simple text file created with the `create webhook` subcommand"


### PR DESCRIPTION
This improves the robustness of the external plugin examples in the docs by adding proper error handling when parsing flags with `pflag`.

If parsing fails, the plugin sets `pluginResponse.Error = true` and includes a clear error message in `ErrorMsgs`, preventing silent failures and making debugging easier for plugin authors following the tutorial.