### PR TITLE
✨ (API) add contextual error wrapping for external plugin helpers

### DIFF
--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -84,7 +84,12 @@ func (m *mockValidFlagOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, e
 		Universe: nil,
 		Flags:    getFlags(),
 	}
-	return json.Marshal(response)
+	marshaledResponse, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling response: %w", err)
+	}
+
+	return marshaledResponse, nil
 }
 
 type mockValidMEOutputGetter struct{}
@@ -97,7 +102,12 @@ func (m *mockValidMEOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, err
 		Metadata: getMetadata(),
 	}
 
-	return json.Marshal(response)
+	marshaledResponse, err := json.Marshal(response)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling response: %w", err)
+	}
+
+	return marshaledResponse, nil
 }
 
 const (

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -57,7 +57,7 @@ func (e *execOutputGetter) GetExecOutput(request []byte, path string) ([]byte, e
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting output for cmd %q: %w", cmd, err)
 	}
 
 	return out, nil
@@ -84,17 +84,17 @@ func (o *osWdGetter) GetCurrentDir() (string, error) {
 func makePluginRequest(req external.PluginRequest, path string) (*external.PluginResponse, error) {
 	reqBytes, err := json.Marshal(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error marshalling plugin request: %w", err)
 	}
 
 	out, err := outputGetter.GetExecOutput(reqBytes, path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error executing plugin request: %w", err)
 	}
 
 	res := external.PluginResponse{}
-	if err := json.Unmarshal(out, &res); err != nil {
-		return nil, err
+	if err = json.Unmarshal(out, &res); err != nil {
+		return nil, fmt.Errorf("error unmarshalling plugin response: %w", err)
 	}
 
 	// Error if the plugin failed.
@@ -114,7 +114,7 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 
 	err := afero.Walk(fs.FS, ".", func(path string, info iofs.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("error walking path %q: %w", path, err)
 		}
 
 		if info.IsDir() {
@@ -123,7 +123,7 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 
 		file, err := fs.FS.Open(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("error opening file %q: %w", path, err)
 		}
 
 		defer func() {
@@ -134,7 +134,7 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 
 		content, err := io.ReadAll(file)
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading file %q: %w", path, err)
 		}
 
 		universe[path] = string(content)
@@ -142,7 +142,7 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error walking the directory: %w", err)
 	}
 
 	return universe, nil
@@ -153,7 +153,7 @@ func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, p
 
 	req.Universe, err = getUniverseMap(fs)
 	if err != nil {
-		return err
+		return fmt.Errorf("error getting universe map: %w", err)
 	}
 
 	res, err := makePluginRequest(req, path)
@@ -167,27 +167,27 @@ func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, p
 	}
 
 	for filename, data := range res.Universe {
-		path := filepath.Join(currentDir, filename)
-		dir := filepath.Dir(path)
+		file := filepath.Join(currentDir, filename)
+		dir := filepath.Dir(file)
 
 		// create the directory if it does not exist
-		if err := os.MkdirAll(dir, 0o750); err != nil {
+		if err = os.MkdirAll(dir, 0o750); err != nil {
 			return fmt.Errorf("error creating the directory: %w", err)
 		}
 
-		f, err := fs.FS.Create(path)
-		if err != nil {
-			return err
+		f, createErr := fs.FS.Create(file)
+		if createErr != nil {
+			return fmt.Errorf("error creating file %q: %w", file, createErr)
 		}
 
 		defer func() {
-			if err := f.Close(); err != nil {
+			if err = f.Close(); err != nil {
 				return
 			}
 		}()
 
-		if _, err := f.Write([]byte(data)); err != nil {
-			return err
+		if _, err = f.Write([]byte(data)); err != nil {
+			return fmt.Errorf("error writing file %q: %w", file, err)
 		}
 	}
 


### PR DESCRIPTION
This change wraps error returns in the plugins external helpers functions with contextual messages to provide more informative error outputs. This helps in debugging and understanding the source of errors more easily.