### PR TITLE
🌱 (chore): remove unnecessary string() and []byte conversions

### DIFF
--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -170,7 +170,7 @@ func extractPairs(contents []byte, path string) ([]commentCodePair, error) {
 	file := fileSet.AddFile(path, -1, len(contents))
 	scan := scanner.Scanner{}
 	var errs []error
-	scan.Init(file, []byte(contents), func(pos token.Position, msg string) {
+	scan.Init(file, contents, func(pos token.Position, msg string) {
 		errs = append(errs, fmt.Errorf("error parsing file %s: %s", pos, msg))
 	}, scanner.ScanComments)
 

--- a/docs/book/utils/plugin/utils.go
+++ b/docs/book/utils/plugin/utils.go
@@ -49,7 +49,7 @@ func EachCommand(book *Book, cmd string, callback func(chapter *BookChapter, arg
 			if err != nil {
 				return err
 			}
-			res = append(res, string(newContents))
+			res = append(res, newContents)
 			res = append(res, part[endDelim+2:])
 		}
 

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -170,7 +170,7 @@ func (s *editScaffolder) Scaffold() error {
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs)
 
-	configPath := string(configFilePath)
+	configPath := configFilePath
 
 	templatesBuilder := []machinery.Builder{
 		&templates.RuntimeManifest{},

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
@@ -51,6 +51,6 @@ func (s *initScaffolder) Scaffold() error {
 	return scaffold.Execute(
 		&templates.RuntimeManifest{},
 		&templates.ResourcesManifest{},
-		&templates.CustomMetricsConfigManifest{ConfigPath: string(configFilePath)},
+		&templates.CustomMetricsConfigManifest{ConfigPath: configFilePath},
 	)
 }


### PR DESCRIPTION
This change removes unnecessary `string()` and `[]byte` conversions in various files. These conversions were redundant and could lead to performance overhead.