### PR TITLE
:sparkles: (ux/cli) Improve `kubebuilder version` info output formatting

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -53,14 +53,18 @@ func versionString() string {
 		}
 	}
 
-	return fmt.Sprintf("Version: %#v", version{
+	return fmt.Sprintf(`Kubebuilder Version: %s
+Kubernetes Vendor: %s
+OS: %s
+Arch: %s
+Git Commit: %s
+Build Date: %s`,
 		kubeBuilderVersion,
 		kubernetesVendorVersion,
-		gitCommit,
-		buildDate,
 		goos,
 		goarch,
-	})
+		gitCommit,
+		buildDate)
 }
 
 // getKubebuilderVersion returns only the CLI version string


### PR DESCRIPTION
Updates `versionString()` to return a string with better formatting and increased readability. This change also helps users provide version info when reporting bugs.

- Currently, the `kubebuilder version` command outputs version info the following format:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder$ ./bin/kubebuilder version
Version: cmd.version{KubeBuilderVersion:"v4.6.0", KubernetesVendor:"1.33.0", GitCommit:"1d79aa1ec8204a11ae6be06cb96bae77dd0210bf", BuildDate:"2025-06-06T19:38:06Z", GoOs:"linux", GoArch:"amd64"}
```
- This PR improves formatting to a more readable multi-line layout, similar to other CLI tools:
```
vitorfloriano@pc:~/go/src/github.com/vitorfloriano/kubebuilder$ ./bin/kubebuilder version
Kubebuilder Version: v4.6.0-dirty
Kubernetes Vendor: 1.33.0
OS: linux
Arch: amd64
Git Commit: 1d79aa1ec8204a11ae6be06cb96bae77dd0210bf
Build Date: 2025-06-06T19:38:34Z
```
This is a small but meaningful quality-of-life improvement for the user experience.