### PR TITLE
✨ (go/v4): scaffold kube-api-linter support in new projects

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.custom-gcl.yml
@@ -4,8 +4,14 @@
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: v2.12.2
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -25,5 +25,11 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - name: Run lint target
         run: make lint

--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -24,11 +24,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -52,6 +63,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/docs/book/src/getting-started/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/getting-started/testdata/project/.custom-gcl.yml
@@ -4,8 +4,14 @@
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: v2.12.2
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -25,5 +25,11 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - name: Run lint target
         run: make lint

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -24,11 +24,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -52,6 +63,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/docs/book/src/multiversion-tutorial/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.custom-gcl.yml
@@ -4,8 +4,14 @@
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: v2.12.2
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -25,5 +25,11 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - name: Run lint target
         run: make lint

--- a/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
@@ -24,11 +24,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -52,6 +63,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/customgcl.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/customgcl.go
@@ -50,9 +50,15 @@ const customGclTemplate = `# This file configures golangci-lint with module plug
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: {{ .GolangciLintVersion }}
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -73,6 +73,12 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: {{ .GolangciLintVersion }}
+
+      - name: Run lint target
         run: make lint
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -67,11 +67,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -95,6 +106,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/testdata/project-v4-multigroup/.custom-gcl.yml
+++ b/testdata/project-v4-multigroup/.custom-gcl.yml
@@ -4,8 +4,14 @@
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: v2.12.2
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest

--- a/testdata/project-v4-multigroup/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/lint.yml
@@ -25,5 +25,11 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - name: Run lint target
         run: make lint

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -24,11 +24,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -52,6 +63,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/testdata/project-v4-with-plugins/.custom-gcl.yml
+++ b/testdata/project-v4-with-plugins/.custom-gcl.yml
@@ -4,8 +4,14 @@
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: v2.12.2
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -25,5 +25,11 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - name: Run lint target
         run: make lint

--- a/testdata/project-v4-with-plugins/.golangci.yml
+++ b/testdata/project-v4-with-plugins/.golangci.yml
@@ -24,11 +24,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -52,6 +63,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$

--- a/testdata/project-v4/.custom-gcl.yml
+++ b/testdata/project-v4/.custom-gcl.yml
@@ -4,8 +4,14 @@
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
 version: v2.12.2
+name: golangci-lint-custom
+destination: ./bin
+
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"
     import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest 
+  # kube-api-linter checks Kubernetes API conventions
+  - module: "sigs.k8s.io/kube-api-linter"
     version: latest

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -25,5 +25,11 @@ jobs:
 
       - name: Check linter configuration
         run: make lint-config
+
       - name: Run linter
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+      - name: Run lint target
         run: make lint

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -24,11 +24,22 @@ linters:
     - unparam
     - unused
     - logcheck
+    - kubeapilinter
   settings:
     custom:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+      kubeapilinter:
+        type: module
+        description: "Kube API Linter plugin"
+        original-url: "sigs.k8s.io/kube-api-linter"
+        settings:
+          linters: {}
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: WhenRequired
     depguard:
       rules:
         forbid-sort-pkg:
@@ -52,6 +63,9 @@ linters:
           - dupl
           - lll
         path: internal/*
+      - path-except: "^api/"
+        linters:
+          - kubeapilinter
     paths:
       - third_party$
       - builtin$


### PR DESCRIPTION
## Summary
- Kubebuilder projects typically scaffold CRD-style APIs, and kube-api-linter exists to enforce those Kubernetes API conventions automatically for CRD authors rather than just core API teams.
- This change wires kube-api-linter directly into the project template: the scaffold now creates a `.custom-gcl.yml`, adds Makefile and CI hooks, and enables the `kubeapilinter` module in `.golangci.yml` so every new operator starts with CRD-focused linting out of the box.
- The `optionalfields` pointer policy defaults to `WhenRequired`, matching the kube-api-linter maintainers’ recommendation for CRDs and avoiding the stricter setting that targets core Kubernetes API types ([kube-api-linter#128](https://github.com/kubernetes-sigs/kube-api-linter/issues/128)).


Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4809