### PR TITLE
⚠️ (helm/v1-alpha): Migrate from installCRDs=true to crds.enabled=true in GitHub action `test-chart.yml`

### DIFF
--- a/.github/workflows/test-helm-book.yml
+++ b/.github/workflows/test-helm-book.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 
       - name: Wait for cert-manager to be ready
         run: |

--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 
       - name: Wait for cert-manager to be ready
         run: |

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 
       - name: Wait for cert-manager to be ready
         run: |

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test-chart.yml
@@ -51,7 +51,7 @@ jobs:
 #        run: |
 #          helm repo add jetstack https://charts.jetstack.io
 #          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 #
 #      - name: Wait for cert-manager to be ready
 #        run: |

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 
       - name: Wait for cert-manager to be ready
         run: |

--- a/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/webhook.go
@@ -142,7 +142,7 @@ func (s *webhookScaffolder) Scaffold() error {
 #        run: |
 #          helm repo add jetstack https://charts.jetstack.io
 #          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 #
 #      - name: Wait for cert-manager to be ready
 #        run: |

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -110,7 +110,7 @@ func (p *editSubcommand) PostScaffold() error {
 #        run: |
 #          helm repo add jetstack https://charts.jetstack.io
 #          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 #
 #      - name: Wait for cert-manager to be ready
 #        run: |

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/github/test_chart.go
@@ -97,7 +97,7 @@ jobs:
 #        run: |
 #          helm repo add jetstack https://charts.jetstack.io
 #          helm repo update
-#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+#          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 #
 #      - name: Wait for cert-manager to be ready
 #        run: |

--- a/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           helm repo add jetstack https://charts.jetstack.io
           helm repo update
-          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+          helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true
 
       - name: Wait for cert-manager to be ready
         run: |


### PR DESCRIPTION
The Helm chart flag installCRDs has been replaced with the community-standard crds.enabled. Update your GitHub action `test-chart.yml`to ensure CRDs are installed during chart deployment.
