### PR TITLE
✨ (helm/v2alpha) Extract image and resources from kustomize

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -34,7 +34,12 @@ spec:
                     {{- end }}
                   command:
                     - /manager
+                  {{- if .Values.controllerManager.image.digest }}
+                  image: "{{ .Values.controllerManager.image.repository }}@{{ .Values.controllerManager.image.digest }}"
+                  {{- else }}
                   image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
+                  {{- end }}
+                  imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -52,13 +57,10 @@ spec:
                         port: 8081
                     initialDelaySeconds: 5
                     periodSeconds: 10
+                  {{- with .Values.controllerManager.resources }}
                   resources:
-                    limits:
-                        cpu: 500m
-                        memory: 128Mi
-                    requests:
-                        cpu: 10m
-                        memory: 64Mi
+{{- toYaml . | nindent 20 }}
+                  {{- end }}
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -28,7 +28,12 @@ spec:
                     - --health-probe-bind-address=:8081
                   command:
                     - /manager
+                  {{- if .Values.controllerManager.image.digest }}
+                  image: "{{ .Values.controllerManager.image.repository }}@{{ .Values.controllerManager.image.digest }}"
+                  {{- else }}
                   image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
+                  {{- end }}
+                  imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -43,13 +48,10 @@ spec:
                         port: 8081
                     initialDelaySeconds: 5
                     periodSeconds: 10
+                  {{- with .Values.controllerManager.resources }}
                   resources:
-                    limits:
-                        cpu: 500m
-                        memory: 128Mi
-                    requests:
-                        cpu: 10m
-                        memory: 64Mi
+{{- toYaml . | nindent 20 }}
+                  {{- end }}
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -34,7 +34,12 @@ spec:
                     {{- end }}
                   command:
                     - /manager
+                  {{- if .Values.controllerManager.image.digest }}
+                  image: "{{ .Values.controllerManager.image.repository }}@{{ .Values.controllerManager.image.digest }}"
+                  {{- else }}
                   image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
+                  {{- end }}
+                  imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -52,13 +57,10 @@ spec:
                         port: 8081
                     initialDelaySeconds: 5
                     periodSeconds: 10
+                  {{- with .Values.controllerManager.resources }}
                   resources:
-                    limits:
-                        cpu: 500m
-                        memory: 128Mi
-                    requests:
-                        cpu: 10m
-                        memory: 64Mi
+{{- toYaml . | nindent 20 }}
+                  {{- end }}
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -158,6 +158,12 @@ var _ = Describe("ChartConverter", func() {
 			Expect(config).NotTo(BeNil())
 			Expect(config).To(HaveKey("env"))
 			Expect(config).To(HaveKey("resources"))
+
+			// Verify image extraction
+			Expect(config).To(HaveKey("image"))
+			imageConfig := config["image"].(map[string]interface{})
+			Expect(imageConfig["repository"]).To(Equal("controller"))
+			Expect(imageConfig["tag"]).To(Equal("latest"))
 		})
 
 		It("should handle deployment without containers", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -219,8 +219,8 @@ func (t *HelmTemplater) substituteRBACValues(yamlContent string) string {
 func (t *HelmTemplater) templateDeploymentFields(yamlContent string) string {
 	// Template configuration fields
 	yamlContent = t.templateImageReference(yamlContent)
-	yamlContent = t.templateEnvironmentVariables(yamlContent)
 	yamlContent = t.templateResources(yamlContent)
+	yamlContent = t.templateEnvironmentVariables(yamlContent)
 	yamlContent = t.templateSecurityContexts(yamlContent)
 	yamlContent = t.templateVolumeMounts(yamlContent)
 	yamlContent = t.templateVolumes(yamlContent)
@@ -237,9 +237,115 @@ func (t *HelmTemplater) templateEnvironmentVariables(yamlContent string) string 
 
 // templateResources converts resource sections to Helm templates
 func (t *HelmTemplater) templateResources(yamlContent string) string {
-	// This ensures that volumeMounts, volumes, and other fields are preserved
-	// The resources will remain as-is from the kustomize output and can be templated later
-	return yamlContent
+	// Find the containers: block and its indent
+	contHdr := regexp.MustCompile(`(?m)^(\s*)containers:\s*$`)
+	hdrLoc := contHdr.FindStringSubmatchIndex(yamlContent)
+	if hdrLoc == nil {
+		return yamlContent
+	}
+
+	// Find list items - they should be after containers:
+	afterContainers := yamlContent[hdrLoc[1]:]
+
+	// Find first list item to determine actual indentation
+	firstItemRe := regexp.MustCompile(`(?m)^(\s*)- `)
+	firstItemMatch := firstItemRe.FindStringSubmatchIndex(afterContainers)
+	if firstItemMatch == nil {
+		return yamlContent
+	}
+
+	itemIndent := afterContainers[firstItemMatch[2]:firstItemMatch[3]]
+
+	// Process with the detected indentation
+	rest := afterContainers
+	itemRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(itemIndent) + `- `)
+
+	var out strings.Builder
+	out.WriteString(yamlContent[:hdrLoc[1]])
+	idx := 0
+	for {
+		start := itemRe.FindStringIndex(rest[idx:])
+		if start == nil {
+			out.WriteString(rest[idx:])
+			break
+		}
+		// Absolute bounds in 'rest'
+		s := idx + start[0]
+		e := idx + start[1]
+
+		// Find end of this item: next item at same indent (search from end of current match)
+		next := itemRe.FindStringIndex(rest[e:])
+		itemEnd := len(rest)
+		if next != nil {
+			itemEnd = e + next[0]
+		}
+		item := rest[s:itemEnd]
+
+		// Only touch the item that has name: manager|controller-manager
+		// Handle both cases: "- name: manager" and separate "  name: manager" lines
+		// Capture the indent from the name line for consistent field alignment
+		nameRe := regexp.MustCompile(`(?m)^([ \t]*)-?\s*name:\s*(manager|controller-manager)\s*$`)
+		nameMatch := nameRe.FindStringSubmatchIndex(item)
+		if nameMatch != nil {
+			// If already templated, do nothing to avoid double insertion
+			if !strings.Contains(item, "{{- with .Values.controllerManager.resources }}") {
+				// Get the indent for fields in this container
+				rawIndent := item[nameMatch[2]:nameMatch[3]]
+				// If the name is on the same line as "- ", we need to add 2 spaces for field indentation
+				// Otherwise, use the existing indentation
+				indent := rawIndent
+				if strings.Contains(item[nameMatch[0]:nameMatch[1]], "- ") {
+					indent = rawIndent + "  " // Add 2 spaces for field alignment after "- "
+				}
+				nindent := len(indent) + 2
+
+				// Build resources template with proper indentation
+				resourcesTemplate := indent + `{{- with .Values.controllerManager.resources }}` + "\n" +
+					indent + `resources:` + "\n" +
+					`{{- toYaml . | nindent ` + fmt.Sprint(nindent) + ` }}` + "\n" +
+					indent + `{{- end }}`
+
+				// Find the resources section specifically
+				// Look for "resources:" at the correct indent, then find where it ends
+				resStartRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(indent) + `resources:\s*$`)
+				if resMatch := resStartRe.FindStringIndex(item); resMatch != nil {
+					// Find where the resources section ends (next field at same indent level)
+					afterResources := item[resMatch[1]:]
+
+					// Look for the next field at the same indentation level
+					nextFieldRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(indent) + `[a-zA-Z]`)
+					endMatch := nextFieldRe.FindStringIndex(afterResources)
+
+					var resourcesEnd int
+					if endMatch != nil {
+						// Found next field, resources ends there
+						resourcesEnd = resMatch[1] + endMatch[0]
+					} else {
+						// No next field, resources goes to end of container
+						resourcesEnd = len(item)
+					}
+
+					// Replace just the resources section
+					item = item[:resMatch[0]] + resourcesTemplate + "\n" + item[resourcesEnd:]
+				} else {
+					// Prefer insertion right after the image digest/tag conditional end if present
+					endRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(indent) + `{{- end }}\s*$`)
+					if m := endRe.FindStringIndex(item); m != nil {
+						item = item[:m[1]] + "\n" + resourcesTemplate + "\n" + item[m[1]:]
+					} else {
+						// Fallback: insert immediately after the "name: manager" line
+						nameLineRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(indent) + `name:\s*(manager|controller-manager)\s*$`)
+						item = nameLineRe.ReplaceAllString(item, `$0`+"\n"+resourcesTemplate+"\n")
+					}
+				}
+			}
+		}
+
+		out.WriteString(rest[idx:s])
+		out.WriteString(item)
+		idx = itemEnd
+	}
+	return out.String()
 }
 
 // templateSecurityContexts preserves security contexts from kustomize output
@@ -265,27 +371,106 @@ func (t *HelmTemplater) templateVolumes(yamlContent string) string {
 
 // templateImageReference converts hardcoded image references to Helm templates
 func (t *HelmTemplater) templateImageReference(yamlContent string) string {
-	// Replace hardcoded controller image with Helm template
-	// This handles the common case where kustomize outputs "controller:latest"
-	// or other hardcoded image references
-	imagePattern := regexp.MustCompile(`(\s+)image:\s+controller:latest`)
-	yamlContent = imagePattern.ReplaceAllString(yamlContent,
-		`${1}image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"`)
+	// Find the containers: block and its indent
+	contHdr := regexp.MustCompile(`(?m)^(\s*)containers:\s*$`)
+	hdrLoc := contHdr.FindStringSubmatchIndex(yamlContent)
+	if hdrLoc == nil {
+		return yamlContent
+	}
 
-	// Also handle any other common image patterns that might appear
-	imagePattern2 := regexp.MustCompile(`(\s+)image:\s+([^"'\s]+):(latest|[\w\.\-]+)`)
-	yamlContent = imagePattern2.ReplaceAllStringFunc(yamlContent, func(match string) string {
-		// Only replace if it looks like a controller image (contains "controller" or "manager")
-		if strings.Contains(match, "controller") || strings.Contains(match, "manager") {
-			indentMatch := regexp.MustCompile(`^(\s+)`)
-			indent := indentMatch.FindString(match)
-			return fmt.Sprintf(
-				`%simage: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"`, indent)
+	// Find list items - they should be after containers:
+	afterContainers := yamlContent[hdrLoc[1]:]
+
+	// Find first list item to determine actual indentation
+	firstItemRe := regexp.MustCompile(`(?m)^(\s*)- `)
+	firstItemMatch := firstItemRe.FindStringSubmatchIndex(afterContainers)
+	if firstItemMatch == nil {
+		return yamlContent
+	}
+
+	itemIndent := afterContainers[firstItemMatch[2]:firstItemMatch[3]]
+
+	// Process with the detected indentation
+	rest := afterContainers
+	itemRe := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(itemIndent) + `- `)
+
+	var out strings.Builder
+	out.WriteString(yamlContent[:hdrLoc[1]])
+
+	idx := 0
+	for {
+		start := itemRe.FindStringIndex(rest[idx:])
+		if start == nil {
+			out.WriteString(rest[idx:])
+			break
 		}
-		return match
-	})
+		// Absolute bounds in 'rest'
+		s := idx + start[0]
+		e := idx + start[1]
 
-	return yamlContent
+		// Find end of this item: next item at same indent (search from end of current match)
+		next := itemRe.FindStringIndex(rest[e:])
+		itemEnd := len(rest)
+		if next != nil {
+			itemEnd = e + next[0]
+		}
+		item := rest[s:itemEnd]
+
+		// Only touch the item that has name: manager|controller-manager
+		// Handle both cases: "- name: manager" and separate "  name: manager" lines
+		// Capture the indent from the name line for consistent field alignment
+		nameRe := regexp.MustCompile(`(?m)^([ \t]*)-?\s*name:\s*(manager|controller-manager)\s*$`)
+		nameMatch := nameRe.FindStringSubmatchIndex(item)
+		if nameMatch != nil {
+			// Get the indent for fields in this container
+			rawIndent := item[nameMatch[2]:nameMatch[3]]
+			// If the name is on the same line as "- ", we need to add 2 spaces for field indentation
+			// Otherwise, use the existing indentation
+			indent := rawIndent
+			if strings.Contains(item[nameMatch[0]:nameMatch[1]], "- ") {
+				indent = rawIndent + "  " // Add 2 spaces for field alignment after "- "
+			}
+
+			// Build the image block with proper indentation
+			imageBlock :=
+				indent + `{{- if .Values.controllerManager.image.digest }}` + "\n" +
+					indent + `image: "{{ .Values.controllerManager.image.repository }}@{{ .Values.controllerManager.image.digest }}"` + "\n" +
+					indent + `{{- else }}` + "\n" +
+					indent + `image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"` + "\n" +
+					indent + `{{- end }}`
+
+			// Replace existing image line or insert after name
+			imgLineRe := regexp.MustCompile(`(?m)^[ \t]*image:\s*.*$`)
+			if imgLineRe.MatchString(item) {
+				item = imgLineRe.ReplaceAllString(item, imageBlock)
+			} else {
+				// Insert after name line
+				item = nameRe.ReplaceAllString(item, `$0`+"\n"+imageBlock)
+			}
+
+			// Handle imagePullPolicy without relying on backrefs
+			ppRe := regexp.MustCompile(`(?m)^[ \t]*imagePullPolicy:\s*.*$`)
+			if ppRe.MatchString(item) {
+				item = ppRe.ReplaceAllStringFunc(item, func(_ string) string {
+					return indent + `imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"`
+				})
+			} else {
+				// Insert immediately after the image block
+				endLine := indent + `{{- end }}`
+				item = strings.Replace(
+					item,
+					endLine,
+					endLine+"\n"+indent+`imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"`,
+					1,
+				)
+			}
+		}
+
+		out.WriteString(rest[idx:s])
+		out.WriteString(item)
+		idx = itemEnd
+	}
+	return out.String()
 }
 
 // makeWebhookAnnotationsConditional makes only cert-manager annotations conditional, not the entire webhook

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -36,7 +36,12 @@ spec:
                       value: busybox:1.36.1
                     - name: MEMCACHED_IMAGE
                       value: memcached:1.6.26-alpine3.19
+                  {{- if .Values.controllerManager.image.digest }}
+                  image: "{{ .Values.controllerManager.image.repository }}@{{ .Values.controllerManager.image.digest }}"
+                  {{- else }}
                   image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
+                  {{- end }}
+                  imagePullPolicy: "{{ .Values.controllerManager.image.pullPolicy }}"
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -54,13 +59,10 @@ spec:
                         port: 8081
                     initialDelaySeconds: 5
                     periodSeconds: 10
+                  {{- with .Values.controllerManager.resources }}
                   resources:
-                    limits:
-                        cpu: 500m
-                        memory: 128Mi
-                    requests:
-                        cpu: 10m
-                        memory: 64Mi
+{{- toYaml . | nindent 20 }}
+                  {{- end }}
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:


### PR DESCRIPTION
Ensures Helm v2-alpha extracts deployment configuration (image, imagePullPolicy, resources) from kustomize output instead of using hardcoded defaults. 

#### Changes
- **chart_converter.go**: 
  Added `parseImageString()` helper (parses image strings into repository/tag/digest components with registry port detection) / Updated `ExtractDeploymentConfig()` (finds manager container by name, extracts image, imagePullPolicy, and resources from actual kustomize deployment).
- **values_basic.go**: 
  Updated `generateBasicValues()` (populates values.yaml with extracted kustomize data instead of hardcoded defaults, implements digest-over-tag priority logic, conditional tag/digest inclusion based on actual deployment config).
- **helm_templater.go**: 
  Implemented `templateImageReference()` (creates conditional digest/tag templating with `{{- if .Values.controllerManager.image.digest }}` logic) / Implemented `templateResources()` (generates dynamic resource templating with precise boundary detection using regex patterns), handles both `- name: manager` and `  name: manager` container formats.
- **tests**: 
  Added test assertions validating image parsing, extraction logic, templating behavior, and generated output correctness with specific scenarios for tag/digest formats.


**Before**: `helm install` deployed hardcoded `controller:latest` with static resource limits regardless of kustomize content .
**After**: `helm install` deploys exact same image/resources as `make build-installer`.

Fixes #5113
