### PR TITLE
✨: Add *.kubeconfig to .gitignore.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig

--- a/docs/book/src/getting-started/testdata/project/.gitignore
+++ b/docs/book/src/getting-started/testdata/project/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig

--- a/docs/book/src/multiversion-tutorial/testdata/project/.gitignore
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gitignore.go
@@ -65,4 +65,7 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig
 `

--- a/testdata/project-v4-multigroup/.gitignore
+++ b/testdata/project-v4-multigroup/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig

--- a/testdata/project-v4-with-plugins/.gitignore
+++ b/testdata/project-v4-with-plugins/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig

--- a/testdata/project-v4/.gitignore
+++ b/testdata/project-v4/.gitignore
@@ -25,3 +25,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Kubeconfig might contain secrets
+*.kubeconfig


### PR DESCRIPTION
Add *.kubeconfig to .gitignore.

The file might contain secrets, and should usually not be stored in git.

