### PR TITLE
🐛 (deploy-image/v1alpha1): drop patchStrategy/protobuf tags from Conditions

### DIFF
--- a/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
+++ b/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
@@ -51,7 +51,7 @@ type MemcachedStatus struct {
 	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -265,7 +265,7 @@ const newStatusAPI = `// Represents the observations of a Memcached's current st
 	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition ` + "`json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`"
+	Conditions []metav1.Condition ` + "`json:\"conditions,omitempty\"`"
 
 const sampleSizeFragment = `# TODO(user): edit the following value to ensure the number
   # of Pods/Instances your Operand must have on cluster

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -101,7 +101,7 @@ type {{ .Resource.Kind }}Status struct {
 	// {{ .Resource.Kind }}.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition ` + "`" + `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"` + "`" + `
+	Conditions []metav1.Condition ` + "`" + `json:"conditions,omitempty"` + "`" + `
 }
 
 // +kubebuilder:object:root=true

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
@@ -48,7 +48,7 @@ type BusyboxStatus struct {
 	// Busybox.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
@@ -51,7 +51,7 @@ type MemcachedStatus struct {
 	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
@@ -48,7 +48,7 @@ type BusyboxStatus struct {
 	// Busybox.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
@@ -51,7 +51,7 @@ type MemcachedStatus struct {
 	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
 	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Simplify the Conditions field in status scaffolding by removing patchStrategy, patchMergeKey, and protobuf tags.

Applied to:
- deploy-image/alpha-v1 plugin template
- Getting Started Memcached example

These fields are unnecessary by default and can introduce unexpected
strategic merge behavior. Omitting them simplifies CRD scaffolding
and avoids compatibility risks for most use cases.

Follows Kubernetes API conventions:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties


**Motivation**
- https://github.com/kubernetes-sigs/kubebuilder/issues/4809
- https://github.com/kubernetes-sigs/kubebuilder/pull/4888#discussion_r2171476294