### PR TITLE
🌱 (chore): wrap plugin and util error returns for better context

### DIFF
--- a/pkg/plugin/util/exec.go
+++ b/pkg/plugin/util/exec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -30,5 +31,10 @@ func RunCmd(msg, cmd string, args ...string) error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	log.Println(msg + ":\n$ " + strings.Join(c.Args, " "))
-	return c.Run()
+
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("error running %q: %w", cmd, err)
+	}
+
+	return nil
 }

--- a/pkg/plugin/version.go
+++ b/pkg/plugin/version.go
@@ -54,12 +54,12 @@ func (v *Version) Parse(version string) error {
 		if n, errParse := strconv.Atoi(version); errParse == nil && n < 0 {
 			return errNegative
 		}
-		return err
+		return fmt.Errorf("error converting version number %q: %w", substrings[0], err)
 	}
 
 	if len(substrings) > 1 {
 		if err = v.Stage.Parse(substrings[1]); err != nil {
-			return err
+			return fmt.Errorf("error parsing stage %q: %w", substrings[1], err)
 		}
 	}
 
@@ -81,7 +81,11 @@ func (v Version) Validate() error {
 		return errNegative
 	}
 
-	return v.Stage.Validate()
+	if err := v.Stage.Validate(); err != nil {
+		return fmt.Errorf("error validating stage %q: %w", v.Stage, err)
+	}
+
+	return nil
 }
 
 // Compare returns -1 if v < other, 0 if v == other, and 1 if v > other.


### PR DESCRIPTION
This change updates several pkg/plugin files to ensure consistent use of error wrapping via `fmt.Errorf` with `%w`. This improves debugging and traceability by providing more context when errors occur, especially in scenarios involving file I/O and scaffolding.

The goal is to enforce best practices across the codebase for error handling, making logs and failure points easier to diagnose.