### PR TITLE
🐛 (revert) only changes done in the default scaffold in the pr: 4932 ( kept helm chart changes )

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/manager/manager.yaml
@@ -64,7 +64,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         name: manager
         ports: []
         securityContext:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4213,7 +4213,6 @@ spec:
         command:
         - /manager
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/manager/manager.yaml
@@ -64,7 +64,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         name: manager
         ports: []
         securityContext:

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -442,7 +442,6 @@ spec:
         command:
         - /manager
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/manager/manager.yaml
@@ -64,7 +64,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         name: manager
         ports: []
         securityContext:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -8110,7 +8110,6 @@ spec:
         command:
         - /manager
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/manager/config.go
@@ -110,7 +110,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: {{ .Image }}
-        imagePullPolicy: IfNotPresent
         name: manager
         ports: []
         securityContext:

--- a/testdata/project-v4-multigroup/config/manager/manager.yaml
+++ b/testdata/project-v4-multigroup/config/manager/manager.yaml
@@ -64,7 +64,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         name: manager
         env:
         - name: BUSYBOX_IMAGE

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -2947,7 +2947,6 @@ spec:
         - name: MEMCACHED_IMAGE
           value: memcached:1.6.26-alpine3.19
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4-with-plugins/config/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/config/manager/manager.yaml
@@ -64,7 +64,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         name: manager
         env:
         - name: BUSYBOX_IMAGE

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -992,7 +992,6 @@ spec:
         - name: MEMCACHED_IMAGE
           value: memcached:1.6.26-alpine3.19
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/project-v4/config/manager/manager.yaml
+++ b/testdata/project-v4/config/manager/manager.yaml
@@ -64,7 +64,6 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         name: manager
         ports: []
         securityContext:

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -975,7 +975,6 @@ spec:
         command:
         - /manager
         image: controller:latest
-        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Why are we reverting the scaffold changes?

- Scaffold Stability: Changes to the default scaffold can't be done lightly. They can create a lot of extra work and cause issues for end-users when they upgrade to a new version. We want to avoid causing upgrade burden.
- Complexity: Adding a large number of defaults to the scaffold would make it overly complex and difficult to maintain over time.
- A Better Approach: We need to address the Helm chart plugin's design in a more comprehensive way, as outlined in the Kubebuilder issues:

- https://github.com/kubernetes-sigs/kubebuilder/issues/4833
- https://github.com/kubernetes-sigs/kubebuilder/milestone/39
- https://github.com/kubernetes-sigs/kubebuilder/issues/4912

Thank you to the original author for their contribution. This change is being made to ensure project stability for all users.