### PR TITLE
🌱 (chore): add detailed error wrapping across Golang plugin commands

### DIFF
--- a/pkg/plugins/golang/repository.go
+++ b/pkg/plugins/golang/repository.go
@@ -45,8 +45,8 @@ func findGoModulePath() (string, error) {
 		return "", err
 	}
 	mod := goMod{}
-	if err := json.Unmarshal(out, &mod); err != nil {
-		return "", err
+	if err = json.Unmarshal(out, &mod); err != nil {
+		return "", fmt.Errorf("failed to unmarshal go.mod: %w", err)
 	}
 	return mod.Module.Path, nil
 }

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -139,16 +139,16 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 	// Ensure that external API options cannot be used when creating an API in the project.
 	if p.options.DoAPI {
 		if len(p.options.ExternalAPIPath) != 0 || len(p.options.ExternalAPIDomain) != 0 {
-			return errors.New("Cannot use '--external-api-path' or '--external-api-domain' " +
+			return errors.New("cannot use '--external-api-path' or '--external-api-domain' " +
 				"when creating an API in the project with '--resource=true'. " +
-				"Use '--resource=false' when referencing an external API.")
+				"Use '--resource=false' when referencing an external API")
 		}
 	}
 
 	p.options.UpdateResource(p.resource, p.config)
 
 	if err := p.resource.Validate(); err != nil {
-		return err
+		return fmt.Errorf("error validating resource: %w", err)
 	}
 
 	// In case we want to scaffold a resource API we need to do some checks
@@ -180,18 +180,22 @@ func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder := scaffolds.NewAPIScaffolder(p.config, *p.resource, p.force)
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding API: %w", err)
+	}
+
+	return nil
 }
 
 func (p *createAPISubcommand) PostScaffold() error {
 	err := util.RunCmd("Update dependencies", "go", "mod", "tidy")
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating go dependencies: %w", err)
 	}
 	if p.runMake && p.resource.HasAPI() {
 		err = util.RunCmd("Running make", "make", "generate")
 		if err != nil {
-			return err
+			return fmt.Errorf("error running make generate: %w", err)
 		}
 		fmt.Print("Next: implement your new API and generate the manifests (e.g. CRDs,CRs) with:\n$ make manifests\n")
 	}

--- a/pkg/plugins/golang/v4/edit.go
+++ b/pkg/plugins/golang/v4/edit.go
@@ -61,5 +61,9 @@ func (p *editSubcommand) InjectConfig(c config.Config) error {
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder := scaffolds.NewEditScaffolder(p.config, p.multigroup)
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("failed to edit scaffold: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -106,27 +106,30 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 		p.repo = repoPath
 	}
 
-	return p.config.SetRepository(p.repo)
+	if err := p.config.SetRepository(p.repo); err != nil {
+		return fmt.Errorf("error setting repository: %w", err)
+	}
+
+	return nil
 }
 
 func (p *initSubcommand) PreScaffold(machinery.Filesystem) error {
 	// Ensure Go version is in the allowed range if check not turned off.
 	if !p.skipGoVersionCheck {
 		if err := golang.ValidateGoVersion(goVerMin, goVerMax); err != nil {
-			return err
+			return fmt.Errorf("error validating go version: %w", err)
 		}
 	}
 
-	// Check if the current directory has not files or directories which does not allow to init the project
+	// Check if the current directory has no files or directories which does not allow to init the project
 	return checkDir()
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder := scaffolds.NewInitScaffolder(p.config, p.license, p.owner, p.commandName)
 	scaffolder.InjectFS(fs)
-	err := scaffolder.Scaffold()
-	if err != nil {
-		return err
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding init plugin: %w", err)
 	}
 
 	if !p.fetchDeps {
@@ -136,10 +139,10 @@ func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 
 	// Ensure that we are pinning controller-runtime version
 	// xref: https://github.com/kubernetes-sigs/kubebuilder/issues/997
-	err = util.RunCmd("Get controller runtime", "go", "get",
+	err := util.RunCmd("Get controller runtime", "go", "get",
 		"sigs.k8s.io/controller-runtime@"+scaffolds.ControllerRuntimeVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting controller-runtime version: %w", err)
 	}
 
 	return nil
@@ -148,7 +151,7 @@ func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 func (p *initSubcommand) PostScaffold() error {
 	err := util.RunCmd("Update dependencies", "go", "mod", "tidy")
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating go dependencies: %w", err)
 	}
 
 	fmt.Printf("Next: define a resource with:\n$ %s create api\n", p.commandName)
@@ -162,7 +165,7 @@ func checkDir() error {
 	err := filepath.Walk(".",
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return err
+				return fmt.Errorf("error walking path %q: %w", path, err)
 			}
 			// Allow directory trees starting with '.'
 			if info.IsDir() && strings.HasPrefix(info.Name(), ".") && info.Name() != "." {
@@ -202,11 +205,11 @@ func checkDir() error {
 			// Do not allow any other file
 			return fmt.Errorf(
 				"target directory is not empty and contains a disallowed file %q. "+
-					"files with the following extensions [%s] are not allowed to avoid conflicts with the tooling.",
+					"files with the following extensions [%s] are not allowed to avoid conflicts with the tooling",
 				path, strings.Join(disallowedExtensions, ", "))
 		})
 	if err != nil {
-		return err
+		return fmt.Errorf("error walking directory: %w", err)
 	}
 	return nil
 }

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -114,14 +114,13 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 	p.resource = res
 
 	if len(p.options.ExternalAPIPath) != 0 && len(p.options.ExternalAPIDomain) != 0 && p.isLegacyPath {
-		return errors.New("You cannot scaffold webhooks for external types " +
-			"using the legacy path")
+		return errors.New("you cannot scaffold webhooks for external types using the legacy path")
 	}
 
 	for _, spoke := range p.options.Spoke {
 		spoke = strings.TrimSpace(spoke)
 		if !isValidVersion(spoke, res, p.config) {
-			return fmt.Errorf("invalid spoke version: %s", spoke)
+			return fmt.Errorf("invalid spoke version %q", spoke)
 		}
 		res.Webhooks.Spoke = append(res.Webhooks.Spoke, spoke)
 	}
@@ -129,7 +128,7 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 	p.options.UpdateResource(p.resource, p.config)
 
 	if err := p.resource.Validate(); err != nil {
-		return err
+		return fmt.Errorf("error validating resource: %w", err)
 	}
 
 	if !p.resource.HasDefaultingWebhook() && !p.resource.HasValidationWebhook() && !p.resource.HasConversionWebhook() {
@@ -157,19 +156,23 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 func (p *createWebhookSubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder := scaffolds.NewWebhookScaffolder(p.config, *p.resource, p.force, p.isLegacyPath)
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("failed to scaffold webhook: %w", err)
+	}
+
+	return nil
 }
 
 func (p *createWebhookSubcommand) PostScaffold() error {
 	err := pluginutil.RunCmd("Update dependencies", "go", "mod", "tidy")
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating go dependencies: %w", err)
 	}
 
 	if p.runMake {
 		err = pluginutil.RunCmd("Running make", "make", "generate")
 		if err != nil {
-			return err
+			return fmt.Errorf("error running make generate: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This PR improves error diagnostics for the Golang plugin commands (`init`, `edit`, `create api`, `create webhook`, etc.) by consistently wrapping returned errors with contextual messages.

Improved developer experience: easier to trace and understand failure origins.