### PR TITLE
🌱 chore: enforce internal package import aliases

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - goconst
     - gocyclo
     - govet
+    - importas
     - ineffassign
     - lll
     - misspell
@@ -34,6 +35,23 @@ linters:
       disable:
         - fieldalignment
       enable-all: true
+    importas:
+      no-unaliased: true
+      alias:
+        - pkg: sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha
+          alias: helmv1alpha
+        - pkg: sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha
+          alias: helmv2alpha
+        - pkg: sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha
+          alias: grafanav1alpha
+        - pkg: "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
+          alias: autoupdatev1alpha
+        - pkg: sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1
+          alias: deployimagev1alpha1
+        - pkg: sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4
+          alias: golangv4
+        - pkg: sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2
+          alias: kustomizecommonv2
     nolintlint:
       allow-unused: false
     revive:
@@ -57,15 +75,16 @@ linters:
         - name: var-naming
           severity: warning
           arguments:
-            - ["ID"]            # allowed initialisms
-            - ["VM"]            # disallowed initialisms
-            - [                 # <-- this is a list containing one map
+            - ["ID"] # allowed initialisms
+            - ["VM"] # disallowed initialisms
+            - [
+                # <-- this is a list containing one map
                 {
                   skip-initialism-name-checks: true,
                   upper-case-const: true,
                   skip-package-name-checks: true,
-                  extra-bad-package-names: ["helpers", "models"]
-                }
+                  extra-bad-package-names: ["helpers", "models"],
+                },
               ]
         - name: var-declaration
         - name: package-comments

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -31,10 +31,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
 	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
-	autoupdatev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
-	grafanav1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
-	helmv1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
-	helmv2alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
+	autoupdatev1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
+	grafanav1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
+	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
+	helmv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
 )
 
 // Run bootstraps & runs the CLI
@@ -71,10 +71,10 @@ func Run() {
 			gov4Bundle,
 			&kustomizecommonv2.Plugin{},
 			&deployimagev1alpha1.Plugin{},
-			&grafanav1alpha1.Plugin{},
-			&helmv1alpha1.Plugin{},
-			&helmv2alpha1.Plugin{},
-			&autoupdatev1alpha1.Plugin{},
+			&grafanav1alpha.Plugin{},
+			&helmv1alpha.Plugin{},
+			&helmv2alpha.Plugin{},
+			&autoupdatev1alpha.Plugin{},
 		),
 		cli.WithPlugins(externalPlugins...),
 		cli.WithDefaultPlugins(cfgv3.Version, gov4Bundle),

--- a/docs/book/src/plugins/extending/extending_cli_features_and_plugins.md
+++ b/docs/book/src/plugins/extending/extending_cli_features_and_plugins.md
@@ -241,7 +241,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	kustomizecommonv2 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
-	deployimage "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
     golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
 
 )
@@ -276,7 +276,7 @@ func GetPluginsCLI() (*cli.CLI) {
 		// Register the plugins options which can be used to do the scaffolds via your CLI tool. See that we are using as example here the plugins which are implemented and provided by Kubebuilder
 		cli.WithPlugins(
 			gov3Bundle,
-			&deployimage.Plugin{},
+			&deployimagev1alpha1.Plugin{},
 		),
 
 		// Defines what will be the default plugin used by your binary. It means that will be the plugin used if no info be provided such as when the user runs `kubebuilder init`

--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -30,11 +30,11 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
-	autoupdate "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
-	hemlv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
-	hemlv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
+	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	autoupdatev1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
+	grafanav1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
+	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
+	helmv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
 )
 
 // Generate store the required info for the command
@@ -240,7 +240,7 @@ func kubebuilderCreate(s store.Store) error {
 // Migrates the Grafana plugin.
 func migrateGrafanaPlugin(s store.Store, src, des string) error {
 	var grafanaPlugin struct{}
-	err := s.Config().DecodePluginConfig(plugin.KeyFor(v1alpha.Plugin{}), grafanaPlugin)
+	err := s.Config().DecodePluginConfig(plugin.KeyFor(grafanav1alpha.Plugin{}), grafanaPlugin)
 	if errors.As(err, &config.PluginKeyNotFoundError{}) {
 		slog.Info("Grafana plugin not found, skipping migration")
 		return nil
@@ -261,7 +261,7 @@ func migrateGrafanaPlugin(s store.Store, src, des string) error {
 
 func migrateAutoUpdatePlugin(s store.Store) error {
 	var autoUpdatePlugin struct{}
-	err := s.Config().DecodePluginConfig(plugin.KeyFor(autoupdate.Plugin{}), autoUpdatePlugin)
+	err := s.Config().DecodePluginConfig(plugin.KeyFor(autoupdatev1alpha.Plugin{}), autoUpdatePlugin)
 	if errors.As(err, &config.PluginKeyNotFoundError{}) {
 		slog.Info("Auto Update plugin not found, skipping migration")
 		return nil
@@ -269,7 +269,7 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 		return fmt.Errorf("failed to decode autoupdate plugin config: %w", err)
 	}
 
-	args := []string{"edit", "--plugins", plugin.KeyFor(v1alpha.Plugin{})}
+	args := []string{"edit", "--plugins", plugin.KeyFor(autoupdatev1alpha.Plugin{})}
 	if err := util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Auto plugin: %w", err)
 	}
@@ -278,8 +278,8 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 
 // Migrates the Deploy Image plugin.
 func migrateDeployImagePlugin(s store.Store) error {
-	var deployImagePlugin v1alpha1.PluginConfig
-	err := s.Config().DecodePluginConfig(plugin.KeyFor(v1alpha1.Plugin{}), &deployImagePlugin)
+	var deployImagePlugin deployimagev1alpha1.PluginConfig
+	err := s.Config().DecodePluginConfig(plugin.KeyFor(deployimagev1alpha1.Plugin{}), &deployImagePlugin)
 	if errors.As(err, &config.PluginKeyNotFoundError{}) {
 		slog.Info("Deploy-image plugin not found, skipping migration")
 		return nil
@@ -297,7 +297,7 @@ func migrateDeployImagePlugin(s store.Store) error {
 }
 
 // Creates an API with Deploy Image plugin.
-func createAPIWithDeployImage(resourceData v1alpha1.ResourceData) error {
+func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) error {
 	args := append([]string{"create", "api"}, getGVKFlagsFromDeployImage(resourceData)...)
 	args = append(args, getDeployImageOptions(resourceData)...)
 	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
@@ -362,7 +362,7 @@ func getGVKFlags(res resource.Resource) []string {
 }
 
 // Gets the GVK flags for a Deploy Image resource.
-func getGVKFlagsFromDeployImage(resourceData v1alpha1.ResourceData) []string {
+func getGVKFlagsFromDeployImage(resourceData deployimagev1alpha1.ResourceData) []string {
 	var args []string
 	if resourceData.Group != "" {
 		args = append(args, "--group", resourceData.Group)
@@ -377,7 +377,7 @@ func getGVKFlagsFromDeployImage(resourceData v1alpha1.ResourceData) []string {
 }
 
 // Gets the options for a Deploy Image resource.
-func getDeployImageOptions(resourceData v1alpha1.ResourceData) []string {
+func getDeployImageOptions(resourceData deployimagev1alpha1.ResourceData) []string {
 	var args []string
 	if resourceData.Options.Image != "" {
 		args = append(args, fmt.Sprintf("--image=%s", resourceData.Options.Image))
@@ -391,7 +391,7 @@ func getDeployImageOptions(resourceData v1alpha1.ResourceData) []string {
 	if resourceData.Options.RunAsUser != "" {
 		args = append(args, fmt.Sprintf("--run-as-user=%s", resourceData.Options.RunAsUser))
 	}
-	args = append(args, fmt.Sprintf("--plugins=%s", plugin.KeyFor(v1alpha1.Plugin{})))
+	args = append(args, fmt.Sprintf("--plugins=%s", plugin.KeyFor(deployimagev1alpha1.Plugin{})))
 	return args
 }
 
@@ -499,7 +499,7 @@ func grafanaConfigMigrate(src, des string) error {
 
 // Edits the project to include the Grafana plugin.
 func kubebuilderGrafanaEdit() error {
-	args := []string{"edit", "--plugins", plugin.KeyFor(v1alpha.Plugin{})}
+	args := []string{"edit", "--plugins", plugin.KeyFor(grafanav1alpha.Plugin{})}
 	if err := util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Grafana plugin: %w", err)
 	}
@@ -512,7 +512,7 @@ func kubebuilderHelmEditWithConfig(s store.Store) error {
 		ManifestsFile string `json:"manifests,omitempty"`
 		OutputDir     string `json:"output,omitempty"`
 	}
-	err := s.Config().DecodePluginConfig(plugin.KeyFor(hemlv2alpha.Plugin{}), &cfg)
+	err := s.Config().DecodePluginConfig(plugin.KeyFor(helmv2alpha.Plugin{}), &cfg)
 	if errors.As(err, &config.PluginKeyNotFoundError{}) {
 		// No previous configuration, use defaults
 		return kubebuilderHelmEdit(true)
@@ -521,7 +521,7 @@ func kubebuilderHelmEditWithConfig(s store.Store) error {
 	}
 
 	// Use tracked configuration values
-	pluginKey := plugin.KeyFor(hemlv2alpha.Plugin{})
+	pluginKey := plugin.KeyFor(helmv2alpha.Plugin{})
 	args := []string{"edit", "--plugins", pluginKey}
 	if cfg.ManifestsFile != "" {
 		args = append(args, "--manifests", cfg.ManifestsFile)
@@ -540,9 +540,9 @@ func kubebuilderHelmEditWithConfig(s store.Store) error {
 func kubebuilderHelmEdit(isV2Alpha bool) error {
 	var pluginKey string
 	if isV2Alpha {
-		pluginKey = plugin.KeyFor(hemlv2alpha.Plugin{})
+		pluginKey = plugin.KeyFor(helmv2alpha.Plugin{})
 	} else {
-		pluginKey = plugin.KeyFor(hemlv1alpha.Plugin{})
+		pluginKey = plugin.KeyFor(helmv1alpha.Plugin{})
 	}
 
 	args := []string{"edit", "--plugins", pluginKey}
@@ -558,13 +558,13 @@ func hasHelmPlugin(cfg store.Store) (bool, bool) {
 	var pluginConfig map[string]interface{}
 
 	// Check for v2alpha first (preferred)
-	err := cfg.Config().DecodePluginConfig(plugin.KeyFor(hemlv2alpha.Plugin{}), &pluginConfig)
+	err := cfg.Config().DecodePluginConfig(plugin.KeyFor(helmv2alpha.Plugin{}), &pluginConfig)
 	if err == nil {
 		return true, true // has helm plugin, is v2alpha
 	}
 
 	// Check for v1alpha
-	err = cfg.Config().DecodePluginConfig(plugin.KeyFor(hemlv1alpha.Plugin{}), &pluginConfig)
+	err = cfg.Config().DecodePluginConfig(plugin.KeyFor(helmv1alpha.Plugin{}), &pluginConfig)
 	if err != nil {
 		// If neither Helm plugin is found, return false
 		if errors.As(err, &config.PluginKeyNotFoundError{}) {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/stage"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
-	goPluginV4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
+	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
 )
 
 func makeMockPluginsFor(projectVersion config.Version, pluginKeys ...string) []plugin.Plugin {
@@ -449,8 +449,8 @@ plugins:
 			It("should create a valid CLI", func() {
 				const version = "version string"
 				c, err = New(
-					WithPlugins(&goPluginV4.Plugin{}),
-					WithDefaultPlugins(projectVersion, &goPluginV4.Plugin{}),
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
 					WithVersion(version),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -479,8 +479,8 @@ plugins:
 		When("enabling completion", func() {
 			It("should create a valid CLI", func() {
 				c, err = New(
-					WithPlugins(&goPluginV4.Plugin{}),
-					WithDefaultPlugins(projectVersion, &goPluginV4.Plugin{}),
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
 					WithCompletion(),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -525,8 +525,8 @@ plugins:
 			It("should create a valid CLI for non-conflicting ones", func() {
 				extraCommand := &cobra.Command{Use: "extra"}
 				c, err = New(
-					WithPlugins(&goPluginV4.Plugin{}),
-					WithDefaultPlugins(projectVersion, &goPluginV4.Plugin{}),
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
 					WithExtraCommands(extraCommand),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -536,8 +536,8 @@ plugins:
 			It("should return an error for conflicting ones", func() {
 				extraCommand := &cobra.Command{Use: "init"}
 				c, err = New(
-					WithPlugins(&goPluginV4.Plugin{}),
-					WithDefaultPlugins(projectVersion, &goPluginV4.Plugin{}),
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
 					WithExtraCommands(extraCommand),
 				)
 				Expect(err).To(HaveOccurred())
@@ -548,8 +548,8 @@ plugins:
 			It("should create a valid CLI for non-conflicting ones", func() {
 				extraAlphaCommand := &cobra.Command{Use: "extra"}
 				c, err = New(
-					WithPlugins(&goPluginV4.Plugin{}),
-					WithDefaultPlugins(projectVersion, &goPluginV4.Plugin{}),
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
 					WithExtraAlphaCommands(extraAlphaCommand),
 				)
 				Expect(err).NotTo(HaveOccurred())
@@ -567,8 +567,8 @@ plugins:
 			It("should return an error for conflicting ones", func() {
 				extraAlphaCommand := &cobra.Command{Use: "extra"}
 				_, err = New(
-					WithPlugins(&goPluginV4.Plugin{}),
-					WithDefaultPlugins(projectVersion, &goPluginV4.Plugin{}),
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
 					WithExtraAlphaCommands(extraAlphaCommand, extraAlphaCommand),
 				)
 				Expect(err).To(HaveOccurred())

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates"
 	charttemplates "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates"
 	templatescertmanager "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds/internal/templates/chart-templates/cert-manager"
@@ -141,7 +141,7 @@ func (s *editScaffolder) getDeployImagesEnvVars() map[string]string {
 		} `json:"resources"`
 	}{}
 
-	err := s.config.DecodePluginConfig(plugin.KeyFor(v1alpha1.Plugin{}), &pluginConfig)
+	err := s.config.DecodePluginConfig(plugin.KeyFor(deployimagev1alpha1.Plugin{}), &pluginConfig)
 	if err == nil {
 		for _, res := range pluginConfig.Resources {
 			image, ok := res.Options["image"]

--- a/test/e2e/alphagenerate/generate_test.go
+++ b/test/e2e/alphagenerate/generate_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
@@ -333,7 +333,7 @@ func validateDeployImagePlugin(projectFile string) {
 	projectConfig := getConfigFromProjectFile(projectFile)
 
 	By("decoding the DeployImage plugin configuration")
-	var deployImageConfig v1alpha1.PluginConfig
+	var deployImageConfig deployimagev1alpha1.PluginConfig
 	err := projectConfig.DecodePluginConfig("deploy-image.go.kubebuilder.io/v1-alpha", &deployImageConfig)
 	Expect(err).NotTo(HaveOccurred(), "Failed to decode DeployImage plugin configuration")
 

--- a/test/e2e/alphagenerate/generate_v4_multigroup_test.go
+++ b/test/e2e/alphagenerate/generate_v4_multigroup_test.go
@@ -24,7 +24,7 @@ import (
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
@@ -400,7 +400,7 @@ func validateV4MultigroupProjectFile(kbc *utils.TestContext, projectFile string)
 		"Wordpress API should have the expected path")
 
 	By("decoding the DeployImage plugin configuration")
-	var deployImageConfig v1alpha1.PluginConfig
+	var deployImageConfig deployimagev1alpha1.PluginConfig
 	err = projectConfig.DecodePluginConfig("deploy-image.go.kubebuilder.io/v1-alpha", &deployImageConfig)
 	Expect(err).NotTo(HaveOccurred(), "Failed to decode DeployImage plugin configuration")
 
@@ -428,7 +428,7 @@ func validateV4MultigroupProjectFile(kbc *utils.TestContext, projectFile string)
 	Expect(options.Image).To(Equal("busybox:1.36.1"), "Expected image to match")
 
 	By("decoding the grafana plugin configuration")
-	var grafanaConfig v1alpha1.PluginConfig
+	var grafanaConfig deployimagev1alpha1.PluginConfig
 	err = projectConfig.DecodePluginConfig("grafana.kubebuilder.io/v1-alpha", &grafanaConfig)
 	Expect(err).NotTo(HaveOccurred(), "Failed to decode DeployImage plugin configuration")
 

--- a/test/e2e/alphagenerate/generate_v4_with_plugins_test.go
+++ b/test/e2e/alphagenerate/generate_v4_with_plugins_test.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
-	hemlv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
+	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	helmv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
@@ -154,7 +154,7 @@ func validateV4WithPluginsProjectFile(kbc *utils.TestContext, projectFile string
 		"Wordpress API should have the expected path")
 
 	By("decoding the DeployImage plugin configuration")
-	var deployImageConfig v1alpha1.PluginConfig
+	var deployImageConfig deployimagev1alpha1.PluginConfig
 	err = projectConfig.DecodePluginConfig("deploy-image.go.kubebuilder.io/v1-alpha", &deployImageConfig)
 	Expect(err).NotTo(HaveOccurred(), "Failed to decode DeployImage plugin configuration")
 
@@ -182,7 +182,7 @@ func validateV4WithPluginsProjectFile(kbc *utils.TestContext, projectFile string
 	Expect(options.Image).To(Equal("busybox:1.36.1"), "Expected image to match")
 
 	By("decoding the grafana plugin configuration")
-	var grafanaConfig v1alpha1.PluginConfig
+	var grafanaConfig deployimagev1alpha1.PluginConfig
 	err = projectConfig.DecodePluginConfig("grafana.kubebuilder.io/v1-alpha", &grafanaConfig)
 	Expect(err).NotTo(HaveOccurred(), "Failed to decode DeployImage plugin configuration")
 
@@ -192,7 +192,7 @@ func validateV4WithPluginsProjectFile(kbc *utils.TestContext, projectFile string
 	By("decoding the helm plugin configuration")
 	var helmConfig map[string]interface{}
 	// Use the proper plugin key from the plugin package
-	pluginKey := plugin.KeyFor(hemlv2alpha.Plugin{})
+	pluginKey := plugin.KeyFor(helmv2alpha.Plugin{})
 	err = projectConfig.DecodePluginConfig(pluginKey, &helmConfig)
 	Expect(err).NotTo(HaveOccurred(), "Failed to decode Helm plugin configuration")
 


### PR DESCRIPTION
As we have some inconsistency on few aliased imports (typo, different alias naming) which also leads to using wrong packages in one/two code path
