### PR TITLE
🐛 refactor: inline getKubebuilderVersion into cli.WithCliVersion setup

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -55,7 +55,7 @@ func Run() {
 	c, err := cli.New(
 		cli.WithCommandName("kubebuilder"),
 		cli.WithVersion(versionString()),
-		cli.WithCliVersion(GetKubebuilderVersion()),
+		cli.WithCliVersion(getKubebuilderVersion()),
 		cli.WithPlugins(
 			golangv4.Plugin{},
 			gov4Bundle,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -63,8 +63,8 @@ func versionString() string {
 	})
 }
 
-// GetKubebuilderVersion returns only the CLI version string
-func GetKubebuilderVersion() string {
+// getKubebuilderVersion returns only the CLI version string
+func getKubebuilderVersion() string {
 	if kubeBuilderVersion == unknown {
 		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
 			kubeBuilderVersion = info.Main.Version


### PR DESCRIPTION
Avoid exporting an unnecessary helper.
This change keeps the API surface minimal and avoids exposing internal details unless truly needed.
Note: the function was newly introduced and hasn't been included in any release yet, so we can safely change its visibility without breaking anything.

