### PR TITLE
🌱: introduce gci as formatter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,16 +83,23 @@ linters:
         path: hack/docs/*
       - linters:
           - revive
-        text: 'should have comment or be unexported'
+        text: "should have comment or be unexported"
     paths:
       - third_party$
       - builtin$
       - examples$
 formatters:
   enable:
+    - gci
     - gofmt
     - gofumpt
     - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(sigs.k8s.io/kubebuilder)
   exclusions:
     generated: lax
     paths:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"

--- a/hack/docs/generate_samples.go
+++ b/hack/docs/generate_samples.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	log "github.com/sirupsen/logrus"
+
 	cronjob "sigs.k8s.io/kubebuilder/v4/hack/docs/internal/cronjob-tutorial"
 	gettingstarted "sigs.k8s.io/kubebuilder/v4/hack/docs/internal/getting-started"
 	multiversion "sigs.k8s.io/kubebuilder/v4/hack/docs/internal/multiversion-tutorial"

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds"

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -20,11 +20,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+	log "github.com/sirupsen/logrus"
 
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
-
-	log "github.com/sirupsen/logrus"
+	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
+
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"

--- a/hack/docs/utils/utils.go
+++ b/hack/docs/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 

--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha"
 )
 

--- a/pkg/cli/alpha/command.go
+++ b/pkg/cli/alpha/command.go
@@ -16,6 +16,7 @@ package alpha
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal"
 )
 

--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -23,10 +23,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/common"
-
 	log "github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/common"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"

--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"golang.org/x/mod/semver"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -27,6 +27,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 )
 

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -18,6 +18,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update"
 )
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/pkg/config/store/yaml/store_test.go
+++ b/pkg/config/store/yaml/store_test.go
@@ -22,14 +22,13 @@ import (
 	"os"
 	"testing"
 
-	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
+
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -20,14 +20,14 @@ import (
 	"fmt"
 	"strings"
 
-	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd"
-
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
+	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/crd"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/rbac"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples"
 )

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
-
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/certmanager"

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-
 	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -23,6 +23,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/spoke.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/spoke.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/api"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
@@ -31,6 +29,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/api"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e"

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -23,12 +23,11 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha/scaffolds/internal/templates"
-
-	"sigs.k8s.io/yaml"
 )
 
 var _ plugins.Scaffolder = &editScaffolder{}

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -23,9 +23,8 @@ import (
 	"regexp"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -20,18 +20,17 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("kubebuilder", func() {

--- a/test/e2e/alphagenerate/generate_v4_multigroup_test.go
+++ b/test/e2e/alphagenerate/generate_v4_multigroup_test.go
@@ -19,13 +19,13 @@ package alphagenerate
 import (
 	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 const testProjectDomain = "testproject.org"

--- a/test/e2e/alphagenerate/generate_v4_test.go
+++ b/test/e2e/alphagenerate/generate_v4_test.go
@@ -19,12 +19,12 @@ package alphagenerate
 import (
 	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("kubebuilder", func() {

--- a/test/e2e/alphagenerate/generate_v4_with_plugins_test.go
+++ b/test/e2e/alphagenerate/generate_v4_with_plugins_test.go
@@ -19,13 +19,13 @@ package alphagenerate
 import (
 	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("kubebuilder", func() {

--- a/test/e2e/alphaupdate/update_test.go
+++ b/test/e2e/alphaupdate/update_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )

--- a/test/e2e/deployimage/plugin_cluster_test.go
+++ b/test/e2e/deployimage/plugin_cluster_test.go
@@ -23,11 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 

--- a/test/e2e/grafana/generate_test.go
+++ b/test/e2e/grafana/generate_test.go
@@ -19,12 +19,10 @@ package grafana
 import (
 	"path/filepath"
 
-	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-
 	. "github.com/onsi/ginkgo/v2"
-
 	. "github.com/onsi/gomega"
 
+	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 

--- a/test/e2e/helm/generate_test.go
+++ b/test/e2e/helm/generate_test.go
@@ -19,17 +19,17 @@ package helm
 import (
 	"path/filepath"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	helmChartLoader "helm.sh/helm/v3/pkg/chart/loader"
+
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("kubebuilder", func() {

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -24,11 +24,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-
 	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 )
 
 const (

--- a/test/e2e/v4/e2e_suite_test.go
+++ b/test/e2e/v4/e2e_suite_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"testing"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
 // Run e2e tests using the Ginkgo runner.


### PR DESCRIPTION
To have a common appearance of the  import section, `gci` as formatter is enforcing the following pattern of imports:

```yaml
    gci:
      sections:
        - standard
        - default
        - prefix(sigs.k8s.io/kubebuilder)
        - dot
```

xref: `gci` documentation - https://golangci-lint.run/usage/formatters/#gci

This is a follow-up task by a PR comment in https://github.com/kubernetes-sigs/kubebuilder/pull/4914
