### PR TITLE
🌱 (chore): wrap deploy-image plugin errors with contextual messages

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -138,7 +138,7 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 	p.options.UpdateResource(p.resource, p.config)
 
 	if err := p.resource.Validate(); err != nil {
-		return err
+		return fmt.Errorf("error validating resource: %w", err)
 	}
 
 	// Check that the provided group can be added to the project
@@ -186,17 +186,17 @@ func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
 	scaffolder.InjectFS(fs)
 	err := scaffolder.Scaffold()
 	if err != nil {
-		return err
+		return fmt.Errorf("error scaffolding deploy-image plugin: %w", err)
 	}
 
 	// Track the resources following a declarative approach
 	cfg := PluginConfig{}
-	if err := p.config.DecodePluginConfig(pluginKey, &cfg); errors.As(err, &config.UnsupportedFieldError{}) {
+	if err = p.config.DecodePluginConfig(pluginKey, &cfg); errors.As(err, &config.UnsupportedFieldError{}) {
 		// Skip tracking as the config doesn't support per-plugin configuration
 		return nil
 	} else if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
 		// Fail unless the key wasn't found, which just means it is the first resource tracked
-		return err
+		return fmt.Errorf("error decoding plugin configuration: %w", err)
 	}
 
 	configDataOptions := options{
@@ -212,25 +212,30 @@ func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
 		Kind:    p.resource.GVK.Kind,
 		Options: configDataOptions,
 	})
-	return p.config.EncodePluginConfig(pluginKey, cfg)
+
+	if err = p.config.EncodePluginConfig(pluginKey, cfg); err != nil {
+		return fmt.Errorf("error encoding plugin configuration: %w", err)
+	}
+
+	return nil
 }
 
 func (p *createAPISubcommand) PostScaffold() error {
 	err := util.RunCmd("Update dependencies", "go", "mod", "tidy")
 	if err != nil {
-		return err
+		return fmt.Errorf("error updating go dependencies: %w", err)
 	}
 	if p.runMake && p.resource.HasAPI() {
 		err = util.RunCmd("Running make", "make", "generate")
 		if err != nil {
-			return err
+			return fmt.Errorf("ailed running make generate: %w", err)
 		}
 	}
 
 	if p.runManifests && p.resource.HasAPI() {
 		err = util.RunCmd("Running make", "make", "manifests")
 		if err != nil {
-			return err
+			return fmt.Errorf("failed running make manifests: %w", err)
 		}
 	}
 

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -294,7 +294,11 @@ func (s *apiScaffolder) scaffoldCreateAPIFromGolang() error {
 	golangV4Scaffolder := golangv4scaffolds.NewAPIScaffolder(s.config,
 		s.resource, true)
 	golangV4Scaffolder.InjectFS(s.fs)
-	return golangV4Scaffolder.Scaffold()
+	if err := golangV4Scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding golang files for the APIs: %v", err)
+	}
+
+	return nil
 }
 
 const containerTemplate = `Containers: []corev1.Container{{


### PR DESCRIPTION
This change wraps errors in the deploy-image plugin with contextual messages to provide more informative error outputs. This helps in debugging and understanding the source of errors more easily.