### PR TITLE
🐛 fix: avoid Docker build failures from missing api/ or internal/ dirs

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/dockerfile.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+)
+
+// ensureDockerfileHasCopy ensures the Dockerfile contains a "COPY src/ dst/" line.
+// If absent, it inserts the line right after the *last* COPY instruction (case-insensitive).
+func ensureDockerfileHasCopy(dockerfilePath, src, dst, label string) error {
+	// Ensure trailing slashes to copy directory contents consistently
+	if !strings.HasSuffix(src, "/") {
+		src += "/"
+	}
+	if !strings.HasSuffix(dst, "/") {
+		dst += "/"
+	}
+	copyStmt := fmt.Sprintf("COPY %s %s", src, dst)
+
+	// Check if Dockerfile exists
+	if _, err := os.Stat(dockerfilePath); os.IsNotExist(err) {
+		slog.Warn("Dockerfile not found, skipping COPY insertion", "path", dockerfilePath, "what", label)
+		return nil
+	}
+
+	// Idempotency check
+	has, err := util.HasFileContentWith(dockerfilePath, copyStmt)
+	if err != nil {
+		slog.Warn("Could not check Dockerfile for COPY", "what", label, "error", err)
+		return fmt.Errorf("unable to find COPY: %s", err)
+	}
+	if has {
+		slog.Debug("COPY already exists in Dockerfile", "what", label, "copy", copyStmt)
+		return fmt.Errorf("COPY already exist: %s", err)
+	}
+
+	// Insert after the last COPY (case-sensitive; matches "COPY ", including "COPY --chown=...")
+	if err := util.InsertAfterLastMatchString(dockerfilePath, "COPY ", copyStmt); err != nil {
+		slog.Warn(
+			"Could not ensure Dockerfile has the required COPY. Please add it manually.",
+			"what", label,
+			"copy", copyStmt,
+			"error", err,
+		)
+		return fmt.Errorf("enable to insert COPY: %w", err)
+	}
+	slog.Info(fmt.Sprintf("Added %s to Dockerfile", copyStmt))
+	return nil
+}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -53,8 +53,6 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/ internal/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/pkg/plugins/golang/v4/scaffolds/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook.go
@@ -153,6 +153,10 @@ You need to implement the conversion.Hub and conversion.Convertible interfaces f
 		}
 	}
 
+	if err := ensureDockerfileHasCopy("Dockerfile", "internal/", "internal/", "Controller"); err != nil {
+		log.Debug("Failed to update Dockerfile for Controller", "error", err)
+	}
+
 	// TODO: remove for go/v5
 	if !s.isLegacy {
 		if hasInternalController, err := pluginutil.HasFileContentWith("Dockerfile", "internal/controller"); err != nil {


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5046

- Default scaffold keeps only COPY cmd/main.go
- COPY api/ api/ is added only when creating an API
- COPY internal/ internal/ is added only when creating a controller or webhook
- If dirs are missing, we warn but do not fail
- Ensures backward compatibility and idempotent Dockerfile updates

**Example**


```
$ kubebuilder init
INFO Writing kustomize manifests for you to edit... 
INFO Writing scaffold for you to edit... 
INFO Get controller runtime 
INFO Update dependencies 
Next: define a resource with:
$ kubebuilder create api



$ make docker-build
docker build -t controller:latest .
[+] Building 22.2s (15/15) FINISHED                                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                                          0.0s
 => => transferring dockerfile: 1.25kB                                                        0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                             0.3s
 => [internal] load metadata for docker.io/library/golang:1.24                                0.0s
 => [internal] load .dockerignore                                                             0.0s
 => => transferring context: 160B                                                             0.0s
 => [builder 1/7] FROM docker.io/library/golang:1.24@sha256:714ad649c558e7d11215af3f168415c7  0.0s
 => => resolve docker.io/library/golang:1.24@sha256:714ad649c558e7d11215af3f168415c765964059  0.0s
 => [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:cdf4daaf154e3e27cfffc799c16f3  0.0s
 => => resolve gcr.io/distroless/static:nonroot@sha256:cdf4daaf154e3e27cfffc799c16f343a38422  0.0s
 => [internal] load build context                                                             0.0s
 => => transferring context: 35.55kB                                                          0.0s
 => CACHED [builder 2/7] WORKDIR /workspace                                                   0.0s
 => CACHED [builder 3/7] COPY go.mod go.mod                                                   0.0s
 => CACHED [builder 4/7] COPY go.sum go.sum                                                   0.0s
 => CACHED [builder 5/7] RUN go mod download                                                  0.0s
 => [builder 6/7] COPY cmd/main.go cmd/main.go                                                0.0s
 => [builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o manager cmd/main  21.6s
 => CACHED [stage-1 2/3] COPY --from=builder /workspace/manager .                             0.0s
 => exporting to image                                                                        0.0s
 => => exporting layers                                                                       0.0s
 => => exporting manifest sha256:0477fc4bc6c097d940164d8f692cfc687a32b27ecdc886d30a1e0e9f0b2  0.0s
 => => exporting config sha256:b8e2697947d49392cf5651546298214596ddc2892f6cd5cb78a59cf2ea0cc  0.0s
 => => exporting attestation manifest sha256:ded6548679a6bd5a568dcff953cdef3769abdffc9fe53e3  0.0s
 => => exporting manifest list sha256:da19be3ff4815b6f22f919d6957bde62a89033a7c41b61011e0dce  0.0s
 => => naming to docker.io/library/controller:latest                                          0.0s
 => => unpacking to docker.io/library/controller:latest                                       0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/jbfe3803xqrkenw5e45nop5z5
```
