### PR TITLE
🐛  (helm/v2-alpha): Fixed an issue where the `ServiceMonitor` resource name did not include the default prefix applied by Kustomize. 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: project
         control-plane: controller-manager
-    name: {{ include "chart.name" . }}-controller-manager-metrics-monitor
+    name: project-controller-manager-metrics-monitor
     namespace: {{ .Release.Namespace }}
 spec:
     endpoints:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -6,7 +6,7 @@ metadata:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: project
         control-plane: controller-manager
-    name: {{ include "chart.name" . }}-controller-manager-metrics-monitor
+    name: project-controller-manager-metrics-monitor
     namespace: {{ .Release.Namespace }}
 spec:
     endpoints:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
@@ -44,7 +44,8 @@ func NewChartWriter(templater *HelmTemplater, outputDir string) *ChartWriter {
 }
 
 // WriteResourceGroup writes a group of resources to a Helm template file
-func (w *ChartWriter) WriteResourceGroup(fs machinery.Filesystem, groupName string,
+func (w *ChartWriter) WriteResourceGroup(
+	fs machinery.Filesystem, groupName string,
 	resources []*unstructured.Unstructured,
 ) error {
 	// Special handling for namespace - write as single file
@@ -73,7 +74,8 @@ func (w *ChartWriter) writeNamespaceFile(fs machinery.Filesystem, namespace *uns
 }
 
 // writeGroupDirectory writes resources as files in a group-specific directory
-func (w *ChartWriter) writeGroupDirectory(fs machinery.Filesystem, groupName string,
+func (w *ChartWriter) writeGroupDirectory(
+	fs machinery.Filesystem, groupName string,
 	resources []*unstructured.Unstructured,
 ) error {
 	var finalContent bytes.Buffer
@@ -112,7 +114,8 @@ func (w *ChartWriter) shouldSplitFiles(groupName string) bool {
 }
 
 // writeSplitFiles writes each resource in the group to its own file
-func (w *ChartWriter) writeSplitFiles(fs machinery.Filesystem, groupName string,
+func (w *ChartWriter) writeSplitFiles(
+	fs machinery.Filesystem, groupName string,
 	resources []*unstructured.Unstructured,
 ) error {
 	// Create the group directory

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -389,6 +389,23 @@ metadata:
 			Expect(result).To(ContainSubstring("name: test-project-controller-manager"))
 			Expect(result).NotTo(ContainSubstring("{{ include"))
 		})
+		It("should preserve name for ServiceMonitor", func() {
+			serviceMonitorResource := &unstructured.Unstructured{}
+			serviceMonitorResource.SetAPIVersion("monitoring.coreos.com/v1")
+			serviceMonitorResource.SetKind("ServiceMonitor")
+			serviceMonitorResource.SetName("test-project-controller-manager-metrics-monitor")
+
+			content := `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: test-project-controller-manager-metrics-monitor`
+
+			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
+
+			// Name should remain unchanged
+			Expect(result).To(ContainSubstring("name: test-project-controller-manager-metrics-monitor"))
+			Expect(result).NotTo(ContainSubstring("{{ include"))
+		})
 	})
 
 	Context("edge cases", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_test.go
@@ -283,4 +283,42 @@ spec:
 			Expect(issuer.GetKind()).To(Equal("Issuer"))
 		})
 	})
+
+	Context("with custom prefix", func() {
+		BeforeEach(func() {
+			yamlContent := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ln-controller-manager
+  namespace: long-name-test-system
+spec:
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ln-controller-manager-metrics-service
+  namespace: long-name-test-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: 8443
+  selector:
+    control-plane: ln-controller-manager
+`
+			err := os.WriteFile(tempFile, []byte(yamlContent), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			parser = NewParser(tempFile)
+		})
+
+		It("should use the correct prefix", func() {
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resources.EstimatePrefix("long-name")).To(Equal("ln"))
+		})
+	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -29,7 +29,12 @@ var _ machinery.Template = &ServiceMonitor{}
 // ServiceMonitor scaffolds a ServiceMonitor for Prometheus monitoring in the Helm chart
 type ServiceMonitor struct {
 	machinery.TemplateMixin
-	machinery.ProjectNameMixin
+
+	// Prefix
+	NamePrefix string
+
+	// ServiceName is the full name of the metrics service, derived from Kustomize
+	ServiceName string
 
 	// OutputDir specifies the output directory for the chart
 	OutputDir string
@@ -59,7 +64,7 @@ metadata:
   labels:
     {{ "{{- include \"chart.labels\" . | nindent 4 }}" }}
     control-plane: controller-manager
-  name: {{ .ProjectName }}-controller-manager-metrics-monitor
+  name: {{ .NamePrefix }}-controller-manager-metrics-monitor
   namespace: {{ "{{ .Release.Namespace }}" }}
 spec:
   endpoints:
@@ -69,7 +74,7 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         {{ "{{- if .Values.certManager.enable }}" }}
-        serverName: {{ .ProjectName }}-controller-manager-metrics-service.{{ "{{ .Release.Namespace }}" }}.svc
+        serverName: {{ .ServiceName }}.{{ "{{ .Release.Namespace }}" }}.svc
         # Apply secure TLS configuration with cert-manager
         insecureSkipVerify: false
         ca:


### PR DESCRIPTION
**Background:**
When working with long names, you will often need to use a shortened (or abbreviated) version of the controller name as the `namePrefix` in the `kustomization.yaml` file. This means a shorter name can be used as the prefix to all the files.

When using the `v2alpha/helm` plugin, this _mostly_ works. The only resource that doesn't use the name generated by Kustomize is the `ServiceMonitor`. This is problematic, as it will use the name (with the custom prefix), then template the chart name (usually the long name) in front of it. This leads to a broken installation.

**The fix:**
This PR fixes this by attempting to get the `namePrefix` from the kustomization config path. If the `namePrefix` and the `projectName` are different, we do not template the file for the service monitor. This way, customisations are honoured, but existing behaviour is maintained.