### PR TITLE
:bug: Fix multiversion doc webhook wrong apiVersion

### DIFF
--- a/docs/book/src/multiversion-tutorial/webhooks.md
+++ b/docs/book/src/multiversion-tutorial/webhooks.md
@@ -5,7 +5,7 @@ controller-runtime about our conversion.
 
 ## Webhook setup...
 
-{{#literatego ./testdata/project/internal/webhook/v1/cronjob_webhook.go}}
+{{#literatego ./testdata/project/internal/webhook/v2/cronjob_webhook.go}}
 
 ## ...and `main.go`
 


### PR DESCRIPTION
Fixes #4614 

The wrong webhook version was used for the documentation.
