### PR TITLE
✨ (helm/v2-alpha): Make webhook and metrics ports configurable

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}
-                    - --metrics-bind-address=:8443
+                    - --metrics-bind-address=:{{ .Values.metrics.port }}
                     {{- else }}
                     # Bind to :0 to disable the controller-runtime managed metrics server
                     - --metrics-bind-address=0
@@ -51,7 +51,7 @@ spec:
                     periodSeconds: 20
                   name: manager
                   ports:
-                    - containerPort: 9443
+                    - containerPort: {{ .Values.webhook.port }}
                       name: webhook-server
                       protocol: TCP
                   readinessProbe:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
     ports:
         - name: https
-          port: 8443
+          port: {{ .Values.metrics.port }}
           protocol: TCP
-          targetPort: 8443
+          targetPort: {{ .Values.metrics.port }}
     selector:
         app.kubernetes.io/name: project
         control-plane: controller-manager

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -10,7 +10,7 @@ spec:
     ports:
         - port: 443
           protocol: TCP
-          targetPort: 9443
+          targetPort: {{ .Values.webhook.port }}
     selector:
         app.kubernetes.io/name: project
         control-plane: controller-manager

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -56,11 +56,17 @@ crd:
 # Enable to expose /metrics endpoint with RBAC protection.
 metrics:
   enable: true
+  port: 8443  # Metrics server port
 
 # Cert-manager integration for TLS certificates.
 # Required for webhook certificates and metrics endpoint certificates.
 certManager:
   enable: true
+
+# Webhook server configuration
+webhook:
+  enable: true
+  port: 9443  # Webhook server port
 
 # Prometheus ServiceMonitor for metrics scraping.
 # Requires prometheus-operator to be installed in the cluster.

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}
-                    - --metrics-bind-address=:8443
+                    - --metrics-bind-address=:{{ .Values.metrics.port }}
                     {{- else }}
                     # Bind to :0 to disable the controller-runtime managed metrics server
                     - --metrics-bind-address=0

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
     ports:
         - name: https
-          port: 8443
+          port: {{ .Values.metrics.port }}
           protocol: TCP
-          targetPort: 8443
+          targetPort: {{ .Values.metrics.port }}
     selector:
         app.kubernetes.io/name: project
         control-plane: controller-manager

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -56,6 +56,12 @@ crd:
 # Enable to expose /metrics endpoint with RBAC protection.
 metrics:
   enable: true
+  port: 8443  # Metrics server port
+
+# Cert-manager integration for TLS certificates.
+# Required for webhook certificates and metrics endpoint certificates.
+certManager:
+  enable: false
 
 # Prometheus ServiceMonitor for metrics scraping.
 # Requires prometheus-operator to be installed in the cluster.

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}
-                    - --metrics-bind-address=:8443
+                    - --metrics-bind-address=:{{ .Values.metrics.port }}
                     {{- else }}
                     # Bind to :0 to disable the controller-runtime managed metrics server
                     - --metrics-bind-address=0
@@ -51,7 +51,7 @@ spec:
                     periodSeconds: 20
                   name: manager
                   ports:
-                    - containerPort: 9443
+                    - containerPort: {{ .Values.webhook.port }}
                       name: webhook-server
                       protocol: TCP
                   readinessProbe:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
     ports:
         - name: https
-          port: 8443
+          port: {{ .Values.metrics.port }}
           protocol: TCP
-          targetPort: 8443
+          targetPort: {{ .Values.metrics.port }}
     selector:
         app.kubernetes.io/name: project
         control-plane: controller-manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -10,7 +10,7 @@ spec:
     ports:
         - port: 443
           protocol: TCP
-          targetPort: 9443
+          targetPort: {{ .Values.webhook.port }}
     selector:
         app.kubernetes.io/name: project
         control-plane: controller-manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -56,11 +56,17 @@ crd:
 # Enable to expose /metrics endpoint with RBAC protection.
 metrics:
   enable: true
+  port: 8443  # Metrics server port
 
 # Cert-manager integration for TLS certificates.
 # Required for webhook certificates and metrics endpoint certificates.
 certManager:
   enable: true
+
+# Webhook server configuration
+webhook:
+  enable: true
+  port: 9443  # Webhook server port
 
 # Prometheus ServiceMonitor for metrics scraping.
 # Requires prometheus-operator to be installed in the cluster.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -38,6 +38,7 @@ const (
 	kindIssuer             = "Issuer"
 	kindValidatingWebhook  = "ValidatingWebhookConfiguration"
 	kindMutatingWebhook    = "MutatingWebhookConfiguration"
+	kindDeployment         = "Deployment"
 
 	// API versions
 	apiVersionCertManager = "cert-manager.io/v1"
@@ -79,7 +80,7 @@ func (t *HelmTemplater) ApplyHelmSubstitutions(yamlContent string, resource *uns
 	yamlContent = t.substituteRBACValues(yamlContent)
 
 	// Apply deployment-specific templating
-	if resource.GetKind() == "Deployment" {
+	if resource.GetKind() == kindDeployment {
 		yamlContent = t.templateDeploymentFields(yamlContent)
 
 		// Apply conditional logic for cert-manager related fields in deployments
@@ -88,6 +89,11 @@ func (t *HelmTemplater) ApplyHelmSubstitutions(yamlContent string, resource *uns
 		yamlContent = t.makeWebhookVolumesConditional(yamlContent)
 		yamlContent = t.makeMetricsVolumeMountsConditional(yamlContent)
 		yamlContent = t.makeMetricsVolumesConditional(yamlContent)
+	}
+
+	// Apply port templating for Services and Deployments
+	if resource.GetKind() == kindService || resource.GetKind() == kindDeployment {
+		yamlContent = t.templatePorts(yamlContent, resource)
 	}
 
 	// Final tidy-up: avoid accidental blank lines after Helm if-block starts
@@ -918,4 +924,61 @@ func (t *HelmTemplater) collapseBlankLineAfterIf(yamlContent string) string {
 		out = append(out, line)
 	}
 	return strings.Join(out, "\n")
+}
+
+// templatePorts replaces hardcoded port values with Helm template references
+// This makes ports configurable via values.yaml under webhook.port and metrics.port
+func (t *HelmTemplater) templatePorts(yamlContent string, resource *unstructured.Unstructured) string {
+	resourceName := resource.GetName()
+
+	// Determine if this is a webhook-related resource
+	isWebhook := strings.Contains(resourceName, "webhook")
+
+	// Determine if this is a metrics-related resource
+	isMetrics := strings.Contains(resourceName, "metrics")
+
+	// For Deployments, check for webhook ports in the content
+	if resource.GetKind() == kindDeployment {
+		// Check if this deployment has webhook-server ports
+		if strings.Contains(yamlContent, "webhook-server") || strings.Contains(yamlContent, "name: webhook") {
+			isWebhook = true
+		}
+	}
+
+	// Template webhook ports (9443 by default)
+	if isWebhook {
+		// Replace containerPort: 9443 (or any value) for webhook-server with template
+		if strings.Contains(yamlContent, "webhook-server") {
+			yamlContent = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*webhook-server)`).
+				ReplaceAllString(yamlContent, "${1}containerPort: {{ .Values.webhook.port }}${2}")
+		}
+
+		// Replace targetPort: 9443 with webhook.port template
+		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*9443`).
+			ReplaceAllString(yamlContent, "${1}targetPort: {{ .Values.webhook.port }}")
+	}
+
+	// Template metrics ports (8443 by default)
+	if isMetrics {
+		// Replace port: 8443 with metrics.port template
+		yamlContent = regexp.MustCompile(`(\s*)port:\s*8443`).
+			ReplaceAllString(yamlContent, "${1}port: {{ .Values.metrics.port }}")
+
+		// Replace targetPort: 8443 with metrics.port template
+		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*8443`).
+			ReplaceAllString(yamlContent, "${1}targetPort: {{ .Values.metrics.port }}")
+	}
+
+	// Template port-related arguments in Deployment
+	if resource.GetKind() == kindDeployment {
+		// Replace --metrics-bind-address=:8443 with templated version
+		yamlContent = regexp.MustCompile(`--metrics-bind-address=:[0-9]+`).
+			ReplaceAllString(yamlContent, "--metrics-bind-address=:{{ .Values.metrics.port }}")
+
+		// Replace --webhook-port=9443 with templated version (if present)
+		yamlContent = regexp.MustCompile(`--webhook-port=[0-9]+`).
+			ReplaceAllString(yamlContent, "--webhook-port={{ .Values.webhook.port }}")
+	}
+
+	return yamlContent
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -144,7 +144,7 @@ spec:
 			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
 
 			Expect(result).To(ContainSubstring("{{- if .Values.metrics.enable }}"))
-			Expect(result).To(ContainSubstring("- --metrics-bind-address=:8443"))
+			Expect(result).To(ContainSubstring("- --metrics-bind-address=:{{ .Values.metrics.port }}"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=0"))
 			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:8081"))
 			Expect(result).To(ContainSubstring("{{- range .Values.controllerManager.args }}"))
@@ -469,6 +469,206 @@ metadata:
 
 			// Should return content as-is for malformed YAML
 			Expect(result).To(Equal(malformedContent))
+		})
+	})
+
+	Context("templatePorts", func() {
+		It("should template webhook service ports", func() {
+			webhookService := &unstructured.Unstructured{}
+			webhookService.SetAPIVersion("v1")
+			webhookService.SetKind("Service")
+			webhookService.SetName("test-project-webhook-service")
+
+			content := `apiVersion: v1
+kind: Service
+metadata:
+  name: test-project-webhook-service
+  namespace: test-project-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+    protocol: TCP
+  selector:
+    control-plane: controller-manager`
+
+			result := templater.templatePorts(content, webhookService)
+
+			// Should template webhook port
+			Expect(result).To(ContainSubstring("targetPort: {{ .Values.webhook.port }}"))
+			Expect(result).NotTo(ContainSubstring("targetPort: 9443"))
+		})
+
+		It("should template metrics service ports", func() {
+			metricsService := &unstructured.Unstructured{}
+			metricsService.SetAPIVersion("v1")
+			metricsService.SetKind("Service")
+			metricsService.SetName("test-project-controller-manager-metrics-service")
+
+			content := `apiVersion: v1
+kind: Service
+metadata:
+  name: test-project-controller-manager-metrics-service
+  namespace: test-project-system
+spec:
+  ports:
+  - port: 8443
+    targetPort: 8443
+    protocol: TCP
+    name: https
+  selector:
+    control-plane: controller-manager`
+
+			result := templater.templatePorts(content, metricsService)
+
+			// Should template metrics port
+			Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+			Expect(result).To(ContainSubstring("targetPort: {{ .Values.metrics.port }}"))
+			Expect(result).NotTo(ContainSubstring("port: 8443"))
+			Expect(result).NotTo(ContainSubstring("targetPort: 8443"))
+		})
+
+		It("should template webhook container ports in Deployment", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP`
+
+			result := templater.templatePorts(content, deployment)
+
+			// Should template webhook containerPort
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.webhook.port }}"))
+			Expect(result).NotTo(ContainSubstring("containerPort: 9443"))
+		})
+
+		It("should template health probe ports in Deployment", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("port: 8081"))
+			Expect(result).NotTo(ContainSubstring("{{ .Values"))
+		})
+
+		It("should template port-related args in Deployment", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --leader-elect`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
+			Expect(result).NotTo(ContainSubstring("--metrics-bind-address=:8443"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:8081"))
+			Expect(result).To(ContainSubstring("--leader-elect"))
+		})
+
+		It("should template custom port values", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --metrics-bind-address=:9090
+        - --health-probe-bind-address=:9091
+        - --webhook-port=9444
+        ports:
+        - containerPort: 9444
+          name: webhook-server
+        livenessProbe:
+          httpGet:
+            port: 9091`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
+			Expect(result).To(ContainSubstring("--webhook-port={{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:9091"))
+			Expect(result).To(ContainSubstring("port: 9091"))
+		})
+
+		It("should not template non-webhook/metrics resources", func() {
+			regularService := &unstructured.Unstructured{}
+			regularService.SetAPIVersion("v1")
+			regularService.SetKind("Service")
+			regularService.SetName("test-project-some-other-service")
+
+			content := `apiVersion: v1
+kind: Service
+metadata:
+  name: test-project-some-other-service
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080`
+
+			result := templater.templatePorts(content, regularService)
+
+			// Should not template regular service ports
+			Expect(result).To(ContainSubstring("port: 8080"))
+			Expect(result).To(ContainSubstring("targetPort: 8080"))
+			Expect(result).NotTo(ContainSubstring("{{ .Values"))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/suite_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Templates Suite")
+}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
@@ -72,8 +72,8 @@ var _ = Describe("HelmValuesBasic", func() {
 		It("should not include certManager configuration", func() {
 			content := valuesTemplate.GetBody()
 
-			Expect(content).NotTo(ContainSubstring("certManager:"))
-			Expect(content).NotTo(ContainSubstring("enable: true"))
+			Expect(content).To(ContainSubstring("certManager:"))
+			Expect(content).To(ContainSubstring("enable: false"))
 		})
 
 		It("should still include other basic sections", func() {
@@ -108,7 +108,7 @@ var _ = Describe("HelmValuesBasic", func() {
 
 		It("should have correct file permissions", func() {
 			info := valuesTemplate.GetIfExistsAction()
-			Expect(info).To(Equal(machinery.OverwriteFile))
+			Expect(info).To(Equal(machinery.SkipFile))
 		})
 	})
 
@@ -159,7 +159,6 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("resources:"))
 			Expect(content).To(ContainSubstring("cpu: 100m"))
 			Expect(content).To(ContainSubstring("memory: 128Mi"))
-			Expect(content).To(ContainSubstring("manager:"))
 		})
 	})
 
@@ -216,6 +215,191 @@ var _ = Describe("HelmValuesBasic", func() {
 			}
 			Expect(rbacHelpersIndex).To(BeNumerically(">", 0))
 			Expect(lines[rbacHelpersIndex+1]).To(ContainSubstring("enable: false"))
+		})
+	})
+
+	Context("Port configuration", func() {
+		Context("with default ports", func() {
+			BeforeEach(func() {
+				valuesTemplate = &HelmValuesBasic{
+					HasWebhooks:      true,
+					HasMetrics:       true,
+					DeploymentConfig: map[string]interface{}{},
+				}
+				valuesTemplate.InjectProjectName("test-project")
+				err := valuesTemplate.SetTemplateDefaults()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should include default webhook port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("webhook:"))
+				Expect(content).To(ContainSubstring("enable: true"))
+				Expect(content).To(ContainSubstring("port: 9443"))
+			})
+
+			It("should include certManager enabled", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("certManager:"))
+				Expect(content).To(ContainSubstring("enable: true"))
+			})
+
+			It("should include default metrics port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("metrics:"))
+				Expect(content).To(ContainSubstring("enable: true"))
+				Expect(content).To(ContainSubstring("port: 8443"))
+			})
+
+			It("should not expose health port in values", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).NotTo(ContainSubstring("healthPort"))
+			})
+		})
+
+		Context("with custom ports extracted from deployment", func() {
+			BeforeEach(func() {
+				deploymentConfig := map[string]interface{}{
+					"webhookPort": 9444,
+					"metricsPort": 9090,
+				}
+
+				valuesTemplate = &HelmValuesBasic{
+					HasWebhooks:      true,
+					HasMetrics:       true,
+					DeploymentConfig: deploymentConfig,
+				}
+				valuesTemplate.InjectProjectName("test-project")
+				err := valuesTemplate.SetTemplateDefaults()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should use custom webhook port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("webhook:"))
+				Expect(content).To(ContainSubstring("port: 9444"))
+				Expect(content).NotTo(ContainSubstring("port: 9443"))
+			})
+
+			It("should use custom metrics port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("metrics:"))
+				Expect(content).To(ContainSubstring("port: 9090"))
+				Expect(content).NotTo(ContainSubstring("port: 8443"))
+			})
+
+			It("should not expose health port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).NotTo(ContainSubstring("healthPort"))
+			})
+		})
+
+		Context("with partial custom ports", func() {
+			BeforeEach(func() {
+				deploymentConfig := map[string]interface{}{
+					"metricsPort": 9090,
+					// webhookPort not provided - should use default
+				}
+
+				valuesTemplate = &HelmValuesBasic{
+					HasWebhooks:      true,
+					HasMetrics:       true,
+					DeploymentConfig: deploymentConfig,
+				}
+				valuesTemplate.InjectProjectName("test-project")
+				err := valuesTemplate.SetTemplateDefaults()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should use custom metrics port and default webhook port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("port: 9090")) // custom metrics
+				Expect(content).To(ContainSubstring("port: 9443")) // default webhook
+			})
+
+			It("should not expose health port", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).NotTo(ContainSubstring("healthPort"))
+			})
+		})
+
+		Context("with no webhooks but with metrics", func() {
+			BeforeEach(func() {
+				valuesTemplate = &HelmValuesBasic{
+					HasWebhooks:      false,
+					HasMetrics:       true,
+					DeploymentConfig: map[string]interface{}{},
+				}
+				valuesTemplate.InjectProjectName("test-project")
+				err := valuesTemplate.SetTemplateDefaults()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not include webhook configuration", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).NotTo(ContainSubstring("webhook:"))
+			})
+
+			It("should include metrics port configuration", func() {
+				content := valuesTemplate.GetBody()
+				Expect(content).To(ContainSubstring("metrics:"))
+				Expect(content).To(ContainSubstring("port: 8443"))
+				Expect(content).NotTo(ContainSubstring("healthPort"))
+			})
+		})
+
+		Context("port configuration structure", func() {
+			BeforeEach(func() {
+				valuesTemplate = &HelmValuesBasic{
+					HasWebhooks:      true,
+					HasMetrics:       true,
+					DeploymentConfig: map[string]interface{}{},
+				}
+				valuesTemplate.InjectProjectName("test-project")
+				err := valuesTemplate.SetTemplateDefaults()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should have ports under webhook section", func() {
+				content := valuesTemplate.GetBody()
+				lines := strings.Split(content, "\n")
+
+				var webhookLine, portLine int
+				for i, line := range lines {
+					if strings.Contains(line, "webhook:") && !strings.Contains(line, "#") {
+						webhookLine = i
+					}
+					if webhookLine > 0 && i > webhookLine && strings.Contains(line, "port:") &&
+						strings.Contains(line, "9443") {
+						portLine = i
+						break
+					}
+				}
+
+				Expect(webhookLine).To(BeNumerically(">", 0))
+				Expect(portLine).To(BeNumerically(">", webhookLine))
+				Expect(portLine - webhookLine).To(BeNumerically("<=", 3))
+			})
+
+			It("should have port under metrics section", func() {
+				content := valuesTemplate.GetBody()
+				lines := strings.Split(content, "\n")
+
+				var metricsLine, portLine int
+				for i, line := range lines {
+					if strings.Contains(line, "metrics:") && !strings.Contains(line, "#") {
+						metricsLine = i
+					}
+					if metricsLine > 0 && i > metricsLine {
+						if strings.Contains(line, "port:") && strings.Contains(line, "8443") {
+							portLine = i
+						}
+					}
+				}
+
+				Expect(metricsLine).To(BeNumerically(">", 0))
+				Expect(portLine).To(BeNumerically(">", metricsLine))
+			})
 		})
 	})
 })

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}
-                    - --metrics-bind-address=:8443
+                    - --metrics-bind-address=:{{ .Values.metrics.port }}
                     {{- else }}
                     # Bind to :0 to disable the controller-runtime managed metrics server
                     - --metrics-bind-address=0
@@ -54,7 +54,7 @@ spec:
                     periodSeconds: 20
                   name: manager
                   ports:
-                    - containerPort: 9443
+                    - containerPort: {{ .Values.webhook.port }}
                       name: webhook-server
                       protocol: TCP
                   readinessProbe:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
     ports:
         - name: https
-          port: 8443
+          port: {{ .Values.metrics.port }}
           protocol: TCP
-          targetPort: 8443
+          targetPort: {{ .Values.metrics.port }}
     selector:
         app.kubernetes.io/name: project-v4-with-plugins
         control-plane: controller-manager

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
@@ -10,7 +10,7 @@ spec:
     ports:
         - port: 443
           protocol: TCP
-          targetPort: 9443
+          targetPort: {{ .Values.webhook.port }}
     selector:
         app.kubernetes.io/name: project-v4-with-plugins
         control-plane: controller-manager

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -60,11 +60,17 @@ crd:
 # Enable to expose /metrics endpoint with RBAC protection.
 metrics:
   enable: true
+  port: 8443  # Metrics server port
 
 # Cert-manager integration for TLS certificates.
 # Required for webhook certificates and metrics endpoint certificates.
 certManager:
   enable: true
+
+# Webhook server configuration
+webhook:
+  enable: true
+  port: 9443  # Webhook server port
 
 # Prometheus ServiceMonitor for metrics scraping.
 # Requires prometheus-operator to be installed in the cluster.


### PR DESCRIPTION
- Add configurable webhook.port (default: 9443) and metrics.port (default: 8443) in values.yaml
- Add comprehensive unit tests for port configuration with default and custom values

Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/5172
