### PR TITLE
🌱 (chore): wrap config parsing and validation errors with contextual messages

### DIFF
--- a/pkg/config/store/yaml/store.go
+++ b/pkg/config/store/yaml/store.go
@@ -60,7 +60,7 @@ func New(fs machinery.Filesystem) store.Store {
 func (s *yamlStore) New(version config.Version) error {
 	cfg, err := config.New(version)
 	if err != nil {
-		return err
+		return fmt.Errorf("could not create config: %w", err)
 	}
 
 	s.cfg = cfg

--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -38,7 +38,7 @@ func (ss *stringSlice) UnmarshalJSON(b []byte) error {
 	if b[0] == '[' {
 		var sl []string
 		if err := yaml.Unmarshal(b, &sl); err != nil {
-			return err
+			return fmt.Errorf("error unmarshalling string slice %q: %w", sl, err)
 		}
 		*ss = sl
 		return nil
@@ -46,7 +46,7 @@ func (ss *stringSlice) UnmarshalJSON(b []byte) error {
 
 	var st string
 	if err := yaml.Unmarshal(b, &st); err != nil {
-		return err
+		return fmt.Errorf("error unmarshalling string %q: %w", st, err)
 	}
 	*ss = stringSlice{st}
 	return nil
@@ -235,7 +235,11 @@ func (c *Cfg) UpdateResource(res resource.Resource) error {
 
 	for i, r := range c.Resources {
 		if res.GVK.IsEqualTo(r.GVK) {
-			return c.Resources[i].Update(res)
+			if err := c.Resources[i].Update(res); err != nil {
+				return fmt.Errorf("failed to update resource %q: %w", res.GVK, err)
+			}
+
+			return nil
 		}
 	}
 

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -54,14 +54,14 @@ func (v *Version) Parse(version string) error {
 		if n, errParse := strconv.Atoi(version); errParse == nil && n < 0 {
 			return errNonPositive
 		}
-		return err
+		return fmt.Errorf("failed to convert version number %q: %w", substrings[0], err)
 	} else if v.Number == 0 {
 		return errNonPositive
 	}
 
 	if len(substrings) > 1 {
 		if err = v.Stage.Parse(substrings[1]); err != nil {
-			return err
+			return fmt.Errorf("failed to parse stage: %w", err)
 		}
 	}
 
@@ -83,7 +83,11 @@ func (v Version) Validate() error {
 		return errNonPositive
 	}
 
-	return v.Stage.Validate()
+	if err := v.Stage.Validate(); err != nil {
+		return fmt.Errorf("failed to validate stage: %w", err)
+	}
+
+	return nil
 }
 
 // Compare returns -1 if v < other, 0 if v == other, and 1 if v > other.
@@ -105,17 +109,22 @@ func (v Version) IsStable() bool {
 // MarshalJSON implements json.Marshaller
 func (v Version) MarshalJSON() ([]byte, error) {
 	if err := v.Validate(); err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("failed to validate version: %w", err)
 	}
 
-	return json.Marshal(v.String())
+	marshaled, err := json.Marshal(v.String())
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to marshal version: %w", err)
+	}
+
+	return marshaled, nil
 }
 
 // UnmarshalJSON implements json.Unmarshaller
 func (v *Version) UnmarshalJSON(b []byte) error {
 	var str string
 	if err := json.Unmarshal(b, &str); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal version: %w", err)
 	}
 
 	return v.Parse(str)


### PR DESCRIPTION
This change updates several pkg/config files to ensure consistent use of error wrapping via `fmt.Errorf` with `%w`. This improves debugging and traceability by providing more context when errors occur, especially in scenarios involving file I/O and scaffolding.

The goal is to enforce best practices across the codebase for error handling, making logs and failure points easier to diagnose.

No functional changes are introduced.