### PR TITLE
:sparkles: Add custom path option for webhooks

### DIFF
--- a/pkg/model/resource/webhooks.go
+++ b/pkg/model/resource/webhooks.go
@@ -35,6 +35,12 @@ type Webhooks struct {
 	Conversion bool `json:"conversion,omitempty"`
 
 	Spoke []string `json:"spoke,omitempty"`
+
+	// ValidatingCustomPath specifies a custom path for the validating webhook
+	ValidatingCustomPath string `json:"validatingCustomPath,omitempty"`
+
+	// DefaultingCustomPath specifies a custom path for the defaulting webhook
+	DefaultingCustomPath string `json:"defaultingCustomPath,omitempty"`
 }
 
 // Validate checks that the Webhooks is valid.

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -71,6 +71,12 @@ type Options struct {
 	DoValidation bool
 	DoConversion bool
 
+	// ValidatingWebhookCustomPath defines the custom path that will be used by the scaffolded validating webhooks
+	ValidatingWebhookCustomPath string
+
+	// DefaultingWebhookCustomPath defines the custom path that will be used by the scaffolded defaulting webhooks
+	DefaultingWebhookCustomPath string
+
 	// Spoke versions for conversion webhook
 	Spoke []string
 }
@@ -108,6 +114,14 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 			res.Webhooks.Conversion = true
 			res.Webhooks.Spoke = opts.Spoke
 		}
+	}
+
+	if opts.ValidatingWebhookCustomPath != "" {
+		res.Webhooks.ValidatingCustomPath = opts.ValidatingWebhookCustomPath
+	}
+
+	if opts.DefaultingWebhookCustomPath != "" {
+		res.Webhooks.DefaultingCustomPath = opts.DefaultingWebhookCustomPath
 	}
 
 	if len(opts.ExternalAPIPath) > 0 {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
@@ -131,6 +131,12 @@ func (r *{{ .Resource.Kind }}) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		{{- if .Resource.HasDefaultingWebhook }}
 		WithDefaulter(&{{ .Resource.Kind }}CustomDefaulter{}).
 		{{- end }}
+		{{- if ne .Resource.Webhooks.ValidatingCustomPath "" }}
+		WithValidatorCustomPath("{{ .Resource.Webhooks.ValidatingCustomPath }}").
+		{{- end }}
+		{{- if ne .Resource.Webhooks.DefaultingCustomPath "" }}
+		WithDefaulterCustomPath("{{ .Resource.Webhooks.DefaultingCustomPath }}").
+		{{- end }}
 		Complete()
 }
 {{- else }}
@@ -148,6 +154,12 @@ func Setup{{ .Resource.Kind }}WebhookWithManager(mgr ctrl.Manager) error {
 		{{- if .Resource.HasDefaultingWebhook }}
 		WithDefaulter(&{{ .Resource.Kind }}CustomDefaulter{}).
 		{{- end }}
+		{{- if ne .Resource.Webhooks.ValidatingCustomPath "" }}
+		WithValidatorCustomPath("{{ .Resource.Webhooks.ValidatingCustomPath }}").
+		{{- end }}
+		{{- if ne .Resource.Webhooks.DefaultingCustomPath "" }}
+		WithDefaulterCustomPath("{{ .Resource.Webhooks.DefaultingCustomPath }}").
+		{{- end }}
 		Complete()
 }
 {{- end }}
@@ -157,7 +169,7 @@ func Setup{{ .Resource.Kind }}WebhookWithManager(mgr ctrl.Manager) error {
 
 	//nolint:lll
 	defaultingWebhookTemplate = `
-// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/mutate-{{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}-{{ else }}{{ .QualifiedGroupWithDash }}-{{ end }}{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}""{{ else }}{{ .Resource.QualifiedGroup }}{{ end }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path={{ if ne .Resource.Webhooks.DefaultingCustomPath "" }}{{ .Resource.Webhooks.DefaultingCustomPath }}{{ else }}/mutate-{{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}-{{ else }}{{ .QualifiedGroupWithDash }}-{{ end }}{{ .Resource.Version }}-{{ lower .Resource.Kind }}{{ end }},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}""{{ else }}{{ .Resource.QualifiedGroup }}{{ end }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
 {{ if .IsLegacyPath -}}
 // +kubebuilder:object:generate=false
@@ -197,7 +209,8 @@ func (d *{{ .Resource.Kind }}CustomDefaulter) Default(_ context.Context, obj run
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path=/validate-{{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}-{{ else }}{{ .QualifiedGroupWithDash }}-{{ end }}{{ .Resource.Version }}-{{ lower .Resource.Kind }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}""{{ else }}{{ .Resource.QualifiedGroup }}{{ end }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+// +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}path={{ if ne .Resource.Webhooks.ValidatingCustomPath "" }}{{ .Resource.Webhooks.ValidatingCustomPath }}{{ else }}/validate-{{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}-{{ else }}{{ .QualifiedGroupWithDash }}-{{ end }}{{ .Resource.Version }}-{{ lower .Resource.Kind }}{{ end }},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}""{{ else }}{{ .Resource.QualifiedGroup }}{{ end }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
+
 
 {{ if .IsLegacyPath -}}
 // +kubebuilder:object:generate=false

--- a/test/e2e/v4/generate_test.go
+++ b/test/e2e/v4/generate_test.go
@@ -195,6 +195,55 @@ func GenerateV4WithNetworkPolicies(kbc *utils.TestContext) {
 	uncommentKustomizeCoversion(kbc)
 }
 
+// GenerateV4WithWebhookCustomPath implements a go/v4 plugin project defined by a TestContext.
+func GenerateV4WithWebhookCustomPath(kbc *utils.TestContext) {
+	initingTheProject(kbc)
+	creatingAPI(kbc)
+
+	By("scaffolding defaulting and validating webhooks")
+	err := kbc.CreateWebhook(
+		"--group", kbc.Group,
+		"--version", kbc.Version,
+		"--kind", kbc.Kind,
+		"--defaulting",
+		"--programmatic-validation",
+		"--validating-custom-path", "/my-validating-custom-path/my-webhook-handler",
+		"--defaulting-custom-path", "/my-defaulting-custom-path/my-webhook-handler",
+		"--make=false",
+	)
+	Expect(err).NotTo(HaveOccurred(), "Failed to scaffold webhooks")
+
+	By("implementing the defaulting and validating webhooks")
+	webhookFilePath := filepath.Join(
+		kbc.Dir, "internal/webhook", kbc.Version,
+		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind)))
+	err = utils.ImplementWebhooks(webhookFilePath, strings.ToLower(kbc.Kind))
+	Expect(err).NotTo(HaveOccurred(), "Failed to implement webhooks")
+
+	scaffoldConversionWebhook(kbc)
+
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../certmanager", "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../prometheus", "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		`#replacements:`, "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		certManagerTarget, "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "prometheus", "kustomization.yaml"),
+		monitorTLSPatch, "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		metricsCertPatch, "#")).To(Succeed())
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		metricsCertReplaces, "#")).To(Succeed())
+	uncommentKustomizeCoversion(kbc)
+}
+
 // GenerateV4WithoutWebhooks implements a go/v4 plugin with APIs and enable Prometheus and CertManager
 func GenerateV4WithoutWebhooks(kbc *utils.TestContext) {
 	initingTheProject(kbc)

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -66,6 +66,10 @@ var _ = Describe("kubebuilder", func() {
 			By("removing controller image and working dir")
 			kbc.Destroy()
 		})
+		It("should generate a runnable project using the custom path for the webhooks", func() {
+			GenerateV4WithWebhookCustomPath(kbc)
+			Run(kbc, true, false, false, true, false)
+		})
 		It("should generate a runnable project", func() {
 			GenerateV4(kbc)
 			Run(kbc, true, false, false, true, false)


### PR DESCRIPTION
Closes #4295 ! This PR brings a way to configure custom webhook path for the defaulting and validating webhooks in the `kubebuilder` cli.

Two new flags are added for the `kubebuilder create webhook` command: `--defaulting-custom-path` & `--validating-custom-path`. Both can be used independently.

Usage:
```sh
kubebuilder create webhook \
    --group mygroup.io --kind MyResource --version v1alpha1 \
    --defaulting --programmatic-validation \
    --defaulting-custom-path=/my-custom-defaulting-webhook-path \
    --validating-custom-path=/my-custom-validating-webhook-path
```

When used, it will:
1. Change the `// +kubebuilder:webhook:path` go marker.
2. Add `WithValidatorCustomPath(...).` or/and `WithDefaulterCustomPath(...).` to the webhook setuper function.

Result from the example above:
```go
func SetupMyResourceWebhookWithManager(mgr ctrl.Manager) error {
	return ctrl.NewWebhookManagedBy(mgr).For(&mygroupiov1alpha1.MyResource{}).
		WithValidator(&MyResourceCustomValidator{}).
		WithDefaulter(&MyResourceCustomDefaulter{}).
		WithValidatorCustomPath("/my-custom-validating-webhook-path").
		WithDefaulterCustomPath("/my-custom-defaulting-webhook-path").
		Complete()
}

// +kubebuilder:webhook:path=/my-custom-defaulting-webhook-path,mutating=true,failurePolicy=fail,sideEffects=None,groups=mygroup.io,resources=myresources,verbs=create;update,versions=v1alpha1,name=mmyresource-v1alpha1.kb.io,admissionReviewVersions=v1

...

// +kubebuilder:webhook:path=/my-custom-validating-webhook-path,mutating=false,failurePolicy=fail,sideEffects=None,groups=mygroup.io,resources=myresources,verbs=create;update,versions=v1alpha1,name=vmyresource-v1alpha1.kb.io,admissionReviewVersions=v1
```