### PR TITLE
🐛 Fix git branch creation error when `main` already exists

### DIFF
--- a/test/e2e/alphaupdate/update_test.go
+++ b/test/e2e/alphaupdate/update_test.go
@@ -399,7 +399,7 @@ func initializeGitRepo(projectDir string) {
 		{"git", "config", "user.name", "Test User"},
 		{"git", "add", "-A"},
 		{"git", "commit", "-m", "Initial project with custom code"},
-		{"git", "checkout", "-b", "main"},
+		{"git", "branch", "-M", "main"},
 	}
 	for _, args := range commands {
 		cmd := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
Replaces:

```bash
git checkout -b main
```

with:

```bash
git branch -M main
```

in the initialize Git Repo function of the e2e test.

This prevents a fatal error when a developer has the following Git configuration:

```ini
[init]
  defaultBranch = main
```

In such cases, the `main` branch already exists after repository initialization, and `git checkout -b main` fails with:

```
fatal: A branch named 'main' already exists.
```

### Motivation

This change ensures the command works smoothly for all developers, regardless of their Git configuration, improving the reliability of the setup process.

