### PR TITLE
🐛 (alpha update): ensure that by default is used merge.conflictStyle=merge to facilitate the review

### DIFF
--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -146,13 +146,12 @@ make all
 ### Changing Extra Git configs only during the run (does not change your ~/.gitconfig)_
 
 By default, `kubebuilder alpha update` applies safe Git configs:
-`merge.renameLimit=999999`, `diff.renameLimit=999999`.
+`merge.renameLimit=999999`, `diff.renameLimit=999999`, `merge.conflictStyle=merge`
 You can add more, or disable them.
 
 - **Add more on top of defaults**
 ```shell
 kubebuilder alpha update \
-  --git-config merge.conflictStyle=diff3 \
   --git-config rerere.enabled=true
 ```
 

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -54,7 +54,7 @@ Other options:
   • --output-branch: override the output branch name.
   • --push: push the output branch to 'origin' after the update.
   • --git-config: pass per-invocation Git config as -c key=value (repeatable). When not set,
-      defaults to -c merge.renameLimit=999999 to improve rename detection during merges.
+      defaults are set to improve detection during merges.
 
 Defaults:
   • --from-version / --to-version: resolved from PROJECT and the latest release if unset.
@@ -92,7 +92,11 @@ Defaults:
 			}
 
 			// Defaults always on unless "disable" is present anywhere
-			defaults := []string{"merge.renameLimit=999999", "diff.renameLimit=999999"}
+			defaults := []string{
+				"merge.renameLimit=999999",
+				"diff.renameLimit=999999",
+				"merge.conflictStyle=merge",
+			}
 
 			hasDisable := false
 			filtered := make([]string, 0, len(gitCfg))
@@ -150,7 +154,7 @@ Defaults:
 		"git-config",
 		nil,
 		"Per-invocation Git config (repeatable). "+
-			"Defaults: -c merge.renameLimit=999999 -c diff.renameLimit=999999. "+
+			"Defaults: -c merge.renameLimit=999999 -c diff.renameLimit=999999 -c merge.conflictStyle=merge. "+
 			"Your configs are applied on top. To disable defaults, include `--git-config disable`")
 	return updateCmd
 }


### PR DESCRIPTION

Switch default Git config to use `merge.conflictStyle=merge`, so conflicts render as:

```diff
<<<<<<< HEAD
foo
=======
bar
>>>>>>> branch
```

Note after we added the configs this configuration was lost. 