### PR TITLE
🌱 (chore): replace '%v' with '%w' in deploy-image v1alpha1 plugin errors

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -108,13 +108,13 @@ func (s *apiScaffolder) Scaffold() error {
 	if err := scaffold.Execute(
 		&api.Types{Port: s.port},
 	); err != nil {
-		return fmt.Errorf("error updating APIs: %v", err)
+		return fmt.Errorf("error updating APIs: %w", err)
 	}
 
 	if err := scaffold.Execute(
 		&samples.CRDSample{Port: s.port},
 	); err != nil {
-		return fmt.Errorf("error updating config/samples: %v", err)
+		return fmt.Errorf("error updating config/samples: %w", err)
 	}
 
 	controller := &controllers.Controller{
@@ -124,22 +124,22 @@ func (s *apiScaffolder) Scaffold() error {
 	if err := scaffold.Execute(
 		controller,
 	); err != nil {
-		return fmt.Errorf("error scaffolding controller: %v", err)
+		return fmt.Errorf("error scaffolding controller: %w", err)
 	}
 
 	if err := s.updateControllerCode(*controller); err != nil {
-		return fmt.Errorf("error updating controller: %v", err)
+		return fmt.Errorf("error updating controller: %w", err)
 	}
 
 	defaultMainPath := "cmd/main.go"
 	if err := s.updateMainByAddingEventRecorder(defaultMainPath); err != nil {
-		return fmt.Errorf("error updating main.go: %v", err)
+		return fmt.Errorf("error updating main.go: %w", err)
 	}
 
 	if err := scaffold.Execute(
 		&controllers.ControllerTest{Port: s.port},
 	); err != nil {
-		return fmt.Errorf("error creating controller/**_controller_test.go: %v", err)
+		return fmt.Errorf("error creating controller/**_controller_test.go: %w", err)
 	}
 
 	return s.addEnvVarIntoManager()
@@ -169,11 +169,11 @@ func (s *apiScaffolder) addEnvVarIntoManager() error {
 // plugins to do the default scaffolds which an API is created
 func (s *apiScaffolder) scaffoldCreateAPI() error {
 	if err := s.scaffoldCreateAPIFromGolang(); err != nil {
-		return fmt.Errorf("error scaffolding golang files for the new API: %v", err)
+		return fmt.Errorf("error scaffolding golang files for the new API: %w", err)
 	}
 
 	if err := s.scaffoldCreateAPIFromKustomize(); err != nil {
-		return fmt.Errorf("error scaffolding kustomize manifests for the new API: %v", err)
+		return fmt.Errorf("error scaffolding kustomize manifests for the new API: %w", err)
 	}
 	return nil
 }
@@ -190,7 +190,7 @@ func (s *apiScaffolder) updateMainByAddingEventRecorder(defaultMainPath string) 
 		Scheme: mgr.GetScheme(),`, s.resource.Kind),
 		fmt.Sprintf(recorderTemplate, strings.ToLower(s.resource.Kind)),
 	); err != nil {
-		return fmt.Errorf("error scaffolding event recorder in %s: %v", defaultMainPath, err)
+		return fmt.Errorf("error scaffolding event recorder in %q: %w", defaultMainPath, err)
 	}
 
 	return nil
@@ -205,7 +205,7 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 			strings.ToLower(s.resource.Kind), // value for the name of the container
 		),
 	); err != nil {
-		return fmt.Errorf("error scaffolding container in the controller path (%s): %v",
+		return fmt.Errorf("error scaffolding container in the controller path %q: %w",
 			controller.Path, err)
 	}
 
@@ -231,7 +231,7 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 								},
 							},
 						},`, fmt.Sprintf(commandTemplate, res)); err != nil {
-			return fmt.Errorf("error scaffolding command in the  controller path (%s): %v",
+			return fmt.Errorf("error scaffolding command in the  controller path %q: %w",
 				controller.Path, err)
 		}
 	}
@@ -254,7 +254,7 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 				strings.ToLower(s.resource.Kind),
 				strings.ToLower(s.resource.Kind)),
 		); err != nil {
-			return fmt.Errorf("error scaffolding container port in the controller path (%s): %v",
+			return fmt.Errorf("error scaffolding container port in the controller path %q: %w",
 				controller.Path,
 				err)
 		}
@@ -266,7 +266,7 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 			`RunAsNonRoot:             ptr.To(true),`,
 			fmt.Sprintf(runAsUserTemplate, s.runAsUser),
 		); err != nil {
-			return fmt.Errorf("error scaffolding user-id in the controller path (%s): %v",
+			return fmt.Errorf("error scaffolding user-id in the controller path %q: %w",
 				controller.Path, err)
 		}
 	}
@@ -284,7 +284,7 @@ func (s *apiScaffolder) scaffoldCreateAPIFromKustomize() error {
 	kustomizeScaffolder.InjectFS(s.fs)
 
 	if err := kustomizeScaffolder.Scaffold(); err != nil {
-		return fmt.Errorf("error scaffolding kustomize files for the APIs: %v", err)
+		return fmt.Errorf("error scaffolding kustomize files for the APIs: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
- Ensured proper error wrapping using `fmt.Errorf(..., %w, ...)` throughout `scaffolds/api.go`
- Used `%q` for filenames and paths for better formatting