### PR TITLE
🐛 (helm/v1-alpha): Append project name to webhook service name

### DIFF
--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/batch.tutorial.kubebuilder.io_cronjobs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/batch.tutorial.kubebuilder.io_cronjobs.yaml
@@ -22,7 +22,7 @@ spec:
       clientConfig:
         service:
           namespace: {{ .Release.Namespace }}
-          name: webhook-service
+          name: project-webhook-service
           path: /convert
       conversionReviewVersions:
       - v1

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -424,6 +424,9 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string, hasCon
   labels:
     {{- include "chart.labels" . | nindent 4 }}`, 1)
 
+	// Append project name to webhook service name
+	contentStr = strings.ReplaceAll(contentStr, "name: webhook-service", "name: "+projectName+"-webhook-service")
+
 	var wrappedContent string
 	if isMetricRBACFile(subDir, srcFile) {
 		wrappedContent = fmt.Sprintf(

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_wordpresses.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_wordpresses.yaml
@@ -22,7 +22,7 @@ spec:
       clientConfig:
         service:
           namespace: {{ .Release.Namespace }}
-          name: webhook-service
+          name: project-v4-with-plugins-webhook-service
           path: /convert
       conversionReviewVersions:
       - v1


### PR DESCRIPTION
fixes: #4807 

The Helm plugin scaffolding did not adjust the service name for conversion webhooks in the CRDs. This prevented the conversion webhook from being reached.

