### PR TITLE
🌱 (chore): consistently wrap and enrich error messages across test utils

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -195,7 +195,7 @@ func GetNonEmptyLines(output string) []string {
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return wd, err
+		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
@@ -208,7 +208,7 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	strContent := string(content)
 
@@ -220,7 +220,7 @@ func UncommentCode(filename, target, prefix string) error {
 	out := new(bytes.Buffer)
 	_, err = out.Write(content[:idx])
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
@@ -228,24 +228,27 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, err = out.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 	}
 
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
+	if _, err = out.Write(content[idx+len(target):]); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
+
 	// false positive
 	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
+	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
+	}
+
+	return nil
 }

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -195,7 +195,7 @@ func GetNonEmptyLines(output string) []string {
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return wd, err
+		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
@@ -208,7 +208,7 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	strContent := string(content)
 
@@ -220,7 +220,7 @@ func UncommentCode(filename, target, prefix string) error {
 	out := new(bytes.Buffer)
 	_, err = out.Write(content[:idx])
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
@@ -228,24 +228,27 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, err = out.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 	}
 
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
+	if _, err = out.Write(content[idx+len(target):]); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
+
 	// false positive
 	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
+	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
+	}
+
+	return nil
 }

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
@@ -195,7 +195,7 @@ func GetNonEmptyLines(output string) []string {
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return wd, err
+		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
@@ -208,7 +208,7 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	strContent := string(content)
 
@@ -220,7 +220,7 @@ func UncommentCode(filename, target, prefix string) error {
 	out := new(bytes.Buffer)
 	_, err = out.Write(content[:idx])
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
@@ -228,24 +228,27 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, err = out.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 	}
 
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
+	if _, err = out.Write(content[idx+len(target):]); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
+
 	// false positive
 	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
+	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
+	}
+
+	return nil
 }

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -195,7 +195,7 @@ func GetNonEmptyLines(output string) []string {
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return wd, err
+		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
@@ -208,7 +208,7 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	strContent := string(content)
 
@@ -220,7 +220,7 @@ func UncommentCode(filename, target, prefix string) error {
 	out := new(bytes.Buffer)
 	_, err = out.Write(content[:idx])
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
@@ -228,24 +228,27 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, err = out.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 	}
 
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
+	if _, err = out.Write(content[idx+len(target):]); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
+
 	// false positive
 	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
+	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
+	}
+
+	return nil
 }

--- a/testdata/project-v4-with-plugins/test/utils/utils.go
+++ b/testdata/project-v4-with-plugins/test/utils/utils.go
@@ -195,7 +195,7 @@ func GetNonEmptyLines(output string) []string {
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return wd, err
+		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
@@ -208,7 +208,7 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	strContent := string(content)
 
@@ -220,7 +220,7 @@ func UncommentCode(filename, target, prefix string) error {
 	out := new(bytes.Buffer)
 	_, err = out.Write(content[:idx])
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
@@ -228,24 +228,27 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, err = out.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 	}
 
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
+	if _, err = out.Write(content[idx+len(target):]); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
+
 	// false positive
 	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
+	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
+	}
+
+	return nil
 }

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -195,7 +195,7 @@ func GetNonEmptyLines(output string) []string {
 func GetProjectDir() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return wd, err
+		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
 	wd = strings.Replace(wd, "/test/e2e", "", -1)
 	return wd, nil
@@ -208,7 +208,7 @@ func UncommentCode(filename, target, prefix string) error {
 	// nolint:gosec
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file %q: %w", filename, err)
 	}
 	strContent := string(content)
 
@@ -220,7 +220,7 @@ func UncommentCode(filename, target, prefix string) error {
 	out := new(bytes.Buffer)
 	_, err = out.Write(content[:idx])
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBufferString(target))
@@ -228,24 +228,27 @@ func UncommentCode(filename, target, prefix string) error {
 		return nil
 	}
 	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
+		if _, err = out.WriteString(strings.TrimPrefix(scanner.Text(), prefix)); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 		// Avoid writing a newline in case the previous line was the last in target.
 		if !scanner.Scan() {
 			break
 		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
+		if _, err = out.WriteString("\n"); err != nil {
+			return fmt.Errorf("failed to write to output: %w", err)
 		}
 	}
 
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
+	if _, err = out.Write(content[idx+len(target):]); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
+
 	// false positive
 	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
+	if err = os.WriteFile(filename, out.Bytes(), 0644); err != nil {
+		return fmt.Errorf("failed to write file %q: %w", filename, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
`utils.go` file under `pkg/plugins/golang/v4/scaffolds/internal/templates/test/` was updated to improve error context in utility functions like `GetProjectDir` and `UncommentCode`.

All returned errors are now consistently wrapped using `fmt.Errorf` with `%w` to preserve the original error while adding context. This aids debugging, especially in test scaffolds that may fail silently otherwise.

These changes continue the effort toward more robust and informative error handling throughout the codebase.
