### PR TITLE
🌱 (ci) - Enable tests against k8s 1.33

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -55,9 +55,9 @@ if [ -n "$TRACE" ]; then
   set -x
 fi
 
-export KIND_K8S_VERSION="${KIND_K8S_VERSION:-"v1.31.0"}"
+export KIND_K8S_VERSION="${KIND_K8S_VERSION:-"v1.33.0"}"
 tools_k8s_version=$(convert_to_tools_ver "${KIND_K8S_VERSION#v*}")
-kind_version=0.22.0
+kind_version=0.29.0
 goarch=amd64
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then


### PR DESCRIPTION
This PR will only allow us to start running the tests against 1.33

```
Docker in Docker enabled, initializing...
================================================================================
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.all.forwarding = 1
Starting Docker: docker.
Waiting for docker to be ready, sleeping for 1 seconds.
================================================================================
Done setting up docker in docker.
+ WRAPPED_COMMAND_PID=234
+ wait 234
+ ./test_e2e.sh
[1;33mBuilding kubebuilder[0m
go: downloading github.com/spf13/afero v1.14.0
go: downloading github.com/sirupsen/logrus v1.9.3
go: downloading github.com/spf13/pflag v1.0.6
go: downloading sigs.k8s.io/yaml v1.4.0
go: downloading golang.org/x/tools v0.33.0
go: downloading github.com/spf13/cobra v1.9.1
go: downloading golang.org/x/text v0.25.0
go: downloading github.com/gobuffalo/flect v1.0.3
go: downloading golang.org/x/sys v0.33.0
go: downloading golang.org/x/sync v0.14.0
go: downloading golang.org/x/mod v0.24.0
[1;33mInstalling setup-envtest to /home/prow/go/bin[0m
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20250517180713-32e5e9e948a5
go: downloading sigs.k8s.io/controller-runtime v0.20.5-0.20250517180713-32e5e9e948a5
go: downloading github.com/go-logr/logr v1.4.2
go: downloading go.uber.org/zap v1.27.0
go: downloading github.com/spf13/afero v1.12.0
go: downloading github.com/go-logr/zapr v1.3.0
go: downloading golang.org/x/text v0.21.0
go: downloading go.uber.org/multierr v1.10.0
[1;33mInstalling e2e tools with setup-envtest[0m
Version: 1.33.0
OS/Arch: linux/amd64
sha512: 2cb7f5468ed7cea1492f971b715bcc27069e824cf7d5927b7f127f1e8c75cf086eea050543cdb5f79faee0a2bf775f160adf27443aa7ee845d962d04e9d43ac9
Path: /root/.local/share/kubebuilder-envtest/k8s/1.33.0-linux-amd64
[1;33mInstalling kind to /home/prow/go/bin[0m
go: downloading sigs.k8s.io/kind v0.22.0
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading github.com/spf13/cobra v1.4.0
go: downloading github.com/alessio/shellescape v1.4.1
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/pelletier/go-toml v1.9.4
go: downloading sigs.k8s.io/yaml v1.3.0
go: downloading github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
go: downloading github.com/BurntSushi/toml v1.0.0
go: downloading github.com/evanphx/json-patch/v5 v5.6.0
go: downloading golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
go: downloading gopkg.in/yaml.v2 v2.4.0
Getting kind config...
No kind clusters found.
Creating cluster...
Creating cluster "kind" ...
 • Ensuring node image (kindest/node:v1.33.0) 🖼  ...
DEBUG: docker/images.go:67] Pulling image: kindest/node:v1.33.0 ...
 ✓ Ensuring node image (kindest/node:v1.33.0) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦 
 • Writing configuration 📜  ...
DEBUG: config/config.go:96] Using the following kubeadm config for node kind-control-plane:
apiServer:
  certSANs:
  - localhost
  - 127.0.0.1
  extraArgs:
    runtime-config: ""
apiVersion: kubeadm.k8s.io/v1beta3
clusterName: kind
controlPlaneEndpoint: kind-control-plane:6443
controllerManager:
  extraArgs:
    enable-hostpath-provisioner: "true"
kind: ClusterConfiguration
kubernetesVersion: v1.33.0
networking:
  podSubnet: 10.244.0.0/16
  serviceSubnet: 10.96.0.0/16
scheduler:
  extraArgs: null
---
apiVersion: kubeadm.k8s.io/v1beta3
bootstrapTokens:
- token: abcdef.0123456789abcdef
kind: InitConfiguration
localAPIEndpoint:
  advertiseAddress: 172.18.0.2
  bindPort: 6443
nodeRegistration:
  criSocket: unix:///run/containerd/containerd.sock
  kubeletExtraArgs:
    node-ip: 172.18.0.2
    node-labels: ""
    provider-id: kind://docker/kind/kind-control-plane
---
apiVersion: kubeadm.k8s.io/v1beta3
controlPlane:
  localAPIEndpoint:
    advertiseAddress: 172.18.0.2
    bindPort: 6443
discovery:
  bootstrapToken:
    apiServerEndpoint: kind-control-plane:6443
    token: abcdef.0123456789abcdef
    unsafeSkipCAVerification: true
kind: JoinConfiguration
nodeRegistration:
  criSocket: unix:///run/containerd/containerd.sock
  kubeletExtraArgs:
    node-ip: 172.18.0.2
    node-labels: ""
    provider-id: kind://docker/kind/kind-control-plane
---
apiVersion: kubelet.config.k8s.io/v1beta1
cgroupDriver: systemd
cgroupRoot: /kubelet
evictionHard:
  imagefs.available: 0%
  nodefs.available: 0%
  nodefs.inodesFree: 0%
failSwapOn: false
imageGCHighThresholdPercent: 100
kind: KubeletConfiguration
---
apiVersion: kubeproxy.config.k8s.io/v1alpha1
conntrack:
  maxPerCore: 0
iptables:
  minSyncPeriod: 1s
kind: KubeProxyConfiguration
mode: iptables
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
DEBUG: kubeadminit/init.go:82] I0601 20:53:18.173443     175 initconfiguration.go:261] loading configuration from "/kind/kubeadm.conf"
W0601 20:53:18.174115     175 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.
W0601 20:53:18.174712     175 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "InitConfiguration"). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.
W0601 20:53:18.175216     175 common.go:101] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "JoinConfiguration"). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.
W0601 20:53:18.175527     175 initconfiguration.go:362] [config] WARNING: Ignored configuration document with GroupVersionKind kubeadm.k8s.io/v1beta3, Kind=JoinConfiguration
[init] Using Kubernetes version: v1.33.0
[certs] Using certificateDir folder "/etc/kubernetes/pki"
I0601 20:53:18.177204     175 certs.go:112] creating a new certificate authority for ca
[certs] Generating "ca" certificate and key
I0601 20:53:18.884095     175 certs.go:473] validating certificate period for ca certificate
[certs] Generating "apiserver" certificate and key
[certs] apiserver serving cert is signed for DNS names [kind-control-plane kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local localhost] and IPs [10.96.0.1 172.18.0.2 127.0.0.1]
[certs] Generating "apiserver-kubelet-client" certificate and key
I0601 20:53:20.590150     175 certs.go:112] creating a new certificate authority for front-proxy-ca
[certs] Generating "front-proxy-ca" certificate and key
I0601 20:53:20.936002     175 certs.go:473] validating certificate period for front-proxy-ca certificate
[certs] Generating "front-proxy-client" certificate and key
I0601 20:53:21.090199     175 certs.go:112] creating a new certificate authority for etcd-ca
[certs] Generating "etcd/ca" certificate and key
I0601 20:53:21.540396     175 certs.go:473] validating certificate period for etcd/ca certificate
[certs] Generating "etcd/server" certificate and key
[certs] etcd/server serving cert is signed for DNS names [kind-control-plane localhost] and IPs [172.18.0.2 127.0.0.1 ::1]
[certs] Generating "etcd/peer" certificate and key
[certs] etcd/peer serving cert is signed for DNS names [kind-control-plane localhost] and IPs [172.18.0.2 127.0.0.1 ::1]
[certs] Generating "etcd/healthcheck-client" certificate and key
[certs] Generating "apiserver-etcd-client" certificate and key
I0601 20:53:23.452564     175 certs.go:78] creating new public/private key files for signing service account users
[certs] Generating "sa" key and public key
[kubeconfig] Using kubeconfig folder "/etc/kubernetes"
I0601 20:53:24.158162     175 kubeconfig.go:111] creating kubeconfig file for admin.conf
[kubeconfig] Writing "admin.conf" kubeconfig file
I0601 20:53:24.252525     175 kubeconfig.go:111] creating kubeconfig file for super-admin.conf
[kubeconfig] Writing "super-admin.conf" kubeconfig file
I0601 20:53:24.573190     175 kubeconfig.go:111] creating kubeconfig file for kubelet.conf
[kubeconfig] Writing "kubelet.conf" kubeconfig file
I0601 20:53:25.404328     175 kubeconfig.go:111] creating kubeconfig file for controller-manager.conf
[kubeconfig] Writing "controller-manager.conf" kubeconfig file
I0601 20:53:25.801941     175 kubeconfig.go:111] creating kubeconfig file for scheduler.conf
[kubeconfig] Writing "scheduler.conf" kubeconfig file
[etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
I0601 20:53:26.168004     175 local.go:66] [etcd] wrote Static Pod manifest for a local etcd member to "/etc/kubernetes/manifests/etcd.yaml"
I0601 20:53:26.168080     175 manifests.go:104] [control-plane] getting StaticPodSpecs
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
I0601 20:53:26.168469     175 certs.go:473] validating certificate period for CA certificate
I0601 20:53:26.168587     175 manifests.go:130] [control-plane] adding volume "ca-certs" for component "kube-apiserver"
I0601 20:53:26.168614     175 manifests.go:130] [control-plane] adding volume "etc-ca-certificates" for component "kube-apiserver"
I0601 20:53:26.168622     175 manifests.go:130] [control-plane] adding volume "k8s-certs" for component "kube-apiserver"
I0601 20:53:26.168630     175 manifests.go:130] [control-plane] adding volume "usr-local-share-ca-certificates" for component "kube-apiserver"
I0601 20:53:26.168637     175 manifests.go:130] [control-plane] adding volume "usr-share-ca-certificates" for component "kube-apiserver"
[control-plane] Creating static Pod manifest for "kube-controller-manager"
I0601 20:53:26.170016     175 manifests.go:159] [control-plane] wrote static Pod manifest for component "kube-apiserver" to "/etc/kubernetes/manifests/kube-apiserver.yaml"
I0601 20:53:26.170052     175 manifests.go:104] [control-plane] getting StaticPodSpecs
I0601 20:53:26.170376     175 manifests.go:130] [control-plane] adding volume "ca-certs" for component "kube-controller-manager"
I0601 20:53:26.170400     175 manifests.go:130] [control-plane] adding volume "etc-ca-certificates" for component "kube-controller-manager"
I0601 20:53:26.170407     175 manifests.go:130] [control-plane] adding volume "flexvolume-dir" for component "kube-controller-manager"
I0601 20:53:26.170413     175 manifests.go:130] [control-plane] adding volume "k8s-certs" for component "kube-controller-manager"
I0601 20:53:26.170419     175 manifests.go:130] [control-plane] adding volume "kubeconfig" for component "kube-controller-manager"
I0601 20:53:26.170425     175 manifests.go:130] [control-plane] adding volume "usr-local-share-ca-certificates" for component "kube-controller-manager"
I0601 20:53:26.170430     175 manifests.go:130] [control-plane] adding volume "usr-share-ca-certificates" for component "kube-controller-manager"
[control-plane] Creating static Pod manifest for "kube-scheduler"
I0601 20:53:26.171655     175 manifests.go:159] [control-plane] wrote static Pod manifest for component "kube-controller-manager" to "/etc/kubernetes/manifests/kube-controller-manager.yaml"
I0601 20:53:26.171712     175 manifests.go:104] [control-plane] getting StaticPodSpecs
I0601 20:53:26.172039     175 manifests.go:130] [control-plane] adding volume "kubeconfig" for component "kube-scheduler"
I0601 20:53:26.172972     175 manifests.go:159] [control-plane] wrote static Pod manifest for component "kube-scheduler" to "/etc/kubernetes/manifests/kube-scheduler.yaml"
I0601 20:53:26.173019     175 kubelet.go:70] Stopping the kubelet
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Starting the kubelet
I0601 20:53:26.523873     175 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
I0601 20:53:26.524385     175 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0601 20:53:26.524432     175 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0601 20:53:26.524444     175 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0601 20:53:26.524454     175 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0601 20:53:26.524463     175 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests"
[kubelet-check] Waiting for a healthy kubelet at http://127.0.0.1:10248/healthz. This can take up to 4m0s
[kubelet-check] The kubelet is healthy after 1.502077942s
[control-plane-check] Waiting for healthy control plane components. This can take up to 4m0s
[control-plane-check] Checking kube-apiserver at https://172.18.0.2:6443/livez
[control-plane-check] Checking kube-controller-manager at https://127.0.0.1:10257/healthz
[control-plane-check] Checking kube-scheduler at https://127.0.0.1:10259/livez
I0601 20:53:28.032586     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="" milliseconds=1
I0601 20:53:28.533053     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="" milliseconds=0
I0601 20:53:29.032119     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="" milliseconds=0
I0601 20:53:29.532503     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="" milliseconds=1
[control-plane-check] kube-controller-manager is healthy after 3.047878677s
I0601 20:53:32.878247     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=2846
I0601 20:53:32.880942     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=1
[control-plane-check] kube-scheduler is healthy after 4.939448188s
I0601 20:53:33.034684     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=2
I0601 20:53:33.533148     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=1
I0601 20:53:34.033207     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=1
I0601 20:53:34.533432     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/livez?timeout=10s" status="200 OK" milliseconds=1
[control-plane-check] kube-apiserver is healthy after 6.502264117s
I0601 20:53:34.534159     175 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
I0601 20:53:34.535090     175 loader.go:402] Config loaded from file:  /etc/kubernetes/super-admin.conf
I0601 20:53:34.535775     175 kubeconfig.go:665] ensuring that the ClusterRoleBinding for the kubeadm:cluster-admins Group exists
I0601 20:53:34.537095     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="403 Forbidden" milliseconds=1
I0601 20:53:34.537232     175 kubeconfig.go:738] creating the ClusterRoleBinding for the kubeadm:cluster-admins Group by using super-admin.conf
I0601 20:53:34.547744     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=10
[upload-config] Storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
I0601 20:53:34.547873     175 uploadconfig.go:112] [upload-config] Uploading the kubeadm ClusterConfiguration to a ConfigMap
I0601 20:53:34.551778     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/api/v1/namespaces/kube-system/configmaps?timeout=10s" status="201 Created" milliseconds=3
I0601 20:53:34.554950     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/roles?timeout=10s" status="201 Created" milliseconds=2
I0601 20:53:34.558448     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/rolebindings?timeout=10s" status="201 Created" milliseconds=3
[kubelet] Creating a ConfigMap "kubelet-config" in namespace kube-system with the configuration for the kubelets in the cluster
I0601 20:53:34.558571     175 uploadconfig.go:126] [upload-config] Uploading the kubelet component config to a ConfigMap
I0601 20:53:34.562040     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/api/v1/namespaces/kube-system/configmaps?timeout=10s" status="201 Created" milliseconds=2
I0601 20:53:34.565058     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/roles?timeout=10s" status="201 Created" milliseconds=2
I0601 20:53:34.568215     175 round_trippers.go:632] "Response" verb="POST" url="https://kind-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/rolebindings?timeout=10s" status="201 Created" milliseconds=2
I0601 20:53:34.568317     175 uploadconfig.go:132] [upload-config] Preserving the CRISocket information for the control-plane node
I0601 20:53:34.568339     175 patchnode.go:32] [patchnode] Uploading the CRI socket "unix:///run/containerd/containerd.sock" to Node "kind-control-plane" as an annotation
I0601 20:53:34.570776     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/api/v1/nodes/kind-control-plane?timeout=10s" status="200 OK" milliseconds=2
I0601 20:53:34.577098     175 round_trippers.go:632] "Response" verb="PATCH" url="https://kind-control-plane:6443/api/v1/nodes/kind-control-plane?timeout=10s" status="200 OK" milliseconds=5
[upload-certs] Skipping phase. Please see --upload-certs
[mark-control-plane] Marking the node kind-control-plane as control-plane by adding the labels: [node-role.kubernetes.io/control-plane node.kubernetes.io/exclude-from-external-load-balancers]
[mark-control-plane] Marking the node kind-control-plane as control-plane by adding the taints [node-role.kubernetes.io/control-plane:NoSchedule]
I0601 20:53:34.579679     175 round_trippers.go:632] "Response" verb="GET" url="https://kind-control-plane:6443/api/v1/nodes/kind-control-plane?timeout=10s" status="200 OK" milliseconds=2
I0601 20:53:34.585714     175 round_trippers.go:632] "Response" verb="PATCH" url="https://kind-control-plane:6443/api/v1/nodes/kind-control-plane?timeout=10s" status="200 OK" milliseconds=5
[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles
I0601 20:53:34.586507     175 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
I0601 20:53:34.588992     175 round_trippers.go:632] "Response" 
```

However, as a follow-up, we must fix the tests for 1.33
Two scenarios starts to fail:

```
Summarizing 2 Failures:
  [FAIL] kubebuilder plugin go/v4 [It] should generate a runnable project with metrics protected by network policies
  /home/prow/go/src/sigs.k8s.io/kubebuilder/test/e2e/v4/plugin_cluster_test.go:526
  [FAIL] kubebuilder plugin go/v4 [It] should generate a runnable project with the manager running as restricted and without webhooks
  /home/prow/go/src/sigs.k8s.io/kubebuilder/test/e2e/v4/plugin_cluster_test.go:526
```



