### PR TITLE
🐛 (cli): Fixed an issue where `alpha generate` skipped files and directories beginning with a dot (e.g., `.github/`, `.env`, `.golangci.yaml`). These are now properly removed during cleanup, except `.git` and `PROJECT`, which are intentionally preserved.

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -71,6 +71,17 @@ func (opts *Generate) Generate() error {
 				log.Error("Cleanup failed:", err)
 				return fmt.Errorf("cleanup failed: %w", err)
 			}
+
+			// Note that we should remove ALL files except the PROJECT file and .git directory
+			cleanupCmd = fmt.Sprintf(
+				`find %q -mindepth 1 -maxdepth 1 ! -name '.git' ! -name 'PROJECT' -exec rm -rf {} +`,
+				opts.OutputDir,
+			)
+			err = util.RunCmd("Running cleanup", "sh", "-c", cleanupCmd)
+			if err != nil {
+				log.Error("Cleanup failed:", err)
+				return fmt.Errorf("cleanup failed: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Alpha generate should re-scaffold the full project.
This bug does not allow users to get changes, for example, in GitHub actions. 