### PR TITLE
🌱 (chore): wrap errors using '%w' and improve formatting in golang plugin

### DIFF
--- a/pkg/plugins/golang/go_version.go
+++ b/pkg/plugins/golang/go_version.go
@@ -64,18 +64,18 @@ func (v *GoVersion) parse(verStr string) error {
 
 	v.major, err = strconv.Atoi(m[1])
 	if err != nil {
-		return fmt.Errorf("error parsing major version '%s': %s", m[1], err)
+		return fmt.Errorf("error parsing major version %q: %w", m[1], err)
 	}
 
 	v.minor, err = strconv.Atoi(m[2])
 	if err != nil {
-		return fmt.Errorf("error parsing minor version '%s': %s", m[2], err)
+		return fmt.Errorf("error parsing minor version %q: %w", m[2], err)
 	}
 
 	if m[3] != "" {
 		v.patch, err = strconv.Atoi(m[3])
 		if err != nil {
-			return fmt.Errorf("error parsing patch version '%s': %s", m[2], err)
+			return fmt.Errorf("error parsing patch version %q: %w", m[2], err)
 		}
 	}
 
@@ -126,7 +126,7 @@ func (v GoVersion) Compare(other GoVersion) int {
 func ValidateGoVersion(minVersion, maxVersion GoVersion) error {
 	err := fetchAndCheckGoVersion(minVersion, maxVersion)
 	if err != nil {
-		return fmt.Errorf("%s. You can skip this check using the --skip-go-version-check flag", err)
+		return fmt.Errorf("you can skip this check using the --skip-go-version-check flag: %w", err)
 	}
 	return nil
 }
@@ -144,7 +144,7 @@ func fetchAndCheckGoVersion(minVersion, maxVersion GoVersion) error {
 	}
 	goVer := split[2]
 	if err := checkGoVersion(goVer, minVersion, maxVersion); err != nil {
-		return fmt.Errorf("go version '%s' is incompatible because '%s'", goVer, err)
+		return fmt.Errorf("go version %q is incompatible: %w", goVer, err)
 	}
 	return nil
 }
@@ -156,7 +156,7 @@ func checkGoVersion(verStr string, minVersion, maxVersion GoVersion) error {
 	}
 
 	if version.Compare(minVersion) < 0 || version.Compare(maxVersion) >= 0 {
-		return fmt.Errorf("plugin requires %s <= version < %s", minVersion, maxVersion)
+		return fmt.Errorf("plugin requires %q <= version < %q", minVersion, maxVersion)
 	}
 
 	return nil

--- a/pkg/plugins/golang/repository.go
+++ b/pkg/plugins/golang/repository.go
@@ -82,7 +82,7 @@ func FindCurrentRepo() (string, error) {
 		}
 		// give up, let the user figure it out
 		return "", fmt.Errorf("could not determine repository path from module data, "+
-			"package data, or by initializing a module: %v", err)
+			"package data, or by initializing a module: %w", err)
 	}
 	//nolint:errcheck
 	defer os.Remove("go.mod") // clean up after ourselves

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -101,7 +101,7 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 	if p.repo == "" {
 		repoPath, err := golang.FindCurrentRepo()
 		if err != nil {
-			return fmt.Errorf("error finding current repository: %v", err)
+			return fmt.Errorf("error finding current repository: %w", err)
 		}
 		p.repo = repoPath
 	}

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -101,7 +101,7 @@ func (s *apiScaffolder) Scaffold() error {
 			&api.Types{Force: s.force},
 			&api.Group{},
 		); err != nil {
-			return fmt.Errorf("error scaffolding APIs: %v", err)
+			return fmt.Errorf("error scaffolding APIs: %w", err)
 		}
 	}
 
@@ -111,14 +111,14 @@ func (s *apiScaffolder) Scaffold() error {
 			&controllers.Controller{ControllerRuntimeVersion: ControllerRuntimeVersion, Force: s.force},
 			&controllers.ControllerTest{Force: s.force, DoAPI: doAPI},
 		); err != nil {
-			return fmt.Errorf("error scaffolding controller: %v", err)
+			return fmt.Errorf("error scaffolding controller: %w", err)
 		}
 	}
 
 	if err := scaffold.Execute(
 		&cmd.MainUpdater{WireResource: doAPI, WireController: doController},
 	); err != nil {
-		return fmt.Errorf("error updating cmd/main.go: %v", err)
+		return fmt.Errorf("error updating cmd/main.go: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Replaced usage of `%v` with `%w` in `fmt.Errorf` calls to enable proper error chaining across:
- `pkg/plugins/golang/repository.go`
- `go_version.go`
- `v4/scaffolds/api.go`

Also improved formatting by quoting dynamic values with `%q` and removed redundant error wrapping logic.
