### PR TITLE
🌱 Removing calico - using default CNI from Kind

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,8 @@ To manually setup run:
 ```shell
 # To generate an Kubebuilder local binary with your changes
 make install
-# To create the cluster and configure a CNI which supports NetworkPolicy
+# To create the cluster
 kind create cluster --config ./test/e2e/kind-config.yaml
-kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
 ```
 
 Now, you can for example, run in debug mode the `test/e2e/v4/e2e_suite_test.go`:

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -15,6 +15,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
-  disableDefaultCNI: true  # Disable the default CNI so that we can test NetworkPolicies
+  disableDefaultCNI: false # Let it use default CNI so we can test NetworkPolicies
 nodes:
   - role: control-plane

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -39,8 +39,6 @@ function create_cluster {
     fi
     echo "Creating cluster..."
     kind create cluster -v 4 --name $KIND_CLUSTER --retain --wait=1m --config ${kind_config} --image=kindest/node:$1
-    echo "Installing Calico..."
-    kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
   fi
 }
 

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -207,18 +207,6 @@ func Run(kbc *utils.TestContext, hasWebhook, isToUseInstaller, isToUseHelmChart,
 	Expect(err).NotTo(HaveOccurred())
 
 	if hasNetworkPolicies {
-		By("Checking for Calico pods")
-		var outputGet string
-		outputGet, err = kbc.Kubectl.Get(
-			false,
-			"pods",
-			"-n", "kube-system",
-			"-l", "k8s-app=calico-node",
-			"-o", "jsonpath={.items[*].status.phase}",
-		)
-		Expect(err).NotTo(HaveOccurred(), "Failed to get Calico pods")
-		Expect(outputGet).To(ContainSubstring("Running"), "All Calico pods should be in Running state")
-
 		if hasMetrics {
 			By("labeling the namespace to allow consume the metrics")
 			Expect(kbc.Kubectl.Command("label", "namespaces", kbc.Kubectl.Namespace,


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

> The recent changes in https://github.com/kubernetes-sigs/kind/pull/3612 have made it possible to test Kubernetes NetworkPolicy resources without requiring a custom CNI like Calico.

This PR fixes issue https://github.com/kubernetes-sigs/kubebuilder/issues/4790

The kind cluster doesn't need calico to test network policies anymore. 


After making changes to setup and cluster config - I got rid of test cases checking for Calico pods so e2e runs successfully - Adding a screenshot for reference

<img width="823" alt="Screenshot 2025-04-30 at 10 13 52 AM" src="https://github.com/user-attachments/assets/6b01452a-8f72-483d-8dbd-1b756f206e35" />

