### PR TITLE
🌱 (chore): convert plugin.Version receiver methods to use pointer receiver

### DIFF
--- a/pkg/cli/suite_test.go
+++ b/pkg/cli/suite_test.go
@@ -52,7 +52,7 @@ func newMockPlugin(name, version string, projVers ...config.Version) plugin.Plug
 }
 
 func (p mockPlugin) Name() string                               { return p.name }
-func (p mockPlugin) Version() plugin.Version                    { return p.version }
+func (p mockPlugin) Version() *plugin.Version                   { return &p.version }
 func (p mockPlugin) SupportedProjectVersions() []config.Version { return p.projectVersions }
 
 type mockDeprecatedPlugin struct { //nolint:maligned

--- a/pkg/plugin/bundle.go
+++ b/pkg/plugin/bundle.go
@@ -103,8 +103,8 @@ func (b bundle) Name() string {
 }
 
 // Version implements Plugin
-func (b bundle) Version() Version {
-	return b.version
+func (b bundle) Version() *Version {
+	return &b.version
 }
 
 // SupportedProjectVersions implements Plugin

--- a/pkg/plugin/filter.go
+++ b/pkg/plugin/filter.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 )
 
-// FilterPluginsByKey returns the set of plugins that match the provided key (may be not-fully qualified)
+// FilterPluginsByKey returns the set of plugins that match the provided key (maybe not-fully qualified)
 func FilterPluginsByKey(plugins []Plugin, key string) ([]Plugin, error) {
 	name, ver := SplitKey(key)
 	hasVersion := ver != ""

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -29,7 +29,7 @@ type Plugin interface {
 	// Version returns the plugin's version.
 	//
 	// NOTE: this version is different from config version.
-	Version() Version
+	Version() *Version
 	// SupportedProjectVersions lists all project configuration versions this plugin supports.
 	// The returned slice cannot be empty.
 	SupportedProjectVersions() []config.Version

--- a/pkg/plugin/suite_test.go
+++ b/pkg/plugin/suite_test.go
@@ -37,5 +37,5 @@ type mockPlugin struct {
 }
 
 func (p mockPlugin) Name() string                               { return p.name }
-func (p mockPlugin) Version() Version                           { return p.version }
+func (p mockPlugin) Version() *Version                          { return &p.version }
 func (p mockPlugin) SupportedProjectVersions() []config.Version { return p.supportedProjectVersions }

--- a/pkg/plugin/version.go
+++ b/pkg/plugin/version.go
@@ -67,7 +67,7 @@ func (v *Version) Parse(version string) error {
 }
 
 // String returns the string representation of v.
-func (v Version) String() string {
+func (v *Version) String() string {
 	stageStr := v.Stage.String()
 	if len(stageStr) == 0 {
 		return fmt.Sprintf("v%d", v.Number)
@@ -76,7 +76,7 @@ func (v Version) String() string {
 }
 
 // Validate ensures that the version number is positive and the stage is one of the valid stages.
-func (v Version) Validate() error {
+func (v *Version) Validate() error {
 	if v.Number < 0 {
 		return errNegative
 	}
@@ -85,7 +85,7 @@ func (v Version) Validate() error {
 }
 
 // Compare returns -1 if v < other, 0 if v == other, and 1 if v > other.
-func (v Version) Compare(other Version) int {
+func (v *Version) Compare(other Version) int {
 	if v.Number > other.Number {
 		return 1
 	} else if v.Number < other.Number {
@@ -96,7 +96,7 @@ func (v Version) Compare(other Version) int {
 }
 
 // IsStable returns true if v is stable.
-func (v Version) IsStable() bool {
+func (v *Version) IsStable() bool {
 	// Plugin version 0 is not considered stable
 	if v.Number == 0 {
 		return false

--- a/pkg/plugins/common/kustomize/v2/plugin.go
+++ b/pkg/plugins/common/kustomize/v2/plugin.go
@@ -51,7 +51,7 @@ type Plugin struct {
 func (Plugin) Name() string { return pluginName }
 
 // Version returns the version of the plugin
-func (Plugin) Version() plugin.Version { return pluginVersion }
+func (Plugin) Version() *plugin.Version { return &pluginVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }

--- a/pkg/plugins/external/plugin.go
+++ b/pkg/plugins/external/plugin.go
@@ -37,7 +37,7 @@ type Plugin struct {
 func (p Plugin) Name() string { return p.PName }
 
 // Version returns the version of the plugin
-func (p Plugin) Version() plugin.Version { return p.PVersion }
+func (p Plugin) Version() *plugin.Version { return &p.PVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (p Plugin) SupportedProjectVersions() []config.Version { return p.PSupportedProjectVersions }

--- a/pkg/plugins/golang/deploy-image/v1alpha1/plugin.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/plugin.go
@@ -43,7 +43,7 @@ type Plugin struct {
 func (Plugin) Name() string { return pluginName }
 
 // Version returns the version of the plugin
-func (Plugin) Version() plugin.Version { return pluginVersion }
+func (Plugin) Version() *plugin.Version { return &pluginVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }

--- a/pkg/plugins/golang/v4/plugin.go
+++ b/pkg/plugins/golang/v4/plugin.go
@@ -45,7 +45,7 @@ type Plugin struct {
 func (Plugin) Name() string { return pluginName }
 
 // Version returns the version of the plugin
-func (Plugin) Version() plugin.Version { return pluginVersion }
+func (Plugin) Version() *plugin.Version { return &pluginVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }

--- a/pkg/plugins/optional/grafana/v1alpha/plugin.go
+++ b/pkg/plugins/optional/grafana/v1alpha/plugin.go
@@ -44,7 +44,7 @@ var _ plugin.Init = Plugin{}
 func (Plugin) Name() string { return pluginName }
 
 // Version returns the version of the grafana plugin
-func (Plugin) Version() plugin.Version { return pluginVersion }
+func (Plugin) Version() *plugin.Version { return &pluginVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }

--- a/pkg/plugins/optional/helm/v1alpha/plugin.go
+++ b/pkg/plugins/optional/helm/v1alpha/plugin.go
@@ -49,7 +49,7 @@ type pluginConfig struct{}
 func (Plugin) Name() string { return pluginName }
 
 // Version returns the version of the Helm plugin
-func (Plugin) Version() plugin.Version { return pluginVersion }
+func (Plugin) Version() *plugin.Version { return &pluginVersion }
 
 // SupportedProjectVersions returns an array with all project versions supported by the plugin
 func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }


### PR DESCRIPTION
This PR updates all implementations of the `plugin.Plugin` interface to return `*plugin.Version` instead of `plugin.Version` by value.

### Motivation

- Prevents unnecessary copies of the version struct
- Makes pointer semantics explicit and consistent across plugins and mocks

### Changes

- Updated all `.Version()` implementations to return a pointer
- Updated `plugin.Version` method receivers (e.g., `Validate`, `Compare`, `String`) to pointer receivers
- Adjusted affected test mocks and helpers