### PR TITLE
🐛 (go/v4): Remove the certWatcher in favor of use internal implementation provided by controller-runtime to do the same

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
@@ -232,7 +232,6 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
-	"path/filepath"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -242,7 +241,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -312,34 +310,22 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
-	// Create watchers for metrics and webhooks certificates
-	var metricsCertWatcher, webhookCertWatcher  *certwatcher.CertWatcher
-
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
+	webhookServerOptions := webhook.Options{
+		TLSOpts: webhookTLSOpts,
+	}
 
 	if len(webhookCertPath) > 0 {
 		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
 			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
 
-		var err error
-		webhookCertWatcher, err = certwatcher.New(
-			filepath.Join(webhookCertPath, webhookCertName),
-			filepath.Join(webhookCertPath, webhookCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
-			os.Exit(1)
-		}
-
-		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
-			config.GetCertificate = webhookCertWatcher.GetCertificate
-		})
+		webhookServerOptions.CertDir = webhookCertPath
+		webhookServerOptions.CertName = webhookCertName
+		webhookServerOptions.KeyName = webhookCertKey
 	}
 
-	webhookServer := webhook.NewServer(webhook.Options{
-		TLSOpts: webhookTLSOpts,
-	})
+	webhookServer := webhook.NewServer(webhookServerOptions)
 
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:
@@ -371,19 +357,9 @@ func main() {
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
 
-		var err error
-		metricsCertWatcher, err = certwatcher.New(
-			filepath.Join(metricsCertPath, metricsCertName),
-			filepath.Join(metricsCertPath, metricsCertKey),
-		)
-		if err != nil {
-			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
-			os.Exit(1)
-		}
-
-		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
-			config.GetCertificate = metricsCertWatcher.GetCertificate
-		})
+		metricsServerOptions.CertDir = metricsCertPath
+		metricsServerOptions.CertName = metricsCertName
+		metricsServerOptions.KeyName = metricsCertKey
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -415,23 +391,6 @@ func main() {
 	}
 
 	%s
-
-    if metricsCertWatcher != nil {
-        setupLog.Info("Adding metrics certificate watcher to manager")
-        if err := mgr.Add(metricsCertWatcher); err != nil {
-            setupLog.Error(err, "unable to add metrics certificate watcher to manager")
-            os.Exit(1)
-        }
-    }
-
-    if webhookCertWatcher != nil {
-        setupLog.Info("Adding webhook certificate watcher to manager")
-        if err := mgr.Add(webhookCertWatcher); err != nil {
-            setupLog.Error(err, "unable to add webhook certificate watcher to manager")
-            os.Exit(1)
-        }
-    }
-
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")


### PR DESCRIPTION
Fixes #4792

Updating the `main.go` template for the webhook and metrics server certificate handling. Instead of creating a separate `CertWatcher`, this supplies the three fields to the options. When `controller-runtime` has those three values, it will set up its own `CertWatcher`.

This allows non-leader replicas to properly reload the cert and key when updated, which is necessary for the webhook and metrics server that end up serving the endpoints even when they are not leaders.

This was tested with our own currently running controller by deleting the `cert-manager` managed `Certificate` resource, letting it recreate a new one, which updated the `Secret` and then the file in the `Pod`s. Reloading the certificate and key can be seen in the logs:

```
2025-08-12T15:10:02Z	INFO	setup	Initializing webhook certificate watcher using provided certificates	{"webhook-cert-path": "/tmp/k8s-webhook-server/serving-certs", "webhook-cert-name": "tls.crt", "webhook-cert-key": "tls.key"}
2025-08-12T15:10:02Z	INFO	setup	Initializing metrics certificate watcher using provided certificates	{"metrics-cert-path": "/tmp/k8s-metrics-server/metrics-certs", "metrics-cert-name": "tls.crt", "metrics-cert-key": "tls.key"}
2025-08-12T15:10:02Z	INFO	controller-runtime.builder	Registering a mutating webhook	{"GVK": "my-group.example.com/v1alpha1, kind=Thing", "path": "/mutate-my-group-example-com-v1alpha1-thing"}
2025-08-12T15:10:02Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/mutate-my-group-example-com-v1alpha1-thing"}
2025-08-12T15:10:02Z	INFO	controller-runtime.builder	Registering a validating webhook	{"GVK": "my-group.example.com/v1alpha1, kind=Thing", "path": "/validate-my-group-example-com-v1alpha1-thing"}
2025-08-12T15:10:02Z	INFO	controller-runtime.webhook	Registering webhook	{"path": "/validate-my-group-example-com-v1alpha1-thing"}
2025-08-12T15:10:02Z	INFO	setup	starting manager
2025-08-12T15:10:02Z	INFO	controller-runtime.metrics	Starting metrics server
2025-08-12T15:10:02Z	INFO	setup	disabling http/2
2025-08-12T15:10:02Z	INFO	starting server	{"name": "health probe", "addr": "[::]:8081"}
2025-08-12T15:10:02Z	INFO	controller-runtime.webhook	Starting webhook server
2025-08-12T15:10:02Z	INFO	setup	disabling http/2
I0812 15:10:02.713385       1 leaderelection.go:257] attempting to acquire leader lease my-namespace/84d4f733.example.com...
2025-08-12T15:10:02Z	INFO	controller-runtime.certwatcher	Updated current TLS certificate
2025-08-12T15:10:02Z	INFO	controller-runtime.metrics	Serving metrics server	{"bindAddress": ":8443", "secure": true}
2025-08-12T15:10:02Z	INFO	controller-runtime.certwatcher	Updated current TLS certificate
2025-08-12T15:10:02Z	INFO	controller-runtime.certwatcher	Starting certificate poll+watcher	{"interval": "10s"}
2025-08-12T15:10:02Z	INFO	controller-runtime.webhook	Serving webhook server	{"host": "", "port": 9443}
2025-08-12T15:10:02Z	INFO	controller-runtime.certwatcher	Starting certificate poll+watcher	{"interval": "10s"}
2025-08-12T15:15:50Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "CHMOD         \"/tmp/k8s-webhook-server/serving-certs/tls.crt\""}
2025-08-12T15:15:50Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "REMOVE        \"/tmp/k8s-webhook-server/serving-certs/tls.crt\""}
2025-08-12T15:15:50Z	DEBUG	controller-runtime.certwatcher	certificate event	{"event": "CHMOD         \"/tmp/k8s-webhook-server/serving-certs/tls.key\""}
```
