### PR TITLE
🌱 Revert "🐛 (alpha commands): alpha update command with `--force` now runs post-merge fixes in best-effort mode raising warnings instead of errors to allow properly automation with this option"

### DIFF
--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -210,25 +210,13 @@ func cleanupBranch() error {
 	return nil
 }
 
-// runMakeTargets runs the specified make targets to ensure the project is in a good state.
-// If force is true, do not run target with || true to move forward when failures are faced.
-func runMakeTargets(force bool) {
+// runMakeTargets is a helper function to run make with the targets necessary
+// to ensure all the necessary components are generated, formatted and linted.
+func runMakeTargets() {
 	targets := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
-
 	for _, target := range targets {
-		var cmd []string
-		var msg string
-
-		if force {
-			msg = fmt.Sprintf("Running make %s (with --force)", target)
-			shellCmd := fmt.Sprintf("make %s || true", target)
-			cmd = []string{"sh", "-c", shellCmd}
-		} else {
-			msg = fmt.Sprintf("Running make %s", target)
-			cmd = []string{"make", target}
-		}
-
-		if err := util.RunCmd(msg, cmd[0], cmd[1:]...); err != nil {
+		err := util.RunCmd(fmt.Sprintf("Running make %s", target), "make", target)
+		if err != nil {
 			log.Warn("make target failed", "target", target, "error", err)
 		}
 	}
@@ -270,8 +258,8 @@ func runAlphaGenerate(tempDir, version string) error {
 	// It was added because the alpha generate command in versions prior to v4.7.0 does
 	// not run those commands automatically which will not allow we properly ensure
 	// that all manifests, code generation, formatting, and linting are applied to
-	// properly do the 3-way merge. We use true to ignore errors and do our best effort
-	runMakeTargets(false)
+	// properly do the 3-way merge.
+	runMakeTargets()
 	return nil
 }
 
@@ -367,8 +355,8 @@ func (opts *Update) mergeOriginalToUpgrade() error {
 		log.Info("Merge happened without conflicts.")
 	}
 
-	// When the --force flag is used has the best effort to run the make targets
-	runMakeTargets(opts.Force)
+	// Best effort to run make targets to ensure the project is in a good state
+	runMakeTargets()
 
 	// Step 4: Stage and commit
 	if err := exec.Command("git", "add", "--all").Run(); err != nil {

--- a/pkg/cli/alpha/internal/update/update_test.go
+++ b/pkg/cli/alpha/internal/update/update_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Prepare for internal update", func() {
 			err = mockBinResponse(fakeBinScript, mockMake)
 			Expect(err).ToNot(HaveOccurred())
 
-			runMakeTargets(true)
+			runMakeTargets()
 		})
 	})
 


### PR DESCRIPTION
Reverts kubernetes-sigs/kubebuilder#4992

After more tests we realized that is not needed reverting it