### PR TITLE
🐛 (deploy-image/v1-alpha1): Remove default max size validation

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -80,8 +80,6 @@ type {{ .Resource.Kind }}Spec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3
-	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 ` + "`" + `json:"size,omitempty"` + "`" + `
 
 	{{ if not (isEmptyStr .Port) -}}

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
@@ -32,8 +32,6 @@ type BusyboxSpec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3
-	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
@@ -32,8 +32,6 @@ type MemcachedSpec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3
-	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 
 	// Port defines the port that will be used to init the container with the image

--- a/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_busyboxes.yaml
@@ -45,7 +45,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-multigroup/config/crd/bases/example.com.testproject.org_memcacheds.yaml
@@ -50,7 +50,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -161,7 +161,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object
@@ -673,7 +672,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
@@ -32,8 +32,6 @@ type BusyboxSpec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3
-	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 }
 

--- a/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
@@ -32,8 +32,6 @@ type MemcachedSpec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=3
-	// +kubebuilder:validation:ExclusiveMaximum=false
 	Size int32 `json:"size,omitempty"`
 
 	// Port defines the port that will be used to init the container with the image

--- a/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_busyboxes.yaml
@@ -45,7 +45,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-with-plugins/config/crd/bases/example.com.testproject.org_memcacheds.yaml
@@ -50,7 +50,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_busyboxes.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_busyboxes.yaml
@@ -51,7 +51,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_memcacheds.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/example.com.testproject.org_memcacheds.yaml
@@ -56,7 +56,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -53,7 +53,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object
@@ -187,7 +186,6 @@ spec:
                   The following markers will use OpenAPI v3 schema to validate the value
                   More info: https://book.kubebuilder.io/reference/markers/crd-validation.html
                 format: int32
-                maximum: 3
                 minimum: 1
                 type: integer
             type: object


### PR DESCRIPTION
This removes the default max validation for the size field in the deploy-image plugin.

Since the plugin allows deploying any image, setting a default maximum doesn’t seem appropriate and could be misleading.
We believe it’s better to leave this responsibility to the user.

This change aligns with flexibility and avoids setting unnecessary constraints by default.