### PR TITLE
🐛 (go/v4) Handle empty CRD directories in Makefile install/uninstall targets

### DIFF
--- a/.github/workflows/test-e2e-samples.yml
+++ b/.github/workflows/test-e2e-samples.yml
@@ -120,4 +120,44 @@ jobs:
       - name: Testing make test-e2e for project-v4-multigroup
         working-directory: testdata/project-v4-multigroup/
         run: |
-          make test-e2e          
+          make test-e2e
+
+  # Test to validate e2e integration when no APIs are scaffolded
+  e2e-test-basic-project:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Verify kind installation
+        run: kind version
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Build kubebuilder CLI from this repo
+        run: make install
+
+      - name: Scaffold empty go/v4 project
+        run: |
+          mkdir -p /tmp/basic-project-v4
+          cd /tmp/basic-project-v4
+          kubebuilder init --plugins go/v4 --domain example.com --repo example.com/empty-operator
+          go mod tidy
+          make
+
+      - name: Run make test-e2e on empty project
+        working-directory: /tmp/basic-project-v4
+        run: make test-e2e

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -158,11 +158,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -154,11 +154,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -158,11 +158,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -233,11 +233,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -154,11 +154,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -154,11 +154,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -154,11 +154,13 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) apply -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
+	if [ -n "$$out" ]; then echo "$$out" | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -; else echo "No CRDs to delete; skipping."; fi
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
## Description

  This PR fixes an issue where `make install` fails on freshly initialized Kubebuilder projects that have no APIs created yet. The
  scaffolded Makefile now gracefully handles missing CRD directories.

  ## Motivation

  When users run `kubebuilder init` without creating any APIs, the `config/crd` directory doesn't exist. This causes `make install` to  fail with: Error: must build at directory: not a valid directory: evalsymlink failure on 'config/crd' : lstat .../config/crd: no such file or directory

  This breaks the basic e2e tests and GitHub Actions workflows for projects in their initial state.

  ## Changes

  1. **Updated Makefile template** (`pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go`):
     - Modified `install` target to check if CRDs exist before attempting to install
     - Modified `uninstall` target with the same graceful handling
     - Both targets now output "No CRDs to install/delete; skipping" when no CRDs exist

  2. **Added e2e test validation** (`.github/workflows/test-e2e-samples.yml`):
     - Added new job `e2e-test-basic-project` to test Scenario 1 from #4977
     - Validates that empty projects (init only, no APIs) work correctly with basic make commands

  ## Testing

  - Built kubebuilder locally with the changes
  - Created test project without APIs
  - Verified `make install` now outputs "No CRDs to install; skipping" instead of failing
  - Confirmed `make uninstall` works similarly

## Motivation

  - Closes #5033
  - Closes https://github.com/kubernetes-sigs/kubebuilder/issues/5097
  Addresses Scenario 1 from #4977