### PR TITLE
🌱 (chore): consistently wrap and enrich error messages across helm plugin

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/commons.go
+++ b/pkg/plugins/optional/helm/v1alpha/commons.go
@@ -18,6 +18,7 @@ package v1alpha
 
 import (
 	"errors"
+	"fmt"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 )
@@ -26,10 +27,10 @@ func insertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
 	err := target.DecodePluginConfig(pluginKey, cfg)
 	if !errors.As(err, &config.UnsupportedFieldError{}) {
 		if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
-			return err
+			return fmt.Errorf("error decoding plugin configuration: %w", err)
 		}
 		if err = target.EncodePluginConfig(pluginKey, cfg); err != nil {
-			return err
+			return fmt.Errorf("error encoding plugin config: %w", err)
 		}
 	}
 

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -78,7 +78,7 @@ func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder.InjectFS(fs)
 	err := scaffolder.Scaffold()
 	if err != nil {
-		return err
+		return fmt.Errorf("error scaffolding Helm chart: %w", err)
 	}
 
 	// Track the resources following a declarative approach

--- a/pkg/plugins/optional/helm/v1alpha/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/init.go
@@ -51,7 +51,7 @@ func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder.InjectFS(fs)
 	err := scaffolder.Scaffold()
 	if err != nil {
-		return err
+		return fmt.Errorf("error scaffolding helm chart: %w", err)
 	}
 
 	// Track the resources following a declarative approach

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -246,7 +246,7 @@ func (s *initScaffolder) copyConfigFiles() error {
 
 		files, err := filepath.Glob(filepath.Join(dir.SrcDir, "*.yaml"))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed finding files in %q: %w", dir.SrcDir, err)
 		}
 
 		// Skip processing if the directory is empty (no matching files)
@@ -291,13 +291,13 @@ func (s *initScaffolder) copyConfigFiles() error {
 func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string, hasConvertionalWebhook bool) error {
 	if _, err := os.Stat(srcFile); os.IsNotExist(err) {
 		log.Printf("Source file does not exist: %s", srcFile)
-		return err
+		return fmt.Errorf("source file does not exist %q: %w", srcFile, err)
 	}
 
 	content, err := os.ReadFile(srcFile)
 	if err != nil {
 		log.Printf("Error reading source file: %s", srcFile)
-		return err
+		return fmt.Errorf("failed to read file %q: %w", srcFile, err)
 	}
 
 	contentStr := string(content)
@@ -433,13 +433,13 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string, hasCon
 	}
 
 	if err = os.MkdirAll(filepath.Dir(destFile), os.ModePerm); err != nil {
-		return err
+		return fmt.Errorf("error creating directory %q: %w", filepath.Dir(destFile), err)
 	}
 
 	err = os.WriteFile(destFile, []byte(wrappedContent), os.ModePerm)
 	if err != nil {
 		log.Printf("Error writing destination file: %s", destFile)
-		return err
+		return fmt.Errorf("error writing destination file %q: %w", destFile, err)
 	}
 
 	log.Printf("Successfully copied %s to %s", srcFile, destFile)


### PR DESCRIPTION
This change updates several Helm plugin files to ensure consistent use of error wrapping via `fmt.Errorf` with `%w`. This improves debugging and traceability by providing more context when errors occur, especially in scenarios involving file I/O and scaffolding.

The goal is to enforce best practices across the codebase for error handling, making logs and failure points easier to diagnose.

No functional changes are introduced—this is purely an internal consistency and developer experience improvement.