### PR TITLE
✨ (go/v4) add e2e build tag to prevent accidental execution of end-to-end tests

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -87,7 +87,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -83,7 +83,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -87,7 +87,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/hack/docs/internal/cronjob-tutorial/e2e_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/e2e_implementation.go
@@ -17,42 +17,39 @@ limitations under the License.
 package cronjob
 
 const isPrometheusInstalledVar = `
-// isPrometheusOperatorAlreadyInstalled will be set true when prometheus CRDs be found on the cluster
-isPrometheusOperatorAlreadyInstalled = false
-`
+	// isPrometheusOperatorAlreadyInstalled will be set true when prometheus CRDs be found on the cluster
+	isPrometheusOperatorAlreadyInstalled = false`
 
 const beforeSuitePrometheus = `
-By("Ensure that Prometheus is enabled")
+	By("Ensure that Prometheus is enabled")
 	_ = utils.UncommentCode("config/default/kustomization.yaml", "#- ../prometheus", "#")
 `
 
 const afterSuitePrometheus = `
-// Teardown Prometheus after the suite if it was not already installed
-if !isPrometheusOperatorAlreadyInstalled {
-	_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling Prometheus Operator...\n")
-	utils.UninstallPrometheusOperator()
-}
+	// Teardown Prometheus after the suite if it was not already installed
+	if !isPrometheusOperatorAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling Prometheus Operator...\n")
+		utils.UninstallPrometheusOperator()
+	}
 `
 
 const checkPrometheusInstalled = `
-// To prevent errors when tests run in environments with Prometheus already installed,
-// we check for its presence before execution.
-// Setup Prometheus before the suite if not already installed
-By("checking if prometheus is installed already")
-isPrometheusOperatorAlreadyInstalled = utils.IsPrometheusCRDsInstalled()
-if !isPrometheusOperatorAlreadyInstalled {
-	_, _ = fmt.Fprintf(GinkgoWriter, "Installing Prometheus Operator...\n")
-	Expect(utils.InstallPrometheusOperator()).To(Succeed(), "Failed to install Prometheus Operator")
-} else {
-	_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Prometheus Operator is already installed. Skipping installation...\n")
-}
+	// To prevent errors when tests run in environments with Prometheus already installed,
+	// we check for its presence before execution.
+	// Setup Prometheus before the suite if not already installed
+	By("checking if prometheus is installed already")
+	isPrometheusOperatorAlreadyInstalled = utils.IsPrometheusCRDsInstalled()
+	if !isPrometheusOperatorAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Installing Prometheus Operator...\n")
+		Expect(utils.InstallPrometheusOperator()).To(Succeed(), "Failed to install Prometheus Operator")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Prometheus Operator is already installed. Skipping installation...\n")
+	}
 `
 
 const serviceMonitorE2e = `
 
-By("validating that the ServiceMonitor for Prometheus is applied in the namespace")
-	cmd = exec.Command("kubectl", "get", "ServiceMonitor", "-n", namespace)
-	_, err = utils.Run(cmd)
-	Expect(err).NotTo(HaveOccurred(), "ServiceMonitor should exist")
-
-`
+			By("validating that the ServiceMonitor for Prometheus is applied in the namespace")
+			cmd = exec.Command("kubectl", "get", "ServiceMonitor", "-n", namespace)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "ServiceMonitor should exist")`

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -162,7 +162,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -40,7 +40,10 @@ func (f *SuiteTest) SetTemplateDefaults() error {
 	return nil
 }
 
-var suiteTestTemplate = `{{ .Boilerplate }}
+var suiteTestTemplate = `//go:build e2e
+// +build e2e
+
+{{ .Boilerplate }}
 
 package e2e
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -177,8 +177,10 @@ const conversionWebhookChecksFragment = `It("should have CA injection for %[1]s 
 
 `
 
-var testCodeTemplate = `{{ .Boilerplate }}
+var testCodeTemplate = `//go:build e2e
+// +build e2e
 
+{{ .Boilerplate }}
 
 package e2e
 

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -83,7 +83,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/testdata/project-v4-multigroup/test/e2e/e2e_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -83,7 +83,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -83,7 +83,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e

--- a/testdata/project-v4/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4/test/e2e/e2e_suite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 

--- a/testdata/project-v4/test/e2e/e2e_test.go
+++ b/testdata/project-v4/test/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2025 The Kubernetes authors.
 


### PR DESCRIPTION
### Motivation

Some users unintentionally ran E2E tests against production environments by using `go test ./...`. This can lead to dangerous side effects like uninstalling Cert Manager or modifying shared clusters.

### What’s Changed

- Added `//go:build e2e` tags to all E2E test files.
- Updated the `Makefile` to run E2E tests with `-tags=e2e`.

### How to Run E2E Tests Now

You must explicitly pass the tag:

```bash
make test-e2e
# or
go test -tags=e2e ./test/e2e/...
```

### Result

E2E tests are no longer included in default `go test ./...` runs, reducing risk of accidental execution.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/4116

c/c @applejag 