### PR TITLE
🌱 Fix make test-e2e-local to run on mac and linux

### DIFF
--- a/test/e2e/local.sh
+++ b/test/e2e/local.sh
@@ -23,7 +23,16 @@ if [ -z "${SKIP_KIND_CLEANUP:-}" ]; then
   trap delete_cluster EXIT
 fi
 
+# Wait a moment for the cluster control plane to be fully initialized
+echo "Ensuring cluster is fully initialized..."
+sleep 5
+
+# Export kubeconfig for the cluster
 kind export kubeconfig --kubeconfig $tmp_root/kubeconfig --name $KIND_CLUSTER
 export KUBECONFIG=$tmp_root/kubeconfig
+
+# Verify we can communicate with the cluster
+kubectl cluster-info
+echo "Cluster is ready for testing"
 
 test_cluster -v -ginkgo.v


### PR DESCRIPTION
Now, make test-e2e-local can be executed in both SOs 
Following the local test executed on mac

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5163

```
$ make test-e2e-local 
## To keep the same kind cluster between test runs, use `SKIP_KIND_CLEANUP=1 make test-e2e-local`
./test/e2e/local.sh
Building kubebuilder
Installing e2e tools with setup-envtest
Version: 1.34.0
OS/Arch: darwin/arm64
Path: /Users/camilam/Library/Application Support/io.kubebuilder.envtest/k8s/1.34.0-darwin-arm64
Getting kind config...
Creating cluster...
Creating cluster "local-kubebuilder-e2e" ...
DEBUG: docker/images.go:58] Image: kindest/node:v1.34.0 present locally
 ✓ Ensuring node image (kindest/node:v1.34.0) 🖼
 ✓ Preparing nodes 📦  
DEBUG: config/config.go:96] Using the following kubeadm config for node local-kubebuilder-e2e-control-plane:
apiServer:
  certSANs:
  - localhost
  - 127.0.0.1
  extraArgs:
    runtime-config: ""
apiVersion: kubeadm.k8s.io/v1beta3
clusterName: local-kubebuilder-e2e
controlPlaneEndpoint: local-kubebuilder-e2e-control-plane:6443
controllerManager:
  extraArgs:
    enable-hostpath-provisioner: "true"
kind: ClusterConfiguration
kubernetesVersion: v1.34.0
networking:
  podSubnet: 10.244.0.0/16
  serviceSubnet: 10.96.0.0/16
scheduler:
  extraArgs: null
---
apiVersion: kubeadm.k8s.io/v1beta3
bootstrapTokens:
- token: abcdef.0123456789abcdef
kind: InitConfiguration
localAPIEndpoint:
  advertiseAddress: 172.18.0.4
  bindPort: 6443
nodeRegistration:
  criSocket: unix:///run/containerd/containerd.sock
  kubeletExtraArgs:
    node-ip: 172.18.0.4
    node-labels: ""
    provider-id: kind://docker/local-kubebuilder-e2e/local-kubebuilder-e2e-control-plane
skipPhases:
- preflight
---
apiVersion: kubeadm.k8s.io/v1beta3
controlPlane:
  localAPIEndpoint:
    advertiseAddress: 172.18.0.4
    bindPort: 6443
discovery:
  bootstrapToken:
    apiServerEndpoint: local-kubebuilder-e2e-control-plane:6443
    token: abcdef.0123456789abcdef
    unsafeSkipCAVerification: true
kind: JoinConfiguration
nodeRegistration:
  criSocket: unix:///run/containerd/containerd.sock
  kubeletExtraArgs:
    node-ip: 172.18.0.4
    node-labels: ""
    provider-id: kind://docker/local-kubebuilder-e2e/local-kubebuilder-e2e-control-plane
skipPhases:
- preflight
---
apiVersion: kubelet.config.k8s.io/v1beta1
cgroupDriver: systemd
cgroupRoot: /kubelet
evictionHard:
  imagefs.available: 0%
  nodefs.available: 0%
  nodefs.inodesFree: 0%
failSwapOn: false
imageGCHighThresholdPercent: 100
kind: KubeletConfiguration
---
apiVersion: kubeproxy.config.k8s.io/v1alpha1
conntrack:
  maxPerCore: 0
iptables:
  minSyncPeriod: 1s
kind: KubeProxyConfiguration
mode: iptables
 ✓ Writing configuration 📜
DEBUG: kubeadminit/init.go:96] I1102 13:15:38.032147     170 initconfiguration.go:260] loading configuration from "/kind/kubeadm.conf"
W1102 13:15:38.032419     170 common.go:100] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.
W1102 13:15:38.032643     170 common.go:100] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "InitConfiguration"). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.
W1102 13:15:38.033010     170 common.go:100] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta3" (kind: "JoinConfiguration"). Please use 'kubeadm config migrate --old-config old-config-file --new-config new-config-file', which will write the new, similar spec using a newer API version.
W1102 13:15:38.033231     170 initconfiguration.go:361] [config] WARNING: Ignored configuration document with GroupVersionKind kubeadm.k8s.io/v1beta3, Kind=JoinConfiguration
I1102 13:15:38.034189     170 certs.go:111] creating a new certificate authority for ca
[init] Using Kubernetes version: v1.34.0
[certs] Using certificateDir folder "/etc/kubernetes/pki"
[certs] Generating "ca" certificate and key
I1102 13:15:38.107099     170 certs.go:472] validating certificate period for ca certificate
[certs] Generating "apiserver" certificate and key
[certs] apiserver serving cert is signed for DNS names [kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local local-kubebuilder-e2e-control-plane localhost] and IPs [10.96.0.1 172.18.0.4 127.0.0.1]
[certs] Generating "apiserver-kubelet-client" certificate and key
I1102 13:15:38.346174     170 certs.go:111] creating a new certificate authority for front-proxy-ca
[certs] Generating "front-proxy-ca" certificate and key
I1102 13:15:38.415907     170 certs.go:472] validating certificate period for front-proxy-ca certificate
[certs] Generating "front-proxy-client" certificate and key
I1102 13:15:38.585423     170 certs.go:111] creating a new certificate authority for etcd-ca
[certs] Generating "etcd/ca" certificate and key
I1102 13:15:38.904442     170 certs.go:472] validating certificate period for etcd/ca certificate
[certs] Generating "etcd/server" certificate and key
[certs] etcd/server serving cert is signed for DNS names [local-kubebuilder-e2e-control-plane localhost] and IPs [172.18.0.4 127.0.0.1 ::1]
[certs] Generating "etcd/peer" certificate and key
[certs] etcd/peer serving cert is signed for DNS names [local-kubebuilder-e2e-control-plane localhost] and IPs [172.18.0.4 127.0.0.1 ::1]
[certs] Generating "etcd/healthcheck-client" certificate and key
[certs] Generating "apiserver-etcd-client" certificate and key
I1102 13:15:39.483056     170 certs.go:77] creating new public/private key files for signing service account users
[certs] Generating "sa" key and public key
[kubeconfig] Using kubeconfig folder "/etc/kubernetes"
I1102 13:15:39.810259     170 kubeconfig.go:111] creating kubeconfig file for admin.conf
[kubeconfig] Writing "admin.conf" kubeconfig file
I1102 13:15:39.968724     170 kubeconfig.go:111] creating kubeconfig file for super-admin.conf
[kubeconfig] Writing "super-admin.conf" kubeconfig file
I1102 13:15:40.089856     170 kubeconfig.go:111] creating kubeconfig file for kubelet.conf
[kubeconfig] Writing "kubelet.conf" kubeconfig file
I1102 13:15:40.184083     170 kubeconfig.go:111] creating kubeconfig file for controller-manager.conf
[kubeconfig] Writing "controller-manager.conf" kubeconfig file
I1102 13:15:40.264647     170 kubeconfig.go:111] creating kubeconfig file for scheduler.conf
[kubeconfig] Writing "scheduler.conf" kubeconfig file
[etcd] Creating static Pod manifest for local etcd in "/etc/kubernetes/manifests"
I1102 13:15:40.382699     170 local.go:67] [etcd] wrote Static Pod manifest for a local etcd member to "/etc/kubernetes/manifests/etcd.yaml"
I1102 13:15:40.382728     170 manifests.go:125] [control-plane] getting StaticPodSpecs
[control-plane] Using manifest folder "/etc/kubernetes/manifests"
[control-plane] Creating static Pod manifest for "kube-apiserver"
I1102 13:15:40.382912     170 certs.go:472] validating certificate period for CA certificate
I1102 13:15:40.382947     170 manifests.go:151] [control-plane] adding volume "ca-certs" for component "kube-apiserver"
I1102 13:15:40.382956     170 manifests.go:151] [control-plane] adding volume "etc-ca-certificates" for component "kube-apiserver"
I1102 13:15:40.382958     170 manifests.go:151] [control-plane] adding volume "k8s-certs" for component "kube-apiserver"
I1102 13:15:40.382959     170 manifests.go:151] [control-plane] adding volume "usr-local-share-ca-certificates" for component "kube-apiserver"
I1102 13:15:40.382960     170 manifests.go:151] [control-plane] adding volume "usr-share-ca-certificates" for component "kube-apiserver"
I1102 13:15:40.383243     170 manifests.go:180] [control-plane] wrote static Pod manifest for component "kube-apiserver" to "/etc/kubernetes/manifests/kube-apiserver.yaml"
I1102 13:15:40.383252     170 manifests.go:125] [control-plane] getting StaticPodSpecs
[control-plane] Creating static Pod manifest for "kube-controller-manager"
I1102 13:15:40.383321     170 manifests.go:151] [control-plane] adding volume "ca-certs" for component "kube-controller-manager"
I1102 13:15:40.383327     170 manifests.go:151] [control-plane] adding volume "etc-ca-certificates" for component "kube-controller-manager"
I1102 13:15:40.383331     170 manifests.go:151] [control-plane] adding volume "flexvolume-dir" for component "kube-controller-manager"
I1102 13:15:40.383332     170 manifests.go:151] [control-plane] adding volume "k8s-certs" for component "kube-controller-manager"
I1102 13:15:40.383333     170 manifests.go:151] [control-plane] adding volume "kubeconfig" for component "kube-controller-manager"
I1102 13:15:40.383334     170 manifests.go:151] [control-plane] adding volume "usr-local-share-ca-certificates" for component "kube-controller-manager"
I1102 13:15:40.383336     170 manifests.go:151] [control-plane] adding volume "usr-share-ca-certificates" for component "kube-controller-manager"
I1102 13:15:40.383580     170 manifests.go:180] [control-plane] wrote static Pod manifest for component "kube-controller-manager" to "/etc/kubernetes/manifests/kube-controller-manager.yaml"
I1102 13:15:40.383587     170 manifests.go:125] [control-plane] getting StaticPodSpecs
[control-plane] Creating static Pod manifest for "kube-scheduler"
I1102 13:15:40.383647     170 manifests.go:151] [control-plane] adding volume "kubeconfig" for component "kube-scheduler"
I1102 13:15:40.383813     170 manifests.go:180] [control-plane] wrote static Pod manifest for component "kube-scheduler" to "/etc/kubernetes/manifests/kube-scheduler.yaml"
I1102 13:15:40.383833     170 kubelet.go:69] Stopping the kubelet
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/instance-config.yaml"
[patches] Applied patch of type "application/strategic-merge-patch+json" to target "kubeletconfiguration"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Starting the kubelet
I1102 13:15:40.435871     170 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
I1102 13:15:40.436136     170 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I1102 13:15:40.436153     170 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I1102 13:15:40.436160     170 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I1102 13:15:40.436164     170 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I1102 13:15:40.436166     170 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
[wait-control-plane] Waiting for the kubelet to boot up the control plane as static Pods from directory "/etc/kubernetes/manifests"
[kubelet-check] Waiting for a healthy kubelet at http://127.0.0.1:10248/healthz. This can take up to 4m0s
[kubelet-check] The kubelet is healthy after 502.58025ms
[control-plane-check] Waiting for healthy control plane components. This can take up to 4m0s
[control-plane-check] Checking kube-apiserver at https://172.18.0.4:6443/livez
[control-plane-check] Checking kube-controller-manager at https://127.0.0.1:10257/healthz
[control-plane-check] Checking kube-scheduler at https://127.0.0.1:10259/livez
I1102 13:15:40.942418     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="" milliseconds=0
I1102 13:15:41.444208     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="" milliseconds=0
[control-plane-check] kube-controller-manager is healthy after 1.241697709s
I1102 13:15:43.301317     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=1359
I1102 13:15:43.302984     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=0
[control-plane-check] kube-scheduler is healthy after 2.372762501s
I1102 13:15:43.442712     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=0
I1102 13:15:43.945952     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="403 Forbidden" milliseconds=2
I1102 13:15:44.442348     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="500 Internal Server Error" milliseconds=0
I1102 13:15:44.442462     170 request.go:1500] "Body was not decodable (unable to check for Status)" err="couldn't get version/kind; json parse error: json: cannot unmarshal array into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }"
[control-plane-check] kube-apiserver is healthy after 4.002476419s
I1102 13:15:44.944162     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/livez?timeout=10s" status="200 OK" milliseconds=0
I1102 13:15:44.944773     170 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
I1102 13:15:44.945444     170 loader.go:402] Config loaded from file:  /etc/kubernetes/super-admin.conf
I1102 13:15:44.945968     170 kubeconfig.go:657] ensuring that the ClusterRoleBinding for the kubeadm:cluster-admins Group exists
I1102 13:15:44.946923     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="403 Forbidden" milliseconds=0
I1102 13:15:44.947015     170 kubeconfig.go:730] creating the ClusterRoleBinding for the kubeadm:cluster-admins Group by using super-admin.conf
I1102 13:15:44.954677     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=7
I1102 13:15:44.954733     170 uploadconfig.go:111] [upload-config] Uploading the kubeadm ClusterConfiguration to a ConfigMap
[upload-config] Storing the configuration used in ConfigMap "kubeadm-config" in the "kube-system" Namespace
I1102 13:15:44.957335     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/configmaps?timeout=10s" status="201 Created" milliseconds=2
I1102 13:15:44.959027     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/roles?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:44.960429     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/rolebindings?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:44.960496     170 uploadconfig.go:125] [upload-config] Uploading the kubelet component config to a ConfigMap
[kubelet] Creating a ConfigMap "kubelet-config" in namespace kube-system with the configuration for the kubelets in the cluster
I1102 13:15:44.962067     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/configmaps?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:44.963807     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/roles?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:44.965063     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/rolebindings?timeout=10s" status="201 Created" milliseconds=1
[upload-certs] Skipping phase. Please see --upload-certs
[mark-control-plane] Marking the node local-kubebuilder-e2e-control-plane as control-plane by adding the labels: [node-role.kubernetes.io/control-plane node.kubernetes.io/exclude-from-external-load-balancers]
[mark-control-plane] Marking the node local-kubebuilder-e2e-control-plane as control-plane by adding the taints [node-role.kubernetes.io/control-plane:NoSchedule]
I1102 13:15:44.966107     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/nodes/local-kubebuilder-e2e-control-plane?timeout=10s" status="200 OK" milliseconds=0
I1102 13:15:44.969314     170 round_trippers.go:632] "Response" verb="PATCH" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/nodes/local-kubebuilder-e2e-control-plane?timeout=10s" status="200 OK" milliseconds=2
I1102 13:15:44.969671     170 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
[bootstrap-token] Configuring bootstrap tokens, cluster-info ConfigMap, RBAC Roles
I1102 13:15:44.970520     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/secrets/bootstrap-token-abcdef?timeout=10s" status="404 Not Found" milliseconds=0
I1102 13:15:44.971779     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/secrets?timeout=10s" status="201 Created" milliseconds=1
[bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to get nodes
I1102 13:15:44.972992     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterroles?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:44.974052     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=0
[bootstrap-token] Configured RBAC rules to allow Node Bootstrap tokens to post CSRs in order for nodes to get long term certificate credentials
[bootstrap-token] Configured RBAC rules to allow the csrapprover controller automatically approve CSRs from a Node Bootstrap Token
I1102 13:15:44.975149     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=1
[bootstrap-token] Configured RBAC rules to allow certificate rotation for all node client certificates in the cluster
I1102 13:15:44.976129     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=0
[bootstrap-token] Creating the "cluster-info" ConfigMap in the "kube-public" namespace
I1102 13:15:44.977450     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:44.977496     170 clusterinfo.go:58] [bootstrap-token] copying the cluster from admin.conf to the bootstrap kubeconfig
I1102 13:15:44.977651     170 clusterinfo.go:70] [bootstrap-token] creating/updating ConfigMap in kube-public namespace
I1102 13:15:44.978638     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-public/configmaps?timeout=10s" status="201 Created" milliseconds=0
I1102 13:15:44.978688     170 clusterinfo.go:84] creating the RBAC rules for exposing the cluster-info ConfigMap in the kube-public namespace
I1102 13:15:45.147169     170 request.go:683] "Waited before sending request" delay="168.378166ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-public/roles?timeout=10s"
I1102 13:15:45.152971     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-public/roles?timeout=10s" status="201 Created" milliseconds=5
I1102 13:15:45.346288     170 request.go:683] "Waited before sending request" delay="192.993292ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-public/rolebindings?timeout=10s"
I1102 13:15:45.355556     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-public/rolebindings?timeout=10s" status="201 Created" milliseconds=8
I1102 13:15:45.355921     170 kubeletfinalize.go:90] [kubelet-finalize] Assuming that kubelet client certificate rotation is enabled: found "/var/lib/kubelet/pki/kubelet-client-current.pem"
[kubelet-finalize] Updating "/etc/kubernetes/kubelet.conf" to point to a rotatable kubelet client certificate and key
I1102 13:15:45.356680     170 loader.go:402] Config loaded from file:  /etc/kubernetes/kubelet.conf
I1102 13:15:45.357417     170 kubeletfinalize.go:144] [kubelet-finalize] Restarting the kubelet to enable client certificate rotation
I1102 13:15:45.473140     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/apis/apps/v1/namespaces/kube-system/deployments?labelSelector=k8s-app%3Dkube-dns" status="200 OK" milliseconds=1
I1102 13:15:45.474215     170 round_trippers.go:632] "Response" verb="GET" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/configmaps/coredns?timeout=10s" status="404 Not Found" milliseconds=0
I1102 13:15:45.476209     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/configmaps?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:45.548136     170 request.go:683] "Waited before sending request" delay="71.683626ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterroles?timeout=10s"
I1102 13:15:45.549877     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterroles?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:45.747317     170 request.go:683] "Waited before sending request" delay="197.183583ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s"
I1102 13:15:45.749968     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=2
I1102 13:15:45.752127     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/serviceaccounts?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:45.755581     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/apps/v1/namespaces/kube-system/deployments?timeout=10s" status="201 Created" milliseconds=2
I1102 13:15:45.759245     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/services?timeout=10s" status="201 Created" milliseconds=3
[addons] Applied essential addon: CoreDNS
I1102 13:15:45.761707     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/configmaps?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:45.764437     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/apps/v1/namespaces/kube-system/daemonsets?timeout=10s" status="201 Created" milliseconds=2
I1102 13:15:45.765696     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/api/v1/namespaces/kube-system/serviceaccounts?timeout=10s" status="201 Created" milliseconds=1
I1102 13:15:45.946444     170 request.go:683] "Waited before sending request" delay="180.574292ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s"
I1102 13:15:45.951819     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?timeout=10s" status="201 Created" milliseconds=5
I1102 13:15:46.146326     170 request.go:683] "Waited before sending request" delay="194.172583ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/roles?timeout=10s"
I1102 13:15:46.156233     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/roles?timeout=10s" status="201 Created" milliseconds=9
I1102 13:15:46.346969     170 request.go:683] "Waited before sending request" delay="190.302209ms" reason="client-side throttling, not priority and fairness" verb="POST" URL="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/rolebindings?timeout=10s"
I1102 13:15:46.348961     170 round_trippers.go:632] "Response" verb="POST" url="https://local-kubebuilder-e2e-control-plane:6443/apis/rbac.authorization.k8s.io/v1/namespaces/kube-system/rolebindings?timeout=10s" status="201 Created" milliseconds=1
[addons] Applied essential addon: kube-proxy
I1102 13:15:46.349376     170 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf

Your Kubernetes control-plane has initialized successfully!

To start using your cluster, you need to run the following as a regular user:

  mkdir -p $HOME/.kube
  sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
  sudo chown $(id -u):$(id -g) $HOME/.kube/config

Alternatively, if you are the root user, you can run:

  export KUBECONFIG=/etc/kubernetes/admin.conf

You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
  https://kubernetes.io/docs/concepts/cluster-administration/addons/

You can now join any number of control-plane nodes by copying certificate authorities
and service account keys on each node and then running the following as root:

  kubeadm join local-kubebuilder-e2e-control-plane:6443 --token <value withheld> \
	--discovery-token-ca-cert-hash sha256:d53057492c78239e5770e15eabd1dc7efe8d89ada71b4d8679f264ba2680b845 \
	--control-plane 

Then you can join any number of worker nodes by running the following on each as root:

kubeadm join local-kubebuilder-e2e-control-plane:6443 --token <value withheld> \
	--discovery-token-ca-cert-hash sha256:d53057492c78239e5770e15eabd1dc7efe8d89ada71b4d8679f264ba2680b845 
I1102 13:15:46.349664     170 loader.go:402] Config loaded from file:  /etc/kubernetes/admin.conf
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Waiting ≤ 5m0s for control-plane = Ready ⏳ 
 • Ready after 17s 💚
Set kubectl context to "kind-local-kubebuilder-e2e"
You can now use your cluster with:

kubectl cluster-info --context kind-local-kubebuilder-e2e

Thanks for using kind! 😊
Waiting for cluster to be fully ready...
node/local-kubebuilder-e2e-control-plane condition met
Ensuring cluster is fully initialized...
Set kubectl context to "kind-local-kubebuilder-e2e"
Kubernetes control plane is running at https://127.0.0.1:58631
CoreDNS is running at https://127.0.0.1:58631/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
Cluster is ready for testing
1.6.26-alpine3.19: Pulling from library/memcached
Digest: sha256:8906e7654a202d07e6b1bd6a1382b309e718feb9084987c365337ec8161ccaab
Status: Image is up to date for memcached:1.6.26-alpine3.19
docker.io/library/memcached:1.6.26-alpine3.19
1.36.1: Pulling from library/busybox
Digest: sha256:355b3a1bf5609da364166913878a8508d4ba30572d02020a97028c75477e24ff
Status: Image is up to date for busybox:1.36.1
docker.io/library/busybox:1.36.1
docker.io/library/memcached:1.6.26 alpin	saved	
application/vnd.oci.image.index.v1+json sha256:8906e7654a202d07e6b1bd6a1382b309e718feb9084987c365337ec8161ccaab
Importing	elapsed: 0.2 s	total:   0.0 B	(0.0 B/s)	
docker.io/library/busybox:1.36.1        	saved	
application/vnd.oci.image.index.v1+json sha256:355b3a1bf5609da364166913878a8508d4ba30572d02020a97028c75477e24ff
Importing	elapsed: 0.1 s	total:   0.0 B	(0.0 B/s)	
=== RUN   TestE2E
  Starting kubebuilder suite
Running Suite: Kubebuilder e2e suite - /Users/camilam/go/src/sigs.k8s.io/kubebuilder/test/e2e/deployimage
=========================================================================================================
Random Seed: 1762089372

Will run 2 of 2 specs
------------------------------
kubebuilder deploy image plugin should generate a runnable project with deploy-image/v1-alpha options 
/Users/camilam/go/src/sigs.k8s.io/kubebuilder/test/e2e/deployimage/plugin_cluster_test.go:52
  running: kubectl version -o json
  cleaning up tools
  preparing testing directory: /Users/camilam/go/src/sigs.k8s.io/kubebuilder/test/e2e/deployimage/e2e-rhwj
  STEP: initializing a project @ 11/02/25 13:16:12.437
  running: kubebuilder init --plugins go/v4 --project-version 3 --domain example.comrhwj
  STEP: creating API definition with deploy-image/v1-alpha plugin @ 11/02/25 13:16:13.354
  running: kubebuilder create api --group barrhwj --version v1alpha1 --kind Foorhwj --plugins deploy-image/v1-alpha --image memcached:1.6.26-alpine3.19 --image-container-port 11211 --image-container-command memcached,--memory-limit=64,-o,modern,-v --run-as-user 1001 --make=false --manifests=false
  STEP: updating the go.mod @ 11/02/25 13:16:13.415
  running: go mod tidy
  STEP: run make manifests @ 11/02/25 13:16:13.448
  running: make manifests
  STEP: run make generate @ 11/02/25 13:16:15.853
  running: make generate
  STEP: run make all @ 11/02/25 13:16:16.77
  running: make all
  STEP: run make install @ 11/02/25 13:16:25.329
```
