### PR TITLE
📖 fix examples how to specify watched CR in Watches()

### DIFF
--- a/docs/book/src/reference/watching-resources/predicates-with-watch.md
+++ b/docs/book/src/reference/watching-resources/predicates-with-watch.md
@@ -87,7 +87,7 @@ func (r *BackupBusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
     return ctrl.NewControllerManagedBy(mgr).
         For(&examplecomv1alpha1.BackupBusybox{}).  // Watch the primary resource (BackupBusybox)
         Watches(
-            &source.Kind{Type: &examplecomv1alpha1.Busybox{}},  // Watch the Busybox CR
+            &examplecomv1alpha1.Busybox{},  // Watch the Busybox CR
             handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
                 return []reconcile.Request{
                     {

--- a/docs/book/src/reference/watching-resources/secondary-resources-not-owned.md
+++ b/docs/book/src/reference/watching-resources/secondary-resources-not-owned.md
@@ -39,7 +39,7 @@ func (r *BackupBusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
     return ctrl.NewControllerManagedBy(mgr).
         For(&examplecomv1alpha1.BackupBusybox{}).  // Watch the primary resource (BackupBusybox)
         Watches(
-            &source.Kind{Type: &examplecomv1alpha1.Busybox{}},  // Watch the Busybox CR
+            &examplecomv1alpha1.Busybox{},  // Watch the Busybox CR
             handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
                 // Trigger reconciliation for the BackupBusybox in the same namespace
                 return []reconcile.Request{
@@ -66,7 +66,7 @@ func (r *BackupBusyboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
     return ctrl.NewControllerManagedBy(mgr).
         For(&examplecomv1alpha1.BackupBusybox{}).  // Watch the primary resource (BackupBusybox)
         Watches(
-            &source.Kind{Type: &examplecomv1alpha1.Busybox{}},  // Watch the Busybox CR
+            &examplecomv1alpha1.Busybox{},  // Watch the Busybox CR
             handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
                 // Check if the Busybox resource has the label 'backup-needed: "true"'
                 if val, ok := obj.GetLabels()["backup-enable"]; ok && val == "true" {


### PR DESCRIPTION
I've followed the Kubebuilder book to add the Watches() method with predicates.
I'm using a project scaffolded with Kubebuilder v4.
I found that the examples didn't compile due to:
![image](https://github.com/user-attachments/assets/c8c5129d-12ed-45c7-924d-f228a233790e)

related bug: https://github.com/kubernetes-sigs/kubebuilder/issues/3698

The last remaining place that uses source.Kind{} is migration guide from v0 to v1 (which does the opposite operation - it introduces the source.Kind)
https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/migration_guide.md?plain=1#L107-L108


