### PR TITLE
✨ (alpha update) initial code for the `alpha update` command

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -31,6 +31,7 @@ const (
 var alphaCommands = []*cobra.Command{
 	newAlphaCommand(),
 	alpha.NewScaffoldCommand(),
+	alpha.NewUpdateCommand(),
 }
 
 func newAlphaCommand() *cobra.Command {

--- a/pkg/cli/alpha/internal/common/common.go
+++ b/pkg/cli/alpha/internal/common/common.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+// LoadProjectConfig load the project config.
+func LoadProjectConfig(inputDir string) (store.Store, error) {
+	projectConfig := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
+	if err := projectConfig.LoadFrom(fmt.Sprintf("%s/%s", inputDir, yaml.DefaultPath)); err != nil {
+		return nil, fmt.Errorf("failed to load PROJECT file: %w", err)
+	}
+	return projectConfig, nil
+}
+
+// GetInputPath will return the input path for the project.
+func GetInputPath(inputPath string) (string, error) {
+	if inputPath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get working directory: %w", err)
+		}
+		inputPath = cwd
+	}
+	projectPath := fmt.Sprintf("%s/%s", inputPath, yaml.DefaultPath)
+	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("project path %q does not exist: %w", projectPath, err)
+	}
+	return inputPath, nil
+}

--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -1,0 +1,538 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"golang.org/x/mod/semver"
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+)
+
+// Update contains configuration for the update operation
+type Update struct {
+	// FromVersion specifies which version of Kubebuilder to use for the update.
+	// If empty, the version from the PROJECT file will be used.
+	FromVersion string
+	// FromBranch specifies which branch to use as current when updating
+	FromBranch string
+	// CliVersion holds the version to be used during the upgrade process
+	CliVersion string
+	// BinaryURL holds the URL for downloading the specified binary from
+	// the releases on GitHub
+	BinaryURL string
+}
+
+// Update performs a complete project update by creating a three-way merge to help users
+// upgrade their Kubebuilder projects. The process creates multiple Git branches:
+// - ancestor: Clean state with old Kubebuilder version scaffolding
+// - current: User's current project state
+// - upgrade: New Kubebuilder version scaffolding
+// - merge: Attempts to merge upgrade changes into current state
+func (opts *Update) Update() error {
+	// Download the specific Kubebuilder binary version for generating clean scaffolding
+	tempDir, err := opts.downloadKubebuilderBinary()
+	if err != nil {
+		return fmt.Errorf("failed to download Kubebuilder %s binary: %w", opts.CliVersion, err)
+	}
+	log.Infof("Downloaded binary kept at %s for debugging purposes", tempDir)
+
+	// Create ancestor branch with clean state for three-way merge
+	if err := opts.checkoutAncestorBranch(); err != nil {
+		return fmt.Errorf("failed to checkout the ancestor branch: %w", err)
+	}
+
+	// Remove all existing files to create a clean slate for re-scaffolding
+	if err := opts.cleanUpAncestorBranch(); err != nil {
+		return fmt.Errorf("failed to clean up the ancestor branch: %w", err)
+	}
+
+	// Generate clean scaffolding using the old Kubebuilder version
+	if err := opts.runAlphaGenerate(tempDir, opts.CliVersion); err != nil {
+		return fmt.Errorf("failed to run alpha generate on ancestor branch: %w", err)
+	}
+
+	// Create current branch representing user's existing project state
+	if err := opts.checkoutCurrentOffAncestor(); err != nil {
+		return fmt.Errorf("failed to checkout current off ancestor: %w", err)
+	}
+
+	// Create upgrade branch with new Kubebuilder version scaffolding
+	if err := opts.checkoutUpgradeOffAncestor(); err != nil {
+		return fmt.Errorf("failed to checkout upgrade off ancestor: %w", err)
+	}
+
+	// Create merge branch to attempt automatic merging of changes
+	if err := opts.checkoutMergeOffCurrent(); err != nil {
+		return fmt.Errorf("failed to checkout merge branch off current: %w", err)
+	}
+
+	// Attempt to merge upgrade changes into the user's current state
+	if err := opts.mergeUpgradeIntoMerge(); err != nil {
+		return fmt.Errorf("failed to merge upgrade into merge branch: %w", err)
+	}
+
+	return nil
+}
+
+// downloadKubebuilderBinary downloads the specified version of Kubebuilder binary
+// from GitHub releases and saves it to a temporary directory with executable permissions.
+// Returns the temporary directory path containing the binary.
+func (opts *Update) downloadKubebuilderBinary() (string, error) {
+	// Construct GitHub release URL based on current OS and architecture
+	url := opts.BinaryURL
+
+	log.Infof("Downloading the Kubebuilder %s binary from: %s", opts.CliVersion, url)
+
+	// Create temporary directory for storing the downloaded binary
+	fs := afero.NewOsFs()
+	tempDir, err := afero.TempDir(fs, "", "kubebuilder"+opts.CliVersion+"-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+
+	// Create the binary file in the temporary directory
+	binaryPath := tempDir + "/kubebuilder"
+	file, err := os.Create(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create the binary file: %w", err)
+	}
+	defer func() {
+		if err = file.Close(); err != nil {
+			log.Errorf("failed to close the file: %v", err)
+		}
+	}()
+
+	// Download the binary from GitHub releases
+	response, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to download the binary: %w", err)
+	}
+	defer func() {
+		if err = response.Body.Close(); err != nil {
+			log.Errorf("failed to close the connection: %v", err)
+		}
+	}()
+
+	// Check if download was successful
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download the binary: HTTP %d", response.StatusCode)
+	}
+
+	// Copy the downloaded content to the local file
+	_, err = io.Copy(file, response.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write the binary content to file: %w", err)
+	}
+
+	// Make the binary executable
+	if err := os.Chmod(binaryPath, 0o755); err != nil {
+		return "", fmt.Errorf("failed to make binary executable: %w", err)
+	}
+
+	log.Infof("Kubebuilder version %s successfully downloaded to %s", opts.CliVersion, binaryPath)
+
+	return tempDir, nil
+}
+
+// checkoutAncestorBranch creates and switches to the 'ancestor' branch.
+// This branch will serve as the common ancestor for the three-way merge,
+// containing clean scaffolding from the old Kubebuilder version.
+func (opts *Update) checkoutAncestorBranch() error {
+	gitCmd := exec.Command("git", "checkout", "-b", "tmp-kb-update-ancestor")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to create and checkout ancestor branch: %w", err)
+	}
+	log.Info("Created and checked out ancestor branch")
+
+	return nil
+}
+
+// cleanUpAncestorBranch removes all files from the ancestor branch to create
+// a clean state for re-scaffolding. This ensures the ancestor branch only
+// contains pure scaffolding without any user modifications.
+func (opts *Update) cleanUpAncestorBranch() error {
+	log.Info("Cleaning all files and folders except .git and PROJECT")
+	// Remove all tracked files from the Git repository
+	cmd := exec.Command("find", ".", "-mindepth", "1", "-maxdepth", "1",
+		"!", "-name", ".git",
+		"!", "-name", "PROJECT",
+		"-exec", "rm", "-rf", "{}", "+")
+	log.Infof("Running cleanup command: %v", cmd.Args)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to clean up files in ancestor branch: %w", err)
+	}
+	log.Info("Successfully cleanup files in ancestor branch")
+
+	// Remove all untracked files and directories
+	gitCmd := exec.Command("git", "add", ".")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage changes in ancestor: %w", err)
+	}
+	log.Info("Successfully staged changes in ancestor")
+
+	// Commit the cleanup to establish the clean state
+	gitCmd = exec.Command("git", "commit", "-m", "Clean up the ancestor branch")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to commit the cleanup in ancestor branch: %w", err)
+	}
+	log.Info("Successfully committed cleanup on ancestor")
+
+	return nil
+}
+
+// runMakeTargets is a helper function to run make with the targets necessary
+// to ensure all the necessary components are generated, formatted and linted.
+func runMakeTargets() error {
+	targets := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
+	for _, target := range targets {
+		log.Infof("Running: make %s", target)
+		err := util.RunCmd(fmt.Sprintf("Running make %s", target), "make", target)
+		if err != nil {
+			return fmt.Errorf("make %s failed: %v", target, err)
+		}
+	}
+	return nil
+}
+
+// runAlphaGenerate executes the old Kubebuilder version's 'alpha generate' command
+// to create clean scaffolding in the ancestor branch. This uses the downloaded
+// binary with the original PROJECT file to recreate the project's initial state.
+func (opts *Update) runAlphaGenerate(tempDir, version string) error {
+	// Temporarily modify PATH to use the downloaded Kubebuilder binary
+	tempBinaryPath := tempDir + "/kubebuilder"
+	originalPath := os.Getenv("PATH")
+	tempEnvPath := tempDir + ":" + originalPath
+
+	if err := os.Setenv("PATH", tempEnvPath); err != nil {
+		return fmt.Errorf("failed to set temporary PATH: %w", err)
+	}
+
+	// Restore original PATH when function completes
+	defer func() {
+		if err := os.Setenv("PATH", originalPath); err != nil {
+			log.Errorf("failed to restore original PATH: %v", err)
+		}
+	}()
+
+	// Prepare the alpha generate command with proper I/O redirection
+	cmd := exec.Command(tempBinaryPath, "alpha", "generate")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	// Execute the alpha generate command to create clean scaffolding
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run alpha generate: %w", err)
+	}
+	log.Info("Successfully ran alpha generate using Kubebuilder ", version)
+
+	// Run make targets to ensure all the necessary components are generated,
+	// formatted and linted.
+	log.Info("Running 'make manifests generate fmt vet lint-fix'")
+	if err := runMakeTargets(); err != nil {
+		return fmt.Errorf("failed to run make: %w", err)
+	}
+	log.Info("Successfully ran make targets in ancestor")
+
+	// Stage all generated files
+	gitCmd := exec.Command("git", "add", ".")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage changes in ancestor: %w", err)
+	}
+	log.Info("Successfully staged all changes in ancestor")
+
+	// Commit the re-scaffolded project to the ancestor branch
+	gitCmd = exec.Command("git", "commit", "-m", "Re-scaffold in ancestor")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to commit changes in ancestor: %w", err)
+	}
+	log.Info("Successfully committed changes in ancestor")
+
+	return nil
+}
+
+// checkoutCurrentOffAncestor creates the 'current' branch from ancestor and
+// populates it with the user's actual project content from the default branch.
+// This represents the current state of the user's project.
+func (opts *Update) checkoutCurrentOffAncestor() error {
+	// Create current branch starting from the clean ancestor state
+	gitCmd := exec.Command("git", "checkout", "-b", "tmp-kb-update-current", "tmp-kb-update-ancestor")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout current branch off ancestor: %w", err)
+	}
+	log.Info("Successfully checked out current branch off ancestor")
+
+	// Overlay the user's actual project content from default branch
+	gitCmd = exec.Command("git", "checkout", opts.FromBranch, "--", ".")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout content from default branch onto current: %w", err)
+	}
+	log.Info("Successfully checked out content from main onto current branch")
+
+	// Stage all the user's current project content
+	gitCmd = exec.Command("git", "add", ".")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage all changes in current: %w", err)
+	}
+	log.Info("Successfully staged all changes in current")
+
+	// Commit the user's current state to the current branch
+	gitCmd = exec.Command("git", "commit", "-m", "Add content from main onto current branch")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to commit changes: %w", err)
+	}
+	log.Info("Successfully committed changes in current")
+
+	return nil
+}
+
+// checkoutUpgradeOffAncestor creates the 'upgrade' branch from ancestor and
+// generates fresh scaffolding using the current (latest) Kubebuilder version.
+// This represents what the project should look like with the new version.
+func (opts *Update) checkoutUpgradeOffAncestor() error {
+	// Create upgrade branch starting from the clean ancestor state
+	gitCmd := exec.Command("git", "checkout", "-b", "tmp-kb-update-upgrade", "tmp-kb-update-ancestor")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout upgrade branch off ancestor: %w", err)
+	}
+	log.Info("Successfully checked out upgrade branch off ancestor")
+
+	// Run alpha generate with the current (new) Kubebuilder version
+	// This uses the system's installed kubebuilder binary
+	cmd := exec.Command("kubebuilder", "alpha", "generate")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run alpha generate on upgrade branch: %w", err)
+	}
+	log.Info("Successfully ran alpha generate on upgrade branch")
+
+	// Run make targets to ensure all the necessary components are generated,
+	// formatted and linted.
+	log.Info("Running 'make manifests generate fmt vet lint-fix'")
+	if err := runMakeTargets(); err != nil {
+		return fmt.Errorf("failed to run make: %w", err)
+	}
+	log.Info("Successfully ran make targets in upgrade")
+
+	// Stage all the newly generated files
+	gitCmd = exec.Command("git", "add", ".")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage changes on upgrade: %w", err)
+	}
+	log.Info("Successfully staged all changes in upgrade branch")
+
+	// Commit the new version's scaffolding to the upgrade branch
+	gitCmd = exec.Command("git", "commit", "-m", "alpha generate in upgrade branch")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to commit changes in upgrade branch: %w", err)
+	}
+	log.Info("Successfully committed changes in upgrade branch")
+
+	return nil
+}
+
+// checkoutMergeOffCurrent creates the 'merge' branch from the current branch.
+// This branch will be used to attempt automatic merging of upgrade changes
+// with the user's current project state.
+func (opts *Update) checkoutMergeOffCurrent() error {
+	gitCmd := exec.Command("git", "checkout", "-b", "tmp-kb-update-merge", "tmp-kb-update-current")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout merge branch off current: %w", err)
+	}
+
+	return nil
+}
+
+// mergeUpgradeIntoMerge attempts to merge the upgrade branch (containing new
+// Kubebuilder scaffolding) into the merge branch (containing user's current state).
+// If conflicts occur, it warns the user to resolve them manually rather than failing.
+func (opts *Update) mergeUpgradeIntoMerge() error {
+	gitCmd := exec.Command("git", "merge", "upgrade")
+	err := gitCmd.Run()
+	if err != nil {
+		// Check if the error is due to merge conflicts (exit code 1)
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			log.Warn("Merge with conflicts. Please resolve them manually")
+			return nil // Don't treat conflicts as fatal errors
+		}
+		return fmt.Errorf("failed to merge the upgrade branch into the merge branch: %w", err)
+	}
+
+	// Run make targets to ensure all the necessary components are generated,
+	// formatted and linted.
+	log.Info("Running 'make manifests generate fmt vet lint-fix'")
+	if err := runMakeTargets(); err != nil {
+		return fmt.Errorf("failed to run make: %w", err)
+	}
+	log.Info("Successfully ran make targets in merge")
+
+	return nil
+}
+
+// Validate checks if the user is in a git repository and if the repository is in a clean state.
+// It also validates if the version specified by the user is in a valid format and available for
+// download as a binary.
+func (opts *Update) Validate() error {
+	// Validate git repository
+	if err := opts.validateGitRepo(); err != nil {
+		return fmt.Errorf("failed to validate git repository: %w", err)
+	}
+
+	// Validate --from-branch
+	if err := opts.validateFromBranch(); err != nil {
+		return fmt.Errorf("failed to validate --from-branch: %w", err)
+	}
+
+	// Load the PROJECT configuration file
+	projectConfigFile, err := opts.loadConfigFile()
+	if err != nil {
+		return fmt.Errorf("failed to load the PROJECT file: %w", err)
+	}
+
+	// Extract the cliVersion field from the PROJECT file
+	opts.CliVersion = projectConfigFile.Config().GetCliVersion()
+
+	// Determine which Kubebuilder version to use for the update
+	if err := opts.defineFromVersion(); err != nil {
+		return fmt.Errorf("failed to define version: %w", err)
+	}
+
+	// Validate if the specified version is available as a binary in the releases
+	if err := opts.validateBinaryAvailability(); err != nil {
+		return fmt.Errorf("failed to validate binary availability: %w", err)
+	}
+
+	return nil
+}
+
+// Load the PROJECT configuration file to get the current CLI version
+func (opts *Update) loadConfigFile() (store.Store, error) {
+	projectConfigFile := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
+	// TODO: assess if DefaultPath could be renamed to a more self-descriptive name
+	if err := projectConfigFile.LoadFrom(yaml.DefaultPath); err != nil {
+		if _, statErr := os.Stat(yaml.DefaultPath); os.IsNotExist(statErr) {
+			return projectConfigFile, fmt.Errorf("no PROJECT file found. Make sure you're in the project root directory")
+		}
+		return projectConfigFile, fmt.Errorf("fail to load the PROJECT file: %w", err)
+	}
+	return projectConfigFile, nil
+}
+
+// Define the version of the binary to be downloaded
+func (opts *Update) defineFromVersion() error {
+	// Allow override of the version from PROJECT file via command line flag
+	if opts.FromVersion != "" {
+		if !semver.IsValid(opts.FromVersion) {
+			return fmt.Errorf("invalid semantic version. Expect: vX.Y.Z (Ex: v4.5.0)")
+		}
+		opts.CliVersion = opts.FromVersion
+	}
+
+	if opts.CliVersion == "" {
+		return fmt.Errorf("failed to retrieve Kubebuilder version from PROJECT file. Please use --from-version to inform it")
+	}
+
+	return nil
+}
+
+// Validate if the version specified is available as a binary for download
+// from the releases
+func (opts *Update) validateBinaryAvailability() error {
+	// Ensure version has 'v' prefix for consistency with GitHub releases
+	if !strings.HasPrefix(opts.CliVersion, "v") {
+		opts.CliVersion = "v" + opts.CliVersion
+	}
+
+	// Construct the URL for pulling the binary from GitHub releases
+	opts.BinaryURL = fmt.Sprintf("https://github.com/kubernetes-sigs/kubebuilder/releases/download/%s/kubebuilder_%s_%s",
+		opts.CliVersion, runtime.GOOS, runtime.GOARCH)
+
+	resp, err := http.Head(opts.BinaryURL)
+	if err != nil {
+		return fmt.Errorf("failed to check binary availability: %w", err)
+	}
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			log.Errorf("failed to close connection: %s", err)
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		log.Infof("Binary version %v is available", opts.CliVersion)
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("binary version %s not found. Check versions available in releases",
+			opts.CliVersion)
+	default:
+		return fmt.Errorf("unexpected response %d when checking binary availability for version %s",
+			resp.StatusCode, opts.CliVersion)
+	}
+}
+
+// Validate if in a git repository with clean state
+func (opts *Update) validateGitRepo() error {
+	// Check if in a git repository
+	gitCmd := exec.Command("git", "rev-parse", "--git-dir")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("not in a git repository")
+	}
+
+	// Check if the branch has uncommitted changes
+	gitCmd = exec.Command("git", "status", "--porcelain")
+	output, err := gitCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to check branch status: %w", err)
+	}
+
+	if len(strings.TrimSpace(string(output))) > 0 {
+		return fmt.Errorf("working directory has uncommitted changes. Please commit or stash them before updating")
+	}
+
+	return nil
+}
+
+// Validate the branch passed to the --from-branch flag
+func (opts *Update) validateFromBranch() error {
+	// Set default if not specified
+	if opts.FromBranch == "" {
+		opts.FromBranch = "main"
+	}
+
+	// Check if the branch exists
+	gitCmd := exec.Command("git", "rev-parse", "--verify", opts.FromBranch)
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("%s branch does not exist locally. Run 'git branch -a' to see all available branches",
+			opts.FromBranch)
+	}
+
+	return nil
+}

--- a/pkg/cli/alpha/internal/update/prepare.go
+++ b/pkg/cli/alpha/internal/update/prepare.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/common"
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
+)
+
+type releaseResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+// Prepare resolves version and binary URL details after validation.
+// Should be called after Validate().
+func (opts *Update) Prepare() error {
+	if opts.FromBranch == "" {
+		// TODO: Check if is possible to use get to determine the default branch
+		log.Warning("No --from-branch specified, using 'main' as default")
+		opts.FromBranch = "main"
+	}
+
+	path, err := common.GetInputPath("")
+	if err != nil {
+		return fmt.Errorf("failed to determine project path: %w", err)
+	}
+	config, err := common.LoadProjectConfig(path)
+	if err != nil {
+		return fmt.Errorf("failed to load PROJECT config: %w", err)
+	}
+	opts.FromVersion, err = opts.defineFromVersion(config)
+	if err != nil {
+		return fmt.Errorf("failed to determine the version to use for the upgrade from: %w", err)
+	}
+	opts.ToVersion = opts.defineToVersion()
+	return nil
+}
+
+// defineFromVersion will return the CLI version to be used for the update with the v prefix.
+func (opts *Update) defineFromVersion(config store.Store) (string, error) {
+	if len(opts.FromBranch) == 0 && len(config.Config().GetCliVersion()) == 0 {
+		return "", fmt.Errorf("no version specified in PROJECT file. " +
+			"Please use --from-version flag to specify the version to update from")
+	}
+
+	if opts.FromVersion != "" {
+		if !strings.HasPrefix(opts.FromVersion, "v") {
+			return "v" + opts.FromVersion, nil
+		}
+		return opts.FromVersion, nil
+	}
+	return "v" + config.Config().GetCliVersion(), nil
+}
+
+func (opts *Update) defineToVersion() string {
+	if len(opts.ToVersion) != 0 {
+		if !strings.HasPrefix(opts.FromVersion, "v") {
+			return "v" + opts.ToVersion
+		}
+		return opts.ToVersion
+	}
+
+	opts.ToVersion, _ = fetchLatestRelease()
+
+	return opts.ToVersion
+}
+
+func fetchLatestRelease() (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases/latest")
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest release: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Infof("failed to close connection: %s", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var release releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return release.TagName, nil
+}

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+)
+
+// Update contains configuration for the update operation
+type Update struct {
+	// FromVersion stores the version to update from, e.g., "v4.5.0".
+	FromVersion string
+	// ToVersion stores the version to update to, e.g., "v4.6.0".
+	ToVersion string
+	// FromBranch stores the branch to update from, e.g., "main".
+	FromBranch string
+
+	// UpdateBranches
+	AncestorBranch string
+	OriginalBranch string
+	UpgradeBranch  string
+	MergeBranch    string
+}
+
+// Update a project using a default three-way Git merge.
+// This helps apply new scaffolding changes while preserving custom code.
+func (opts *Update) Update() error {
+	log.Infof("Checking out base branch: %s", opts.FromBranch)
+	checkoutCmd := exec.Command("git", "checkout", opts.FromBranch)
+	if err := checkoutCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout base branch %s: %w", opts.FromBranch, err)
+	}
+
+	suffix := time.Now().Format("02-01-06-15-04")
+
+	opts.AncestorBranch = "tmp-ancestor-" + suffix
+	opts.OriginalBranch = "tmp-original-" + suffix
+	opts.UpgradeBranch = "tmp-upgrade-" + suffix
+	opts.MergeBranch = "tmp-merge-" + suffix
+
+	log.Infof("Using branch names:")
+	log.Infof("  Ancestor: %s", opts.AncestorBranch)
+	log.Infof("  Original:  %s", opts.OriginalBranch)
+	log.Infof("  Upgrade:  %s", opts.UpgradeBranch)
+	log.Infof("  Merge:    %s", opts.MergeBranch)
+
+	// 1. Creates an ancestor branch based on base branch
+	// 2. Deletes everything except .git and PROJECT
+	// 3. Installs old release
+	// 4. Runs alpha generate with old release binary
+	// 5. Commits the result
+	log.Infof("Preparing Ancestor branch with name %s", opts.AncestorBranch)
+	if err := opts.prepareAncestorBranch(); err != nil {
+		return fmt.Errorf("failed to prepare ancestor branch: %w", err)
+	}
+	// 1. Creates original branch
+	// 2. Ensure that original branch is == Based on user’s current base branch content with
+	// git checkout "main" -- .
+	// 3. Commits this state
+	log.Infof("Preparing Original branch with name %s", opts.OriginalBranch)
+	if err := opts.prepareOriginalBranch(); err != nil {
+		return fmt.Errorf("failed to checkout current off ancestor: %w", err)
+	}
+	// 1. Creates upgrade branch from ancestor
+	// 2. Cleans up the branch by removing all files except .git and PROJECT
+	// 2. Regenerates scaffold using alpha generate with new version
+	// 3. Commits the result
+	log.Infof("Preparing Upgrade branch with name %s", opts.UpgradeBranch)
+	if err := opts.prepareUpgradeBranch(); err != nil {
+		return fmt.Errorf("failed to checkout upgrade off ancestor: %w", err)
+	}
+
+	// 1. Creates merge branch from upgrade
+	// 2. Merges in original (user code)
+	// 3. If conflicts occur, it will warn the user and leave the merge branch for manual resolution
+	// 4. If merge is clean, it stages the changes and commits the result
+	log.Infof("Preparing Merge branch with name %s and performing merge", opts.MergeBranch)
+	if err := opts.mergeOriginalToUpgrade(); err != nil {
+		return fmt.Errorf("failed to merge upgrade into merge branch: %w", err)
+	}
+	return nil
+}
+
+// regenerateProjectWithVersion downloads the release binary for the specified version,
+// and runs the `alpha generate` command to re-scaffold the project
+func regenerateProjectWithVersion(version string) error {
+	tempDir, err := binaryWithVersion(version)
+	if err != nil {
+		return fmt.Errorf("failed to download release %s binary: %w", version, err)
+	}
+	if err := runAlphaGenerate(tempDir, version); err != nil {
+		return fmt.Errorf("failed to run alpha generate on ancestor branch: %w", err)
+	}
+	return nil
+}
+
+// prepareAncestorBranch prepares the ancestor branch by checking it out,
+// cleaning up the project files, and regenerating the project with the specified version.
+func (opts *Update) prepareAncestorBranch() error {
+	gitCmd := exec.Command("git", "checkout", "-b", opts.AncestorBranch, opts.FromBranch)
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to create %s from %s: %w", opts.AncestorBranch, opts.FromBranch, err)
+	}
+	checkoutCmd := exec.Command("git", "checkout", opts.AncestorBranch)
+	if err := checkoutCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout base branch %s: %w", opts.AncestorBranch, err)
+	}
+	if err := cleanupBranch(); err != nil {
+		return fmt.Errorf("failed to cleanup the %s : %w", opts.AncestorBranch, err)
+	}
+	if err := regenerateProjectWithVersion(opts.FromVersion); err != nil {
+		return fmt.Errorf("failed to regenerate project with fromVersion %s: %w", opts.FromVersion, err)
+	}
+	gitCmd = exec.Command("git", "add", "--all")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage changes in %s: %w", opts.AncestorBranch, err)
+	}
+	commitMessage := "Clean scaffold from release version:" + opts.FromVersion
+	_ = exec.Command("git", "commit", "-m", commitMessage).Run()
+	return nil
+}
+
+// binaryWithVersion downloads the specified released version from GitHub releases and saves it
+// to a temporary directory with executable permissions.
+// Returns the temporary directory path containing the binary.
+func binaryWithVersion(version string) (string, error) {
+	url := buildReleaseURL(version)
+
+	fs := afero.NewOsFs()
+	tempDir, err := afero.TempDir(fs, "", "kubebuilder"+version+"-")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+
+	binaryPath := tempDir + "/kubebuilder"
+	file, err := os.Create(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create the binary file: %w", err)
+	}
+	defer func() {
+		if err = file.Close(); err != nil {
+			log.Errorf("failed to close the file: %v", err)
+		}
+	}()
+
+	response, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to download the binary: %w", err)
+	}
+	defer func() {
+		if err = response.Body.Close(); err != nil {
+			log.Errorf("failed to close the connection: %v", err)
+		}
+	}()
+
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to download the binary: HTTP %d", response.StatusCode)
+	}
+
+	_, err = io.Copy(file, response.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write the binary content to file: %w", err)
+	}
+
+	if err := os.Chmod(binaryPath, 0o755); err != nil {
+		return "", fmt.Errorf("failed to make binary executable: %w", err)
+	}
+	return tempDir, nil
+}
+
+// cleanupBranch removes all files and folders in the current directory
+// except for the .git directory and the PROJECT file.
+// This is necessary to ensure the ancestor branch starts with a clean slate
+// TODO: Analise if this command is still needed in the future.
+// It is required because the alpha generate command in versions prior to v4.7.0 do not properly
+// handle the removal of files in the ancestor branch.
+func cleanupBranch() error {
+	cmd := exec.Command("sh", "-c", "find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name 'PROJECT' -exec rm -rf {} +")
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to clean up files: %w", err)
+	}
+	return nil
+}
+
+// runMakeTargets is a helper function to run make with the targets necessary
+// to ensure all the necessary components are generated, formatted and linted.
+func runMakeTargets() {
+	targets := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
+	for _, target := range targets {
+		err := util.RunCmd(fmt.Sprintf("Running make %s", target), "make", target)
+		if err != nil {
+			log.Warnf("make %s failed: %v", target, err)
+		}
+	}
+}
+
+// runAlphaGenerate executes the old Kubebuilder version's 'alpha generate' command
+// to create clean scaffolding in the ancestor branch. This uses the downloaded
+// binary with the original PROJECT file to recreate the project's initial state.
+func runAlphaGenerate(tempDir, version string) error {
+	log.Infof("Generating project with version %s", version)
+	// Temporarily modify PATH to use the downloaded Kubebuilder binary
+	tempBinaryPath := tempDir + "/kubebuilder"
+	originalPath := os.Getenv("PATH")
+	tempEnvPath := tempDir + ":" + originalPath
+
+	if err := os.Setenv("PATH", tempEnvPath); err != nil {
+		return fmt.Errorf("failed to set temporary PATH: %w", err)
+	}
+
+	defer func() {
+		if err := os.Setenv("PATH", originalPath); err != nil {
+			log.Errorf("failed to restore original PATH: %v", err)
+		}
+	}()
+
+	// TODO: we need improve the implementation from utils to allow us
+	// to pass the path of the binary and use it to run the alpha generate command.
+	cmd := exec.Command(tempBinaryPath, "alpha", "generate")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run alpha generate: %w", err)
+	}
+	log.Info("Successfully ran alpha generate", version)
+
+	// TODO: Analyse if this command is still needed in the future.
+	// It was added because the alpha generate command in versions prior to v4.7.0 does
+	// not run those commands automatically which will not allow we properly ensure
+	// that all manifests, code generation, formatting, and linting are applied to
+	// properly do the 3-way merge.
+	runMakeTargets()
+	return nil
+}
+
+// prepareOriginalBranch creates the 'original' branch from ancestor and
+// populates it with the user's actual project content from the default branch.
+// This represents the current state of the user's project.
+func (opts *Update) prepareOriginalBranch() error {
+	gitCmd := exec.Command("git", "checkout", "-b", opts.OriginalBranch)
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout branch %s: %w", opts.OriginalBranch, err)
+	}
+
+	gitCmd = exec.Command("git", "checkout", opts.FromBranch, "--", ".")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout content from %s branch onto %s: %w", opts.FromBranch, opts.OriginalBranch, err)
+	}
+
+	gitCmd = exec.Command("git", "add", "--all")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage all changes in current: %w", err)
+	}
+
+	_ = exec.Command("git", "commit", "-m",
+		fmt.Sprintf("Add code from %s into %s",
+			opts.FromBranch, opts.OriginalBranch)).Run()
+	return nil
+}
+
+// prepareUpgradeBranch creates the 'upgrade' branch from ancestor and
+// generates fresh scaffolding using the current (latest) CLI version.
+// This represents what the project should look like with the new version.
+func (opts *Update) prepareUpgradeBranch() error {
+	gitCmd := exec.Command("git", "checkout", "-b", opts.UpgradeBranch, opts.AncestorBranch)
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout %s branch off %s: %w",
+			opts.UpgradeBranch, opts.AncestorBranch, err)
+	}
+
+	checkoutCmd := exec.Command("git", "checkout", opts.UpgradeBranch)
+	if err := checkoutCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout base branch %s: %w", opts.UpgradeBranch, err)
+	}
+
+	if err := cleanupBranch(); err != nil {
+		return fmt.Errorf("failed to cleanup the %s branch: %w", opts.UpgradeBranch, err)
+	}
+	if err := regenerateProjectWithVersion(opts.ToVersion); err != nil {
+		return fmt.Errorf("failed to regenerate project with version %s: %w", opts.ToVersion, err)
+	}
+	gitCmd = exec.Command("git", "add", "--all")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("failed to stage changes in %s: %w", opts.UpgradeBranch, err)
+	}
+
+	_ = exec.Command("git", "commit", "-m", "Clean scaffolding from version "+opts.ToVersion).Run()
+	return nil
+}
+
+// mergeOriginalToUpgrade attempts to merge the upgrade branch
+func (opts *Update) mergeOriginalToUpgrade() error {
+	if err := exec.Command("git", "checkout", "-b", opts.MergeBranch, opts.UpgradeBranch).Run(); err != nil {
+		return fmt.Errorf("failed to create merge branch %s from %s: %w", opts.MergeBranch, opts.OriginalBranch, err)
+	}
+
+	checkoutCmd := exec.Command("git", "checkout", opts.MergeBranch)
+	if err := checkoutCmd.Run(); err != nil {
+		return fmt.Errorf("failed to checkout base branch %s: %w", opts.MergeBranch, err)
+	}
+
+	mergeCmd := exec.Command("git", "merge", "--no-edit", "--no-commit", opts.OriginalBranch)
+	err := mergeCmd.Run()
+
+	hasConflicts := false
+	if err != nil {
+		var exitErr *exec.ExitError
+		// If the merge has an error that is not a conflict, return an error 2
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			log.Warn("Merge completed with conflicts. Manual resolution required.")
+			hasConflicts = true
+		} else {
+			return fmt.Errorf("merge failed unexpectedly: %w", err)
+		}
+	}
+
+	if !hasConflicts {
+		log.Info("Merge happened without conflicts.")
+	}
+
+	// Best effort to run make targets to ensure the project is in a good state
+	runMakeTargets()
+
+	// Step 4: Stage and commit
+	if err := exec.Command("git", "add", "--all").Run(); err != nil {
+		return fmt.Errorf("failed to stage merge results: %w", err)
+	}
+
+	message := fmt.Sprintf("Merge from %s to %s.", opts.FromVersion, opts.ToVersion)
+	if hasConflicts {
+		message += " With conflicts - manual resolution required."
+	} else {
+		message += " Merge happened without conflicts."
+	}
+
+	_ = exec.Command("git", "commit", "-m", message).Run()
+
+	return nil
+}

--- a/pkg/cli/alpha/internal/update/utils.go
+++ b/pkg/cli/alpha/internal/update/utils.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"fmt"
+	"runtime"
+)
+
+const releaseURL = "https://github.com/kubernetes-sigs/kubebuilder/releases/download/%s/kubebuilder_%s_%s"
+
+func buildReleaseURL(version string) string {
+	return fmt.Sprintf(releaseURL, version, runtime.GOOS, runtime.GOARCH)
+}

--- a/pkg/cli/alpha/internal/update/validate.go
+++ b/pkg/cli/alpha/internal/update/validate.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/mod/semver"
+)
+
+// Validate checks the input info provided for the update and populates the cliVersion
+func (opts *Update) Validate() error {
+	if err := opts.validateGitRepo(); err != nil {
+		return fmt.Errorf("failed to validate git repository: %w", err)
+	}
+	if err := opts.validateFromBranch(); err != nil {
+		return fmt.Errorf("failed to validate --from-branch: %w", err)
+	}
+	if err := opts.validateSemanticVersions(); err != nil {
+		return fmt.Errorf("failed to validate the versions: %w", err)
+	}
+	if err := validateReleaseAvailability(opts.FromVersion); err != nil {
+		return fmt.Errorf("unable to find release %s: %w", opts.FromVersion, err)
+	}
+	if err := validateReleaseAvailability(opts.ToVersion); err != nil {
+		return fmt.Errorf("unable to find release %s: %w", opts.ToVersion, err)
+	}
+	return nil
+}
+
+// validateGitRepo verifies if the current directory is a valid Git repository and checks for uncommitted changes.
+func (opts *Update) validateGitRepo() error {
+	log.Info("Checking if is a git repository")
+	gitCmd := exec.Command("git", "rev-parse", "--git-dir")
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("not in a git repository")
+	}
+
+	log.Info("Checking if branch has uncommitted changes")
+	gitCmd = exec.Command("git", "status", "--porcelain")
+	output, err := gitCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to check branch status: %w", err)
+	}
+	if len(strings.TrimSpace(string(output))) > 0 {
+		return fmt.Errorf("working directory has uncommitted changes. " +
+			"Please commit or stash them before updating")
+	}
+	return nil
+}
+
+// validateFromBranch the branch passed to the --from-branch flag
+func (opts *Update) validateFromBranch() error {
+	// Check if the branch exists
+	gitCmd := exec.Command("git", "rev-parse", "--verify", opts.FromBranch)
+	if err := gitCmd.Run(); err != nil {
+		return fmt.Errorf("%s branch does not exist locally. "+
+			"Run 'git branch -a' to see all available branches",
+			opts.FromBranch)
+	}
+	return nil
+}
+
+// validateSemanticVersions the version informed by the user via --from-version flag
+func (opts *Update) validateSemanticVersions() error {
+	if !semver.IsValid(opts.FromVersion) {
+		return fmt.Errorf(" version informed (%s) has invalid semantic version. "+
+			"Expect: vX.Y.Z (Ex: v4.5.0)", opts.FromVersion)
+	}
+	if !semver.IsValid(opts.ToVersion) {
+		return fmt.Errorf(" version informed (%s) has invalid semantic version. "+
+			"Expect: vX.Y.Z (Ex: v4.5.0)", opts.ToVersion)
+	}
+	return nil
+}
+
+// validateReleaseAvailability will verify if the binary to scaffold from-version flag is available
+func validateReleaseAvailability(version string) error {
+	url := buildReleaseURL(version)
+	resp, err := http.Head(url)
+	if err != nil {
+		return fmt.Errorf("failed to check binary availability: %w", err)
+	}
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			log.Errorf("failed to close connection: %s", err)
+		}
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		log.Infof("Binary version %v is available", version)
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("binary version %s not found. Check versions available in releases",
+			version)
+	default:
+		return fmt.Errorf("unexpected response %d when checking binary availability for version %s",
+			resp.StatusCode, version)
+	}
+}

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update"
+)
+
+// NewUpdateCommand creates and returns a new Cobra command for updating Kubebuilder projects.
+// This command helps users upgrade their projects to newer versions of Kubebuilder by performing
+// a three-way merge between:
+// - The original scaffolding (ancestor)
+// - The user's current project state (current)
+// - The new version's scaffolding (upgrade)
+//
+// The update process creates multiple Git branches to facilitate the merge and help users
+// resolve any conflicts that may arise during the upgrade process.
+func NewUpdateCommand() *cobra.Command {
+	opts := update.Update{}
+	updateCmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a Kubebuilder project to a newer version",
+		Long: `This command upgrades your Kubebuilder project to the latest scaffold layout using a 3-way merge strategy.
+
+It performs the following steps:
+  1. Creates an 'ancestor' branch from the version originally used to scaffold the project
+  2. Creates a 'current' branch with your project's current state
+  3. Creates an 'upgrade' branch using the new version's scaffolding
+  4. Attempts a 3-way merge into a 'merge' branch
+
+The process uses Git branches:
+  - ancestor: clean scaffold from the original version
+  - current: your existing project state
+  - upgrade: scaffold from the target version
+  - merge: result of the 3-way merge
+
+If conflicts occur during the merge, resolve them manually in the 'merge' branch. 
+Once resolved, commit and push it as a pull request. This branch will contain the 
+final upgraded project with the latest Kubebuilder layout and your custom code.
+
+Examples:
+  # Update from the version specified in the PROJECT file to the latest release
+  kubebuilder alpha update
+
+  # Update from a specific version to the latest release
+  kubebuilder alpha update --from-version v4.6.0
+
+  # Update from a specific version to an specific release
+  kubebuilder alpha update --from-version v4.5.0 --to-version v4.7.0	
+
+`,
+
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			err := opts.Prepare()
+			if err != nil {
+				return fmt.Errorf("failed to prepare update: %w", err)
+			}
+			return opts.Validate()
+		},
+
+		Run: func(_ *cobra.Command, _ []string) {
+			if err := opts.Update(); err != nil {
+				log.Fatalf("Update failed: %s", err)
+			}
+		},
+	}
+
+	updateCmd.Flags().StringVar(&opts.FromVersion, "from-version", "",
+		"binary release version to upgrade from. Should match the version used to init the project and be"+
+			"a valid release version, e.g., v4.6.0. If not set, "+
+			"it defaults to the version specified in the PROJECT file. ")
+
+	updateCmd.Flags().StringVar(&opts.ToVersion, "to-version", "",
+		"binary release version to upgrade to. Should be a valid release version, e.g., v4.7.0. "+
+			"If not set, it defaults to the latest release version available in the project repository.")
+
+	updateCmd.Flags().StringVar(&opts.FromBranch, "from-branch", "",
+		"Git branch to use as current state of the project for the update.")
+
+	return updateCmd
+}


### PR DESCRIPTION
The `kubebuilder alpha update` command performs a **three-way Git merge** to upgrade a project to a newer Kubebuilder version while preserving user-defined code. The process is fully automated and follows these main steps:

**1. Ancestor Branch (baseline scaffold)**

- Created from the specified base branch (default is main)
- Cleans the branch, keeping only .git and PROJECT
- Downloads and uses the old Kubebuilder release to re-scaffold the project
- Commits the result — this branch serves as the synthetic ancestor

**2. Original Branch (user’s current code)**

- Created from the ancestor branch
- Checks out all files from the user’s base branch (git checkout main -- .)
- Stages and commits the current project state

**3. Upgrade Branch (target scaffold)**

- Created from the ancestor branch
- Cleaned similarly (preserving only .git and PROJECT)
- Uses the new Kubebuilder release to re-scaffold the project
- Stages and commits the upgraded scaffold

**4. Merge Branch (final result)**

- Created from the upgrade branch
- Merges in the original branch (user code)
- If conflicts occur:
  - The user is notified and must resolve them manually
- If the merge is clean:
  - The result is committed automatically

This command provides a reliable and repeatable way to upgrade project scaffolding while preserving user customizations. Flags like --from-version, --to-version, and --from-branch offer full control over the versions and branches involved in the update.

Example:

```
$ kubebuilder alpha update --from-version v4.5.2
WARN No --from-branch specified, using 'main' as default 
INFO Checking if is a git repository              
INFO Checking if branch has uncommitted changes   
INFO Binary version v4.5.2 is available           
INFO Binary version v4.6.0 is available           
INFO Checking out base branch: main               
INFO Using branch names:                          
INFO   Ancestor: tmp-ancestor-29-06-25-20-46      
INFO   Original:  tmp-original-29-06-25-20-46     
INFO   Upgrade:  tmp-upgrade-29-06-25-20-46       
INFO   Merge:    tmp-merge-29-06-25-20-46         
INFO Created and checked out ancestor branch      
INFO Cleaning all files and folders except .git and PROJECT 
INFO Successfully cleanup files in ancestor branch 
INFO Downloading the release v4.5.2 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.5.2/kubebuilder_darwin_arm64 
INFO release binary version v4.5.2 successfully downloaded to /var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/kubebuilderv4.5.2-520327151/kubebuilder 
INFO Downloaded binary kept at /var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/kubebuilderv4.5.2-520327151 for debugging purposes 
INFO Generating project with version v4.5.2       
WARN Using current working directory to re-scaffold the project 
WARN This directory will be cleaned up and all files removed before the re-generation 
INFO Cleaning directory:/Users/camilam/go/src/github/camilamacedo86/wordpress-operator 
INFO Running cleanup:
$ sh -c rm -rf /Users/camilam/go/src/github/camilamacedo86/wordpress-operator/* 
INFO kubebuilder init:
$ kubebuilder init --plugins go.kubebuilder.io/v4 --domain my.domain --repo github/camilamacedo86/wordpress-operator 
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO Get controller runtime:
$ go get sigs.k8s.io/controller-runtime@v0.20.4 
INFO Update dependencies:
$ go mod tidy           
Next: define a resource with:
$ kubebuilder create api
INFO kubebuilder create api:
$ kubebuilder create api --plural wordpresses --group example.com --version v1 --kind Wordpress --resource --namespaced --controller 
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO api/v1/wordpress_types.go                    
INFO api/v1/groupversion_info.go                  
INFO internal/controller/suite_test.go            
INFO internal/controller/wordpress_controller.go  
INFO internal/controller/wordpress_controller_test.go 
INFO Update dependencies:
$ go mod tidy           
INFO Running make:
$ make generate                
mkdir -p /Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.2
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Next: implement your new API and generate the manifests (e.g. CRDs,CRs) with:
$ make manifests
INFO kubebuilder create webhook:
$ kubebuilder create webhook --plural wordpresses --group example.com --version v1 --kind Wordpress --programmatic-validation --defaulting 
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO internal/webhook/v1/wordpress_webhook.go     
INFO internal/webhook/v1/wordpress_webhook_test.go 
INFO internal/webhook/v1/webhook_suite_test.go    
INFO Update dependencies:
$ go mod tidy           
INFO Running make:
$ make generate                
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Next: implement your new Webhook and generate the manifests with:
$ make manifests
INFO Grafana plugin not found, skipping migration 
INFO Deploy-image plugin not found, skipping migration 
INFO Successfully ran alpha generatev4.5.2        
INFO Running make manifests:
$ make manifests     
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
INFO Running make generate:
$ make generate       
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
INFO Running make fmt:
$ make fmt                 
go fmt ./...
INFO Running make vet:
$ make vet                 
go vet ./...
INFO Running make lint-fix:
$ make lint-fix       
Downloading github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/golangci-lint run --fix
INFO Successfully committed tmp-ancestor-29-06-25-20-46 with clean scaffolding 
INFO Successfully checked out tmp-original-29-06-25-20-46 
INFO Successfully checked out content from main onto tmp-original-29-06-25-20-46 branch 
INFO Successfully staged all changes in current   
INFO Successfully committed changes in tmp-original-29-06-25-20-46 
INFO Successfully checked out tmp-upgrade-29-06-25-20-46 off tmp-ancestor-29-06-25-20-46 
INFO Cleaning all files and folders except .git and PROJECT 
INFO Successfully cleanup files in ancestor branch 
INFO Downloading the release v4.6.0 binary from: https://github.com/kubernetes-sigs/kubebuilder/releases/download/v4.6.0/kubebuilder_darwin_arm64 
INFO release binary version v4.6.0 successfully downloaded to /var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/kubebuilderv4.6.0-603848834/kubebuilder 
INFO Downloaded binary kept at /var/folders/n4/j272tr6d7hq63mf7_skv6zr80000gn/T/kubebuilderv4.6.0-603848834 for debugging purposes 
INFO Generating project with version v4.6.0       
WARN Using current working directory to re-scaffold the project 
WARN This directory will be cleaned up and all files removed before the re-generation 
INFO Cleaning directory:/Users/camilam/go/src/github/camilamacedo86/wordpress-operator 
INFO Running cleanup:
$ sh -c rm -rf /Users/camilam/go/src/github/camilamacedo86/wordpress-operator/* 
INFO kubebuilder init:
$ kubebuilder init --plugins go.kubebuilder.io/v4 --domain my.domain --repo github/camilamacedo86/wordpress-operator 
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO Get controller runtime:
$ go get sigs.k8s.io/controller-runtime@v0.21.0 
INFO Update dependencies:
$ go mod tidy           
Next: define a resource with:
$ kubebuilder create api
INFO kubebuilder create api:
$ kubebuilder create api --plural wordpresses --group example.com --version v1 --kind Wordpress --resource --namespaced --controller 
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO api/v1/wordpress_types.go                    
INFO api/v1/groupversion_info.go                  
INFO internal/controller/suite_test.go            
INFO internal/controller/wordpress_controller.go  
INFO internal/controller/wordpress_controller_test.go 
INFO Update dependencies:
$ go mod tidy           
INFO Running make:
$ make generate                
mkdir -p /Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin
Downloading sigs.k8s.io/controller-tools/cmd/controller-gen@v0.18.0
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Next: implement your new API and generate the manifests (e.g. CRDs,CRs) with:
$ make manifests
INFO kubebuilder create webhook:
$ kubebuilder create webhook --plural wordpresses --group example.com --version v1 --kind Wordpress --programmatic-validation --defaulting 
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit...          
INFO internal/webhook/v1/wordpress_webhook.go     
INFO internal/webhook/v1/wordpress_webhook_test.go 
INFO internal/webhook/v1/webhook_suite_test.go    
INFO Update dependencies:
$ go mod tidy           
INFO Running make:
$ make generate                
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Next: implement your new Webhook and generate the manifests with:
$ make manifests
INFO Grafana plugin not found, skipping migration 
INFO Deploy-image plugin not found, skipping migration 
INFO Successfully ran alpha generatev4.6.0        
INFO Running make manifests:
$ make manifests     
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
INFO Running make generate:
$ make generate       
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
INFO Running make fmt:
$ make fmt                 
go fmt ./...
INFO Running make vet:
$ make vet                 
go vet ./...
INFO Running make lint-fix:
$ make lint-fix       
Downloading github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.0
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/golangci-lint run --fix
0 issues.
INFO Successfully staged changes in tmp-upgrade-29-06-25-20-46 
INFO Successfully committed tmp-upgrade-29-06-25-20-46 with clean scaffolding 
INFO Checked out merge branch: tmp-merge-29-06-25-20-46 
INFO Merging in original code (tmp-original-29-06-25-20-46) into merge branch (tmp-merge-29-06-25-20-46) 
INFO Running make manifests:
$ make manifests     
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
INFO Running make generate:
$ make generate       
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
INFO Running make fmt:
$ make fmt                 
go fmt ./...
INFO Running make vet:
$ make vet                 
go vet ./...
INFO Running make lint-fix:
$ make lint-fix       
/Users/camilam/go/src/github/camilamacedo86/wordpress-operator/bin/golangci-lint run --fix
0 issues.
```
