### PR TITLE
✨ (helm/v1-alpha): Update Helm values.yaml with Kustomize manager spec changes when using --force flag

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -53,6 +53,10 @@ dist/chart/
     └── manager/
         └── manager.yaml
 
+When the "--force" flag is used, values.yaml will be updated with values from the Kustomize manager 
+configuration (such as replicas, resource limits, etc.) ensuring the Helm chart accurately reflects 
+your latest resource configurations.
+
 The following files are never updated after their initial creation:
   - chart/Chart.yaml
   - chart/templates/_helpers.tpl


### PR DESCRIPTION
fixes: #4625

- Improves YAML number type handling for replicas, terminationGracePeriodSeconds, and other numeric values
- Ensures proper extraction of resource limits, requests, container args, and termination grace period from manager.yaml
- Correctly populates values.yaml with the latest configuration from manager.yaml when using the --force flag

![Screenshot from 2025-04-14 22-38-12](https://github.com/user-attachments/assets/0d09657e-a03a-450c-a353-be8387f06a82)<br>
![Screenshot from 2025-04-14 22-39-01](https://github.com/user-attachments/assets/8c13b2f2-ea99-43ae-a6cb-c0c870576365)

