### PR TITLE
🌱 (chore): optimize CI time and usage of resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ test-coverage: ## Run unit tests creating the output to report coverage
 .PHONY: test-integration
 test-integration: ## Run the integration tests
 	./test/integration.sh
+	./test/features.sh
 
 .PHONY: check-testdata
 check-testdata: ## Run the script to ensure that the testdata is updated

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -74,21 +74,24 @@ var _ = Describe("kubebuilder", func() {
 			validateProjectFile(kbc, filepath.Join(kbc.Dir, "PROJECT"))
 		})
 
-		It("should regenerate project with grafana plugin with success", func() {
-			generateProjectWithGrafanaPlugin(kbc)
+		It("should regenerate project with plugins with success", func() {
+			By("Enabling the Grafana plugin")
+			err := kbc.Edit("--plugins", "grafana.kubebuilder.io/v1-alpha")
+			Expect(err).NotTo(HaveOccurred(), "Failed to edit project to enable Grafana Plugin")
+
+			By("Generate API with Deploy Image plugin")
+			generateAPIWithDeployImage(kbc)
+
+			By("Enabling Helm plugin")
+			err = kbc.Edit("--plugins", "helm.kubebuilder.io/v1-alpha")
+			Expect(err).NotTo(HaveOccurred(), "Failed to edit project to enable Helm Plugin")
+
+			By("Re-generating the project with plugins")
 			regenerateProjectWith(kbc, projectOutputDir)
+
+			By("By validating the expected scaffolded files")
 			validateGrafanaPlugin(projectFilePath)
-		})
-
-		It("should regenerate project with DeployImage plugin with success", func() {
-			generateProjectWithDeployImagePlugin(kbc)
-			regenerateProjectWith(kbc, projectOutputDir)
 			validateDeployImagePlugin(projectFilePath)
-		})
-
-		It("should regenerate project with helm plugin with success", func() {
-			generateProjectWithHelmPlugin(kbc)
-			regenerateProjectWith(kbc, projectOutputDir)
 			validateHelmPlugin(projectFilePath)
 		})
 	})
@@ -200,19 +203,7 @@ func regenerateProjectWith(kbc *utils.TestContext, projectOutputDir string) {
 	Expect(err).NotTo(HaveOccurred(), "Failed to regenerate project")
 }
 
-func generateProjectWithGrafanaPlugin(kbc *utils.TestContext) {
-	By("editing project to enable Grafana plugin")
-	err := kbc.Edit("--plugins", "grafana.kubebuilder.io/v1-alpha")
-	Expect(err).NotTo(HaveOccurred(), "Failed to edit project to enable Grafana Plugin")
-}
-
-func generateProjectWithHelmPlugin(kbc *utils.TestContext) {
-	By("editing project to enable Helm plugin")
-	err := kbc.Edit("--plugins", "helm.kubebuilder.io/v1-alpha")
-	Expect(err).NotTo(HaveOccurred(), "Failed to edit project to enable Helm Plugin")
-}
-
-func generateProjectWithDeployImagePlugin(kbc *utils.TestContext) {
+func generateAPIWithDeployImage(kbc *utils.TestContext) {
 	By("creating an API with DeployImage plugin")
 	err := kbc.CreateAPI(
 		"--group", "crew",

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -64,8 +64,6 @@ function test_cluster {
   docker pull busybox:1.36.1
   kind load docker-image --name $KIND_CLUSTER busybox:1.36.1
 
-  go test $(dirname "$0")/grafana $flags -timeout 30m
   go test $(dirname "$0")/deployimage $flags -timeout 30m
   go test $(dirname "$0")/v4 $flags -timeout 30m
-  go test $(dirname "$0")/alphagenerate $flags -timeout 30m
 }

--- a/test/features.sh
+++ b/test/features.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+header_text "Running e2e tests that do not require a cluster"
+
+build_kb
+fetch_tools
+
+pushd . >/dev/null
+
+header_text "Running Grafana Plugin E2E tests"
+go test "$(dirname "$0")/e2e/grafana" ${flags:-} -timeout 30m
+
+header_text "Running Alpha Generate Command E2E tests"
+go test "$(dirname "$0")/e2e/alphagenerate" ${flags:-} -timeout 30m
+
+popd >/dev/null


### PR DESCRIPTION
- Move the tests that do not require running on the cluster to run in the job pull-kubebuilder-test just once
- Change TestContext to work well outside of the cluster (it tries to capture the Kubernetes version so we have it tracked in case we want to skip a test for a specific version)
- Update e2e tests to move grafana and alphagenerate to run on this job, since they do not require a cluster
- Improve e2e tests for alpha generate by reducing the number of mocks — we don’t need one mock per plugin; we can use a single mock with all plugins scaffolded to validate properly. This should significantly reduce the time needed to perform the tests


We can check that the tests were executed here: https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kubebuilder/4921/pull-kubebuilder-test/1943729959755321344/build-log.txt