### PR TITLE
🌱 (chore): improve error context and wrapping in utility and test helpers

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -59,7 +59,7 @@ type TestContext struct {
 func NewTestContext(binaryName string, env ...string) (*TestContext, error) {
 	testSuffix, err := util.RandomSuffix()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to generate random suffix: %w", err)
 	}
 
 	cc := &CmdContext{
@@ -74,12 +74,12 @@ func NewTestContext(binaryName string, env ...string) (*TestContext, error) {
 	}
 	k8sVersion, err := kubectl.Version()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get kubernetes version: %w", err)
 	}
 
 	// Set CmdContext.Dir after running Kubectl.Version() because dir does not exist yet.
 	if cc.Dir, err = filepath.Abs("e2e-" + testSuffix); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to determine absolute path to %q: %w", "e2e-"+testSuffix, err)
 	}
 
 	return &TestContext{
@@ -108,13 +108,17 @@ func (t *TestContext) Prepare() error {
 	for _, toolName := range []string{"controller-gen", "kustomize"} {
 		if toolPath, err := exec.LookPath(toolName); err == nil {
 			if err := os.RemoveAll(toolPath); err != nil {
-				return err
+				return fmt.Errorf("failed to remove %q: %w", toolName, err)
 			}
 		}
 	}
 
 	_, _ = fmt.Fprintf(GinkgoWriter, "preparing testing directory: %s\n", t.Dir)
-	return os.MkdirAll(t.Dir, 0o755)
+	if err := os.MkdirAll(t.Dir, 0o755); err != nil {
+		return fmt.Errorf("error creating test directory %q: %w", t.Dir, err)
+	}
+
+	return nil
 }
 
 // makeCertManagerURL returns a kubectl-able URL for the cert-manager bundle.
@@ -320,13 +324,13 @@ func (t *TestContext) AllowProjectBeMultiGroup() error {
 `
 	projectBytes, err := os.ReadFile(filepath.Join(t.Dir, "PROJECT"))
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot read project file: %w", err)
 	}
 
 	projectBytes = append([]byte(multiGroup), projectBytes...)
 	err = os.WriteFile(filepath.Join(t.Dir, "PROJECT"), projectBytes, 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not write to project file: %w", err)
 	}
 	return nil
 }

--- a/test/e2e/utils/webhooks.go
+++ b/test/e2e/utils/webhooks.go
@@ -28,7 +28,7 @@ func ImplementWebhooks(filename, lowerKind string) error {
 	//nolint:gosec // false positive
 	bs, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading webhooks file %q: %w", filename, err)
 	}
 	str := string(bs)
 
@@ -38,7 +38,7 @@ func ImplementWebhooks(filename, lowerKind string) error {
 		`import (
 	"errors"`)
 	if err != nil {
-		return err
+		return fmt.Errorf("error replacing imports in webhooks file %q: %w", filename, err)
 	}
 
 	// implement defaulting webhook logic
@@ -51,7 +51,7 @@ func ImplementWebhooks(filename, lowerKind string) error {
 		replace,
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("error replacing default logic in webhooks file %q: %w", filename, err)
 	}
 
 	// implement validation webhook logic
@@ -62,7 +62,7 @@ func ImplementWebhooks(filename, lowerKind string) error {
 		return nil, errors.New(".spec.count must >= 0")
 	}`, lowerKind))
 	if err != nil {
-		return err
+		return fmt.Errorf("error replacing validation logic in webhooks file %q: %w", filename, err)
 	}
 	str, err = util.EnsureExistAndReplace(
 		str,
@@ -71,8 +71,12 @@ func ImplementWebhooks(filename, lowerKind string) error {
 		return nil, errors.New(".spec.count must >= 0")
 	}`, lowerKind))
 	if err != nil {
-		return err
+		return fmt.Errorf("error replacing validation logic in webhooks file %q: %w", filename, err)
 	}
 	//nolint:gosec // false positive
-	return os.WriteFile(filename, []byte(str), 0o644)
+	if writeFileErr := os.WriteFile(filename, []byte(str), 0o644); writeFileErr != nil {
+		return fmt.Errorf("error writing webhooks file %q: %w", filename, writeFileErr)
+	}
+
+	return nil
 }

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -621,17 +621,17 @@ func removeCurlPod(kbc *utils.TestContext) {
 // TokenRequest API in raw format in order to make it generic for all version of the k8s that
 // is currently being supported in kubebuilder test infra.
 // TokenRequest API returns the token in raw JWT format itself. There is no conversion required.
-func serviceAccountToken(kbc *utils.TestContext) (out string, err error) {
+func serviceAccountToken(kbc *utils.TestContext) (string, error) {
+	var out string
+
 	secretName := fmt.Sprintf("%s-token-request", kbc.Kubectl.ServiceAccount)
 	tokenRequestFile := filepath.Join(kbc.Dir, secretName)
-	err = os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o755))
-	if err != nil {
-		return out, err
+	if err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o755)); err != nil {
+		return out, fmt.Errorf("error creating token request file %s: %w", tokenRequestFile, err)
 	}
-	var rawJSON string
 	getToken := func(g Gomega) {
 		// Output of this is already a valid JWT token. No need to covert this from base64 to string format
-		rawJSON, err = kbc.Kubectl.Command(
+		rawJSON, err := kbc.Kubectl.Command(
 			"create",
 			"--raw", fmt.Sprintf(
 				"/api/v1/namespaces/%s/serviceaccounts/%s/token",
@@ -650,5 +650,5 @@ func serviceAccountToken(kbc *utils.TestContext) (out string, err error) {
 	}
 	Eventually(getToken, time.Minute, time.Second).Should(Succeed())
 
-	return out, err
+	return out, nil
 }


### PR DESCRIPTION
This change updates several test/e2e/utils files to ensure consistent use of error wrapping via `fmt.Errorf` with `%w`. This improves debugging and traceability by providing more context when errors occur, especially in scenarios involving file I/O and scaffolding.

The goal is to enforce best practices across the codebase for error handling, making logs and failure points easier to diagnose.

No functional changes are introduced.