### PR TITLE
🐛 (go/v4): ensure manager and curl pod use readOnlyRootFilesystem to comply with PSA rules

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
         name: manager
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4197,6 +4197,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-metrics-server/metrics-certs
           name: metrics-certs

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -226,6 +226,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]

--- a/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
         name: manager
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -453,6 +453,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         volumeMounts: []
       securityContext:
         runAsNonRoot: true

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
@@ -221,6 +221,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
         name: manager
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -8049,6 +8049,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-metrics-server/metrics-certs
           name: metrics-certs

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -226,6 +226,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -113,6 +113,7 @@ spec:
         name: manager
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -384,6 +384,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]

--- a/test/e2e/v4/plugin_cluster_test.go
+++ b/test/e2e/v4/plugin_cluster_test.go
@@ -595,6 +595,7 @@ func cmdOptsToCreateCurlPod(kbc *utils.TestContext, token string) []string {
 					"command": ["/bin/sh", "-c"],
 					"args": ["curl -v -k -H 'Authorization: Bearer %s' https://e2e-%s-controller-manager-metrics-service.%s.svc.cluster.local:8443/metrics"],
 					"securityContext": {
+						"readOnlyRootFilesystem": true,
 						"allowPrivilegeEscalation": false,
 						"capabilities": {
 							"drop": ["ALL"]

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -72,6 +72,7 @@ spec:
           value: memcached:1.6.26-alpine3.19
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -2157,6 +2157,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs

--- a/testdata/project-v4-multigroup/test/e2e/e2e_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_test.go
@@ -221,6 +221,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]

--- a/testdata/project-v4-with-plugins/config/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/config/manager/manager.yaml
@@ -72,6 +72,7 @@ spec:
           value: memcached:1.6.26-alpine3.19
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -850,6 +850,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_test.go
@@ -221,6 +221,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -67,6 +67,7 @@ spec:
         name: manager
         ports: []
         securityContext:
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -715,6 +715,7 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs

--- a/testdata/project-v4/test/e2e/e2e_test.go
+++ b/testdata/project-v4/test/e2e/e2e_test.go
@@ -221,6 +221,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"command": ["/bin/sh", "-c"],
 							"args": ["curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics"],
 							"securityContext": {
+								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
 								"capabilities": {
 									"drop": ["ALL"]


### PR DESCRIPTION
Kubernetes 1.25+ with Pod Security Admission (PSA) in restricted mode requires containers to run with readOnlyRootFilesystem=true. This updates both the manager deployment and the test-created curl pod accordingly.
