### PR TITLE
🐛 (helm/v2alpha) Use manager instead of controllerManager to expose manager values

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
                     - --metrics-bind-address=0
                     {{- end }}
                     - --health-probe-bind-address=:8081
-                    {{- range .Values.controllerManager.args }}
+                    {{- range .Values.manager.args }}
                     - {{ . }}
                     {{- end }}
                     {{- if and .Values.certManager.enable .Values.metrics.enable }}
@@ -41,8 +41,8 @@ spec:
                     {{- end }}
                   command:
                     - /manager
-                  image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
-                  imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+                  image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+                  imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -61,14 +61,14 @@ spec:
                     initialDelaySeconds: 5
                     periodSeconds: 10
                   resources:
-                    {{- if .Values.controllerManager.resources }}
-                    {{- toYaml .Values.controllerManager.resources | nindent 20 }}
+                    {{- if .Values.manager.resources }}
+                    {{- toYaml .Values.manager.resources | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
                   securityContext:
-                    {{- if .Values.controllerManager.securityContext }}
-                    {{- toYaml .Values.controllerManager.securityContext | nindent 20 }}
+                    {{- if .Values.manager.securityContext }}
+                    {{- toYaml .Values.manager.securityContext | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
@@ -84,8 +84,8 @@ spec:
                       readOnly: true
                     {{- end }}
             securityContext:
-              {{- if .Values.controllerManager.podSecurityContext }}
-              {{- toYaml .Values.controllerManager.podSecurityContext | nindent 14 }}
+              {{- if .Values.manager.podSecurityContext }}
+              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
               {{- else }}
               {}
               {{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -1,5 +1,5 @@
 # Configure the controller manager deployment
-controllerManager:
+manager:
   replicas: 1
   
   image:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -30,13 +30,13 @@ spec:
                     - --metrics-bind-address=0
                     {{- end }}
                     - --health-probe-bind-address=:8081
-                    {{- range .Values.controllerManager.args }}
+                    {{- range .Values.manager.args }}
                     - {{ . }}
                     {{- end }}
                   command:
                     - /manager
-                  image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
-                  imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+                  image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+                  imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -52,21 +52,21 @@ spec:
                     initialDelaySeconds: 5
                     periodSeconds: 10
                   resources:
-                    {{- if .Values.controllerManager.resources }}
-                    {{- toYaml .Values.controllerManager.resources | nindent 20 }}
+                    {{- if .Values.manager.resources }}
+                    {{- toYaml .Values.manager.resources | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
                   securityContext:
-                    {{- if .Values.controllerManager.securityContext }}
-                    {{- toYaml .Values.controllerManager.securityContext | nindent 20 }}
+                    {{- if .Values.manager.securityContext }}
+                    {{- toYaml .Values.manager.securityContext | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
                   volumeMounts: []
             securityContext:
-              {{- if .Values.controllerManager.podSecurityContext }}
-              {{- toYaml .Values.controllerManager.podSecurityContext | nindent 14 }}
+              {{- if .Values.manager.podSecurityContext }}
+              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
               {{- else }}
               {}
               {{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -1,5 +1,5 @@
 # Configure the controller manager deployment
-controllerManager:
+manager:
   replicas: 1
   
   image:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
                     - --metrics-bind-address=0
                     {{- end }}
                     - --health-probe-bind-address=:8081
-                    {{- range .Values.controllerManager.args }}
+                    {{- range .Values.manager.args }}
                     - {{ . }}
                     {{- end }}
                     {{- if and .Values.certManager.enable .Values.metrics.enable }}
@@ -41,8 +41,8 @@ spec:
                     {{- end }}
                   command:
                     - /manager
-                  image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
-                  imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+                  image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+                  imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -61,14 +61,14 @@ spec:
                     initialDelaySeconds: 5
                     periodSeconds: 10
                   resources:
-                    {{- if .Values.controllerManager.resources }}
-                    {{- toYaml .Values.controllerManager.resources | nindent 20 }}
+                    {{- if .Values.manager.resources }}
+                    {{- toYaml .Values.manager.resources | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
                   securityContext:
-                    {{- if .Values.controllerManager.securityContext }}
-                    {{- toYaml .Values.controllerManager.securityContext | nindent 20 }}
+                    {{- if .Values.manager.securityContext }}
+                    {{- toYaml .Values.manager.securityContext | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
@@ -84,8 +84,8 @@ spec:
                       readOnly: true
                     {{- end }}
             securityContext:
-              {{- if .Values.controllerManager.podSecurityContext }}
-              {{- toYaml .Values.controllerManager.podSecurityContext | nindent 14 }}
+              {{- if .Values.manager.podSecurityContext }}
+              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
               {{- else }}
               {}
               {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -1,5 +1,5 @@
 # Configure the controller manager deployment
-controllerManager:
+manager:
   replicas: 1
   
   image:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -216,7 +216,7 @@ func (t *HelmTemplater) templateEnvironmentVariables(yamlContent string) string 
 			}
 		}
 
-		if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.controllerManager.env") {
+		if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.manager.env") {
 			return yamlContent
 		}
 
@@ -225,8 +225,8 @@ func (t *HelmTemplater) templateEnvironmentVariables(yamlContent string) string 
 
 		block := []string{
 			indentStr + "env:",
-			childIndent + "{{- if .Values.controllerManager.env }}",
-			childIndent + "{{- toYaml .Values.controllerManager.env | nindent " + childIndentWidth + " }}",
+			childIndent + "{{- if .Values.manager.env }}",
+			childIndent + "{{- toYaml .Values.manager.env | nindent " + childIndentWidth + " }}",
 			childIndent + "{{- else }}",
 			childIndent + "[]",
 			childIndent + "{{- end }}",
@@ -273,7 +273,7 @@ func (t *HelmTemplater) templateResources(yamlContent string) string {
 			}
 		}
 
-		if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.controllerManager.resources") {
+		if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.manager.resources") {
 			return yamlContent
 		}
 
@@ -282,8 +282,8 @@ func (t *HelmTemplater) templateResources(yamlContent string) string {
 
 		block := []string{
 			indentStr + "resources:",
-			childIndent + "{{- if .Values.controllerManager.resources }}",
-			childIndent + "{{- toYaml .Values.controllerManager.resources | nindent " + childIndentWidth + " }}",
+			childIndent + "{{- if .Values.manager.resources }}",
+			childIndent + "{{- toYaml .Values.manager.resources | nindent " + childIndentWidth + " }}",
 			childIndent + "{{- else }}",
 			childIndent + "{}",
 			childIndent + "{{- end }}",
@@ -352,7 +352,7 @@ func (t *HelmTemplater) templatePodSecurityContext(yamlContent string) string {
 			continue
 		}
 
-		if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.controllerManager.podSecurityContext") {
+		if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.manager.podSecurityContext") {
 			return yamlContent
 		}
 
@@ -361,8 +361,8 @@ func (t *HelmTemplater) templatePodSecurityContext(yamlContent string) string {
 
 		block := []string{
 			indentStr + "securityContext:",
-			childIndent + "{{- if .Values.controllerManager.podSecurityContext }}",
-			childIndent + "{{- toYaml .Values.controllerManager.podSecurityContext | nindent " + childIndentWidth + " }}",
+			childIndent + "{{- if .Values.manager.podSecurityContext }}",
+			childIndent + "{{- toYaml .Values.manager.podSecurityContext | nindent " + childIndentWidth + " }}",
 			childIndent + "{{- else }}",
 			childIndent + "{}",
 			childIndent + "{{- end }}",
@@ -415,7 +415,7 @@ func (t *HelmTemplater) templateContainerSecurityContext(yamlContent string) str
 			lookAheadEnd = len(lines)
 		}
 		joined := strings.Join(lines[i:lookAheadEnd], "\n")
-		if strings.Contains(joined, ".Values.controllerManager.securityContext") {
+		if strings.Contains(joined, ".Values.manager.securityContext") {
 			return yamlContent
 		}
 
@@ -424,8 +424,8 @@ func (t *HelmTemplater) templateContainerSecurityContext(yamlContent string) str
 
 		block := []string{
 			indentStr + "securityContext:",
-			childIndent + "{{- if .Values.controllerManager.securityContext }}",
-			childIndent + "{{- toYaml .Values.controllerManager.securityContext | nindent " + childIndentWidth + " }}",
+			childIndent + "{{- if .Values.manager.securityContext }}",
+			childIndent + "{{- toYaml .Values.manager.securityContext | nindent " + childIndentWidth + " }}",
 			childIndent + "{{- else }}",
 			childIndent + "{}",
 			childIndent + "{{- end }}",
@@ -459,7 +459,7 @@ func (t *HelmTemplater) templateControllerManagerArgs(yamlContent string) string
 	}
 
 	match := yamlContent[loc[0]:loc[1]]
-	if strings.Contains(match, ".Values.controllerManager.args") {
+	if strings.Contains(match, ".Values.manager.args") {
 		return yamlContent
 	}
 
@@ -531,7 +531,7 @@ func (t *HelmTemplater) templateControllerManagerArgs(yamlContent string) string
 	}
 
 	builder.WriteString(itemIndent)
-	builder.WriteString("{{- range .Values.controllerManager.args }}\n")
+	builder.WriteString("{{- range .Values.manager.args }}\n")
 	builder.WriteString(itemIndent)
 	builder.WriteString("- {{ . }}\n")
 	builder.WriteString(itemIndent)
@@ -560,7 +560,7 @@ func (t *HelmTemplater) templateImageReference(yamlContent string) string {
 			continue
 		}
 
-		if strings.Contains(lines[i], ".Values.controllerManager.image.repository") {
+		if strings.Contains(lines[i], ".Values.manager.image.repository") {
 			return yamlContent
 		}
 
@@ -597,9 +597,8 @@ func (t *HelmTemplater) templateImageReference(yamlContent string) string {
 		lines = append(lines[:i+1], append(filtered, lines[end:]...)...)
 		end = i + 1 + len(filtered)
 
-		//nolint:lll
-		imageLine := indentStr + "image: \"{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}\""
-		pullPolicyLine := indentStr + "imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}"
+		imageLine := indentStr + "image: \"{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}\""
+		pullPolicyLine := indentStr + "imagePullPolicy: {{ .Values.manager.image.pullPolicy }}"
 
 		remainder := lines[end:]
 		if len(remainder) > 0 && strings.HasPrefix(strings.TrimSpace(remainder[0]), "imagePullPolicy:") {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -147,12 +147,12 @@ spec:
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=:8443"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=0"))
 			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:8081"))
-			Expect(result).To(ContainSubstring("{{- range .Values.controllerManager.args }}"))
+			Expect(result).To(ContainSubstring("{{- range .Values.manager.args }}"))
 			Expect(result).NotTo(ContainSubstring("BUSYBOX_IMAGE"))
 			Expect(result).NotTo(ContainSubstring("MEMCACHED_IMAGE"))
 			Expect(result).To(ContainSubstring("image: " +
-				"\"{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}\""))
-			Expect(result).To(ContainSubstring("imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}"))
+				"\"{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}\""))
+			Expect(result).To(ContainSubstring("imagePullPolicy: {{ .Values.manager.image.pullPolicy }}"))
 			Expect(result).NotTo(ContainSubstring("controller:latest"))
 		})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -90,7 +90,7 @@ func (f *HelmValuesBasic) generateBasicValues() string {
 	}
 
 	buf.WriteString(fmt.Sprintf(`# Configure the controller manager deployment
-controllerManager:
+manager:
   replicas: 1
   
   image:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
@@ -49,7 +49,7 @@ var _ = Describe("HelmValuesBasic", func() {
 		It("should include all basic sections", func() {
 			content := valuesTemplate.GetBody()
 
-			Expect(content).To(ContainSubstring("controllerManager:"))
+			Expect(content).To(ContainSubstring("manager:"))
 			Expect(content).To(ContainSubstring("args: []"))
 			Expect(content).To(ContainSubstring("env: []"))
 			Expect(content).To(ContainSubstring("metrics:"))
@@ -79,7 +79,7 @@ var _ = Describe("HelmValuesBasic", func() {
 		It("should still include other basic sections", func() {
 			content := valuesTemplate.GetBody()
 
-			Expect(content).To(ContainSubstring("controllerManager:"))
+			Expect(content).To(ContainSubstring("manager:"))
 			Expect(content).To(ContainSubstring("args: []"))
 			Expect(content).To(ContainSubstring("metrics:"))
 			Expect(content).To(ContainSubstring("prometheus:"))

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
                     - --metrics-bind-address=0
                     {{- end }}
                     - --health-probe-bind-address=:8081
-                    {{- range .Values.controllerManager.args }}
+                    {{- range .Values.manager.args }}
                     - {{ . }}
                     {{- end }}
                     {{- if .Values.certManager.enable }}
@@ -39,13 +39,13 @@ spec:
                   command:
                     - /manager
                   env:
-                    {{- if .Values.controllerManager.env }}
-                    {{- toYaml .Values.controllerManager.env | nindent 20 }}
+                    {{- if .Values.manager.env }}
+                    {{- toYaml .Values.manager.env | nindent 20 }}
                     {{- else }}
                     []
                     {{- end }}
-                  image: "{{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}"
-                  imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+                  image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+                  imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
                   livenessProbe:
                     httpGet:
                         path: /healthz
@@ -64,14 +64,14 @@ spec:
                     initialDelaySeconds: 5
                     periodSeconds: 10
                   resources:
-                    {{- if .Values.controllerManager.resources }}
-                    {{- toYaml .Values.controllerManager.resources | nindent 20 }}
+                    {{- if .Values.manager.resources }}
+                    {{- toYaml .Values.manager.resources | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
                   securityContext:
-                    {{- if .Values.controllerManager.securityContext }}
-                    {{- toYaml .Values.controllerManager.securityContext | nindent 20 }}
+                    {{- if .Values.manager.securityContext }}
+                    {{- toYaml .Values.manager.securityContext | nindent 20 }}
                     {{- else }}
                     {}
                     {{- end }}
@@ -82,8 +82,8 @@ spec:
                       readOnly: true
                     {{- end }}
             securityContext:
-              {{- if .Values.controllerManager.podSecurityContext }}
-              {{- toYaml .Values.controllerManager.podSecurityContext | nindent 14 }}
+              {{- if .Values.manager.podSecurityContext }}
+              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
               {{- else }}
               {}
               {{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -1,5 +1,5 @@
 # Configure the controller manager deployment
-controllerManager:
+manager:
   replicas: 1
   
   image:


### PR DESCRIPTION
controllerManager does not seems the best name for we expose the manager values
This PR simplifies in favor of manager