### PR TITLE
📖 (docs) drop patchStrategy/protobuf tags from Conditions in Getting Started section

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -99,7 +99,10 @@ similar to how we do with any resource from the Kubernetes API.
 ```go
 // MemcachedStatus defines the observed state of Memcached
 type MemcachedStatus struct {
-	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+    // +listType=map
+    // +listMapKey=type
+    // +optional
+    Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 ```
 


### PR DESCRIPTION
Followup of PR #4893

These tags are of no use for CRDs. They have their use
in k8s core types in order to produce proper strategic merge patches, see
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md
but are superseded by +listType and +listMapKey in CRD world.

Added `+listType`, `+listMapKey` and `+optional` markers to the example snippet

