### PR TITLE
🌱 (Follow up of #4752 )Remove 'install-mode: goinstall' from the GitHub Action. This was added temporarily to allow us to move forward. (removed this temporary addition before any release.)

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2
           working-directory: ${{ matrix.folder }}
           args: --config .golangci.yml ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall 
           version: v2.0.2
 
   yamllint:

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -68,6 +68,5 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: {{ .GolangciLintVersion }}
 `

--- a/testdata/project-v4-multigroup/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v7
         with:
-          install-mode: goinstall
           version: v2.0.2


### PR DESCRIPTION
To allow us to upgrade GolangCI-Lint and Golang in separate pull requests, we temporarily added this option to move forward without blocking progress.
This PR simply removes that temporary addition to ensure it’s not included in any future releases.

Follow up of : #4752 
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4750