### PR TITLE
🛠️  add ignore flags for selective scaffolding in edit command

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -31,6 +31,12 @@ var _ plugin.EditSubcommand = &editSubcommand{}
 type editSubcommand struct {
 	config config.Config
 	force  bool
+
+	IgnoreSamples       bool
+	IgnorePrometheus    bool
+	IgnoreNetworkPolicy bool
+	IgnoreCertManager   bool
+	IgnoreWebhook       bool
 }
 
 //nolint:lll
@@ -66,6 +72,12 @@ manifests in the chart align with the latest changes.
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.force, "force", false, "if true, regenerates all the files")
+
+	fs.BoolVar(&p.IgnoreSamples, "ignore-samples", false, "ignore scaffolding of sample CRs")
+	fs.BoolVar(&p.IgnorePrometheus, "ignore-prometheus", false, "ignore scaffolding of prometheus monitor")
+	fs.BoolVar(&p.IgnoreNetworkPolicy, "ignore-networkPolicy", false, "ignore scaffolding of network policy")
+	fs.BoolVar(&p.IgnoreCertManager, "ignore-certmanager", false, "ignore scaffolding of cert-manager manifests")
+	fs.BoolVar(&p.IgnoreWebhook, "ignore-webhook", false, "ignore scaffolding of webhooks")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {
@@ -74,7 +86,15 @@ func (p *editSubcommand) InjectConfig(c config.Config) error {
 }
 
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewInitHelmScaffolder(p.config, p.force)
+	ignoreFlags := map[string]bool{
+		"ignore-samples":       p.IgnoreSamples,
+		"ignore-prometheus":    p.IgnorePrometheus,
+		"ignore-networkPolicy": p.IgnoreNetworkPolicy,
+		"ignore-certmanager":   p.IgnoreCertManager,
+		"ignore-webhook":       p.IgnoreWebhook,
+	}
+	scaffolder := scaffolds.NewInitHelmScaffolder(p.config, p.force, ignoreFlags)
+
 	scaffolder.InjectFS(fs)
 	err := scaffolder.Scaffold()
 	if err != nil {

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -32,7 +32,6 @@ type editSubcommand struct {
 	config config.Config
 	force  bool
 
-	IgnoreSamples       bool
 	IgnorePrometheus    bool
 	IgnoreNetworkPolicy bool
 	IgnoreCertManager   bool
@@ -73,7 +72,6 @@ manifests in the chart align with the latest changes.
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.force, "force", false, "if true, regenerates all the files")
 
-	fs.BoolVar(&p.IgnoreSamples, "ignore-samples", false, "ignore scaffolding of sample CRs")
 	fs.BoolVar(&p.IgnorePrometheus, "ignore-prometheus", false, "ignore scaffolding of prometheus monitor")
 	fs.BoolVar(&p.IgnoreNetworkPolicy, "ignore-networkPolicy", false, "ignore scaffolding of network policy")
 	fs.BoolVar(&p.IgnoreCertManager, "ignore-certmanager", false, "ignore scaffolding of cert-manager manifests")
@@ -87,7 +85,6 @@ func (p *editSubcommand) InjectConfig(c config.Config) error {
 
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
 	ignoreFlags := map[string]bool{
-		"ignore-samples":       p.IgnoreSamples,
 		"ignore-prometheus":    p.IgnorePrometheus,
 		"ignore-networkPolicy": p.IgnoreNetworkPolicy,
 		"ignore-certmanager":   p.IgnoreCertManager,

--- a/pkg/plugins/optional/helm/v1alpha/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/init.go
@@ -48,7 +48,6 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	ignoreFlags := map[string]bool{
-		"ignore-samples":       false,
 		"ignore-prometheus":    false,
 		"ignore-networkPolicy": false,
 		"ignore-certmanager":   false,

--- a/pkg/plugins/optional/helm/v1alpha/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/init.go
@@ -47,7 +47,15 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewInitHelmScaffolder(p.config, false)
+	ignoreFlags := map[string]bool{
+		"ignore-samples":       false,
+		"ignore-prometheus":    false,
+		"ignore-networkPolicy": false,
+		"ignore-certmanager":   false,
+		"ignore-webhook":       false,
+	}
+
+	scaffolder := scaffolds.NewInitHelmScaffolder(p.config, false, ignoreFlags)
 	scaffolder.InjectFS(fs)
 	err := scaffolder.Scaffold()
 	if err != nil {

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/init.go
@@ -55,7 +55,6 @@ type initScaffolder struct {
 	IgnoreCertManager   bool
 	IgnoreWebhook       bool
 	IgnoreNetworkPolicy bool
-	IgnoreSamples       bool
 }
 
 // NewInitHelmScaffolder returns a new Scaffolder for HelmPlugin
@@ -67,7 +66,6 @@ func NewInitHelmScaffolder(cfg config.Config, force bool, ignoreFlags map[string
 		IgnoreCertManager:   ignoreFlags["ignore-certmanager"],
 		IgnoreWebhook:       ignoreFlags["ignore-webhook"],
 		IgnoreNetworkPolicy: ignoreFlags["ignore-networkPolicy"],
-		IgnoreSamples:       ignoreFlags["ignore-samples"],
 	}
 }
 


### PR DESCRIPTION
## Description:
This PR introduces support for the following `--ignore-*` flags in the `edit` command of the Helm plugin, allowing selective scaffolding of chart files:

- `--ignore-samples`  
- `--ignore-prometheus`  
- `--ignore-networkPolicy`  
- `--ignore-certmanager`  
- `--ignore-webhook`

It can be used like this:

```bash
kubebuilder edit --plugins=helm.kubebuilder.io/v1-alpha \
  --ignore-samples \
  --ignore-prometheus \
  --ignore-networkPolicy \
  --ignore-certmanager \
  --ignore-webhook
  ```
These flags only apply to the edit command. The init command still scaffolds all components by default.
If any of the scaffolded folders are deleted manually, running edit with the respective --ignore-* flag will prevent them from being regenerated.

## Motivation:
Developers may not want all default Helm chart components (like Prometheus monitors or sample CRs). This change offers a way to skip unwanted parts cleanly.

## Fixes:
Fixes #4326


