### PR TITLE
📖 Update getting-started.md

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -180,7 +180,7 @@ reconcile App {
   // Check the Database Deployment's replicas size
   // If deployment.replicas size doesn't match cr.size, then update it
   // Then, restart from the beginning of the reconcile. For example, by returning `reconcile.Result{Requeue: true}, nil`.
-  if err != nil {
+  if needRequeue {
     return reconcile.Result{Requeue: true}, nil
   }
   ...


### PR DESCRIPTION
The change introduces a needRequeue flag to separate the logic for requeueing reconciliation from error handling. Previously, using err != nil to trigger a requeue was confusing, as it mixed error checking with the need for the process to be re-executed.
