### PR TITLE
📖 (doc): fixed the broken links

### DIFF
--- a/docs/book/src/cronjob-tutorial/writing-tests.md
+++ b/docs/book/src/cronjob-tutorial/writing-tests.md
@@ -28,6 +28,6 @@ This Status update example above demonstrates a general testing strategy for a c
 
 You can use the plugin [DeployImage](../plugins/available/deploy-image-plugin-v1-alpha.md) to check examples. This plugin allows users to scaffold API/Controllers to deploy and manage an Operand (image) on the cluster following the guidelines and best practices. It abstracts the complexities of achieving this goal while allowing users to customize the generated code.
 
-Therefore, you can check that a test using ENV TEST will be generated for the controller which has the purpose to ensure that the Deployment is created successfully. You can see an example of its code implementation under the `testdata` directory with the [DeployImage](../plugins/available/deploy-image-plugin-v1-alpha.md) samples [here](https://github.com/kubernetes-sigs/kubebuilder/blob/v3.7.0/testdata/project-v4-with-plugins/controllers/busybox_controller_test.go).
+Therefore, you can check that a test using ENV TEST will be generated for the controller which has the purpose to ensure that the Deployment is created successfully. You can see an example of its code implementation under the `testdata` directory with the [DeployImage](../plugins/available/deploy-image-plugin-v1-alpha.md) samples [here](https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/project-v4-with-plugins).
 
 </aside>

--- a/docs/book/src/cronjob-tutorial/writing-tests.md
+++ b/docs/book/src/cronjob-tutorial/writing-tests.md
@@ -28,6 +28,6 @@ This Status update example above demonstrates a general testing strategy for a c
 
 You can use the plugin [DeployImage](../plugins/available/deploy-image-plugin-v1-alpha.md) to check examples. This plugin allows users to scaffold API/Controllers to deploy and manage an Operand (image) on the cluster following the guidelines and best practices. It abstracts the complexities of achieving this goal while allowing users to customize the generated code.
 
-Therefore, you can check that a test using ENV TEST will be generated for the controller which has the purpose to ensure that the Deployment is created successfully. You can see an example of its code implementation under the `testdata` directory with the [DeployImage](../plugins/available/deploy-image-plugin-v1-alpha.md) samples [here](https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/project-v4-with-plugins).
+Therefore, you can check that a test using ENV TEST will be generated for the controller which has the purpose to ensure that the Deployment is created successfully. You can see an example of its code implementation under the `testdata` directory with the [DeployImage](../plugins/available/deploy-image-plugin-v1-alpha.md) samples [here](https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v4-with-plugins/internal/controller/busybox_controller_test.go).
 
 </aside>

--- a/docs/book/src/plugins/available/deploy-image-plugin-v1-alpha.md
+++ b/docs/book/src/plugins/available/deploy-image-plugin-v1-alpha.md
@@ -105,7 +105,7 @@ files are affected, in addition to the existing Kubebuilder scaffolding:
 [video]: https://youtu.be/UwPuRjjnMjY
 [operator-pattern]: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
-[testdata]: ./.././../../../../testdata/project-v4-with-plugins
+[testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/project-v4-with-plugins
 [envtest]: ./../../reference/envtest.md
 [quick-start]: ./../../quick-start.md
 [create-apis]: ../../cronjob-tutorial/new-api.md

--- a/docs/book/src/plugins/available/go-v4-plugin.md
+++ b/docs/book/src/plugins/available/go-v4-plugin.md
@@ -42,7 +42,7 @@ kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io
 
 [controller-runtime]: https://github.com/kubernetes-sigs/controller-runtime
 [quickstart]: ./../../quick-start.md
-[testdata]: ./../../../../../testdata
+[testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata
 [plugins-main]: ./../../../../../cmd/main.go
 [kustomize-plugin]: ./../../plugins/available/kustomize-v2.md
 [kustomize]: https://github.com/kubernetes-sigs/kustomize


### PR DESCRIPTION
This pr is about fixing some of the broken links on https://book.kubebuilder.io/

fixes #4906 
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
