### PR TITLE
🐛 (helm/v1-alpha): When scaffolding a Helm project with webhooks, the generated GitHub Actions workflow now installs and waits for cert-manager. Without webhooks, the cert-manager step remains commented.

### DIFF
--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -88,3 +88,70 @@ jobs:
       - name: Check Presence of ServiceMonitor
         run: |
           kubectl wait --namespace project-v4-with-plugins-system --for=jsonpath='{.kind}'=ServiceMonitor servicemonitor/project-v4-with-plugins-controller-manager-metrics-monitor
+
+  # Test scenario: 
+  # - scaffold project without creating webhooks, 
+  # - deploy helm chart without installing cert manager;
+  # - check that deployment has been deployed;
+  #
+  # Command to use to scaffold project without creating webhooks and so no need to install cert manager:
+  # - kubebuilder init
+  # - kubebuilder create api --group example.com --version v1 --kind App --controller=true --resource=true
+  # - kubebuilder edit --plugins=helm.kubebuilder.io/v1-alpha
+  test-helm-no-webhooks:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install the latest version of kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Create kind cluster
+        run: kind create cluster
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Install kubebuilder binary
+        run: make install
+
+      - name: Create test directory
+        run: mkdir -p test-helm-no-webhooks
+
+      - name: Scaffold project with kubebuilder commands
+        working-directory: test-helm-no-webhooks
+        run: |
+          go mod init test-helm-no-webhooks
+          kubebuilder init
+          kubebuilder create api --group example.com --version v1 --kind App --controller=true --resource=true
+          kubebuilder edit --plugins=helm.kubebuilder.io/v1-alpha
+
+      - name: Build and load Docker image
+        working-directory: test-helm-no-webhooks
+        run: |
+          make docker-build IMG=test-helm-no-webhooks:v0.1.0
+          kind load docker-image test-helm-no-webhooks:v0.1.0
+
+      - name: Lint Helm chart
+        working-directory: test-helm-no-webhooks
+        run: helm lint ./dist/chart
+
+      - name: Deploy Helm chart without cert-manager
+        working-directory: test-helm-no-webhooks
+        run: helm install my-release ./dist/chart --create-namespace --namespace test-helm-no-webhooks-system
+
+      - name: Verify deployment is working
+        working-directory: test-helm-no-webhooks
+        run: |
+          helm status my-release --namespace test-helm-no-webhooks-system

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -47,17 +47,17 @@ jobs:
           helm lint ./dist/chart
 
 # TODO: Uncomment if cert-manager is enabled
-#      - name: Install cert-manager via Helm
-#        run: |
-#          helm repo add jetstack https://charts.jetstack.io
-#          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
-#
-#      - name: Wait for cert-manager to be ready
-#        run: |
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
+      - name: Install cert-manager via Helm
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+
+      - name: Wait for cert-manager to be ready
+        run: |
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
 
 # TODO: Uncomment if Prometheus is enabled
 #      - name: Install Prometheus Operator CRDs

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -58,6 +58,7 @@ jobs:
           kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
           kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
           kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
+
 # TODO: Uncomment if Prometheus is enabled
 #      - name: Install Prometheus Operator CRDs
 #        run: |

--- a/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
@@ -47,17 +47,17 @@ jobs:
           helm lint ./dist/chart
 
 # TODO: Uncomment if cert-manager is enabled
-#      - name: Install cert-manager via Helm
-#        run: |
-#          helm repo add jetstack https://charts.jetstack.io
-#          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
-#
-#      - name: Wait for cert-manager to be ready
-#        run: |
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
-#          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
+      - name: Install cert-manager via Helm
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+
+      - name: Wait for cert-manager to be ready
+        run: |
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-cainjector
+          kubectl wait --namespace cert-manager --for=condition=available --timeout=300s deployment/cert-manager-webhook
 
 # TODO: Uncomment if Prometheus is enabled
 #      - name: Install Prometheus Operator CRDs


### PR DESCRIPTION
This pr implements #5020 

Notes:
- I have added additional comment character `#` in `pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go` so that when we uncomment the whole block TODO comment stays commented; 
- I specified the whole uncomment block as is in pkg/plugins/optional/helm/v1alpha/edit.go similar how it is done now in example given in `pkg/plugins/common/kustomize/v2/scaffolds/webhook.go` let me know if it is better to arrange this block to not repeat the code block :blush: 

Here is an example of a project scaffolded with the set of commands provided in the issue (with kubebuilder build from changes in this pr) **with webhook**:

```sh
kubebuilder init

kubebuilder create api --group example.com --version v1 --kind App --controller=true --resource=true

kubebuilder create webhook --group example.com --version v1 --kind App --defaulting

kubebuilder edit --plugins=helm.kubebuilder.io/v1-alpha
```

https://github.com/n2h9/kubebuilder-init-cm 

github workflows (including install cert manager and install helm) are passing :white_check_mark: 
 
<details>
<summary>screenshot</summary>
<img width="1657" height="943" alt="image" src="https://github.com/user-attachments/assets/7508e3db-def0-4795-9206-2ece5b08cbc2" />
</details>

----

Here is an example of a project scaffolded with the set of commands provided in the issue (with kubebuilder build from changes in this pr) **without webhooks**:
```sh
kubebuilder init

kubebuilder create api --group example.com --version v1 --kind App --controller=true --resource=true

kubebuilder edit --plugins=helm.kubebuilder.io/v1-alpha
```

https://github.com/n2h9/kubebuilder-init-no-cm 

github workflows (including install helm) are passing :white_check_mark: 


<details>
<summary>screenshot</summary>
<img width="1657" height="913" alt="image" src="https://github.com/user-attachments/assets/950e079c-f1b8-4134-9753-d0a288ffff37" />
</details>

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
