### PR TITLE
✨ alpha(update): add `--open-gh-issue` flag

### DIFF
--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -119,9 +119,10 @@ kubebuilder alpha update --force --squash \
 ```
 
 **Idempotent Behavior**: The command is safe to run multiple times:
-- If a remote branch already exists with the same name, the command will not push or create an issue (prevents overwriting existing work)
+- If a remote branch already exists with the same name, the command will not push (prevents overwriting existing work)
 - If an issue already exists for the same update (from → to versions), no new issue is created
-- The command will log when existing branches/issues are found and exit successfully
+- If a branch exists but no issue exists, an issue will be created to link to the existing branch
+- The command will log when existing branches/issues are found and handle each case appropriately
 
 ## Merge Conflicts with `--force`
 

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -48,7 +48,7 @@ Use this command when you:
 
 4. **(Optional) Squash**
    With `--squash`, copies the merge result to a stable output branch and commits **once**:
-   - Default output branch: `kubebuilder-alpha-update-to-<to-version>`
+   - Default output branch: `kubebuilder-alpha-update-from-<from-version>-to-<to-version>`
    - Or set your own with `--output-branch`
      If there are conflicts, the single commit will include conflict markers.
 
@@ -92,8 +92,36 @@ Use a **custom output branch** name:
 
 ```shell
 kubebuilder alpha update --force --squash \
-  -output-branch upgrade/kb-to-v4.7.0
+  --output-branch chore/upgrade-kb-to-v4.7.0
 ```
+
+**GitHub Integration** - automatically create an issue:
+
+```shell
+kubebuilder alpha update --force --squash --open-gh-issue
+```
+
+## GitHub Integration Requirements
+
+The GitHub integration feature (`--open-gh-issue`) requires:
+
+- **gh CLI** installed and authenticated
+  - For local use: `gh auth login`
+  - For GitHub Actions: authentication is automatic with `GITHUB_TOKEN`
+- **`--force` flag** to handle potential conflicts during automation
+- **Push access** to the repository
+
+**GitHub Token Permissions**: When using GitHub tokens (e.g., in CI/CD), you may need to preserve workflow files to avoid permission issues:
+
+```shell
+kubebuilder alpha update --force --squash \
+  --preserve-path .github/workflows --open-gh-issue
+```
+
+**Idempotent Behavior**: The command is safe to run multiple times:
+- If a remote branch already exists with the same name, the command will not push or create an issue (prevents overwriting existing work)
+- If an issue already exists for the same update (from → to versions), no new issue is created
+- The command will log when existing branches/issues are found and exit successfully
 
 ## Merge Conflicts with `--force`
 
@@ -113,7 +141,7 @@ Incoming changes
 
 ## Commit message used in `--squash` mode
 
-> [kubebuilder-automated-update]: update scaffold from <from> to <to>; (squashed 3-way merge)
+> (kubebuilder): update scaffold from <from> to <to>
 
 <aside class="note warning">
 <h1>You might need to upgrade your project first</h1>
@@ -155,7 +183,8 @@ make all
 | `--force`         | Continue even if merge conflicts happen. Conflicted files are committed with conflict markers (useful for CI/cron).                         |
 | `--squash`        | Write the merge result as **one commit** on a stable output branch.                                                                         |
 | `--preserve-path` | Repeatable. With `--squash`, restore these paths from the base branch (e.g., `--preserve-path .github/workflows`).                          |
-| `--output-branch` | Branch name to use for the squashed commit (default: `kubebuilder-alpha-update-to-<to-version>`).                                          |
+| `--output-branch` | Branch name to use for the squashed commit (default: `kubebuilder-alpha-update-from-<from-version>-to-<to-version>`).                                          |
+| `--open-gh-issue` | Create an issue using gh CLI after successful update. Requires gh CLI and `--force` flag. Safe to re-run - skips if remote branch or issue already exists. |
 | `-h, --help`      | Show help for this command.                                                                                                                |
 
 <aside class="note">

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -568,8 +568,8 @@ func (opts *Update) createIssue() error {
 
 	var pushed bool
 	if branchExists {
-		log.Info("Remote branch already exists, skipping push to avoid overwriting existing work", "branch", branchName)
-		log.Info("Branch was not pushed (already exists), ensuring no work is overwritten", "branch", branchName)
+		log.Info("Remote branch already exists. Branch was not pushed to avoid overwriting existing work",
+			"branch", branchName)
 		pushed = false
 	} else {
 		pushed, err = opts.pushBranchToRemote(branchName)

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -90,13 +90,6 @@ func (opts *Update) Update() error {
 		"upgrade_branch", opts.UpgradeBranch,
 		"merge_branch", opts.MergeBranch)
 
-	// Configure git identity if GitHub integration is enabled (needed for commits during 3-way merge)
-	if opts.OpenIssue {
-		if err := opts.ensureGitIdentity(); err != nil {
-			return fmt.Errorf("failed to configure git identity: %w", err)
-		}
-	}
-
 	// 1. Creates an ancestor branch based on base branch
 	// 2. Deletes everything except .git and PROJECT
 	// 3. Installs old release
@@ -722,18 +715,4 @@ func (opts *Update) checkExistingIssue() (bool, error) {
 
 	issueCount := strings.TrimSpace(string(output))
 	return issueCount != "0", nil
-}
-
-// ensureGitIdentity configures git user identity for commits
-func (opts *Update) ensureGitIdentity() error {
-	if err := exec.Command("git", "config", "user.name", "github-actions[bot]").Run(); err != nil {
-		return fmt.Errorf("failed to set git user.name: %w", err)
-	}
-
-	if err := exec.Command("git", "config", "user.email",
-		"github-actions[bot]@users.noreply.github.com").Run(); err != nil {
-		return fmt.Errorf("failed to set git user.email: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/cli/alpha/internal/update/update_test.go
+++ b/pkg/cli/alpha/internal/update/update_test.go
@@ -134,22 +134,6 @@ var _ = Describe("Prepare for internal update", func() {
 			Expect(readErr).ToNot(HaveOccurred())
 			Expect(string(logs)).To(ContainSubstring("checkout"))
 		})
-		It("Should fail when git config fails with --open-gh-issue flag", func() {
-			opts.OpenIssue = true
-			opts.Force = true // Required for --open-gh-issue
-			// Create a script that succeeds for most git commands but fails for "git config"
-			fakeBinScript := `#!/bin/bash
-			       echo "$@" >> "` + logFile + `"
-			       if [[ "$1" == "config" ]]; then
-			           exit 1
-			       fi
-			       exit 0`
-			err = mockBinResponse(fakeBinScript, mockGit)
-			Expect(err).ToNot(HaveOccurred())
-			err = opts.Update()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to configure git identity"))
-		})
 		It("Should fail when kubebuilder binary could not be downloaded", func() {
 			gock.Off()
 

--- a/pkg/cli/alpha/internal/update/validate.go
+++ b/pkg/cli/alpha/internal/update/validate.go
@@ -47,6 +47,9 @@ func (opts *Update) Validate() error {
 	if err := validateReleaseAvailability(opts.ToVersion); err != nil {
 		return fmt.Errorf("unable to find release %s: %w", opts.ToVersion, err)
 	}
+	if err := opts.validateGitHubIntegrationFlags(); err != nil {
+		return fmt.Errorf("failed to validate GitHub integration flags: %w", err)
+	}
 	return nil
 }
 
@@ -138,6 +141,14 @@ func (opts *Update) validateEqualVersions() error {
 			log.Info("Your project already uses the specified version. No action taken.", "version", opts.FromVersion)
 		}
 		os.Exit(0)
+	}
+	return nil
+}
+
+// validateGitHubIntegrationFlags validates that --force is used with GitHub integration flags
+func (opts *Update) validateGitHubIntegrationFlags() error {
+	if opts.OpenIssue && !opts.Force {
+		return fmt.Errorf("--force flag is required when using --open-gh-issue to handle potential conflicts")
 	}
 	return nil
 }

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -48,7 +48,7 @@ By default, the merge result is committed on the temporary 'merge' branch.
 Use --squash to snapshot that result into a SINGLE commit on a stable branch,
 ready for a PR:
 
-  kubebuilder-alpha-update-to-<to-version>
+  kubebuilder-alpha-update-from-<from-version>-to-<to-version>
 
 This keeps history tidy (one commit per update run) and enables idempotent PRs.
 
@@ -77,6 +77,9 @@ Examples:
   # Squash into a custom output branch name
   kubebuilder alpha update --force --squash --output-branch my-update-branch
 
+  # Create an issue automatically using gh CLI
+  kubebuilder alpha update --force --squash --open-gh-issue
+
 Behavior summary:
   • Without --force:
       - If conflicts occur during the 3-way merge, the command stops on the 'merge' branch
@@ -85,7 +88,7 @@ Behavior summary:
       - Conflicted files are committed on the 'merge' branch with conflict markers.
   • With --squash:
       - After the merge step, the exact 'merge' tree is copied to a new/updated branch
-        (default: kubebuilder-alpha-update-to-<to-version>) and committed ONCE, keeping markers
+        (default: kubebuilder-alpha-update-from-<from-version>-to-<to-version>) and committed ONCE, keeping markers
         if present. This branch is intended for opening/refreshing a PR.`,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			err := opts.Prepare()
@@ -115,12 +118,14 @@ Behavior summary:
 			"commit will be created automatically. Ideal for automation (e.g., cronjobs, CI).")
 	updateCmd.Flags().BoolVar(&opts.Squash, "squash", false,
 		"After merging, write a single squashed commit with the merge result to a fixed branch "+
-			"named kubebuilder-alpha-update-to-<to-version>.")
+			"named kubebuilder-alpha-update-from-<from-version>-to-<to-version>.")
 	updateCmd.Flags().StringArrayVar(&opts.PreservePath, "preserve-path", nil,
 		"Paths to preserve from the base branch when squashing (repeatable). "+
 			"Example: --preserve-path .github/workflows")
 	updateCmd.Flags().StringVar(&opts.OutputBranch, "output-branch", "",
-		"Override the default kubebuilder-alpha-update-to-<to-version> branch name (used with --squash).")
+		"Override the default kubebuilder-alpha-update-from-<from-version>-to-<to-version> branch name (used with --squash).")
+	updateCmd.Flags().BoolVar(&opts.OpenIssue, "open-gh-issue", false,
+		"Create an issue using gh CLI after successful update. Requires gh CLI to be installed and authenticated.")
 
 	return updateCmd
 }

--- a/pkg/cli/alpha/update_test.go
+++ b/pkg/cli/alpha/update_test.go
@@ -37,6 +37,7 @@ var _ = Describe("NewUpdateCommand", func() {
 			Expect(flags.Lookup("squash")).NotTo(BeNil())
 			Expect(flags.Lookup("preserve-path")).NotTo(BeNil())
 			Expect(flags.Lookup("output-branch")).NotTo(BeNil())
+			Expect(flags.Lookup("open-gh-issue")).NotTo(BeNil())
 		})
 	})
 })

--- a/test/e2e/alphaupdate/update_test.go
+++ b/test/e2e/alphaupdate/update_test.go
@@ -185,7 +185,7 @@ var _ = Describe("kubebuilder", func() {
 				"Expected latest scaffold version in conflict")
 
 			By("checking that the squashed branch is created with the expected commit message")
-			prBranch := "kubebuilder-alpha-update-to-" + toVersionWithConflict
+			prBranch := fmt.Sprintf("kubebuilder-alpha-update-from-%s-to-%s", fromVersion, toVersionWithConflict)
 
 			git := func(args ...string) ([]byte, error) {
 				cmd := exec.Command("git", args...)
@@ -206,7 +206,7 @@ var _ = Describe("kubebuilder", func() {
 			out, err = git("log", "-1", "--pretty=%B", prBranch)
 			Expect(err).NotTo(HaveOccurred(), string(out))
 			expected := fmt.Sprintf(
-				"[kubebuilder-automated-update]: update scaffold from %s to %s; (squashed 3-way merge)",
+				"(kubebuilder): update scaffold from %s to %s",
 				fromVersion, toVersionWithConflict,
 			)
 			Expect(string(out)).To(ContainSubstring(expected))


### PR DESCRIPTION
## Summary

This PR introduces the `--open-gh-issue` flag, which enhances the `kubebuilder alpha update` command with automated GitHub integration and intelligent conflict warning system, making it ready for automated update workflows using GitHub Actions while informing users when manual intervention is needed.

## Use Case

When used with GitHub Actions, `--open-gh-issue` will:

1. Perform an update using a 3-way merge.
2. Create a branch to commit the result.
3. Create an issue to notify about the update, with a link to create a PR.

## Issue Template

> There's a new scaffold available for update!
> 
> Check out what's new in [Kubebuilder v4.7.1 Release Notes](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v4.7.1).
> 
> ### What to do?
> To make your life easier, Kubebuilder has updated your project scaffold from v4.6.0 to v4.7.1 on the [kubebuilder-alpha-update-from-v4.6.0-to-v4.7.1](https://github.com/vitorfloriano/test-operator/tree/kubebuilder-alpha-update-from-v4.6.0-to-v4.7.1) branch.
> 
> You can create a Pull Request with the changes using the link below:
> 
> https://github.com/vitorfloriano/test-operator/pull/new/kubebuilder-alpha-update-from-v4.6.0-to-v4.7.1
> 
> **ATTENTION**: This update was performed by automation. Always review and test your code before merging the changes.
> 
> **HINT**: You can learn more ways to automate updates in the [alpha update documentation](https://kubebuilder.io/reference/commands/alpha_update).
> 
> **WARNING**: Conflict markers were committed to make this automation possible. You should resolve the conflicts before anything.

## Idempotency

`--open-gh-issue` validates if a branch for the same update already exists before pushing anything, which avoids overwritting existing work that may have been started on the update branch.