### PR TITLE
🐛 (helm/v2-alpha): ensure that certmanager option is exposed always

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
@@ -72,8 +72,8 @@ var _ = Describe("HelmValuesBasic", func() {
 		It("should not include certManager configuration", func() {
 			content := valuesTemplate.GetBody()
 
-			Expect(content).NotTo(ContainSubstring("certManager:"))
-			Expect(content).NotTo(ContainSubstring("enable: true"))
+			Expect(content).To(ContainSubstring("certManager:"))
+			Expect(content).To(ContainSubstring("enable: false"))
 		})
 
 		It("should still include other basic sections", func() {


### PR DESCRIPTION
It can either be used by the metrics so should be always exposed