### PR TITLE
📖 (docs) include 2025 roadmap

### DIFF
--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -12,6 +12,7 @@ specific objectives set for the project during that time, the motivation behind 
 made towards achieving them:
 
 - [Roadmap 2024](roadmap_2024.md)
+- [Roadmap 2025](roadmap_2025.md)
 
 ## :point_right: New plugins/RFEs to provide integrations within other Projects
 


### PR DESCRIPTION
This PR adds a link to the 2025 roadmap in the documentation.

At first glance of it didn’t appear there was a roadmap for the year, adding the reference for clarify and visibility.