### PR TITLE
⚠️  Migrate from logrus to log/slog

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,11 +17,15 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/sirupsen/logrus"
+	"log"
+	"log/slog"
+	"os"
+
 	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/logging"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	kustomizecommonv2 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2"
@@ -33,8 +37,14 @@ import (
 )
 
 func init() {
-	// Disable timestamps on the default TextFormatter
-	logrus.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	opts := logging.HandlerOptions{
+		SlogOpts: slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		},
+	}
+	handler := logging.NewHandler(os.Stdout, opts)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
 }
 
 // Run bootstraps & runs the CLI
@@ -50,7 +60,7 @@ func Run() {
 	}
 	externalPlugins, err := cli.DiscoverExternalPlugins(fs.FS)
 	if err != nil {
-		logrus.Error(err)
+		slog.Error("error discovering external plugins", "error", err)
 	}
 
 	c, err := cli.New(
@@ -71,9 +81,9 @@ func Run() {
 		cli.WithCompletion(),
 	)
 	if err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 	if err := c.Run(); err != nil {
-		logrus.Fatal(err)
+		log.Fatal(err)
 	}
 }

--- a/docs/book/src/plugins/extending/extending_cli_features_and_plugins.md
+++ b/docs/book/src/plugins/extending/extending_cli_features_and_plugins.md
@@ -233,7 +233,7 @@ program in `kubebuilder init`. Following an example:
 package cli
 
 import (
-	log "github.com/sirupsen/logrus"
+	log "log/slog"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/gobuffalo/flect v1.0.3
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.38.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.14.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.14.0 h1:9tH6MapGnn/j0eb0yIXiLjERO8RB6xIVZRDCX7PtqWA=
 github.com/spf13/afero v1.14.0/go.mod h1:acJQ8t0ohCGuMN3O+Pv0V0hgMxNYDlvdk+VTfyZmbYo=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
@@ -60,7 +58,6 @@ github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -78,7 +75,6 @@ golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
 golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
 golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.27.0 h1:4fGWRpyh641NLlecmyl4LOe6yDdfaYNrGb2zdfo4JV4=

--- a/hack/docs/generate_samples.go
+++ b/hack/docs/generate_samples.go
@@ -17,11 +17,13 @@ limitations under the License.
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
+	"log/slog"
+	"os"
 
 	cronjob "sigs.k8s.io/kubebuilder/v4/hack/docs/internal/cronjob-tutorial"
 	gettingstarted "sigs.k8s.io/kubebuilder/v4/hack/docs/internal/getting-started"
 	multiversion "sigs.k8s.io/kubebuilder/v4/hack/docs/internal/multiversion-tutorial"
+	"sigs.k8s.io/kubebuilder/v4/pkg/logging"
 )
 
 // KubebuilderBinName make sure executing `build_kb` to generate kb executable from the source code
@@ -43,11 +45,18 @@ func main() {
 		"multiversion":    updateMultiversionTutorial,
 	}
 
-	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
-	log.Println("Generating documents...")
+	opts := logging.HandlerOptions{
+		SlogOpts: slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		},
+	}
+	handler := logging.NewHandler(os.Stdout, opts)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+	slog.Info("Generating documents...")
 
 	for tutorial, updater := range tutorials {
-		log.Printf("Generating %s tutorial\n", tutorial)
+		slog.Info("Generating tutorial", "name", tutorial)
 		updater()
 	}
 }

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -18,10 +18,10 @@ package cronjob
 
 import (
 	"fmt"
+	log "log/slog"
 	"os/exec"
 	"path/filepath"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
@@ -37,17 +37,17 @@ type Sample struct {
 
 // NewSample create a new instance of the cronjob sample and configure the KB CLI that will be used
 func NewSample(binaryPath, samplePath string) Sample {
-	log.Infof("Generating the sample context of Cronjob...")
+	log.Info("Generating the sample context of Cronjob...")
 	ctx := hackutils.NewSampleContext(binaryPath, samplePath, "GO111MODULE=on")
 	return Sample{&ctx}
 }
 
 // Prepare the Context for the sample project
 func (sp *Sample) Prepare() {
-	log.Infof("destroying directory for cronjob sample project")
+	log.Info("destroying directory for cronjob sample project")
 	sp.ctx.Destroy()
 
-	log.Infof("refreshing tools and creating directory...")
+	log.Info("refreshing tools and creating directory...")
 	err := sp.ctx.Prepare()
 
 	hackutils.CheckError("creating directory for sample project", err)
@@ -55,7 +55,7 @@ func (sp *Sample) Prepare() {
 
 // GenerateSampleProject will generate the sample
 func (sp *Sample) GenerateSampleProject() {
-	log.Infof("Initializing the cronjob project")
+	log.Info("Initializing the cronjob project")
 
 	err := sp.ctx.Init(
 		"--domain", "tutorial.kubebuilder.io",
@@ -65,7 +65,7 @@ func (sp *Sample) GenerateSampleProject() {
 	)
 	hackutils.CheckError("Initializing the cronjob project", err)
 
-	log.Infof("Adding a new config type")
+	log.Info("Adding a new config type")
 	err = sp.ctx.CreateAPI(
 		"--group", "batch",
 		"--version", "v1",
@@ -74,7 +74,7 @@ func (sp *Sample) GenerateSampleProject() {
 	)
 	hackutils.CheckError("Creating the API", err)
 
-	log.Infof("Implementing admission webhook")
+	log.Info("Implementing admission webhook")
 	err = sp.ctx.CreateWebhook(
 		"--group", "batch",
 		"--version", "v1",
@@ -86,7 +86,7 @@ func (sp *Sample) GenerateSampleProject() {
 
 // UpdateTutorial the cronjob tutorial with the scaffold changes
 func (sp *Sample) UpdateTutorial() {
-	log.Println("Update tutorial with cronjob code")
+	log.Info("Update tutorial with cronjob code")
 	// 1. update specs
 	sp.updateSpec()
 	// 2. update webhook

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -17,10 +17,9 @@ limitations under the License.
 package gettingstarted
 
 import (
+	"log/slog"
 	"os/exec"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
@@ -34,7 +33,7 @@ type Sample struct {
 
 // NewSample create a new instance of the getting started sample and configure the KB CLI that will be used
 func NewSample(binaryPath, samplePath string) Sample {
-	log.Infof("Generating the sample context of getting-started...")
+	slog.Info("Generating the sample context of getting-started...")
 	ctx := hackutils.NewSampleContext(binaryPath, samplePath, "GO111MODULE=on")
 	return Sample{&ctx}
 }
@@ -192,10 +191,10 @@ func (sp *Sample) updateController() {
 
 // Prepare the Context for the sample project
 func (sp *Sample) Prepare() {
-	log.Infof("Destroying directory for getting-started sample project")
+	slog.Info("Destroying directory for getting-started sample project")
 	sp.ctx.Destroy()
 
-	log.Infof("Refreshing tools and creating directory...")
+	slog.Info("Refreshing tools and creating directory...")
 	err := sp.ctx.Prepare()
 
 	hackutils.CheckError("Creating directory for sample project", err)
@@ -203,7 +202,7 @@ func (sp *Sample) Prepare() {
 
 // GenerateSampleProject will generate the sample
 func (sp *Sample) GenerateSampleProject() {
-	log.Infof("Initializing the getting started project")
+	slog.Info("Initializing the getting started project")
 	err := sp.ctx.Init(
 		"--domain", "example.com",
 		"--repo", "example.com/memcached",
@@ -212,7 +211,7 @@ func (sp *Sample) GenerateSampleProject() {
 	)
 	hackutils.CheckError("Initializing the getting started project", err)
 
-	log.Infof("Adding a new config type")
+	slog.Info("Adding a new config type")
 	err = sp.ctx.CreateAPI(
 		"--group", "cache",
 		"--version", "v1alpha1",

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -17,10 +17,9 @@ limitations under the License.
 package multiversion
 
 import (
+	log "log/slog"
 	"os/exec"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	hackutils "sigs.k8s.io/kubebuilder/v4/hack/docs/utils"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
@@ -34,23 +33,23 @@ type Sample struct {
 
 // NewSample create a new instance of the sample and configure the KB CLI that will be used
 func NewSample(binaryPath, samplePath string) Sample {
-	log.Infof("Generating the sample context of MultiVersion Cronjob...")
+	log.Info("Generating the sample context of MultiVersion Cronjob...")
 	ctx := hackutils.NewSampleContext(binaryPath, samplePath, "GO111MODULE=on")
 	return Sample{&ctx}
 }
 
 // Prepare the Context for the sample project
 func (sp *Sample) Prepare() {
-	log.Infof("refreshing tools and creating directory for multiversion ...")
+	log.Info("refreshing tools and creating directory for multiversion ...")
 	err := sp.ctx.Prepare()
 	hackutils.CheckError("creating directory for multiversion project", err)
 }
 
 // GenerateSampleProject will generate the sample
 func (sp *Sample) GenerateSampleProject() {
-	log.Infof("Initializing the multiversion cronjob project")
+	log.Info("Initializing the multiversion cronjob project")
 
-	log.Infof("Creating v2 API")
+	log.Info("Creating v2 API")
 	err := sp.ctx.CreateAPI(
 		"--group", "batch",
 		"--version", "v2",
@@ -60,7 +59,7 @@ func (sp *Sample) GenerateSampleProject() {
 	)
 	hackutils.CheckError("Creating the v2 API without controller", err)
 
-	log.Infof("Creating conversion webhook for v1")
+	log.Info("Creating conversion webhook for v1")
 	err = sp.ctx.CreateWebhook(
 		"--group", "batch",
 		"--version", "v1",
@@ -71,7 +70,7 @@ func (sp *Sample) GenerateSampleProject() {
 	)
 	hackutils.CheckError("Creating conversion webhook for v1", err)
 
-	log.Infof("Workaround to fix the issue with the conversion webhook")
+	log.Info("Workaround to fix the issue with the conversion webhook")
 	// FIXME: This is a workaround to fix the issue with the conversion webhook
 	// We should be able to inject the code when we create webhooks with different
 	// types of webhooks. However, currently, we are not able to do that and we need to
@@ -81,7 +80,7 @@ func (sp *Sample) GenerateSampleProject() {
 	_, err = sp.ctx.Run(cmd)
 	hackutils.CheckError("Copying the code from cronjob tutorial", err)
 
-	log.Infof("Creating defaulting and validation webhook for v2")
+	log.Info("Creating defaulting and validation webhook for v2")
 	err = sp.ctx.CreateWebhook(
 		"--group", "batch",
 		"--version", "v2",
@@ -94,7 +93,7 @@ func (sp *Sample) GenerateSampleProject() {
 
 // UpdateTutorial the muilt-version sample tutorial with the scaffold changes
 func (sp *Sample) UpdateTutorial() {
-	log.Println("Update tutorial with multiversion code")
+	log.Info("Update tutorial with multiversion code")
 
 	// Update files according to the multiversion
 	sp.updateCronjobV1DueForce()

--- a/hack/docs/utils/utils.go
+++ b/hack/docs/utils/utils.go
@@ -17,9 +17,8 @@ limitations under the License.
 package utils
 
 import (
+	log "log/slog"
 	"os"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
@@ -27,7 +26,7 @@ import (
 // CheckError will exit with exit code 1 when err is not nil.
 func CheckError(msg string, err error) {
 	if err != nil {
-		log.Errorf("error %s: %s", msg, err)
+		log.Error("error occurred", "message", msg, "error", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cli/alpha/command.go
+++ b/pkg/cli/alpha/command.go
@@ -14,7 +14,8 @@ limitations under the License.
 package alpha
 
 import (
-	log "github.com/sirupsen/logrus"
+	"log"
+
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal"

--- a/pkg/cli/alpha/internal/update/prepare.go
+++ b/pkg/cli/alpha/internal/update/prepare.go
@@ -19,10 +19,9 @@ package update
 import (
 	"encoding/json"
 	"fmt"
+	log "log/slog"
 	"net/http"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/common"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
@@ -37,7 +36,7 @@ type releaseResponse struct {
 func (opts *Update) Prepare() error {
 	if opts.FromBranch == "" {
 		// TODO: Check if is possible to use get to determine the default branch
-		log.Warning("No --from-branch specified, using 'main' as default")
+		log.Warn("No --from-branch specified, using 'main' as default")
 		opts.FromBranch = "main"
 	}
 
@@ -94,7 +93,7 @@ func fetchLatestRelease() (string, error) {
 
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			log.Infof("failed to close connection: %s", err)
+			log.Info("failed to close connection", "error", err)
 		}
 	}()
 

--- a/pkg/cli/alpha/internal/update/validate.go
+++ b/pkg/cli/alpha/internal/update/validate.go
@@ -18,12 +18,12 @@ package update
 
 import (
 	"fmt"
+	log "log/slog"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 )
 
@@ -105,13 +105,13 @@ func validateReleaseAvailability(version string) error {
 	}
 	defer func() {
 		if err = resp.Body.Close(); err != nil {
-			log.Errorf("failed to close connection: %s", err)
+			log.Error("failed to close connection", "error", err)
 		}
 	}()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		log.Infof("Binary version %v is available", version)
+		log.Info("Binary version available", "version", version)
 		return nil
 	case http.StatusNotFound:
 		return fmt.Errorf("binary version %s not found. Check versions available in releases",
@@ -133,9 +133,9 @@ func (opts *Update) validateEqualVersions() error {
 		}
 
 		if opts.ToVersion == latestVersion {
-			log.Infof("Your project already uses the latest version (%s). No action taken.", opts.FromVersion)
+			log.Info("Your project already uses the latest version. No action taken.", "version", opts.FromVersion)
 		} else {
-			log.Infof("Your project already uses the specified version (%s). No action taken.", opts.FromVersion)
+			log.Info("Your project already uses the specified version. No action taken.", "version", opts.FromVersion)
 		}
 		os.Exit(0)
 	}

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -15,8 +15,8 @@ package alpha
 
 import (
 	"fmt"
+	"log"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -19,10 +19,10 @@ package cli
 import (
 	"errors"
 	"fmt"
+	log "log/slog"
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -301,9 +301,11 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 	for _, rep := range replacements {
 		if strings.Contains(modified, rep.Old) {
 			modified = strings.ReplaceAll(modified, rep.Old, rep.New)
-			log.Warnf("This project is using an old and no longer supported plugin layout %q. "+
-				"Replace in memory to %q to allow `alpha generate` to work.",
-				rep.Old, rep.New)
+			log.Warn("Project is using an old and unsupported plugin layout",
+				"old_layout", rep.Old,
+				"new_layout", rep.New,
+				"note", "Replace in memory to allow `alpha generate` to work.",
+			)
 		}
 	}
 

--- a/pkg/logging/handler.go
+++ b/pkg/logging/handler.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2025 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+)
+
+const (
+	ColorReset = "\033[0m"
+	ColorError = "\033[31m"
+	ColorWarn  = "\033[33m"
+	ColorInfo  = "\033[36m"
+	ColorDebug = "\033[32m"
+)
+
+type HandlerOptions struct {
+	SlogOpts slog.HandlerOptions
+}
+
+type Handler struct {
+	slog.Handler
+	l *log.Logger
+}
+
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.Handler.Enabled(ctx, level)
+}
+
+func (h *Handler) Handle(_ context.Context, r slog.Record) error {
+	var color string
+	switch r.Level {
+	case slog.LevelDebug:
+		color = ColorDebug + r.Level.String() + ColorReset
+	case slog.LevelInfo:
+		color = ColorInfo + r.Level.String() + ColorReset
+	case slog.LevelWarn:
+		color = ColorWarn + r.Level.String() + ColorReset
+	case slog.LevelError:
+		color = ColorError + r.Level.String() + ColorReset
+	}
+	attrs := ""
+	r.Attrs(func(attr slog.Attr) bool {
+		attrs += fmt.Sprintf("%s=%v", attr.Key, attr.Value.Any())
+		return true
+	})
+
+	h.l.Println(color, r.Message, attrs)
+	return nil
+}
+
+func (h *Handler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *Handler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+func NewHandler(out io.Writer, opts HandlerOptions) *Handler {
+	h := &Handler{
+		Handler: slog.NewTextHandler(out, &opts.SlogOpts),
+		l:       log.New(out, "", 0),
+	}
+
+	return h
+}

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -20,12 +20,12 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	log "log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"golang.org/x/tools/imports"
 
@@ -241,7 +241,7 @@ func (s Scaffold) updateFileModel(i Inserter, models map[string]*File) error {
 		// If the file path starts with test/, warn and skip
 		// Workaround to allow projects be backwards compatible with previous versions
 		if strings.HasPrefix(i.GetPath(), "test/") {
-			log.Warnf("Skipping missing test file: %s", i.GetPath())
+			log.Warn("Skipping missing test file", "file_path", i.GetPath())
 			log.Warn("The code fragments will not be inserted.")
 			return nil
 		}

--- a/pkg/plugin/util/exec.go
+++ b/pkg/plugin/util/exec.go
@@ -18,11 +18,10 @@ package util
 
 import (
 	"fmt"
+	log "log/slog"
 	"os"
 	"os/exec"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // RunCmd prints the provided message and command and then executes it binding stdout and stderr
@@ -30,7 +29,7 @@ func RunCmd(msg, cmd string, args ...string) error {
 	c := exec.Command(cmd, args...) //nolint:gosec
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	log.Println(msg + ":\n$ " + strings.Join(c.Args, " "))
+	log.Info(msg, "command", strings.Join(c.Args, " "))
 
 	if err := c.Run(); err != nil {
 		return fmt.Errorf("error running %q: %w", cmd, err)

--- a/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/api.go
@@ -18,9 +18,8 @@ package scaffolds
 
 import (
 	"fmt"
+	log "log/slog"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -63,7 +62,7 @@ func (s *apiScaffolder) InjectFS(fs machinery.Filesystem) {
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *apiScaffolder) Scaffold() error {
-	log.Println("Writing kustomize manifests for you to edit...")
+	log.Info("Writing kustomize manifests for you to edit...")
 
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs,
@@ -95,8 +94,8 @@ func (s *apiScaffolder) Scaffold() error {
 		if err != nil {
 			hasCRUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../crd")
 			if !hasCRUncommented || errCheck != nil {
-				log.Errorf("Unable to find the target #- ../crd to uncomment in the file "+
-					"%s.", kustomizeFilePath)
+				log.Error("Unable to find the target #- ../crd to uncomment in the file ",
+					"file_path", kustomizeFilePath)
 			}
 		}
 
@@ -107,8 +106,8 @@ func (s *apiScaffolder) Scaffold() error {
 		err = pluginutil.AppendCodeIfNotExist(rbacKustomizeFilePath,
 			comment)
 		if err != nil {
-			log.Errorf("Unable to append the admin/edit/view roles comment in the file "+
-				"%s.", rbacKustomizeFilePath)
+			log.Error("Unable to append the admin/edit/view roles comment in the file ",
+				"file_path", rbacKustomizeFilePath)
 		}
 		crdName := strings.ToLower(s.resource.Kind)
 		if s.config.IsMultiGroup() && s.resource.Group != "" {
@@ -117,8 +116,8 @@ func (s *apiScaffolder) Scaffold() error {
 		err = pluginutil.InsertCodeIfNotExist(rbacKustomizeFilePath, comment,
 			fmt.Sprintf("\n- %[1]s_admin_role.yaml\n- %[1]s_editor_role.yaml\n- %[1]s_viewer_role.yaml", crdName))
 		if err != nil {
-			log.Errorf("Unable to add Admin, Editor and Viewer roles in the file "+
-				"%s.", rbacKustomizeFilePath)
+			log.Error("Unable to add Admin, Editor and Viewer roles in the file ",
+				"file_path", rbacKustomizeFilePath)
 		}
 		// Add an empty line at the end of the file
 		err = pluginutil.AppendCodeIfNotExist(rbacKustomizeFilePath,
@@ -126,8 +125,8 @@ func (s *apiScaffolder) Scaffold() error {
 
 `)
 		if err != nil {
-			log.Errorf("Unable to append empty line at the end of the file"+
-				"%s.", rbacKustomizeFilePath)
+			log.Error("Unable to append empty line at the end of the file",
+				"file_path", rbacKustomizeFilePath)
 		}
 	}
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/init.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/init.go
@@ -18,8 +18,7 @@ package scaffolds
 
 import (
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
+	log "log/slog"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -58,7 +57,7 @@ func (s *initScaffolder) InjectFS(fs machinery.Filesystem) {
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *initScaffolder) Scaffold() error {
-	log.Println("Writing kustomize manifests for you to edit...")
+	log.Info("Writing kustomize manifests for you to edit...")
 
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs,

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -19,8 +19,7 @@ package scaffolds
 import (
 	"errors"
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
+	log "log/slog"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -67,7 +66,7 @@ func (s *webhookScaffolder) InjectFS(fs machinery.Filesystem) { s.fs = fs }
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *webhookScaffolder) Scaffold() error {
-	log.Println("Writing kustomize manifests for you to edit...")
+	log.Info("Writing kustomize manifests for you to edit...")
 
 	// Will validate the scaffold
 	// Users that scaffolded the project previously
@@ -185,10 +184,10 @@ func uncommentCodeForConversionWebhooks(r resource.Resource) {
 		"#",
 	)
 	if err != nil {
-		log.Warningf("Unable to find the certificate namespace replacement for "+
-			"CRD %s to uncomment in %s. Conversion webhooks require this replacement "+
+		log.Warn("Unable to find the certificate namespace replacement for "+
+			"CRD to uncomment in the file. Conversion webhooks require this replacement "+
 			"to inject the CA properly.",
-			crdName, kustomizeFilePath)
+			"crdName", crdName, "file", kustomizeFilePath)
 	}
 	err = pluginutil.UncommentCode(
 		kustomizeFilePath,
@@ -211,10 +210,10 @@ func uncommentCodeForConversionWebhooks(r resource.Resource) {
 		"#",
 	)
 	if err != nil {
-		log.Warningf("Unable to find the certificate name replacement for CRD %s "+
-			"to uncomment in %s. Conversion webhooks require this replacement to inject "+
+		log.Warn("Unable to find the certificate name replacement for CRD "+
+			"to uncomment in the file. Conversion webhooks require this replacement to inject "+
 			"the CA properly.",
-			crdName, kustomizeFilePath)
+			"crdName", crdName, "file", kustomizeFilePath)
 	}
 
 	err = pluginutil.UncommentCode(kustomizeCRDFilePath, `#configurations:
@@ -224,9 +223,9 @@ func uncommentCodeForConversionWebhooks(r resource.Resource) {
 			`configurations:
 - kustomizeconfig.yaml`)
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the target configurations with kustomizeconfig.yaml"+
-				"to uncomment in the file %s. ConverstionWebhooks requires this configuration "+
-				"to be uncommented to inject CA", kustomizeCRDFilePath)
+			log.Warn("Unable to find the target configurations with kustomizeconfig.yaml "+
+				"to uncomment in the file. ConverstionWebhooks requires this configuration "+
+				"to be uncommented to inject CA", "file", kustomizeCRDFilePath)
 		}
 	}
 }
@@ -272,10 +271,10 @@ func uncommentCodeForDefaultWebhooks() {
      - select:
          kind: MutatingWebhookConfiguration`)
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the MutatingWebhookConfiguration section "+
-				"to uncomment in %s. Webhooks scaffolded with '--defaulting' require "+
+			log.Warn("Unable to find the MutatingWebhookConfiguration section "+
+				"to uncomment in the file. Webhooks scaffolded with '--defaulting' require "+
 				"this configuration for CA injection.",
-				kustomizeFilePath)
+				"file", kustomizeFilePath)
 		}
 	}
 }
@@ -321,10 +320,10 @@ func uncommentCodeForValidationWebhooks() {
      - select:
          kind: ValidatingWebhookConfiguration`)
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the ValidatingWebhookConfiguration section "+
-				"to uncomment in %s. Webhooks scaffolded with '--programmatic-validation' "+
+			log.Warn("Unable to find the ValidatingWebhookConfiguration section "+
+				"to uncomment in the file. Webhooks scaffolded with '--programmatic-validation' "+
 				"require this configuration for CA injection.",
-				kustomizeFilePath)
+				"file", kustomizeFilePath)
 		}
 	}
 }
@@ -334,8 +333,8 @@ func enableWebhookDefaults() {
 	if err != nil {
 		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath, "- ../webhook")
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the target #- ../webhook to uncomment in the file "+
-				"%s.", kustomizeFilePath)
+			log.Warn("Unable to find the target #- ../webhook to uncomment in the file",
+				"file", kustomizeFilePath)
 		}
 	}
 
@@ -343,8 +342,8 @@ func enableWebhookDefaults() {
 	if err != nil {
 		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath, "patches:")
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the line '#patches:' to uncomment in the file "+
-				"%s.", kustomizeFilePath)
+			log.Warn("Unable to find the line '#patches:' to uncomment in the file",
+				"file", kustomizeFilePath)
 		}
 	}
 
@@ -355,8 +354,8 @@ func enableWebhookDefaults() {
 		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath,
 			"- path: manager_webhook_patch.yaml")
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the target #- path: manager_webhook_patch.yaml to uncomment in the file "+
-				"%s.", kustomizeFilePath)
+			log.Warn("Unable to find the target #- path: manager_webhook_patch.yaml to uncomment in the file",
+				"file", kustomizeFilePath)
 		}
 	}
 
@@ -365,10 +364,10 @@ func enableWebhookDefaults() {
 		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath,
 			"../certmanager")
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the '../certmanager' section to uncomment in %s. "+
+			log.Warn("Unable to find the '../certmanager' section to uncomment in the file. "+
 				"Projects that use webhooks must enable certificate management."+
 				"Please ensure cert-manager integration is enabled.",
-				kustomizeFilePath)
+				"file", kustomizeFilePath)
 		}
 	}
 
@@ -377,10 +376,10 @@ func enableWebhookDefaults() {
 		hasWebHookUncommented, errCheck := pluginutil.HasFileContentWith(kustomizeFilePath,
 			"replacements:")
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the '#replacements:' section to uncomment in %s."+
+			log.Warn("Unable to find the '#replacements:' section to uncomment in the file"+
 				"Projects using webhooks must enable cert-manager CA injection by uncommenting"+
 				"the required replacements.",
-				kustomizeFilePath)
+				"file", kustomizeFilePath)
 		}
 	}
 
@@ -431,10 +430,10 @@ func enableWebhookDefaults() {
      name: webhook-service
      fieldPath: .metadata.name`)
 		if !hasWebHookUncommented || errCheck != nil {
-			log.Warningf("Unable to find the '#- source: # Uncomment the following block if you have any webhook' "+
-				"section to uncomment in %s. "+
+			log.Warn("Unable to find the '#- source: # Uncomment the following block if you have any webhook' "+
+				"section to uncomment in the file. "+
 				"Projects with webhooks must enable certificates via cert-manager.",
-				kustomizeFilePath)
+				"file", kustomizeFilePath)
 		}
 	}
 }
@@ -444,8 +443,8 @@ func addNetworkPoliciesForWebhooks() {
 	err := pluginutil.InsertCodeIfNotExist(policyKustomizeFilePath,
 		"resources:", allowWebhookTrafficFragment)
 	if err != nil {
-		log.Errorf("Unable to add the line '- allow-webhook-traffic.yaml' at the end of the file"+
-			"%s to allow webhook traffic.", policyKustomizeFilePath)
+		log.Error("Unable to add the line '- allow-webhook-traffic.yaml' at the end of the file "+
+			"to allow webhook traffic.", "file", policyKustomizeFilePath)
 	}
 }
 
@@ -456,7 +455,7 @@ func validateScaffoldedProject() {
 		"crdkustomizecainjectionpatch")
 
 	if hasCertManagerPatch {
-		log.Warning(`
+		log.Warn(`
 
 1. **Remove the CERTMANAGER Section from config/crd/kustomization.yaml:**
 

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -19,10 +19,10 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	log "log/slog"
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -175,7 +175,7 @@ func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {
 }
 
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
-	log.Println("updating scaffold with deploy-image/v1alpha1 plugin...")
+	log.Info("updating scaffold with deploy-image/v1alpha1 plugin...")
 
 	scaffolder := scaffolds.NewDeployImageScaffolder(p.config,
 		*p.resource,

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -19,10 +19,10 @@ package scaffolds
 import (
 	"errors"
 	"fmt"
+	log "log/slog"
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -74,7 +74,7 @@ func (s *apiScaffolder) InjectFS(fs machinery.Filesystem) {
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *apiScaffolder) Scaffold() error {
-	log.Println("Writing scaffold for you to edit...")
+	log.Info("Writing scaffold for you to edit...")
 
 	if err := s.scaffoldCreateAPI(); err != nil {
 		return err
@@ -87,11 +87,11 @@ func (s *apiScaffolder) Scaffold() error {
 	boilerplate, err := afero.ReadFile(s.fs.FS, boilerplatePath)
 	if err != nil {
 		if errors.Is(err, afero.ErrFileNotFound) {
-			log.Warnf("Unable to find %s : %s .\n"+
+			log.Warn("Unable to find boilerplate file. "+
 				"This file is used to generate the license header in the project.\n"+
 				"Note that controller-gen will also use this. Therefore, ensure that you "+
 				"add the license file or configure your project accordingly.",
-				boilerplatePath, err)
+				"file_path", boilerplatePath, "error", err)
 			boilerplate = []byte("")
 		} else {
 			return fmt.Errorf("error scaffolding API/controller: unable to load boilerplate: %w", err)

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -17,9 +17,8 @@ limitations under the License.
 package api
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -50,7 +49,7 @@ func (f *Types) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.TemplateBody = typesTemplate
 

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/config/samples/crd_sample.go
@@ -17,9 +17,8 @@ limitations under the License.
 package samples
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -46,7 +45,7 @@ func (f *CRDSample) SetTemplateDefaults() error {
 		}
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.IfExistsAction = machinery.OverwriteFile
 

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -17,9 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -49,12 +48,12 @@ func (f *ControllerTest) SetTemplateDefaults() error {
 		}
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.PackageName = "controller"
 	f.IfExistsAction = machinery.OverwriteFile
 
-	log.Println("creating import for %", f.Resource.Path)
+	log.Info("creating import", "resource", f.Resource.Path)
 	f.TemplateBody = controllerTestTemplate
 
 	return nil

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -17,9 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -51,11 +50,11 @@ func (f *Controller) SetTemplateDefaults() error {
 		}
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.PackageName = "controller"
 
-	log.Println("creating import for %", f.Resource.Path)
+	log.Info("creating import for", "resource_path", f.Resource.Path)
 	f.TemplateBody = controllerTemplate
 
 	// This one is to overwrite the controller if it exist

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -20,9 +20,9 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	log "log/slog"
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -128,11 +128,11 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 
 	reader := bufio.NewReader(os.Stdin)
 	if !p.resourceFlag.Changed {
-		log.Println("Create Resource [y/n]")
+		log.Info("Create Resource [y/n]")
 		p.options.DoAPI = util.YesNo(reader)
 	}
 	if !p.controllerFlag.Changed {
-		log.Println("Create Controller [y/n]")
+		log.Info("Create Controller [y/n]")
 		p.options.DoController = util.YesNo(reader)
 	}
 

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -18,12 +18,12 @@ package v4
 
 import (
 	"fmt"
+	log "log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"unicode"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -133,7 +133,7 @@ func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 	}
 
 	if !p.fetchDeps {
-		log.Println("Skipping fetching dependencies.")
+		log.Info("Skipping fetching dependencies.")
 		return nil
 	}
 

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -19,8 +19,8 @@ package scaffolds
 import (
 	"errors"
 	"fmt"
+	log "log/slog"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -64,17 +64,17 @@ func (s *apiScaffolder) InjectFS(fs machinery.Filesystem) {
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *apiScaffolder) Scaffold() error {
-	log.Println("Writing scaffold for you to edit...")
+	log.Info("Writing scaffold for you to edit...")
 
 	// Load the boilerplate
 	boilerplate, err := afero.ReadFile(s.fs.FS, hack.DefaultBoilerplatePath)
 	if err != nil {
 		if errors.Is(err, afero.ErrFileNotFound) {
-			log.Warnf("Unable to find %s: %s.\n"+
+			log.Warn("Unable to find boilerplate file."+
 				"This file is used to generate the license header in the project.\n"+
 				"Note that controller-gen will also use this. Therefore, ensure that you "+
 				"add the license file or configure your project accordingly.",
-				hack.DefaultBoilerplatePath, err)
+				"file_path", hack.DefaultBoilerplatePath, "error", err)
 			boilerplate = []byte("")
 		} else {
 			return fmt.Errorf("error scaffolding API/controller: unable to load boilerplate: %w", err)

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -19,9 +19,9 @@ package scaffolds
 import (
 	"errors"
 	"fmt"
+	log "log/slog"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -95,7 +95,7 @@ func getControllerRuntimeReleaseBranch() string {
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *initScaffolder) Scaffold() error {
-	log.Println("Writing scaffold for you to edit...")
+	log.Info("Writing scaffold for you to edit...")
 
 	// Initialize the machinery.Scaffold that will write the boilerplate file to disk
 	// The boilerplate file needs to be scaffolded as a separate step as it is going to
@@ -117,10 +117,12 @@ func (s *initScaffolder) Scaffold() error {
 		boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)
 		if err != nil {
 			if errors.Is(err, afero.ErrFileNotFound) {
-				log.Warnf("Unable to find %s: %s.\n"+"This file is used to generate the license header in the project.\n"+
+				log.Warn("Unable to find boilerplate file. "+
+					"This file is used to generate the license header in the project. "+
 					"Note that controller-gen will also use this. Therefore, ensure that you "+
 					"add the license file or configure your project accordingly.",
-					s.boilerplatePath, err)
+					"file_path", s.boilerplatePath,
+					"error", err)
 				boilerplate = []byte("")
 			} else {
 				return fmt.Errorf("unable to load boilerplate: %w", err)

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/group.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/group.go
@@ -17,9 +17,8 @@ limitations under the License.
 package api
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -45,7 +44,7 @@ func (f *Group) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 	f.TemplateBody = groupTemplate
 
 	return nil

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/hub.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/hub.go
@@ -17,9 +17,8 @@ limitations under the License.
 package api
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -49,7 +48,7 @@ func (f *Hub) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.TemplateBody = hubTemplate
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/spoke.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/spoke.go
@@ -17,9 +17,8 @@ limitations under the License.
 package api
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -50,7 +49,7 @@ func (f *Spoke) SetTemplateDefaults() error {
 
 	// Replace placeholders in the path
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Printf("Creating spoke conversion file at: %s", f.Path)
+	log.Info("Creating spoke conversion file", "path", f.Path)
 
 	f.TemplateBody = spokeTemplate
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -17,9 +17,8 @@ limitations under the License.
 package api
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -49,7 +48,7 @@ func (f *Types) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.TemplateBody = typesTemplate
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
@@ -17,9 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -51,7 +50,7 @@ func (f *Controller) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.TemplateBody = controllerTemplate
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -18,9 +18,8 @@ package controllers
 
 import (
 	"fmt"
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -56,7 +55,7 @@ func (f *SuiteTest) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.TemplateBody = fmt.Sprintf(controllerSuiteTestTemplate,
 		machinery.NewMarkerFor(f.Path, importMarker),

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
@@ -17,9 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -51,7 +50,7 @@ func (f *ControllerTest) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	f.TemplateBody = controllerTestTemplate
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/test.go
@@ -19,10 +19,9 @@ package e2e
 import (
 	"bytes"
 	"fmt"
+	log "log/slog"
 	"os"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -89,10 +88,10 @@ func (f *WebhookTestUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
 
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Warnf("Unable to read %q: %v", filePath, err)
-		log.Warnf("Webhook test code injection will be skipped for this file.")
-		log.Warnf("This typically occurs when the file was removed and is missing.")
-		log.Warnf("If you intend to scaffold webhook tests, ensure the file and its markers exist.")
+		log.Warn("Unable to read file", "file", filePath, "error", err)
+		log.Warn("Webhook test code injection will be skipped for this file.")
+		log.Warn("This typically occurs when the file was removed and is missing.")
+		log.Warn("If you intend to scaffold webhook tests, ensure the file and its markers exist.")
 		return nil
 	}
 
@@ -101,8 +100,9 @@ func (f *WebhookTestUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
 
 	for _, marker := range markers {
 		if !bytes.Contains(content, []byte(marker.String())) {
-			log.Warnf("Marker %q not found in %s; skipping injection of webhook test code",
-				marker.String(), filePath)
+			log.Warn("Marker not found in file, skipping webhook test code injection",
+				"marker", marker.String(),
+				"file_path", filePath)
 			continue // skip this marker
 		}
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
@@ -17,10 +17,9 @@ limitations under the License.
 package webhooks
 
 import (
+	log "log/slog"
 	"path/filepath"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -66,7 +65,7 @@ func (f *Webhook) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	webhookTemplate := webhookTemplate
 	if f.Resource.HasDefaultingWebhook() {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -18,9 +18,8 @@ package webhooks
 
 import (
 	"fmt"
+	log "log/slog"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -71,7 +70,7 @@ func (f *WebhookSuite) SetTemplateDefaults() error {
 	}
 
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	if f.IsLegacyPath {
 		f.TemplateBody = fmt.Sprintf(webhookTestSuiteTemplateLegacy,

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_template.go
@@ -18,10 +18,9 @@ package webhooks
 
 import (
 	"fmt"
+	log "log/slog"
 	"path/filepath"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -61,7 +60,7 @@ func (f *WebhookTest) SetTemplateDefaults() error {
 		}
 	}
 	f.Path = f.Resource.Replacer().Replace(f.Path)
-	log.Println(f.Path)
+	log.Info(f.Path)
 
 	webhookTestTemplate := webhookTestTemplate
 	templates := make([]string, 0)

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -19,10 +19,10 @@ package scaffolds
 import (
 	"fmt"
 	"io"
+	log "log/slog"
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -164,7 +164,7 @@ func fillMissingUnit(item templates.CustomMetricItem) templates.CustomMetricItem
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *editScaffolder) Scaffold() error {
-	log.Println("Generating Grafana manifests to visualize controller status...")
+	log.Info("Generating Grafana manifests to visualize controller status...")
 
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs)

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/init.go
@@ -18,8 +18,7 @@ package scaffolds
 
 import (
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
+	log "log/slog"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
@@ -45,7 +44,7 @@ func (s *initScaffolder) InjectFS(fs machinery.Filesystem) {
 
 // Scaffold implements cmdutil.Scaffolder
 func (s *initScaffolder) Scaffold() error {
-	log.Println("Generating Grafana manifests to visualize controller status...")
+	log.Info("Generating Grafana manifests to visualize controller status...")
 
 	// Initialize the machinery.Scaffold that will write the files to disk
 	scaffold := machinery.NewScaffold(s.fs)

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -18,12 +18,12 @@ package scaffolds
 
 import (
 	"fmt"
+	log "log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -66,7 +66,7 @@ func (s *editScaffolder) InjectFS(fs machinery.Filesystem) {
 
 // Scaffold scaffolds the Helm chart with the necessary files.
 func (s *editScaffolder) Scaffold() error {
-	log.Println("Generating Helm Chart to distribute project")
+	log.Info("Generating Helm Chart to distribute project")
 
 	imagesEnvVars := s.getDeployImagesEnvVars()
 
@@ -162,7 +162,7 @@ func (s *editScaffolder) extractWebhooksFromGeneratedFiles() (mutatingWebhooks [
 	manifestFile := "config/webhook/manifests.yaml"
 
 	if _, err = os.Stat(manifestFile); os.IsNotExist(err) {
-		log.Printf("webhook manifests were not found at %s", manifestFile)
+		log.Info("webhook manifests were not found", "path", manifestFile)
 		return nil, nil, nil
 	}
 
@@ -193,7 +193,7 @@ func (s *editScaffolder) extractWebhooksFromGeneratedFiles() (mutatingWebhooks [
 		}
 
 		if err := yaml.Unmarshal([]byte(doc), &webhookConfig); err != nil {
-			log.Errorf("fail to unmarshalling webhook YAML: %v", err)
+			log.Error("fail to unmarshalling webhook YAML", "error", err)
 			continue
 		}
 
@@ -290,13 +290,13 @@ func (s *editScaffolder) copyConfigFiles() error {
 // to spec.conversion if applicable, and writes it to the destination
 func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string, hasConvertionalWebhook bool) error {
 	if _, err := os.Stat(srcFile); os.IsNotExist(err) {
-		log.Printf("Source file does not exist: %s", srcFile)
+		log.Info("Source file does not exist", "source_file", srcFile)
 		return fmt.Errorf("source file does not exist %q: %w", srcFile, err)
 	}
 
 	content, err := os.ReadFile(srcFile)
 	if err != nil {
-		log.Printf("Error reading source file: %s", srcFile)
+		log.Info("Error reading source file", "source_file", srcFile)
 		return fmt.Errorf("failed to read file %q: %w", srcFile, err)
 	}
 
@@ -441,11 +441,11 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string, hasCon
 
 	err = os.WriteFile(destFile, []byte(wrappedContent), 0o644)
 	if err != nil {
-		log.Printf("Error writing destination file: %s", destFile)
+		log.Info("Error writing destination file", "destination_file", destFile)
 		return fmt.Errorf("error writing destination file %q: %w", destFile, err)
 	}
 
-	log.Printf("Successfully copied %s to %s", srcFile, destFile)
+	log.Info("Successfully copied file", "from", srcFile, "to", destFile)
 	return nil
 }
 

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"fmt"
 	"io"
+	log "log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +27,6 @@ import (
 
 	//nolint:staticcheck
 	. "github.com/onsi/ginkgo/v2"
-	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 )
@@ -255,7 +255,7 @@ func (t *TestContext) Destroy() {
 	if t.ImageName != "" {
 		// Check white space from image name
 		if len(strings.TrimSpace(t.ImageName)) == 0 {
-			log.Println("Image not set, skip cleaning up of docker image")
+			log.Info("Image not set, skip cleaning up of docker image")
 		} else {
 			cmd := exec.Command("docker", "rmi", "-f", t.ImageName)
 			if _, err := t.Run(cmd); err != nil {


### PR DESCRIPTION
We want to migrate from the external github.com/sirupsen/logrus dependency to Go's standard library log/slog package. This will eliminate external dependencies and improve performance.

Fixes: https://github.com/kubernetes-sigs/kubebuilder/issues/4930