### PR TITLE
📖 add note about Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ Before starting any work, please either comment on an existing issue or file a n
 
 ## Operating Systems Supported
 
-Currently, Kubebuilder officially supports macOS and Linux platforms. If you are using a Windows OS, you may encounter issues.
-Contributions towards supporting Windows are welcome.
+Currently, Kubebuilder officially supports macOS and Linux platforms. If you are using a Windows OS, we recommend you read the instructions in [here](docs/windows.md).
+
+Contributions towards supporting Windows are not planned.
 
 ## Versions Compatibility and Supportability
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,11 @@
+# Windows Support
+
+Since no efforts have been made to add support for Windows in the past couple of years, we have decided not to pursue native Windows support at this time, considering both the additional maintenance overhead it adds to the project and the limited community contributions in that area.
+
+That said, it’s still possible to use and contribute to Kubebuilder on a Windows machine by using WSL2 (Windows Subsystem for Linux) together with Docker Desktop.
+
+- Learn more about setting up WSL2 in the [official docs](https://learn.microsoft.com/en-us/windows/wsl/).
+- The [Docker Desktop documentation](https://docs.docker.com/desktop/features/wsl/) has instructions on how to set up Docker to use WSL2 as the backend on Windows.
+- You can also learn more about setting up kind with Docker on WSL2 in the [kind official documentation](https://kind.sigs.k8s.io/docs/user/using-wsl2/).
+
+All other dependencies and environment settings can be set up by following the Linux instructions.


### PR DESCRIPTION
This pull request updates the project's documentation to clarify the status of Windows support and provide guidance for Windows users.

Documentation updates regarding Windows support:

* Updated the `README.md` to direct Windows users to a new `docs/windows.md` file for instructions, and clarified that contributions towards native Windows support are not planned.
* Added a new `docs/windows.md` file explaining that native Windows support is not being pursued, and providing instructions for using Kubebuilder on Windows via **WSL2** and **Docker Desktop**, with links to relevant official documentation.

Closes #2940 