### PR TITLE
🌱 (chore): wrap and contextualize errors across Grafana plugin

### DIFF
--- a/pkg/plugins/optional/grafana/v1alpha/commons.go
+++ b/pkg/plugins/optional/grafana/v1alpha/commons.go
@@ -18,6 +18,7 @@ package v1alpha
 
 import (
 	"errors"
+	"fmt"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 )
@@ -27,11 +28,11 @@ func InsertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
 	err := target.DecodePluginConfig(pluginKey, cfg)
 	if !errors.As(err, &config.UnsupportedFieldError{}) {
 		if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
-			return err
+			return fmt.Errorf("error decoding plugin configuration: %w", err)
 		}
 
 		if err = target.EncodePluginConfig(pluginKey, cfg); err != nil {
-			return err
+			return fmt.Errorf("error encoding plugin configuration: %w", err)
 		}
 	}
 

--- a/pkg/plugins/optional/grafana/v1alpha/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/edit.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl
 package v1alpha
 
 import (
@@ -46,10 +47,14 @@ func (p *editSubcommand) InjectConfig(c config.Config) error {
 
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
 	if err := InsertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
-		return err
+		return fmt.Errorf("error inserting project plugin meta to configuration: %w", err)
 	}
 
 	scaffolder := scaffolds.NewEditScaffolder()
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding edit subcommand: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/optional/grafana/v1alpha/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/init.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl
 package v1alpha
 
 import (
@@ -46,10 +47,14 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	if err := InsertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
-		return err
+		return fmt.Errorf("error inserting project plugin meta to configuration: %w", err)
 	}
 
 	scaffolder := scaffolds.NewInitScaffolder()
 	scaffolder.InjectFS(fs)
-	return scaffolder.Scaffold()
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding init subcommand: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -77,20 +77,20 @@ func loadConfig(configPath string) ([]templates.CustomMetricItem, error) {
 		return nil, fmt.Errorf("could not close config.yaml: %w", err)
 	}
 
-	return items, err
+	return items, nil
 }
 
 func configReader(reader io.Reader) ([]templates.CustomMetricItem, error) {
 	yamlFile, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading config.yaml: %w", err)
 	}
 
 	config := templates.CustomMetricsConfig{}
 
 	err = yaml.Unmarshal(yamlFile, &config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing config.yaml: %w", err)
 	}
 
 	validatedMetricItems := validateCustomMetricItems(config.CustomMetrics)
@@ -185,5 +185,9 @@ func (s *editScaffolder) Scaffold() error {
 		_, _ = fmt.Fprintf(os.Stderr, "Error on scaffolding manifest for custom metris:\n%v", err)
 	}
 
-	return scaffold.Execute(templatesBuilder...)
+	if err = scaffold.Execute(templatesBuilder...); err != nil {
+		return fmt.Errorf("error scaffolding Grafana manifests: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -48,9 +50,14 @@ func (s *initScaffolder) Scaffold() error {
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs)
 
-	return scaffold.Execute(
+	err := scaffold.Execute(
 		&templates.RuntimeManifest{},
 		&templates.ResourcesManifest{},
 		&templates.CustomMetricsConfigManifest{ConfigPath: configFilePath},
 	)
+	if err != nil {
+		return fmt.Errorf("error scaffolding Grafana memanifests: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This change wraps error returns in the grafana functions with contextual messages to provide more informative error outputs. This helps in debugging and understanding the source of errors more easily.