### PR TITLE
✨ (go/v4): Add allowed files about tools version management files in go init v4

### DIFF
--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -168,7 +168,7 @@ func checkDir() error {
 			}
 
 			// Only care about top-level files and directories
-			if strings.Count(path, string(os.PathSeparator)) > 1 {
+			if strings.Count(path, string(os.PathSeparator)) > 0 {
 				return nil
 			}
 


### PR DESCRIPTION
### Motivation

I'm using mise-en-place to manage my tools versions. When I want to create a new kubebuilder project. I start by creating a `mise.toml`  file with the versions of go and kubebuilder I want to use. Then run the `kubebuilder init ...`  command. Since .toml files are allowed, I get the error 

```
ERROR CLI run failed error=error executing command: failed to initialize project: unable to run pre-scaffold tasks of "base.go.kubebuilder.io/v4": error walking directory: target directory is not empty and contains a disallowed file "mise.toml". files with the following extensions [.go, .yaml, .mod, .sum] are not allowed to avoid conflicts with the tooling
```

I would like to be able to use mise tool stack,  so we need to allow tools management files like mise-en-place and asdf.

### Description of the change

Adding a simple check of the filename against an hardcoded list. It's the same principle as for the extension check but against the whole filename.

### Prerequisites

- [ ] make test-unit : FAILED, even on master I was not able to run the unit tests successfully
- [X] make install
- [X] make lint 
- [X] make check-testdata
- [ ] make test-e2e-local: FAILED, even on master I was not able to run the e2e tests successfully ( unlinkat /usr/bin/kustomize: permission denied, i didn't look further)
- [X] Manual test using the compiled binary (empty dir with mise.toml, then kubebuilder init, ok)