### PR TITLE
✨ scaffold(v4): add Alpha Update workflow to scaffold

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -184,6 +184,7 @@ func (s *initScaffolder) Scaffold() error {
 		&github.LintCi{
 			GolangciLintVersion: GolangciLintVersion,
 		},
+		&github.AlphaUpdateCi{},
 		&utils.Utils{},
 		&templates.DevContainer{},
 		&templates.DevContainerPostInstallScript{},

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
@@ -27,7 +27,6 @@ var _ machinery.Template = &AlphaUpdateCi{}
 // AlphaUpdateCi scaffolds the GitHub Action to run kubebuilder alpha update
 type AlphaUpdateCi struct {
 	machinery.TemplateMixin
-	machinery.BoilerplateMixin
 }
 
 // SetTemplateDefaults implements machinery.Template

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
@@ -47,7 +47,6 @@ const alphaUpdateCiTemplate = `name: Alpha Update
 permissions:
   contents: write
   issues: write
-  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -91,4 +90,5 @@ jobs:
           --squash \
           --preserve-path .github/workflows \
           --open-gh-issue
+
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
@@ -68,6 +68,11 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
     
+    - name: Configure Git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+    
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/alpha-update.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &AlphaUpdateCi{}
+
+// AlphaUpdateCi scaffolds the GitHub Action to run kubebuilder alpha update
+type AlphaUpdateCi struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+}
+
+// SetTemplateDefaults implements machinery.Template
+func (f *AlphaUpdateCi) SetTemplateDefaults() error {
+	if f.Path == "" {
+		f.Path = filepath.Join(".github", "workflows", "alpha-update.yml")
+	}
+
+	f.TemplateBody = alphaUpdateCiTemplate
+
+	f.IfExistsAction = machinery.SkipFile
+
+	return nil
+}
+
+const alphaUpdateCiTemplate = `name: Alpha Update
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 2" # Every Tuesday at 00:00 UTC
+
+jobs:
+  alpha-update:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    - name: Install Kubebuilder
+      run: |
+        curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
+        chmod +x kubebuilder
+        sudo mv kubebuilder /usr/local/bin/
+        kubebuilder version
+
+    - name: Run kubebuilder alpha update
+      run: |
+        kubebuilder alpha update \
+          --force \
+          --squash \
+          --preserve-path .github/workflows \
+          --open-gh-issue
+`


### PR DESCRIPTION
This PR adds the **Alpha Update** workflow to the `.github/workflows` directory on the initial project scaffold. 

The workflow:
1. Checks out the project.
2. Performs an update using the `kubebuilder alpha update` command
3. Pushes the changes to a new branch
4. Creates an Issue with a link for opening a PR using the new branch

The template:

```
name: Alpha Update
permissions:
  contents: write
  issues: write

on:
  workflow_dispatch:
  schedule:
    - cron: "0 0 * * 2" # Every Tuesday at 00:00 UTC

jobs:
  alpha-update:
    runs-on: ubuntu-latest
    env:
      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

    steps:
    - name: Checkout repository
      uses: actions/checkout@v4
      with:
        token: ${{ secrets.GITHUB_TOKEN }}
        fetch-depth: 0
    
    - name: Configure Git
      run: |
        git config --global user.name "github-actions[bot]"
        git config --global user.email "github-actions[bot]@users.noreply.github.com"
    
    - name: Set up Go
      uses: actions/setup-go@v5
      with:
        go-version: stable

    - name: Install Kubebuilder
      run: |
        curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
        chmod +x kubebuilder
        sudo mv kubebuilder /usr/local/bin/
        kubebuilder version

    - name: Run kubebuilder alpha update
      run: |
        kubebuilder alpha update \
          --force \
          --squash \
          --preserve-path .github/workflows \
          --open-gh-issue
```
