### PR TITLE
🐛 (AutoUpdate/v1-alpha): Adjust comments on Auto Update workflow

### DIFF
--- a/docs/book/src/getting-started/testdata/project/.github/workflows/auto_update.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/auto_update.yml
@@ -58,14 +58,14 @@ jobs:
     # Step 6: Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
+      # Executes the update command with specified flags.
+      # --force: Completes the merge even if conflicts occur, leaving conflict markers.
+      # --push: Automatically pushes the resulting output branch to the 'origin' remote.
+      # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
+      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
+      # --use-gh-models: Adds an AI-generated comment to the created Issue with
+      #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
       run: |
-       # Executes the update command with specified flags.
-       # --force: Completes the merge even if conflicts occur, leaving conflict markers.
-       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
-       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
-       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
-       # --open-gh-models: Adds an AI-generated comment to the created Issue with
-       #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
         kubebuilder alpha update \
           --force \
           --push \

--- a/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github/auto_update.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github/auto_update.go
@@ -102,14 +102,14 @@ jobs:
     # Step 6: Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
+      # Executes the update command with specified flags.
+      # --force: Completes the merge even if conflicts occur, leaving conflict markers.
+      # --push: Automatically pushes the resulting output branch to the 'origin' remote.
+      # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
+      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
+      # --use-gh-models: Adds an AI-generated comment to the created Issue with
+      #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
       run: |
-       # Executes the update command with specified flags.
-       # --force: Completes the merge even if conflicts occur, leaving conflict markers.
-       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
-       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
-       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
-       # --open-gh-models: Adds an AI-generated comment to the created Issue with
-       #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
         kubebuilder alpha update \
           --force \
           --push \

--- a/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
@@ -58,14 +58,14 @@ jobs:
     # Step 6: Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
+      # Executes the update command with specified flags.
+      # --force: Completes the merge even if conflicts occur, leaving conflict markers.
+      # --push: Automatically pushes the resulting output branch to the 'origin' remote.
+      # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
+      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
+      # --use-gh-models: Adds an AI-generated comment to the created Issue with
+      #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
       run: |
-       # Executes the update command with specified flags.
-       # --force: Completes the merge even if conflicts occur, leaving conflict markers.
-       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
-       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
-       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
-       # --open-gh-models: Adds an AI-generated comment to the created Issue with
-       #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
         kubebuilder alpha update \
           --force \
           --push \


### PR DESCRIPTION
This pull request makes a minor adjustment to the Alpha Update workflow by moving comments up and correcting a flag name in the comments. 

* Documentation update: 
  * Changed the flag name from `--open-gh-models` to `--use-gh-models` in the comments above `Run kubebuilder alpha update` step 
  * Moved the comments under `Run kubebuilder alpha update` step up just so the syntax is properly highlighted as a yaml comment

Before:

<img width="1041" height="486" alt="image" src="https://github.com/user-attachments/assets/d9f6b8be-804e-4eb0-86ed-7a3cedc3870c" />


After:

<img width="1051" height="487" alt="image" src="https://github.com/user-attachments/assets/5662a4e3-b44e-4e14-8bcf-b72d4f3c6f6b" />


