### PR TITLE
✨ Add plugin for Alpha Update Command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
 	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
+	autoupdatev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
 	grafanav1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
 	helmv1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
 )
@@ -74,6 +75,7 @@ func Run() {
 			&deployimagev1alpha1.Plugin{},
 			&grafanav1alpha1.Plugin{},
 			&helmv1alpha1.Plugin{},
+			&autoupdatev1alpha1.Plugin{},
 		),
 		cli.WithPlugins(externalPlugins...),
 		cli.WithDefaultPlugins(cfgv3.Version, gov4Bundle),

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -120,9 +120,10 @@
 - [Plugins][plugins]
 
   - [Available Plugins](./plugins/available-plugins.md)
+    - [autoupdate/v1-alpha](./plugins/available/autoupdate-v1-alpha.md)
+    - [deploy-image/v1-alpha](./plugins/available/deploy-image-plugin-v1-alpha.md)
     - [go/v4](./plugins/available/go-v4-plugin.md)
     - [grafana/v1-alpha](./plugins/available/grafana-v1-alpha.md)
-    - [deploy-image/v1-alpha](./plugins/available/deploy-image-plugin-v1-alpha.md)
     - [helm/v1-alpha](./plugins/available/helm-v1-alpha.md)
     - [kustomize/v2](./plugins/available/kustomize-v2.md)
   - [Extending](./plugins/extending.md)

--- a/docs/book/src/plugins/available/autoupdate-v1-alpha.md
+++ b/docs/book/src/plugins/available/autoupdate-v1-alpha.md
@@ -1,0 +1,67 @@
+# AutoUpdate (`autoupdate/v1-alpha`)
+
+Keeping your Kubebuilder project up to date with the latest improvements shouldn’t be a chore.
+With a small amount of setup, you can receive **automatic Pull Request** suggestions whenever a new
+Kubebuilder release is available — keeping your project **maintained, secure, and aligned with ecosystem changes**.
+
+This automation uses the [`kubebuilder alpha update`][alpha-update-command] command with a **3-way merge strategy** to
+refresh your project scaffold, and wraps it in a GitHub Actions workflow that opens an **Issue** with a **Pull Request compare link** so you can create the PR and review it.
+
+## When to Use It
+
+- When you don’t deviate too much from the default scaffold — ensure that you see the note about customization [here](https://book.kubebuilder.io/versions_compatibility_supportability#project-customizations).
+- When you want to reduce the burden of keeping the project updated and well-maintained.
+
+## How to Use It
+
+0 If you want to add the `autoupdate` plugin to your project:
+
+```shell
+kubebuilder edit --plugins="autoupdate.kubebuilder.io/v1-alpha"
+```
+
+- If you want to create a new project with the `autoupdate` plugin:
+
+```shell
+kubebuilder init --plugins=go/v4,autoupdate/v1-alpha
+```
+
+## How It Works
+
+This will scaffold and GitHub Actions workflow that runs the [kubebuilder alpha update][alpha-update-command] command.
+Then, whenever a new Kubebuilder release is available, it will open an Issue with a
+Pull Request compare link so you can create the PR and review it, such as:
+
+<img width="638" height="482" alt="Example Issue" src="https://github.com/user-attachments/assets/589fd16b-7709-4cd5-b169-fd53d69790d4" />
+
+The workflow will check once a week for new releases, and if there are any, it will create an Issue with a Pull Request compare link so you can create the PR and review it.
+The command called by the workflow is:
+
+```shell
+	# More info: https://kubebuilder.io/reference/commands/alpha_update
+    - name: Run kubebuilder alpha update
+      run: |
+		# Executes the update command with specified flags.
+		# --force: Completes the merge even if conflicts occur, leaving conflict markers.
+		# --push: Automatically pushes the resulting output branch to the 'origin' remote.
+		# --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
+		# --open-gh-issue: Creates a GitHub issue with a link to the generated PR for review.
+        kubebuilder alpha update \
+          --force \
+          --push \
+          --restore-path .github/workflows \
+          --open-gh-issue
+```
+
+<aside class="warning">
+<h1>Protect your branches</h1>
+
+This workflow by default **only** creates and pushes the merged files to a branch
+called `kubebuilder-update-from-<from-version>-to-<to-version>`.
+
+To keep your codebase safe, use branch protection rules to ensure that
+changes aren't pushed or merged without proper review.
+
+</aside>
+
+[alpha-update-command]: ./../../reference/commands/alpha_update.md

--- a/docs/book/src/plugins/to-add-optional-features.md
+++ b/docs/book/src/plugins/to-add-optional-features.md
@@ -2,12 +2,14 @@
 
 The following plugins are useful to generate code and take advantage of optional features
 
-| Plugin                                            | Key                     | Description                                                                                                                                         |
-|---------------------------------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| [grafana.kubebuilder.io/v1-alpha][grafana]        | `grafana/v1-alpha`      | Optional helper plugin which can be used to scaffold Grafana Manifests Dashboards for the default metrics which are exported by controller-runtime. |
-| [deploy-image.go.kubebuilder.io/v1-alpha][deploy] | `deploy-image/v1-alpha` | Optional helper plugin which can be used to scaffold APIs and controller with code implementation to Deploy and Manage an Operand(image).           |
-| [helm.kubebuilder.io/v1-alpha][helm]              | `helm/v1-alpha`         | Optional helper plugin which can be used to scaffold a Helm Chart to distribute the project under the `dist` directory                              |
+| Plugin                                              | Key                     | Description                                                                                                                                                                           |
+|-----------------------------------------------------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [autoupdate.kubebuilder.io/v1-alpha][autoupdate]    | `autoupdate/v1-alpha`   | Optional helper which scaffolds a scheduled worker that helps keep your project updated with changes in the ecosystem, significantly reducing the burden of manual maintenance. |
+| [deploy-image.go.kubebuilder.io/v1-alpha][deploy]   | `deploy-image/v1-alpha` | Optional helper plugin which can be used to scaffold APIs and controller with code implementation to Deploy and Manage an Operand(image).                                             |
+| [grafana.kubebuilder.io/v1-alpha][grafana]          | `grafana/v1-alpha`      | Optional helper plugin which can be used to scaffold Grafana Manifests Dashboards for the default metrics which are exported by controller-runtime.                                   |
+| [helm.kubebuilder.io/v1-alpha][helm]                | `helm/v1-alpha`         | Optional helper plugin which can be used to scaffold a Helm Chart to distribute the project under the `dist` directory                                                                |
 
 [grafana]: ./available/grafana-v1-alpha.md
 [deploy]: ./available/deploy-image-plugin-v1-alpha.md
 [helm]: ./available/helm-v1-alpha.md
+[autoupdate]: ./available/autoupdate-v1-alpha.md

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -9,6 +9,16 @@ not re-applying your code.
 By default, the final result is **squashed into a single commit** on a dedicated output branch.
 If you prefer to keep the full history (no squash), use `--show-commits`.
 
+<aside class="note">
+<h1>Automate your Updates</h1>
+
+You can reduce the burden of keeping your project up to date by using the
+[`autoupdate.kubebuilder.io/v1-alpha`][autoupdate-plugin] plugin which
+automates the process of running `kubebuilder alpha update` on a schedule
+workflow when new Kubebuilder releases are available.
+
+</aside>
+
 ## When to Use It
 
 Use this command when you:
@@ -207,6 +217,10 @@ so the current behavior may differ slightly from what is shown in the demo.
 
 ## Further Resources
 
-- WIP: Design proposal for update automation — https://github.com/kubernetes-sigs/kubebuilder/pull/4302
+- [AutoUpdate Plugin][autoupdate-plugin]
+- [Design proposal for update automation][design-proposal]
+- [Project configuration reference][project-config]
 
 [project-config]: ../../reference/project-config.md
+[autoupdate-plugin]: ./../../plugins/available/autoupdate-v1-alpha.md
+[design-proposal]: ./../../../../../designs/update_action.md

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -126,7 +126,7 @@ Create a Pull Request using the URL below to review the changes:
 
 ## Next steps
 
-Verify the changes
+**Verify the changes**
 - Build the project  
 - Run tests  
 - Confirm everything still works

--- a/pkg/plugins/optional/autoupdate/v1alpha/edit.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/edit.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha/scaffolds"
+)
+
+var _ plugin.EditSubcommand = &editSubcommand{}
+
+type editSubcommand struct {
+	config config.Config
+}
+
+func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+	subcmdMeta.Description = metaDataDescription
+
+	subcmdMeta.Examples = fmt.Sprintf(`  # Edit a common project with this plugin
+  %[1]s edit --plugins=%[2]s
+`, cliMeta.CommandName, pluginKey)
+}
+
+func (p *editSubcommand) InjectConfig(c config.Config) error {
+	p.config = c
+	return nil
+}
+
+func (p *editSubcommand) PreScaffold(machinery.Filesystem) error {
+	if len(p.config.GetCliVersion()) == 0 {
+		return fmt.Errorf(
+			"you must manually upgrade your project to a version that records the CLI version in PROJECT (`cliVersion`) " +
+				"to allow the `alpha update` command to work properly before using this plugin.\n" +
+				"More info: https://book.kubebuilder.io/migrations",
+		)
+	}
+	return nil
+}
+
+func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
+	if err := insertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
+		return fmt.Errorf("error inserting project plugin meta to configuration: %w", err)
+	}
+
+	scaffolder := scaffolds.NewInitScaffolder()
+	scaffolder.InjectFS(fs)
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding edit subcommand: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/plugins/optional/autoupdate/v1alpha/init.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/init.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha/scaffolds"
+)
+
+var _ plugin.InitSubcommand = &initSubcommand{}
+
+type initSubcommand struct {
+	config config.Config
+}
+
+func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
+	subcmdMeta.Description = metaDataDescription
+
+	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a common project with this plugin
+  %[1]s init --plugins=%[2]s
+`, cliMeta.CommandName, pluginKey)
+}
+
+func (p *initSubcommand) InjectConfig(c config.Config) error {
+	p.config = c
+	return nil
+}
+
+func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
+	if err := insertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
+		return fmt.Errorf("error inserting project plugin meta to configuration: %w", err)
+	}
+
+	scaffolder := scaffolds.NewInitScaffolder()
+	scaffolder.InjectFS(fs)
+	if err := scaffolder.Scaffold(); err != nil {
+		return fmt.Errorf("error scaffolding init subcommand: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/plugins/optional/autoupdate/v1alpha/plugin.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/plugin.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha
+
+import (
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/model/stage"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
+)
+
+//nolint:lll
+const metaDataDescription = `This plugin scaffolds a GitHub Action that helps you keep your project aligned with the latest Kubebuilder improvements. With a tiny amount of setup, you’ll receive **automatic issue notifications** whenever a new Kubebuilder release is available. Each issue includes a **compare link** so you can open a Pull Request with one click and review the changes safely.
+
+Under the hood, the workflow runs 'kubebuilder alpha update' using a **3-way merge strategy** to refresh your scaffold while preserving your code. It creates and pushes an update branch, then opens a GitHub **Issue** containing the PR URL you can use to review and merge.
+
+### How to set it up
+
+1) **Add the plugin**: Use the Kubebuilder CLI to scaffold the automation into your repo.
+2) **Review the workflow**: The file '.github/workflows/auto_update.yml' runs on a schedule to check for updates.
+3) **Permissions required** (via the built-in 'GITHUB_TOKEN'):
+   - **contents: write** — needed to create and push the update branch.
+   - **issues: write** — needed to create the tracking Issue with the PR link.
+4) **Protect your branches**: Enable **branch protection rules** so automated changes **cannot** be pushed directly. All updates must go through a Pull Request for review.`
+
+const pluginName = "autoupdate." + plugins.DefaultNameQualifier
+
+var (
+	pluginVersion            = plugin.Version{Number: 1, Stage: stage.Alpha}
+	supportedProjectVersions = []config.Version{cfgv3.Version}
+	pluginKey                = plugin.KeyFor(Plugin{})
+)
+
+// Plugin implements the plugin.Full interface
+type Plugin struct {
+	editSubcommand
+	initSubcommand
+}
+
+var _ plugin.Init = Plugin{}
+
+type pluginConfig struct{}
+
+// Name returns the name of the plugin
+func (Plugin) Name() string { return pluginName }
+
+// Version returns the version of the Helm plugin
+func (Plugin) Version() plugin.Version { return pluginVersion }
+
+// SupportedProjectVersions returns an array with all project versions supported by the plugin
+func (Plugin) SupportedProjectVersions() []config.Version { return supportedProjectVersions }
+
+// GetEditSubcommand will return the subcommand which is responsible for adding and/or edit a autoupdate
+func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
+
+// GetInitSubcommand will return the subcommand which is responsible for init autoupdate plugin
+func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
+
+// DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
+func (p Plugin) DeprecationWarning() string {
+	return ""
+}
+
+// insertPluginMetaToConfig will insert the metadata to the plugin configuration
+func insertPluginMetaToConfig(target config.Config, cfg pluginConfig) error {
+	err := target.DecodePluginConfig(pluginKey, cfg)
+	if !errors.As(err, &config.UnsupportedFieldError{}) {
+		if err != nil && !errors.As(err, &config.PluginKeyNotFoundError{}) {
+			return fmt.Errorf("error decoding plugin configuration: %w", err)
+		}
+
+		if err = target.EncodePluginConfig(pluginKey, cfg); err != nil {
+			return fmt.Errorf("error encoding plugin configuration: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/init.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+	log "log/slog"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github"
+)
+
+var _ plugins.Scaffolder = &initScaffolder{}
+
+type initScaffolder struct {
+	config config.Config
+
+	// fs is the filesystem that will be used by the scaffolder
+	fs machinery.Filesystem
+}
+
+// NewInitScaffolder returns a new Scaffolder for project initialization operations
+func NewInitScaffolder() plugins.Scaffolder {
+	return &initScaffolder{}
+}
+
+// InjectFS implements cmdutil.Scaffolder
+func (s *initScaffolder) InjectFS(fs machinery.Filesystem) {
+	s.fs = fs
+}
+
+// Scaffold implements cmdutil.Scaffolder
+func (s *initScaffolder) Scaffold() error {
+	log.Info("Writing scaffold for you to edit...")
+
+	scaffold := machinery.NewScaffold(s.fs,
+		machinery.WithConfig(s.config),
+	)
+
+	err := scaffold.Execute(
+		&github.AutoUpdate{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to execute init scaffold: %w", err)
+	}
+
+	return nil
+}

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -78,6 +78,10 @@ var _ = Describe("kubebuilder", func() {
 			err := kbc.Edit("--plugins", "grafana.kubebuilder.io/v1-alpha")
 			Expect(err).NotTo(HaveOccurred(), "Failed to edit project to enable Grafana Plugin")
 
+			By("Enabling the AutoUpdate plugin")
+			err = kbc.Edit("--plugins", "autoupdate.kubebuilder.io/v1-alpha")
+			Expect(err).NotTo(HaveOccurred(), "Failed to edit project to enable autoupdate Plugin")
+
 			By("Generate API with Deploy Image plugin")
 			generateAPIWithDeployImage(kbc)
 

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -112,6 +112,9 @@ function scaffold_test_project {
   if [[ $project =~ with-plugins ]] ; then
     header_text 'Editing project with Helm plugin ...'
     $kb edit --plugins=helm.kubebuilder.io/v1-alpha
+
+    header_text 'Editing project with Auto Update plugin ...'
+    $kb edit --plugins=autoupdate.kubebuilder.io/v1-alpha
   fi
 
   # To avoid conflicts

--- a/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
@@ -1,0 +1,64 @@
+name: Auto Update
+
+# The 'kubebuilder alpha update 'command requires write access to the repository to create a branch
+# with the update files and allow you to open a pull request using the link provided in the issue.
+# The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
+# To protect your codebase, please ensure that you have branch protection rules configured for your 
+# main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
+permissions:
+  contents: write
+  issues: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 2" # Every Tuesday at 00:00 UTC
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Step 1: Checkout the repository.
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    
+    # Step 2: Configure Git to create commits with the GitHub Actions bot.
+    - name: Configure Git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    # Step 3: Set up Go environment.
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    # Step 4: Install Kubebuilder.
+    - name: Install Kubebuilder
+      run: |
+        curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
+        chmod +x kubebuilder
+        sudo mv kubebuilder /usr/local/bin/
+        kubebuilder version
+
+    # Step 5: Run the Kubebuilder alpha update command.
+    # More info: https://kubebuilder.io/reference/commands/alpha_update
+    - name: Run kubebuilder alpha update
+      run: |
+       # Executes the update command with specified flags.
+       # --force: Completes the merge even if conflicts occur, leaving conflict markers.
+       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
+       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
+       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
+        kubebuilder alpha update \
+          --force \
+          --push \
+          --restore-path .github/workflows \
+          --open-gh-issue

--- a/testdata/project-v4-with-plugins/PROJECT
+++ b/testdata/project-v4-with-plugins/PROJECT
@@ -7,6 +7,7 @@ domain: testproject.org
 layout:
 - go.kubebuilder.io/v4
 plugins:
+  autoupdate.kubebuilder.io/v1-alpha: {}
   deploy-image.go.kubebuilder.io/v1-alpha:
     resources:
     - domain: testproject.org


### PR DESCRIPTION
Adds an optional plugin that scaffolds a GitHub Actions workflow to keep projects aligned with the latest Kubebuilder scaffold. The workflow runs `kubebuilder alpha update` (3-way merge), pushes an update branch, and opens a GitHub Issue with a compare link so maintainers can open a PR and review safely.
