### PR TITLE
🌱 (fix/enhance): correct GNU sed detection method for remove-spaces makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ generate: generate-testdata generate-docs update-k8s-version ## Update/generate 
 remove-spaces:
 	@echo "Removing trailing spaces"
 	@bash -c ' \
-		if [[ "$$(uname)" == "Linux" ]]; then \
+		if sed --version 2>&1 | grep -q "GNU"; then \
 			find . -type f -name "*.md" -exec sed -i "s/[[:space:]]*$$//" {} + || true; \
 		else \
 			find . -type f -name "*.md" -exec sed -i "" "s/[[:space:]]*$$//" {} + || true; \


### PR DESCRIPTION
This change updates the trailing spaces removal in the Makefile. Previously, the script used the `uname` check to determine whether to use GNU or BSD sed syntax, which did not work well on macOS when GNU sed is installed.

Now the script uses a check on `sed --version` for "GNU" to decide which sed syntax to apply. This ensures that, regardless of the OS, if GNU sed is available in the PATH, the GNU sed branch is used.