### PR TITLE
🐛 (alpha commands): alpha update command with `--force` now runs post-merge fixes in best-effort mode raising warnings instead of errors to allow properly automation with this option

### DIFF
--- a/pkg/cli/alpha/internal/update/update_test.go
+++ b/pkg/cli/alpha/internal/update/update_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Prepare for internal update", func() {
 			err = mockBinResponse(fakeBinScript, mockMake)
 			Expect(err).ToNot(HaveOccurred())
 
-			runMakeTargets()
+			runMakeTargets(true)
 		})
 	})
 


### PR DESCRIPTION
This updates the behaviour of runMakeTargets after a merge:
- If --force is set, it runs all make targets (like generate, vet, etc.)
  Even if some fail, this helps keep the project in as consistent a state as possible when conflicts are faced.
  If the conflict is faced, but we are still able to regenerate the manifest, we try to do so. 
- If --force is not set, it fails immediately on the first failed target.

We now use `sh -c "make <target> || true"` when --force is enabled,
So we can continue execution, but still detect and log failures.
