### PR TITLE
✨ (alpha update command): add --force flag

### DIFF
--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -61,6 +61,12 @@ kubebuilder alpha update \
   --from-branch=main
 ```
 
+Force update even with merge conflicts:
+
+```sh
+kubebuilder alpha update --force
+```
+
 <aside class="note warning">
 <h1>You might need to upgrade your project first</h1>
 
@@ -81,16 +87,57 @@ Once updated, you can use `kubebuilder alpha update` for future upgrades.
 | `--from-version`    | **Required for projects initialized with versions earlier than v4.6.0.** Kubebuilder version your project was created with. If unset, uses the `PROJECT` file. |
 | `--to-version`      | Version to upgrade to. Defaults to the latest version.                                                                                                         |
 | `--from-branch`     | Git branch that contains your current project code. Defaults to `main`.                                                                                        |
+| `--force`           | Force the update even if conflicts occur. Conflicted files will include conflict markers, and a commit will be created automatically. Ideal for automation (e.g., cronjobs, CI).                                                                       |
 | `-h, --help`        | Show help for this command.                                                                                                                                    |
-
-<aside class="note warning">
-<h1>Projects generated with </h1>
-
+<aside class="note">
 Projects generated with **Kubebuilder v4.6.0** or later include the `cliVersion` field in the `PROJECT` file.
 This field is used by `kubebuilder alpha update` to determine the correct CLI
 version for upgrading your project.
-
 </aside>
+
+## Merge Conflicts with `--force`
+
+When you use the `--force` flag with `kubebuilder alpha update`, Git will complete the merge even if there are conflicts. The resulting commit will include conflict markers like:
+```
+<<<<<<< HEAD
+Your changes
+=======
+Incoming changes
+>>>>>>> branch-name
+```
+These conflicts will be committed in the
+`tmp-kb-update-merge` branch.
+
+<aside class="note warning">
+You must manually resolve these conflicts before merging into your main branch.
+
+```suggestion
+<aside class="note warning">
+<H1>If you face conflicts (using or not the --force flag) </H1>
+If the merge introduces conflicts, you must resolve them and **ensure** you execute the following command to regenerate the manifests and organise the files properly:
+
+```bash
+make manifests generate fmt vet lint-fix
+```
+
+Alternatively, you may want to run:
+
+```bash
+make all
+```
+</aside>
+
+
+## When to Use `--force`
+Use `--force` only in scenarios like:
+- Automated environments (e.g., CI pipelines or cron jobs)
+- When you need to create a PR even if conflicts are present
+- When a human will resolve the conflicts later
+`kubebuilder alpha update --force`
+
+This ensures the update proceeds without manual blocking but shifts responsibility for conflict resolution to a follow-up manual step.
+
+This approach is typically used in automation workflows where conflict markers are later addressed by a human, or where preserving the conflicting changes is acceptable for follow-up processing.
 
 ## Requirements
 

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -39,6 +39,8 @@ type Update struct {
 	ToVersion string
 	// FromBranch stores the branch to update from, e.g., "main".
 	FromBranch string
+	// Force commits the update changes even with merge conflicts
+	Force bool
 
 	// UpdateBranches
 	AncestorBranch string
@@ -335,8 +337,15 @@ func (opts *Update) mergeOriginalToUpgrade() error {
 		var exitErr *exec.ExitError
 		// If the merge has an error that is not a conflict, return an error 2
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			log.Warn("Merge completed with conflicts. Manual resolution required.")
 			hasConflicts = true
+			if !opts.Force {
+				log.Warn("Merge stopped due to conflicts. Manual resolution is required.")
+				log.Warn("After resolving the conflicts, run the following command:")
+				log.Warn("    make manifests generate fmt vet lint-fix")
+				log.Warn("This ensures manifests and generated files are up to date, and the project layout remains consistent.")
+				return fmt.Errorf("merge stopped due to conflicts")
+			}
+			log.Warn("Merge completed with conflicts. Conflict markers will be committed.")
 		} else {
 			return fmt.Errorf("merge failed unexpectedly: %w", err)
 		}

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -50,9 +50,8 @@ The process uses Git branches:
   - upgrade: scaffold from the target version
   - merge: result of the 3-way merge
 
-If conflicts occur during the merge, resolve them manually in the 'merge' branch. 
-Once resolved, commit and push it as a pull request. This branch will contain the 
-final upgraded project with the latest Kubebuilder layout and your custom code.
+If conflicts occur during the merge, the command will stop and leave the merge branch for manual resolution.
+Use --force to commit conflicts with markers instead. 
 
 Examples:
   # Update from the version specified in the PROJECT file to the latest release
@@ -63,6 +62,9 @@ Examples:
 
   # Update from a specific version to an specific release
   kubebuilder alpha update --from-version v4.5.0 --to-version v4.7.0	
+
+  # Force update even with merge conflicts (commit conflict markers)
+  kubebuilder alpha update --force
 
 `,
 
@@ -92,6 +94,10 @@ Examples:
 
 	updateCmd.Flags().StringVar(&opts.FromBranch, "from-branch", "",
 		"Git branch to use as current state of the project for the update.")
+
+	updateCmd.Flags().BoolVar(&opts.Force, "force", false,
+		"Force the update even if conflicts occur. Conflicted files will include conflict markers, and a "+
+			"commit will be created automatically. Ideal for automation (e.g., cronjobs, CI).")
 
 	return updateCmd
 }


### PR DESCRIPTION
This PR adds the `--force` flag to the `alpha update` command, as well as e2e tests for the flag. 

The `--force` flag makes it possible to run the `alpha update` command in CI workflows.

If the `--force` flag is not passed to the command, the update operation will abort if there are conflicts, informing the user that manual resolution is necessary:

```
vitor@pc:~/go/src/github.com/vitorfloriano/multiversion$ kubebuilder alpha update --from-version v4.5.0 --to-version v4.
6.0 --from-branch main
INFO Checking if is a git repository
INFO Checking if branch has uncommitted changes
INFO Binary version v4.5.0 is available
INFO Binary version v4.6.0 is available
INFO Checking out base branch: main
INFO Using branch names:
INFO   Ancestor: tmp-ancestor-16-07-25-23-25
INFO   Original:  tmp-original-16-07-25-23-25
INFO   Upgrade:  tmp-upgrade-16-07-25-23-25
INFO   Merge:    tmp-merge-16-07-25-23-25
...
...
...
...
WARN Merge stopped due to conflicts. Manual resolution is required. 
WARN After resolving the conflicts, run the following command: 
WARN     make manifests generate fmt vet lint-fix 
WARN This ensures manifests and generated files are up to date, and the project layout remains consistent. 
FATA Update failed: failed to merge upgrade into merge branch: merge stopped due to conflicts 
```
If the `--force` flag is passed, the update will proceed, despite the conflicts, and commit the markers as is:

```
vitor@pc:~/go/src/github.com/vitorfloriano/multiversion$ kubebuilder alpha update --from-version v4.5.0 --to-version v4.6.0 --from-branch main --force
INFO Checking if is a git repository
INFO Checking if branch has uncommitted changes
INFO Binary version v4.5.0 is available
INFO Binary version v4.6.0 is available
INFO Checking out base branch: main
INFO Using branch names:
INFO   Ancestor: tmp-ancestor-16-07-25-23-39
INFO   Original:  tmp-original-16-07-25-23-39
INFO   Upgrade:  tmp-upgrade-16-07-25-23-39
INFO   Merge:    tmp-merge-16-07-25-23-39
...
...
...
...
...
...
INFO Preparing Merge branch with name tmp-merge-16-07-25-23-39 and performing merge
WARN Merge completed with conflicts. Conflict markers will be committed.
```
As a follow-up, we could find a way to not run the make targets if there are conflicts, to avoid the stream of warnings about failing operations caused by the presence of the markers in the code. Ending the operation with so many warnings could be confusing to users:
```
WARN Merge completed with conflicts. Conflict markers will be committed.
...
...
WARN make manifests failed: error running "make": exit status 2
...
...
WARN make generate failed: error running "make": exit status 2
...
...
WARN make fmt failed: error running "make": exit status 2
...
...
WARN make vet failed: error running "make": exit status 2
...
...
ERRO Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/pac
...
...
WARN make lint-fix failed: error running "make": exit status 2
```
