### PR TITLE
🐛 (CLI) fix alpha update command to version pre-require check

### DIFF
--- a/pkg/cli/alpha/internal/update/prepare.go
+++ b/pkg/cli/alpha/internal/update/prepare.go
@@ -75,7 +75,7 @@ func (opts *Update) defineFromVersion(config store.Store) (string, error) {
 
 func (opts *Update) defineToVersion() string {
 	if len(opts.ToVersion) != 0 {
-		if !strings.HasPrefix(opts.FromVersion, "v") {
+		if !strings.HasPrefix(opts.ToVersion, "v") {
 			return "v" + opts.ToVersion
 		}
 		return opts.ToVersion


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

Found this while I was working on writing the Unit Test cases for alpha cli commands.

The alpha update command --to-version verifies if the 'v' prefix is added by user, if not prepends 'v' to the specified version. But here, the check is done on --from-version instead of --to-version which might cause 'v' to be prefixed even if user specifies it in the command line for --to-version field
