### PR TITLE
🐛 Enable cert-manager for ci workflow

### DIFF
--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
@@ -92,18 +92,17 @@ jobs:
         run: |
           helm lint ./dist/chart
 
-# TODO: Uncomment if cert-manager is enabled
-#      - name: Install cert-manager via Helm
-#        run: |
-#          helm repo add jetstack https://charts.jetstack.io
-#          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
-#
-#      - name: Wait for cert-manager to be ready
-#        run: |
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
+      - name: Install cert-manager via Helm
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+
+      - name: Wait for cert-manager to be ready
+        run: |
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
 
 # TODO: Uncomment if Prometheus is enabled
 #      - name: Install Prometheus Operator CRDs


### PR DESCRIPTION
This PR is a part of https://github.com/kubernetes-sigs/kubebuilder/issues/4977, scenario 6.


Below Jobs were failing because of this since it was trying to look for cert-manager CRDs but they were not configured as it was disabled in CI job workflow: 
https://github.com/Shubhamag12/kubebuilder-s6/actions (Run 1)

Adding it in CI workflow
Passed Jobs: 
https://github.com/Shubhamag12/kubebuilder-s6/actions (Run 2)