### PR TITLE
✨ (alpha update) Add option to allow open GitHub Issues after updates

### DIFF
--- a/pkg/cli/alpha/internal/update/prepare.go
+++ b/pkg/cli/alpha/internal/update/prepare.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
 )
 
+const defaultBranch = "main"
+
 type releaseResponse struct {
 	TagName string `json:"tag_name"`
 }
@@ -37,7 +39,7 @@ func (opts *Update) Prepare() error {
 	if opts.FromBranch == "" {
 		// TODO: Check if is possible to use get to determine the default branch
 		log.Warn("No --from-branch specified, using 'main' as default")
-		opts.FromBranch = "main"
+		opts.FromBranch = defaultBranch
 	}
 
 	path, err := common.GetInputPath("")

--- a/pkg/cli/alpha/internal/update/update_test.go
+++ b/pkg/cli/alpha/internal/update/update_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Prepare for internal update", func() {
 		opts = Update{
 			FromVersion: "v4.5.0",
 			ToVersion:   "v4.6.0",
-			FromBranch:  "main",
+			FromBranch:  defaultBranch,
 		}
 
 		// Create temporary directory to house fake bin executables.
@@ -444,7 +444,7 @@ exit 0`
 
 	Context("SquashToOutputBranch", func() {
 		BeforeEach(func() {
-			opts.FromBranch = "main"
+			opts.FromBranch = defaultBranch
 			opts.FromVersion = "v4.5.0"
 			opts.ToVersion = "v4.6.0"
 			if opts.MergeBranch == "" {

--- a/pkg/cli/alpha/internal/update/validate.go
+++ b/pkg/cli/alpha/internal/update/validate.go
@@ -49,6 +49,14 @@ func (opts *Update) Validate() error {
 	if err := validateReleaseAvailability(opts.ToVersion); err != nil {
 		return fmt.Errorf("unable to find release %s: %w", opts.ToVersion, err)
 	}
+
+	if opts.OpenGhIssue {
+		if err := exec.Command("gh", "--version").Run(); err != nil {
+			return fmt.Errorf("`gh` CLI not found or not authenticated. "+
+				"You must have gh instaled to use the --open-gh-issue option: %s", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cli/alpha/internal/update/validate_test.go
+++ b/pkg/cli/alpha/internal/update/validate_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Prepare for internal update", func() {
 		opts = &Update{
 			FromVersion:    "v4.5.0",
 			ToVersion:      "v4.6.0",
-			FromBranch:     "main",
+			FromBranch:     defaultBranch,
 			OriginalBranch: "v4.6.0",
 		}
 

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -114,6 +114,7 @@ Defaults:
 		"Override the default output branch name (default: kubebuilder-update-from-<from-version>-to-<to-version>).")
 	updateCmd.Flags().BoolVar(&opts.Push, "push", false,
 		"Push the output branch to the remote repository after the update.")
-
+	updateCmd.Flags().BoolVar(&opts.OpenGhIssue, "open-gh-issue", false,
+		"Create a GitHub issue with a pre-filled checklist and compare link after the update completes (requires `gh`).")
 	return updateCmd
 }


### PR DESCRIPTION
When running alpha update, you can now pass --open-gh-issue to automatically create a pre-filled GitHub Issue.
