### PR TITLE
🌱 Introduce Mockable getExecutablePath for Testing in Generate

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -42,6 +42,9 @@ type Generate struct {
 	OutputDir string
 }
 
+// Define a variable to allow overriding the behavior of getExecutablePath for testing.
+var getExecutablePathFunc = getExecutablePath
+
 // Generate handles the migration and scaffolding process.
 func (opts *Generate) Generate() error {
 	projectConfig, err := common.LoadProjectConfig(opts.InputDir)
@@ -144,7 +147,7 @@ func (opts *Generate) Validate() error {
 		return fmt.Errorf("error getting input path %q: %w", opts.InputDir, err)
 	}
 
-	_, err = getExecutablePath()
+	_, err = getExecutablePathFunc()
 	if err != nil {
 		return err
 	}
@@ -188,7 +191,7 @@ func changeWorkingDirectory(outputDir string) error {
 // Initializes the project with Kubebuilder.
 func kubebuilderInit(s store.Store) error {
 	args := append([]string{"init"}, getInitArgs(s)...)
-	execPath, err := getExecutablePath()
+	execPath, err := getExecutablePathFunc()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR refactors the generate.go file to make the getExecutablePath function mockable, enabling better testability for functions that rely on it.

The Executable func was introduced as part of this PR: https://github.com/kubernetes-sigs/kubebuilder/pull/5081 which makes the os to use currently running executable which would fail for our UTs as it would try to use testing executable. With this change, it would enable us to mock according to our testing needs.

Here's the UT PR which I'm currently working on where I had made this change and validated: https://github.com/kubernetes-sigs/kubebuilder/pull/5074.