### PR TITLE
🌱 (e2e test context): not try remove ns when we uninstall release

### DIFF
--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -365,11 +365,6 @@ func (t *TestContext) UninstallHelmRelease() error {
 	if err != nil {
 		return err
 	}
-
-	if _, err := t.Kubectl.Wait(false, "namespace", ns, "--for=delete", "--timeout=2m"); err != nil {
-		log.Printf("failed to wait for namespace deletion: %s", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
We should not try to remove the ns when we uninstall the release.
The function should only do what its name suggests, which is to uninstall the Helm release.
Furthermore, if we manage the namespace, it needs to be for all cases, not just when we install the solution with Helm. 