### PR TITLE
Prepare: Patch release 4.7.1

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/utils/utils.go
@@ -111,6 +111,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.

--- a/docs/book/src/getting-started/testdata/project/test/utils/utils.go
+++ b/docs/book/src/getting-started/testdata/project/test/utils/utils.go
@@ -111,6 +111,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/utils/utils.go
@@ -111,6 +111,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -61,6 +61,12 @@ kubebuilder alpha update \
   --from-branch=main
 ```
 
+Force update even with merge conflicts:
+
+```sh
+kubebuilder alpha update --force
+```
+
 <aside class="note warning">
 <h1>You might need to upgrade your project first</h1>
 
@@ -81,16 +87,57 @@ Once updated, you can use `kubebuilder alpha update` for future upgrades.
 | `--from-version`    | **Required for projects initialized with versions earlier than v4.6.0.** Kubebuilder version your project was created with. If unset, uses the `PROJECT` file. |
 | `--to-version`      | Version to upgrade to. Defaults to the latest version.                                                                                                         |
 | `--from-branch`     | Git branch that contains your current project code. Defaults to `main`.                                                                                        |
+| `--force`           | Force the update even if conflicts occur. Conflicted files will include conflict markers, and a commit will be created automatically. Ideal for automation (e.g., cronjobs, CI).                                                                       |
 | `-h, --help`        | Show help for this command.                                                                                                                                    |
-
-<aside class="note warning">
-<h1>Projects generated with </h1>
-
+<aside class="note">
 Projects generated with **Kubebuilder v4.6.0** or later include the `cliVersion` field in the `PROJECT` file.
 This field is used by `kubebuilder alpha update` to determine the correct CLI
 version for upgrading your project.
-
 </aside>
+
+## Merge Conflicts with `--force`
+
+When you use the `--force` flag with `kubebuilder alpha update`, Git will complete the merge even if there are conflicts. The resulting commit will include conflict markers like:
+```
+<<<<<<< HEAD
+Your changes
+=======
+Incoming changes
+>>>>>>> branch-name
+```
+These conflicts will be committed in the
+`tmp-kb-update-merge` branch.
+
+<aside class="note warning">
+You must manually resolve these conflicts before merging into your main branch.
+
+```suggestion
+<aside class="note warning">
+<H1>If you face conflicts (using or not the --force flag) </H1>
+If the merge introduces conflicts, you must resolve them and **ensure** you execute the following command to regenerate the manifests and organise the files properly:
+
+```bash
+make manifests generate fmt vet lint-fix
+```
+
+Alternatively, you may want to run:
+
+```bash
+make all
+```
+</aside>
+
+
+## When to Use `--force`
+Use `--force` only in scenarios like:
+- Automated environments (e.g., CI pipelines or cron jobs)
+- When you need to create a PR even if conflicts are present
+- When a human will resolve the conflicts later
+`kubebuilder alpha update --force`
+
+This ensures the update proceeds without manual blocking but shifts responsibility for conflict resolution to a follow-up manual step.
+
+This approach is typically used in automation workflows where conflict markers are later addressed by a human, or where preserving the conflicting changes is acceptable for follow-up processing.
 
 ## Requirements
 

--- a/pkg/cli/alpha/internal/update/prepare.go
+++ b/pkg/cli/alpha/internal/update/prepare.go
@@ -75,7 +75,7 @@ func (opts *Update) defineFromVersion(config store.Store) (string, error) {
 
 func (opts *Update) defineToVersion() string {
 	if len(opts.ToVersion) != 0 {
-		if !strings.HasPrefix(opts.FromVersion, "v") {
+		if !strings.HasPrefix(opts.ToVersion, "v") {
 			return "v" + opts.ToVersion
 		}
 		return opts.ToVersion

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -49,9 +49,8 @@ The process uses Git branches:
   - upgrade: scaffold from the target version
   - merge: result of the 3-way merge
 
-If conflicts occur during the merge, resolve them manually in the 'merge' branch. 
-Once resolved, commit and push it as a pull request. This branch will contain the 
-final upgraded project with the latest Kubebuilder layout and your custom code.
+If conflicts occur during the merge, the command will stop and leave the merge branch for manual resolution.
+Use --force to commit conflicts with markers instead. 
 
 Examples:
   # Update from the version specified in the PROJECT file to the latest release
@@ -62,6 +61,9 @@ Examples:
 
   # Update from a specific version to an specific release
   kubebuilder alpha update --from-version v4.5.0 --to-version v4.7.0	
+
+  # Force update even with merge conflicts (commit conflict markers)
+  kubebuilder alpha update --force
 
 `,
 
@@ -91,6 +93,10 @@ Examples:
 
 	updateCmd.Flags().StringVar(&opts.FromBranch, "from-branch", "",
 		"Git branch to use as current state of the project for the update.")
+
+	updateCmd.Flags().BoolVar(&opts.Force, "force", false,
+		"Force the update even if conflicts occur. Conflicted files will include conflict markers, and a "+
+			"commit will be created automatically. Ideal for automation (e.g., cronjobs, CI).")
 
 	return updateCmd
 }

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/utils/utils.go
@@ -139,6 +139,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.

--- a/testdata/project-v4-multigroup/test/utils/utils.go
+++ b/testdata/project-v4-multigroup/test/utils/utils.go
@@ -111,6 +111,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.

--- a/testdata/project-v4-with-plugins/test/utils/utils.go
+++ b/testdata/project-v4-with-plugins/test/utils/utils.go
@@ -111,6 +111,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.

--- a/testdata/project-v4/test/utils/utils.go
+++ b/testdata/project-v4/test/utils/utils.go
@@ -111,6 +111,19 @@ func UninstallCertManager() {
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
+
+	// Delete leftover leases in kube-system (not cleaned by default)
+	kubeSystemLeases := []string{
+		"cert-manager-cainjector-leader-election",
+		"cert-manager-controller",
+	}
+	for _, lease := range kubeSystemLeases {
+		cmd = exec.Command("kubectl", "delete", "lease", lease,
+			"-n", "kube-system", "--ignore-not-found", "--force", "--grace-period=0")
+		if _, err := Run(cmd); err != nil {
+			warnError(err)
+		}
+	}
 }
 
 // InstallCertManager installs the cert manager bundle.


### PR DESCRIPTION
Prepare PATCH release with: 

* 🐛 (CLI) fix alpha update command to version pre-require check by @mayuka-c in https://github.com/kubernetes-sigs/kubebuilder/pull/4937
* ✨ (alpha update command): add --force flag by @vitorfloriano in https://github.com/kubernetes-sigs/kubebuilder/pull/4936
* 🐛 (go/v4): gracefully skip webhook test injection if file or markers are missing by @camilamacedo86 in https://github.com/kubernetes-sigs/kubebuilder/pull/4950
sigs/kubebuilder/pull/4959
* 🐛 (go/v4)(fix): (e2e) delete CertManager leftover leases in kube-system (not cleaned by default) by @camilamacedo86 in https://github.com/kubernetes-sigs/kubebuilder/pull/4949