### PR TITLE
🌱 (chore): add error context to golang scaffolder execution steps

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/edit.go
+++ b/pkg/plugins/golang/v4/scaffolds/edit.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"fmt"
+
 	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -52,7 +54,7 @@ func (s *editScaffolder) Scaffold() error {
 	filename := "Dockerfile"
 	bs, err := afero.ReadFile(s.fs.FS, filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading %q: %w", filename, err)
 	}
 	str := string(bs)
 
@@ -66,7 +68,9 @@ func (s *editScaffolder) Scaffold() error {
 	// because there is nothing to replace.
 	if str != "" {
 		// TODO: instead of writing it directly, we should use the scaffolding machinery for consistency
-		return afero.WriteFile(s.fs.FS, filename, []byte(str), 0o644)
+		if err = afero.WriteFile(s.fs.FS, filename, []byte(str), 0o644); err != nil {
+			return fmt.Errorf("error writing %q: %w", filename, err)
+		}
 	}
 
 	return nil

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -110,7 +110,7 @@ func (s *initScaffolder) Scaffold() error {
 		}
 		bpFile.Path = s.boilerplatePath
 		if err := scaffold.Execute(bpFile); err != nil {
-			return err
+			return fmt.Errorf("failed to execute boilerplate: %w", err)
 		}
 
 		boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
@@ -152,7 +152,7 @@ func (s *initScaffolder) Scaffold() error {
 		}
 	}
 
-	return scaffold.Execute(
+	err := scaffold.Execute(
 		&cmd.Main{
 			ControllerRuntimeVersion: ControllerRuntimeVersion,
 		},
@@ -185,4 +185,9 @@ func (s *initScaffolder) Scaffold() error {
 		&templates.DevContainer{},
 		&templates.DevContainerPostInstallScript{},
 	)
+	if err != nil {
+		return fmt.Errorf("failed to execute init scaffold: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -110,7 +110,7 @@ func (s *webhookScaffolder) Scaffold() error {
 		&cmd.MainUpdater{WireWebhook: true, IsLegacyPath: s.isLegacy},
 		&webhooks.WebhookTest{Force: s.force, IsLegacyPath: s.isLegacy},
 	); err != nil {
-		return err
+		return fmt.Errorf("error updating webhook: %w", err)
 	}
 
 	if doConversion {
@@ -131,17 +131,13 @@ func (s *webhookScaffolder) Scaffold() error {
 				"in file %s: %v", resourceFilePath, err)
 		}
 
-		if err := scaffold.Execute(
-			&api.Hub{Force: s.force},
-		); err != nil {
-			return err
+		if err = scaffold.Execute(&api.Hub{Force: s.force}); err != nil {
+			return fmt.Errorf("error scaffold resource with hub: %w", err)
 		}
 
 		for _, spoke := range s.resource.Webhooks.Spoke {
 			log.Printf("Scaffolding for spoke version: %s\n", spoke)
-			if err := scaffold.Execute(
-				&api.Spoke{Force: s.force, SpokeVersion: spoke},
-			); err != nil {
+			if err = scaffold.Execute(&api.Spoke{Force: s.force, SpokeVersion: spoke}); err != nil {
 				return fmt.Errorf("failed to scaffold spoke %s: %w", spoke, err)
 			}
 		}
@@ -152,10 +148,8 @@ You need to implement the conversion.Hub and conversion.Convertible interfaces f
 
 	// TODO: Add test suite for conversion webhook after #1664 has been merged & conversion tests supported in envtest.
 	if doDefaulting || doValidation {
-		if err := scaffold.Execute(
-			&webhooks.WebhookSuite{IsLegacyPath: s.isLegacy},
-		); err != nil {
-			return err
+		if err = scaffold.Execute(&webhooks.WebhookSuite{IsLegacyPath: s.isLegacy}); err != nil {
+			return fmt.Errorf("error scaffold webhook suite: %w", err)
 		}
 	}
 
@@ -167,7 +161,7 @@ You need to implement the conversion.Hub and conversion.Convertible interfaces f
 			log.Warning("Dockerfile is copying internal/controller. To allow copying webhooks, " +
 				"it will be edited, and `internal/controller` will be replaced by `internal/`.")
 
-			if err := pluginutil.ReplaceInFile("Dockerfile", "internal/controller", "internal/"); err != nil {
+			if err = pluginutil.ReplaceInFile("Dockerfile", "internal/controller", "internal/"); err != nil {
 				log.Error("Unable to replace \"internal/controller\" with \"internal/\" in the Dockerfile: ", err)
 			}
 		}


### PR DESCRIPTION
This change updates several v4/scaffolds files to ensure consistent use of error wrapping via `fmt.Errorf` with `%w`. This improves debugging and traceability by providing more context when errors occur, especially in scenarios involving file I/O and scaffolding.

The goal is to enforce best practices across the codebase for error handling, making logs and failure points easier to diagnose.

No functional changes are introduced.