### PR TITLE
🌱 (chore): improve error context in common kustomize plugin scaffolds

### DIFF
--- a/pkg/plugins/common/kustomize/v2/api.go
+++ b/pkg/plugins/common/kustomize/v2/api.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v2
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds"
@@ -34,5 +36,9 @@ func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
 	}
 	scaffolder := scaffolds.NewAPIScaffolder(p.config, *p.resource, p.force)
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("failed to scaffold api subcommand: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/common/kustomize/v2/create.go
+++ b/pkg/plugins/common/kustomize/v2/create.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/spf13/pflag"
@@ -50,7 +51,7 @@ func (p *createSubcommand) InjectResource(res *resource.Resource) error {
 func (p *createSubcommand) configure() (err error) {
 	if forceFlag := p.flagSet.Lookup("force"); forceFlag != nil {
 		if p.force, err = strconv.ParseBool(forceFlag.Value.String()); err != nil {
-			return err
+			return fmt.Errorf("invalid value for --force %s: %w", forceFlag.Value.String(), err)
 		}
 	}
 	return nil

--- a/pkg/plugins/common/kustomize/v2/init.go
+++ b/pkg/plugins/common/kustomize/v2/init.go
@@ -65,7 +65,7 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 	p.config = c
 
 	if err := p.config.SetDomain(p.domain); err != nil {
-		return err
+		return fmt.Errorf("error setting domain: %w", err)
 	}
 
 	// Assign a default project name
@@ -80,11 +80,20 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 	if err := validation.IsDNS1123Label(p.name); err != nil {
 		return fmt.Errorf("project name %q is invalid: %v", p.name, err)
 	}
-	return p.config.SetProjectName(p.name)
+
+	if err := p.config.SetProjectName(p.name); err != nil {
+		return fmt.Errorf("error setting project name: %w", err)
+	}
+
+	return nil
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder := scaffolds.NewInitScaffolder(p.config)
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("failed to scaffold init subcommand: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/common/kustomize/v2/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/init.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -88,5 +90,9 @@ func (s *initScaffolder) Scaffold() error {
 		&prometheus.ServiceMonitorPatch{},
 	}
 
-	return scaffold.Execute(templates...)
+	if err := scaffold.Execute(templates...); err != nil {
+		return fmt.Errorf("failed to scaffold kustomize manifests: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/common/kustomize/v2/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v2
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds"
@@ -34,5 +36,9 @@ func (p *createWebhookSubcommand) Scaffold(fs machinery.Filesystem) error {
 	}
 	scaffolder := scaffolds.NewWebhookScaffolder(p.config, *p.resource, p.force)
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("failed to scaffold webhook subcommand: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This change updates several kustomize/v2 files to ensure consistent use of error wrapping via `fmt.Errorf` with `%w`. This improves debugging and traceability by providing more context when errors occur, especially in scenarios involving file I/O and scaffolding.

The goal is to enforce best practices across the codebase for error handling, making logs and failure points easier to diagnose.

No functional changes are introduced.