### PR TITLE
🐛 Remove redundant/noisy godebug default= lines from go.mod. 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/go.mod
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.mod
@@ -2,8 +2,6 @@ module tutorial.kubebuilder.io/project
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/docs/book/src/getting-started/testdata/project/go.mod
+++ b/docs/book/src/getting-started/testdata/project/go.mod
@@ -2,8 +2,6 @@ module example.com/memcached
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.mod
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.mod
@@ -2,8 +2,6 @@ module tutorial.kubebuilder.io/project
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
@@ -2,8 +2,6 @@ module v1
 
 go 1.23.0
 
-godebug default=go1.23
-
 require (
 	github.com/spf13/pflag v1.0.6
 	sigs.k8s.io/kubebuilder/v4 v4.5.2

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kubebuilder/v4
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/gobuffalo/flect v1.0.3
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
@@ -47,8 +47,6 @@ const goModTemplate = `module {{ .Repo }}
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}
 )

--- a/testdata/project-v4-multigroup/go.mod
+++ b/testdata/project-v4-multigroup/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/cert-manager/cert-manager v1.17.1
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/testdata/project-v4-with-plugins/go.mod
+++ b/testdata/project-v4-with-plugins/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kubebuilder/testdata/project-v4-with-plugins
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/testdata/project-v4/go.mod
+++ b/testdata/project-v4/go.mod
@@ -2,8 +2,6 @@ module sigs.k8s.io/kubebuilder/testdata/project-v4
 
 go 1.24.0
 
-godebug default=go1.24
-
 require (
 	github.com/cert-manager/cert-manager v1.17.1
 	github.com/onsi/ginkgo/v2 v2.22.0


### PR DESCRIPTION
Fixes #4786
