### PR TITLE
✨ (deploy-image/v1alpha1) : Improve clarity and human readability of conditions field documentation in CRDs.

### DIFF
--- a/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
+++ b/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
@@ -42,15 +42,20 @@ type MemcachedSpec struct {
 
 // MemcachedStatus defines the observed state of Memcached.
 type MemcachedStatus struct {
-	// Represents the observations of a Memcached's current state.
-	// Memcached.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// Memcached.status.conditions.status are one of True, False, Unknown.
-	// Memcached.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+	// conditions represent the current state of the Memcached resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/docs/book/src/getting-started/testdata/project/config/crd/bases/cache.example.com_memcacheds.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/crd/bases/cache.example.com_memcacheds.yaml
@@ -53,6 +53,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached.
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -108,6 +118,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/crd/cache.example.com_memcacheds.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/crd/cache.example.com_memcacheds.yaml
@@ -59,6 +59,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached.
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -114,6 +124,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -61,6 +61,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached.
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -116,6 +126,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -256,15 +256,20 @@ const (
 const oldStatusAPI = `// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file`
 
-const newStatusAPI = `// Represents the observations of a Memcached's current state.
-	// Memcached.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// Memcached.status.conditions.status are one of True, False, Unknown.
-	// Memcached.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
-
+const newStatusAPI = `// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	
+	// conditions represent the current state of the Memcached resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition ` + "`json:\"conditions,omitempty\"`"
 
 const sampleSizeFragment = `# TODO(user): edit the following value to ensure the number

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -92,15 +92,20 @@ type {{ .Resource.Kind }}Spec struct {
 
 // {{ .Resource.Kind }}Status defines the observed state of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}Status struct {
-	// Represents the observations of a {{ .Resource.Kind }}'s current state.
-	// {{ .Resource.Kind }}.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// {{ .Resource.Kind }}.status.conditions.status are one of True, False, Unknown.
-	// {{ .Resource.Kind }}.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// {{ .Resource.Kind }}.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+	// conditions represent the current state of the {{ .Resource.Kind }} resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition ` + "`" + `json:"conditions,omitempty"` + "`" + `
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
@@ -39,15 +39,20 @@ type BusyboxSpec struct {
 
 // BusyboxStatus defines the observed state of Busybox
 type BusyboxStatus struct {
-	// Represents the observations of a Busybox's current state.
-	// Busybox.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// Busybox.status.conditions.status are one of True, False, Unknown.
-	// Busybox.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// Busybox.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+	// conditions represent the current state of the Busybox resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
@@ -42,15 +42,20 @@ type MemcachedSpec struct {
 
 // MemcachedStatus defines the observed state of Memcached
 type MemcachedStatus struct {
-	// Represents the observations of a Memcached's current state.
-	// Memcached.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// Memcached.status.conditions.status are one of True, False, Unknown.
-	// Memcached.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+	// conditions represent the current state of the Memcached resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_busyboxes.yaml
@@ -53,6 +53,16 @@ spec:
             description: BusyboxStatus defines the observed state of Busybox
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Busybox resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -108,6 +118,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_memcacheds.yaml
@@ -58,6 +58,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -113,6 +123,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -169,6 +169,16 @@ spec:
             description: BusyboxStatus defines the observed state of Busybox
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Busybox resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -224,6 +234,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true
@@ -668,6 +681,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -723,6 +746,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
@@ -39,15 +39,20 @@ type BusyboxSpec struct {
 
 // BusyboxStatus defines the observed state of Busybox
 type BusyboxStatus struct {
-	// Represents the observations of a Busybox's current state.
-	// Busybox.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// Busybox.status.conditions.status are one of True, False, Unknown.
-	// Busybox.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// Busybox.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+	// conditions represent the current state of the Busybox resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
@@ -42,15 +42,20 @@ type MemcachedSpec struct {
 
 // MemcachedStatus defines the observed state of Memcached
 type MemcachedStatus struct {
-	// Represents the observations of a Memcached's current state.
-	// Memcached.status.conditions.type are: "Available", "Progressing", and "Degraded"
-	// Memcached.status.conditions.status are one of True, False, Unknown.
-	// Memcached.status.conditions.reason the value should be a CamelCase string and producers of specific
-	// condition types may define expected values and meanings for this field, and whether the values
-	// are considered a guaranteed API.
-	// Memcached.status.conditions.Message is a human readable message indicating details about the transition.
-	// For further information see: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+	// For Kubernetes API conventions, see:
+	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
 
+	// conditions represent the current state of the Memcached resource.
+	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
+	//
+	// Standard condition types include:
+	// - "Available": the resource is fully functional.
+	// - "Progressing": the resource is being created or updated.
+	// - "Degraded": the resource failed to reach or maintain its desired state.
+	//
+	// The status of each condition is one of True, False, or Unknown.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_busyboxes.yaml
@@ -53,6 +53,16 @@ spec:
             description: BusyboxStatus defines the observed state of Busybox
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Busybox resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -108,6 +118,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_memcacheds.yaml
@@ -58,6 +58,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -113,6 +123,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_busyboxes.yaml
@@ -59,6 +59,16 @@ spec:
             description: BusyboxStatus defines the observed state of Busybox
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Busybox resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -114,6 +124,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_memcacheds.yaml
@@ -64,6 +64,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -119,6 +129,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -61,6 +61,16 @@ spec:
             description: BusyboxStatus defines the observed state of Busybox
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Busybox resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -116,6 +126,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true
@@ -182,6 +195,16 @@ spec:
             description: MemcachedStatus defines the observed state of Memcached
             properties:
               conditions:
+                description: |-
+                  conditions represent the current state of the Memcached resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional.
+                  - "Progressing": the resource is being created or updated.
+                  - "Degraded": the resource failed to reach or maintain its desired state.
+
+                  The status of each condition is one of True, False, or Unknown.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -237,6 +260,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true


### PR DESCRIPTION
Updated comments for the Conditions field to use more descriptive.
Perform the change for deploy-image and Getting Started sample

- Applied CRD OpenAPI validation markers:
      - `+listType=map` ensures conditions are represented as a map.
      - `+listMapKey=type` enforces uniqueness of condition types.
- Improved in-code comments for maintainability and user clarity.
- Fixed minor typos and updated phrasing for accuracy.



**Motivation**
- https://github.com/kubernetes-sigs/kubebuilder/issues/4809