### PR TITLE
🐛 (go/v4) fix: revert accidental addition of explicit docker.io registry in Dockerfile

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/getting-started/testdata/project/Dockerfile
+++ b/docs/book/src/getting-started/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -22,7 +22,7 @@ import (
 
 const devContainerTemplate = `{
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-with-plugins/Dockerfile
+++ b/testdata/project-v4-with-plugins/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.24",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.24 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
✅ Why?

Docker already defaults to Docker Hub (docker.io) when no registry is specified.
So both forms are functionally the same, but:

---

2. Keeps the scaffold clean and idiomatic
- Most open source projects use the short form (golang:1.24).
- It's easier to read and better for beginners.
- This follows standard Go and Docker community practices.
- Adding docker.io just adds noise to the file.

---

3. Avoids lock-in or assumptions
- Hardcoding docker.io can break things in environments with custom or mirrored registries.
- It may confuse users who want to use private registries or CI configs.
- By writing golang:1.24, we let the Docker config decide where to pull from — which is more flexible and future-proof.

---

TL;DR
golang:1.24 already pulls from Docker Hub.
Adding docker.io is not needed — and removing it keeps the Dockerfile clean, standard, and portable.
It was added by mistake in the PR: https://github.com/kubernetes-sigs/kubebuilder/pull/4585
