### PR TITLE
🌱  (fix): Fix inconsistent logging format  ( Follow up: #4968 )

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"log"
 	"log/slog"
 	"os"
 
@@ -83,9 +82,11 @@ func Run() {
 		cli.WithCompletion(),
 	)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("failed to create CLI", "error", err)
+		os.Exit(1)
 	}
 	if err := c.Run(); err != nil {
-		log.Fatal(err)
+		slog.Error("CLI run failed", "error", err)
+		os.Exit(1)
 	}
 }

--- a/pkg/cli/alpha/generate.go
+++ b/pkg/cli/alpha/generate.go
@@ -14,12 +14,26 @@ limitations under the License.
 package alpha
 
 import (
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal"
+	"sigs.k8s.io/kubebuilder/v4/pkg/logging"
 )
+
+func init() {
+	// Initialize consistent logging for alpha commands
+	opts := logging.HandlerOptions{
+		SlogOpts: slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		},
+	}
+	handler := logging.NewHandler(os.Stdout, opts)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+}
 
 // NewScaffoldCommand returns a new scaffold command, providing the `kubebuilder alpha generate`
 // feature to re-scaffold projects and assist users with updates.
@@ -62,7 +76,8 @@ If no output directory is provided, the current working directory will be cleane
 		},
 		Run: func(_ *cobra.Command, _ []string) {
 			if err := opts.Generate(); err != nil {
-				log.Fatalf("failed to generate project: %s", err)
+				slog.Error("failed to generate project", "error", err)
+				os.Exit(1)
 			}
 		},
 	}

--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -127,7 +127,6 @@ func (opts *Generate) Generate() error {
 	// This is to avoid blocking the migration flow due to non-critical issues during setup.
 	targets := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
 	for _, target := range targets {
-		log.Info("Running make target", "target", target)
 		err := util.RunCmd(fmt.Sprintf("Running make %s", target), "make", target)
 		if err != nil {
 			log.Warn("make target failed", "target", target, "error", err)

--- a/pkg/cli/alpha/internal/update.go
+++ b/pkg/cli/alpha/internal/update.go
@@ -212,7 +212,6 @@ func (opts *Update) cleanUpAncestorBranch() error {
 func runMakeTargets() error {
 	targets := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
 	for _, target := range targets {
-		log.Info("Running make command", "target", target)
 		err := util.RunCmd(fmt.Sprintf("Running make %s", target), "make", target)
 		if err != nil {
 			return fmt.Errorf("make %s failed: %v", target, err)

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -18,12 +18,26 @@ package alpha
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update"
+	"sigs.k8s.io/kubebuilder/v4/pkg/logging"
 )
+
+func init() {
+	// Initialize consistent logging for alpha commands
+	opts := logging.HandlerOptions{
+		SlogOpts: slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		},
+	}
+	handler := logging.NewHandler(os.Stdout, opts)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+}
 
 // NewUpdateCommand creates and returns a new Cobra command for updating Kubebuilder projects.
 func NewUpdateCommand() *cobra.Command {
@@ -119,7 +133,8 @@ Defaults:
 		},
 		Run: func(_ *cobra.Command, _ []string) {
 			if err := opts.Update(); err != nil {
-				log.Fatalf("Update failed: %s", err)
+				slog.Error("Update failed", "error", err)
+				os.Exit(1)
 			}
 		},
 	}

--- a/pkg/plugin/util/exec.go
+++ b/pkg/plugin/util/exec.go
@@ -21,7 +21,6 @@ import (
 	log "log/slog"
 	"os"
 	"os/exec"
-	"strings"
 )
 
 // RunCmd prints the provided message and command and then executes it binding stdout and stderr
@@ -29,7 +28,7 @@ func RunCmd(msg, cmd string, args ...string) error {
 	c := exec.Command(cmd, args...) //nolint:gosec
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	log.Info(msg, "command", strings.Join(c.Args, " "))
+	log.Info(msg)
 
 	if err := c.Run(); err != nil {
 		return fmt.Errorf("error running %q: %w", cmd, err)


### PR DESCRIPTION
(fix): Fix inconsistent logging format 

Follow up: https://github.com/kubernetes-sigs/kubebuilder/pull/4968

Testing alpha update and generate revealed logs were not in the right format.

Changes:
- Initialize consistent logging handler in alpha commands to fix level=info msg= format
- Replace log.Fatalf with slog.Error + os.Exit(1) for proper error handling
- Standardize log imports to use log "log/slog" across all files
- Remove redundant command info from RunCmd logging output
- Ensure all kubebuilder processes use the same colored INFO/WARN format

Before: level=warning msg="Using current working directory..."
After:  WARN Using current working directory...