### PR TITLE
✨ (feat): Expose ProjectConfig to external plugins

### DIFF
--- a/pkg/plugin/external/types.go
+++ b/pkg/plugin/external/types.go
@@ -40,6 +40,10 @@ type PluginRequest struct {
 	// This allows external plugins to know which other plugins are in use.
 	// Format: ["go.kubebuilder.io/v4", "kustomize.common.kubebuilder.io/v2"]
 	PluginChain []string `json:"pluginChain,omitempty"`
+
+	// Config contains the PROJECT file config. This field may be empty if the
+	// project is being initialized and the PROJECT file has not been created yet.
+	Config map[string]interface{} `json:"config,omitempty"`
 }
 
 // PluginResponse is returned to kubebuilder by the plugin and contains all files

--- a/pkg/plugins/external/edit.go
+++ b/pkg/plugins/external/edit.go
@@ -32,12 +32,31 @@ type editSubcommand struct {
 	Path        string
 	Args        []string
 	pluginChain []string
+	config      config.Config
 }
 
 // InjectConfig injects the project configuration to access plugin chain information
 func (p *editSubcommand) InjectConfig(c config.Config) error {
-	p.pluginChain = c.GetPluginChain()
+	p.config = c
+
+	if c == nil {
+		return nil
+	}
+
+	if chain := c.GetPluginChain(); len(chain) > 0 {
+		p.pluginChain = append([]string(nil), chain...)
+	}
+
 	return nil
+}
+
+func (p *editSubcommand) SetPluginChain(chain []string) {
+	if len(chain) == 0 {
+		p.pluginChain = nil
+		return
+	}
+
+	p.pluginChain = append([]string(nil), chain...)
 }
 
 func (p *editSubcommand) UpdateMetadata(_ plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -56,7 +75,7 @@ func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
 		PluginChain: p.pluginChain,
 	}
 
-	err := handlePluginResponse(fs, req, p.Path)
+	err := handlePluginResponse(fs, req, p.Path, p.config)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -30,7 +30,9 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
 
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"
@@ -149,12 +151,28 @@ func getUniverseMap(fs machinery.Filesystem) (map[string]string, error) {
 	return universe, nil
 }
 
-func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, path string) error {
+func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, path string, cfg config.Config) error {
 	var err error
 
 	req.Universe, err = getUniverseMap(fs)
 	if err != nil {
 		return fmt.Errorf("error getting universe map: %w", err)
+	}
+
+	// Marshal config to include in the request if config is provided
+	if cfg != nil {
+		var configData []byte
+		configData, err = cfg.MarshalYAML()
+		if err != nil {
+			return fmt.Errorf("error marshaling config: %w", err)
+		}
+
+		var configMap map[string]interface{}
+		if err = yaml.Unmarshal(configData, &configMap); err != nil {
+			return fmt.Errorf("error unmarshaling config to map: %w", err)
+		}
+
+		req.Config = configMap
 	}
 
 	res, err := makePluginRequest(req, path)

--- a/pkg/plugins/external/init.go
+++ b/pkg/plugins/external/init.go
@@ -32,12 +32,31 @@ type initSubcommand struct {
 	Path        string
 	Args        []string
 	pluginChain []string
+	config      config.Config
 }
 
 // InjectConfig injects the project configuration to access plugin chain information
 func (p *initSubcommand) InjectConfig(c config.Config) error {
-	p.pluginChain = c.GetPluginChain()
+	p.config = c
+
+	if c == nil {
+		return nil
+	}
+
+	if chain := c.GetPluginChain(); len(chain) > 0 {
+		p.pluginChain = append([]string(nil), chain...)
+	}
+
 	return nil
+}
+
+func (p *initSubcommand) SetPluginChain(chain []string) {
+	if len(chain) == 0 {
+		p.pluginChain = nil
+		return
+	}
+
+	p.pluginChain = append([]string(nil), chain...)
 }
 
 func (p *initSubcommand) UpdateMetadata(_ plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -56,7 +75,7 @@ func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
 		PluginChain: p.pluginChain,
 	}
 
-	err := handlePluginResponse(fs, req, p.Path)
+	err := handlePluginResponse(fs, req, p.Path, p.config)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/external/webhook.go
+++ b/pkg/plugins/external/webhook.go
@@ -32,12 +32,31 @@ type createWebhookSubcommand struct {
 	Path        string
 	Args        []string
 	pluginChain []string
+	config      config.Config
 }
 
-// InjectConfig injects the project configuration to access plugin chain information
+// InjectConfig injects the project configuration so external plugins can read the PROJECT file.
 func (p *createWebhookSubcommand) InjectConfig(c config.Config) error {
-	p.pluginChain = c.GetPluginChain()
+	p.config = c
+
+	if c == nil {
+		return nil
+	}
+
+	if chain := c.GetPluginChain(); len(chain) > 0 {
+		p.pluginChain = append([]string(nil), chain...)
+	}
+
 	return nil
+}
+
+func (p *createWebhookSubcommand) SetPluginChain(chain []string) {
+	if len(chain) == 0 {
+		p.pluginChain = nil
+		return
+	}
+
+	p.pluginChain = append([]string(nil), chain...)
 }
 
 func (p *createWebhookSubcommand) InjectResource(*resource.Resource) error {
@@ -61,7 +80,7 @@ func (p *createWebhookSubcommand) Scaffold(fs machinery.Filesystem) error {
 		PluginChain: p.pluginChain,
 	}
 
-	err := handlePluginResponse(fs, req, p.Path)
+	err := handlePluginResponse(fs, req, p.Path, p.config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### PR Description

Expose `ProjectConfig` and keep `chainPlugin` to external plugins.

- External plugins can now access `ProjectConfig` to read project layout and config.
- `chainPlugin` is passed during execution so plugins can adjust behavior based on other plugins in the chain.

This allows external plugins to customise subcommands dynamically and integrate better with the Kubebuilder workflow.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/3553
