### PR TITLE
:WIP sparkles: Add KAL and fix missing parts from tutorials

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Prepare ${{ matrix.folder }}
         working-directory: ${{ matrix.folder }}
         run: go mod tidy
+      - name: Build kubeapilinter
+        working-directory: ${{ matrix.folder }}
+        run: make kube-api-linter
+        env:
+          CGO_ENABLED: 1
       - name: Check linter configuration
         working-directory: ${{ matrix.folder }}
         run: make lint-config
@@ -41,6 +46,7 @@ jobs:
         with:
           version: v2.2.2
           working-directory: ${{ matrix.folder }}
+          install-mode: goinstall
       - name: Run linter via makefile target
         working-directory: ${{ matrix.folder }}
         run: make lint

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2.2
+          install-mode: goinstall

--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -21,11 +21,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -36,6 +45,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -95,7 +95,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -224,6 +224,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -83,6 +83,8 @@ we will allow configuring the number of instances with the following:
 ```go
 type MemcachedSpec struct {
 	...
+	// +kubebuilder:validation:Minimum=0
+	// +required
 	Size int32 `json:"size,omitempty"`
 }
 ```
@@ -97,7 +99,21 @@ similar to how we do with any resource from the Kubernetes API.
 ```go
 // MemcachedStatus defines the observed state of Memcached
 type MemcachedStatus struct {
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+
+	// conditions represent the current state of the {{ .Resource.Kind }} resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 ```
 

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2.2
+          install-mode: goinstall

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -21,11 +21,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -36,6 +45,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -91,7 +91,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -220,6 +220,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2.2
+          install-mode: goinstall

--- a/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
@@ -21,11 +21,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -36,6 +45,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -95,7 +95,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -224,6 +224,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -69,4 +69,5 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: {{ .GolangciLintVersion }}
+          install-mode: goinstall
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -64,11 +64,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -79,6 +88,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -170,7 +170,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -299,6 +299,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/testdata/project-v4-multigroup/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2.2
+          install-mode: goinstall

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -21,11 +21,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -36,6 +45,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -91,7 +91,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -220,6 +220,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2.2
+          install-mode: goinstall

--- a/testdata/project-v4-with-plugins/.golangci.yml
+++ b/testdata/project-v4-with-plugins/.golangci.yml
@@ -21,11 +21,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -36,6 +45,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -91,7 +91,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -220,6 +220,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.2.2
+          install-mode: goinstall

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -21,11 +21,20 @@ linters:
     - unconvert
     - unparam
     - unused
+    - kubeapilinter
   settings:
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
+    custom:
+      kubeapilinter:
+        path: "./bin/kube-api-linter.so"
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: { }
+          lintersConfig: { }
   exclusions:
     generated: lax
     rules:
@@ -36,6 +45,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -91,7 +91,7 @@ cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter
+lint: golangci-lint kube-api-linter ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run
 
 .PHONY: lint-fix
@@ -220,6 +220,23 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# To lint Kubernetes API definitions.
+# More info: https://github.com/kubernetes-sigs/kube-api-linter
+KUBE_API_LINTER_PLUGIN := $(LOCALBIN)/kube-api-linter.so
+KUBE_API_LINTER_BUILD_DIR := ./hack/kube-api-linter
+
+.PHONY: kube-api-linter
+kube-api-linter: $(KUBE_API_LINTER_PLUGIN) ## Build the kube-api-linter plugin
+$(KUBE_API_LINTER_PLUGIN): $(KUBE_API_LINTER_BUILD_DIR)/go.mod
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go build -buildmode=plugin -o "$(abspath $(KUBE_API_LINTER_PLUGIN))" sigs.k8s.io/kube-api-linter/pkg/plugin
+$(KUBE_API_LINTER_BUILD_DIR)/go.mod:
+	@echo "Setting up local module for kube-api-linter plugin..."
+	mkdir -p $(KUBE_API_LINTER_BUILD_DIR)
+	cd $(KUBE_API_LINTER_BUILD_DIR) && \
+	go mod init local-kube-api-linter && \
+	go get sigs.k8s.io/kube-api-linter@latest
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
- Add support for kube-api-linter to validate Kubernetes API definitions
  More info: https://github.com/kubernetes-sigs/kube-api-linter
- Fix all tutorials (getting-started, cronjob, multiversion) to comply with lint rules
- Update all plugins scaffolds to according to rules
- Adjust GitHub Actions to build and run the new custom linter in CI


Experimental PR for: https://github.com/kubernetes-sigs/kubebuilder/issues/4809