### PR TITLE
🐛 (helm/alpha-v1): Add control-plane labels to metrics service and ServiceMonitor templates

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/metrics-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/metrics-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
 spec:
   ports:
     - port: 8443

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
   name: project-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/metrics-service.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/metrics-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
 spec:
   ports:
     - port: 8443

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/monitor.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
   name: project-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/metrics-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/metrics-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
 spec:
   ports:
     - port: 8443

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
   name: project-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/metrics/metrics_service.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/metrics/metrics_service.go
@@ -50,6 +50,7 @@ metadata:
   namespace: {{ "{{ .Release.Namespace }}" }}
   labels:
     {{ "{{- include \"chart.labels\" . | nindent 4 }}" }}
+    control-plane: controller-manager
 spec:
   ports:
     - port: 8443

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/prometheus/monitor.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/prometheus/monitor.go
@@ -49,6 +49,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{ "{{- include \"chart.labels\" . | nindent 4 }}" }}
+    control-plane: controller-manager
   name: {{ .ProjectName }}-controller-manager-metrics-monitor
   namespace: {{ "{{ .Release.Namespace }}" }}
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/metrics/metrics-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/metrics/metrics-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
 spec:
   ports:
     - port: 8443

--- a/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/monitor.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/monitor.yaml
@@ -5,6 +5,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    control-plane: controller-manager
   name: project-v4-with-plugins-controller-manager-metrics-monitor
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
The Helm plugin scaffolding was missing the control-plane: controller-manager label on the metrics service, which prevented the ServiceMonitor from finding the service and collecting metrics when deployed via Helm chart.

fixes: #4591 
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
