### PR TITLE
📖 docs: fix make command and heading formatting in getting started guide

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -385,7 +385,7 @@ how it is implemented in our example:
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 ```
 
-After making changes to the controller, run the make generate command. This will prompt [controller-gen][controller-gen]
+After making changes to the controller, run the make manifests command. This will prompt [controller-gen][controller-gen]
 to refresh the files located under `config/rbac`.
 
 <details><summary><code>config/rbac/role.yaml</code>: Our RBAC Role generated </summary>

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -353,7 +353,7 @@ if err := ctrl.SetControllerReference(memcached, dep, r.Scheme); err != nil {
 
 <aside class="note">
 
-<h1>`ownerRef` and  cascading event</h1>
+<h1><code>ownerRef</code> and Cascading Events</h1>
 
 The ownerRef is crucial not only for allowing us to observe changes on the specific resource but also because,
 if we delete the Memcached Custom Resource (CR) from the cluster, we want all resources owned by it to be automatically


### PR DESCRIPTION
fix: #4810 
This PR makes two small documentation corrections in the getting started guide:

1. Replaces `make generate` with `make manifests` when explaining how to update RBAC files. The original command does not regenerate RBAC roles, which may confuse new users.

2. Fixes a malformed heading by replacing backticks with a proper <code> tag for inline code formatting:

   From:
   <h1>`ownerRef` and  cascading event</h1>

   To:
   <h1><code>ownerRef</code> and Cascading Events</h1>

These changes improve clarity and formatting consistency for readers following the tutorial.
