### PR TITLE
🌱 (chore): check and return error from os.WriteFile when writing litout.json

### DIFF
--- a/docs/book/utils/plugin/plugin.go
+++ b/docs/book/utils/plugin/plugin.go
@@ -64,7 +64,9 @@ func Run(plug Plugin, inputRaw io.Reader, outputRaw io.Writer, args ...string) e
 		return fmt.Errorf("unable to write output book object: %v", err)
 	}
 
-	os.WriteFile("/tmp/litout.json", out, os.ModePerm)
+	if err = os.WriteFile("/tmp/litout.json", out, os.ModePerm); err != nil {
+		return fmt.Errorf("unable to write output book object: %v", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This change adds error handling for the `os.WriteFile` function when writing the `litout.json` file. Previously, the error was not checked, which could lead to silent failures.

Ensuring that errors are properly handled and reported improves the robustness and reliability of the code. This change helps to catch and report any issues that may occur when writing the `litout.json` file.