### PR TITLE
✨ Version bump for golangci-lint to 2.3.0 ( follow up #4957 )

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.2.2
+          version: v2.3.0
           working-directory: ${{ matrix.folder }}
       - name: Run linter via makefile target
         working-directory: ${{ matrix.folder }}

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ yamllint:
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
-	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.2.2  ;\
+	GOBIN=$(shell pwd)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0  ;\
 	}
 
 .PHONY: apidiff


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kubebuilder/issues/4972

This fix updates the version in the Makefile and lint yaml to v2.3.0.