### PR TITLE
 🐛 Fix flakes in e2e tests for metrics

### DIFF
--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_test.go
@@ -211,6 +211,8 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 
+			// +kubebuilder:scaffold:e2e-webhooks-readiness
+
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,

--- a/docs/book/src/reference/markers/scaffold.md
+++ b/docs/book/src/reference/markers/scaffold.md
@@ -107,6 +107,7 @@ properly registered with the manager, so that the controller can reconcile the r
 | `+kubebuilder:scaffold:crdkustomizecainjectioname`                           | `config/default`             | Marks where CA injection patches are added for the conversion webhooks.                                                                                                                |
 | **(No longer supported)** `+kubebuilder:scaffold:crdkustomizecainjectionpatch` | `config/crd`                 | Marks where CA injection patches are added for the webhooks. Replaced by `+kubebuilder:scaffold:crdkustomizecainjectionns` and `+kubebuilder:scaffold:crdkustomizecainjectioname`  |
 | `+kubebuilder:scaffold:manifestskustomizesamples` | `config/samples`           | Marks where Kustomize sample manifests are injected.                            |
+| `+kubebuilder:scaffold:e2e-webhooks-readiness` | `test/e2e`                   | Adds webhooks readiness checks in e2e tests before metrics collection.          |
 | `+kubebuilder:scaffold:e2e-webhooks-checks` | `test/e2e`                   | Adds e2e checks for webhooks depending on the types of webhooks scaffolded.      |
 
 <aside class="note warning">

--- a/testdata/project-v4-multigroup/test/e2e/e2e_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_test.go
@@ -211,6 +211,41 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 
+			By("waiting for webhook service to be ready")
+			verifyWebhookServiceReady := func(g Gomega) {
+				const webhookServiceName = "project-v4-multigroup-webhook-service"
+
+				// Webhook service should exist since webhooks are configured
+				cmd := exec.Command("kubectl", "get", "service", webhookServiceName, "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook service should exist but was not found")
+
+				// Check if webhook server is ready by verifying pod readiness
+				cmd = exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+					"-n", namespace, "-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"),
+					"Controller manager pod not ready (webhook server may not be accepting connections)")
+
+				// Check if webhook service endpoints are available
+				cmd = exec.Command("kubectl", "get", "endpoints", webhookServiceName,
+					"-n", namespace, "-o", "jsonpath={.subsets[*].addresses[*].ip}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "Webhook service endpoints are not ready")
+
+				// Test webhook connectivity by checking if webhook server port is responding
+				cmd = exec.Command("kubectl", "run", "webhook-test", "--rm", "-i", "--restart=Never",
+					"--image=curlimages/curl:latest", "--",
+					"curl", "-k", "--connect-timeout", "5",
+					"https://"+webhookServiceName+"."+namespace+".svc:443/readyz")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook server not responding on port 443")
+			}
+			Eventually(verifyWebhookServiceReady, 2*time.Minute).Should(Succeed())
+			// +kubebuilder:scaffold:e2e-webhooks-readiness
+
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_test.go
@@ -211,6 +211,41 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 
+			By("waiting for webhook service to be ready")
+			verifyWebhookServiceReady := func(g Gomega) {
+				const webhookServiceName = "project-v4-with-plugins-webhook-service"
+
+				// Webhook service should exist since webhooks are configured
+				cmd := exec.Command("kubectl", "get", "service", webhookServiceName, "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook service should exist but was not found")
+
+				// Check if webhook server is ready by verifying pod readiness
+				cmd = exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+					"-n", namespace, "-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"),
+					"Controller manager pod not ready (webhook server may not be accepting connections)")
+
+				// Check if webhook service endpoints are available
+				cmd = exec.Command("kubectl", "get", "endpoints", webhookServiceName,
+					"-n", namespace, "-o", "jsonpath={.subsets[*].addresses[*].ip}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "Webhook service endpoints are not ready")
+
+				// Test webhook connectivity by checking if webhook server port is responding
+				cmd = exec.Command("kubectl", "run", "webhook-test", "--rm", "-i", "--restart=Never",
+					"--image=curlimages/curl:latest", "--",
+					"curl", "-k", "--connect-timeout", "5",
+					"https://"+webhookServiceName+"."+namespace+".svc:443/readyz")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook server not responding on port 443")
+			}
+			Eventually(verifyWebhookServiceReady, 2*time.Minute).Should(Succeed())
+			// +kubebuilder:scaffold:e2e-webhooks-readiness
+
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,

--- a/testdata/project-v4/test/e2e/e2e_test.go
+++ b/testdata/project-v4/test/e2e/e2e_test.go
@@ -211,6 +211,41 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyMetricsServerStarted).Should(Succeed())
 
+			By("waiting for webhook service to be ready")
+			verifyWebhookServiceReady := func(g Gomega) {
+				const webhookServiceName = "project-v4-webhook-service"
+
+				// Webhook service should exist since webhooks are configured
+				cmd := exec.Command("kubectl", "get", "service", webhookServiceName, "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook service should exist but was not found")
+
+				// Check if webhook server is ready by verifying pod readiness
+				cmd = exec.Command("kubectl", "get", "pods", "-l", "control-plane=controller-manager",
+					"-n", namespace, "-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("True"),
+					"Controller manager pod not ready (webhook server may not be accepting connections)")
+
+				// Check if webhook service endpoints are available
+				cmd = exec.Command("kubectl", "get", "endpoints", webhookServiceName,
+					"-n", namespace, "-o", "jsonpath={.subsets[*].addresses[*].ip}")
+				output, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty(), "Webhook service endpoints are not ready")
+
+				// Test webhook connectivity by checking if webhook server port is responding
+				cmd = exec.Command("kubectl", "run", "webhook-test", "--rm", "-i", "--restart=Never",
+					"--image=curlimages/curl:latest", "--",
+					"curl", "-k", "--connect-timeout", "5",
+					"https://"+webhookServiceName+"."+namespace+".svc:443/readyz")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Webhook server not responding on port 443")
+			}
+			Eventually(verifyWebhookServiceReady, 2*time.Minute).Should(Succeed())
+			// +kubebuilder:scaffold:e2e-webhooks-readiness
+
 			By("creating the curl-metrics pod to access the metrics endpoint")
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/kubebuilder/issues/5137

By looking at the logs, looks like during the curl metrics pod creation, calls to the webhook is failing due to connection refused. So added precheck to ensure the webhook is ready before beginning with the pod creation.

Validation
---
Ran the e2e tests multiple times here and did not see the flakes: https://github.com/mayuka-c/kubebuilder/actions/runs/18582517449

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
