### PR TITLE
🌱  (chore): use 'errors.As' and wrap exec errors in repository.go

### DIFF
--- a/pkg/plugins/golang/repository.go
+++ b/pkg/plugins/golang/repository.go
@@ -18,6 +18,7 @@ package golang
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -39,7 +40,8 @@ func findGoModulePath() (string, error) {
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	out, err := cmd.Output()
 	if err != nil {
-		if exitErr, isExitErr := err.(*exec.ExitError); isExitErr {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			err = fmt.Errorf("%s", string(exitErr.Stderr))
 		}
 		return "", err
@@ -77,7 +79,8 @@ func FindCurrentRepo() (string, error) {
 	cmd := exec.Command("go", "mod", "init")
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	if _, err := cmd.Output(); err != nil {
-		if exitErr, isExitErr := err.(*exec.ExitError); isExitErr {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			err = fmt.Errorf("%s", string(exitErr.Stderr))
 		}
 		// give up, let the user figure it out


### PR DESCRIPTION
Refactored error handling in `repository.go`:
- Replaced type assertion with `errors.As` for `*exec.ExitError`
- Ensured command stderr is preserved in the wrapped `fmt.Errorf` output
- Set up for better error introspection and debugging
