### PR TITLE
🌱 (chore): simplify test variable declarations for CLI tests

### DIFF
--- a/pkg/cli/completion_test.go
+++ b/pkg/cli/completion_test.go
@@ -22,9 +22,7 @@ import (
 )
 
 var _ = Describe("Completion", func() {
-	var (
-		c *CLI
-	)
+	var c *CLI
 
 	BeforeEach(func() {
 		c = &CLI{}

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -22,9 +22,7 @@ import (
 )
 
 var _ = Describe("Version", func() {
-	var (
-		c *CLI
-	)
+	var c *CLI
 
 	BeforeEach(func() {
 		c = &CLI{}


### PR DESCRIPTION
Replaced redundant multi-line `var` blocks with single-line declarations in `version_test.go` and `completion_test.go`. This reduces visual noise and aligns with idiomatic Go style for concise test setup.