### PR TITLE
📖 Improve collapsible code sections and formatting of tutorials

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -21,4 +21,3 @@ command = "./markerdocs.sh"
 
 [context.deploy-preview.environment]
   environment = { GO_VERSION = "1.23" }
-

--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -198,7 +198,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// +kubebuilder:docs-gen:collapse=old stuff
+	// +kubebuilder:docs-gen:collapse=Remaining code from main.go
 
 	if err := (&controller.CronJobReconciler{
 		Client: mgr.GetClient(),
@@ -239,5 +239,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-	// +kubebuilder:docs-gen:collapse=old stuff
 }
+
+// +kubebuilder:docs-gen:collapse=Remaining code from main.go

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -68,7 +68,7 @@ type Clock interface {
 	Now() time.Time
 }
 
-// +kubebuilder:docs-gen:collapse=Clock
+// +kubebuilder:docs-gen:collapse=Clock Code Implementation
 
 // Definitions to manage status conditions
 const (

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -208,6 +208,8 @@ var _ = Describe("CronJob controller", func() {
 
 })
 
+// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
+
 /*
 	After writing all this code, you can run `go test ./...` in your `controllers/` directory again to run your new test!
 */

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -170,6 +170,8 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
+// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
+
 /*
 Now that you have your controller running on a test cluster and a client ready to perform operations on your CronJob, we can start writing integration tests!
 */

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
@@ -36,7 +36,7 @@ import (
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
 )
 
-// +kubebuilder:docs-gen:collapse=Go imports
+// +kubebuilder:docs-gen:collapse=Imports
 
 /*
 Next, we'll setup a logger for the webhooks.
@@ -279,4 +279,4 @@ func validateCronJobName(cronjob *batchv1.CronJob) *field.Error {
 	return nil
 }
 
-// +kubebuilder:docs-gen:collapse=Validate object name
+// +kubebuilder:docs-gen:collapse=validateCronJobName() Code Implementation

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -131,7 +131,7 @@ type CronJobStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:docs-gen:collapse=old stuff
+// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_types.go
 
 /*
  Since we'll have more than one version, we'll need to mark a storage version.
@@ -183,4 +183,4 @@ func init() {
 	SchemeBuilder.Register(&CronJob{}, &CronJobList{})
 }
 
-// +kubebuilder:docs-gen:collapse=old stuff
+// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_types.go

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_conversion.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_conversion.go
@@ -90,8 +90,7 @@ func (src *CronJob) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Status.Active = src.Status.Active
 	dst.Status.LastScheduleTime = src.Status.LastScheduleTime
 
-	// +kubebuilder:docs-gen:collapse=rote conversion
-
+	// +kubebuilder:docs-gen:collapse=rest of conversion Code Implementation
 	return nil
 }
 
@@ -141,7 +140,6 @@ func (dst *CronJob) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Status.Active = src.Status.Active
 	dst.Status.LastScheduleTime = src.Status.LastScheduleTime
 
-	// +kubebuilder:docs-gen:collapse=rote conversion
-
+	// +kubebuilder:docs-gen:collapse=rest of conversion Code Implementation
 	return nil
 }

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
@@ -83,10 +83,9 @@ type CronJobSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
-
-	// +kubebuilder:docs-gen:collapse=The rest of Spec
-
 }
+
+// +kubebuilder:docs-gen:collapse=CronJobSpec Full Code
 
 /*
 Next, we'll need to define a type to hold our schedule.

--- a/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
@@ -204,7 +204,6 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "CronJob")
 		os.Exit(1)
 	}
-	// +kubebuilder:docs-gen:collapse=existing setup
 
 	/*
 		Our existing call to SetupWebhookWithManager registers our conversion webhooks with the manager, too.
@@ -225,8 +224,7 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	/*
-	 */
+	// +kubebuilder:docs-gen:collapse=Remaining code from main.go
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
@@ -242,5 +240,8 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-	// +kubebuilder:docs-gen:collapse=existing setup
 }
+
+// +kubebuilder:docs-gen:collapse=Remaining code from main.go
+
+// +kubebuilder:docs-gen:collapse=Remaining code from main.go

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -68,7 +68,7 @@ type Clock interface {
 	Now() time.Time
 }
 
-// +kubebuilder:docs-gen:collapse=Clock
+// +kubebuilder:docs-gen:collapse=Clock Code Implementation
 
 // Definitions to manage status conditions
 const (

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -208,6 +208,8 @@ var _ = Describe("CronJob controller", func() {
 
 })
 
+// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
+
 /*
 	After writing all this code, you can run `go test ./...` in your `controllers/` directory again to run your new test!
 */

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -170,6 +170,8 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
+// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
+
 /*
 Now that you have your controller running on a test cluster and a client ready to perform operations on your CronJob, we can start writing integration tests!
 */

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
@@ -36,7 +36,7 @@ import (
 	batchv1 "tutorial.kubebuilder.io/project/api/v1"
 )
 
-// +kubebuilder:docs-gen:collapse=Go imports
+// +kubebuilder:docs-gen:collapse=Imports
 
 /*
 Next, we'll setup a logger for the webhooks.
@@ -284,4 +284,4 @@ func validateCronJobName(cronjob *batchv1.CronJob) *field.Error {
 	return nil
 }
 
-// +kubebuilder:docs-gen:collapse=Validate object name
+// +kubebuilder:docs-gen:collapse=validateCronJobName() Code Implementation

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+// +kubebuilder:docs-gen:collapse=Apache License
 
 package v2
 

--- a/docs/book/theme/css/markers.css
+++ b/docs/book/theme/css/markers.css
@@ -212,6 +212,11 @@ input.markers-summarize:checked ~ label.markers-summarize::before {
     margin-top: 0.125em;
 }
 
+/* Completely hide low-value collapsed sections (license text, imports) */
+details.collapse-hide {
+    display: none;
+}
+
 /* details elements (not markers) */
 details.collapse-code > summary {
     width: 100%;
@@ -246,6 +251,10 @@ details.collapse-code > summary pre span::after {
 
 details.collapse-code[open] > summary pre span::after {
     content: "";
+}
+
+details.collapse-code > summary pre span.collapse-summary::before {
+    content: "// ";
 }
 
 details.collapse-code > summary pre span::before {

--- a/docs/book/utils/litgo/literate.go
+++ b/docs/book/utils/litgo/literate.go
@@ -242,10 +242,12 @@ func (l Literate) extractContents(contents []byte, pathInfo filePathInfo) (strin
 
 	for _, pair := range pairs {
 		if pair.collapse != "" {
-			// NB(directxman12): we add the hljs class to "cheat" and get the
-			// right background with theming, since hljs doesn't use CSS
-			// variables.
-			out.WriteString("<details class=\"collapse-code\"><summary class=\"hljs\"><pre class=\"hljs\"><span class=\"hljs-comment\">")
+			collapseClass := "collapse-code"
+			// Hide low-value sections entirely (licenses, imports, etc)
+			if strings.EqualFold(pair.collapse, "Apache License") || strings.EqualFold(pair.collapse, "Imports") {
+				collapseClass = "collapse-code collapse-hide"
+			}
+			out.WriteString("<details class=\"" + collapseClass + "\"><summary class=\"hljs\"><pre class=\"hljs\"><span class=\"collapse-summary\">")
 			out.WriteString(pair.collapse)
 			out.WriteString("</span></pre></summary>")
 		}

--- a/hack/docs/internal/cronjob-tutorial/controller_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/controller_implementation.go
@@ -65,7 +65,7 @@ type Clock interface {
 	Now() time.Time
 }
 
-// +kubebuilder:docs-gen:collapse=Clock
+// +kubebuilder:docs-gen:collapse=Clock Code Implementation
 
 // Definitions to manage status conditions
 const (

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -358,7 +358,7 @@ CronJob controller's`+" `"+`SetupWithManager`+"`"+` method.
 		os.Exit(1)
 	}`, `
 
-	// +kubebuilder:docs-gen:collapse=old stuff`)
+	// +kubebuilder:docs-gen:collapse=Remaining code from main.go`)
 	hackutils.CheckError("fixing main.go", err)
 
 	err = pluginutil.InsertCode(
@@ -372,8 +372,9 @@ CronJob controller's`+" `"+`SetupWithManager`+"`"+` method.
 		filepath.Join(sp.ctx.Dir, "cmd/main.go"),
 		`setupLog.Error(err, "problem running manager")
 		os.Exit(1)
-	}`, `
-	// +kubebuilder:docs-gen:collapse=old stuff`)
+	}
+}`, `
+// +kubebuilder:docs-gen:collapse=Remaining code from main.go`)
 	hackutils.CheckError("fixing main.go", err)
 }
 

--- a/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
@@ -19,7 +19,7 @@ package cronjob
 const webhookIntro = `batchv1 "tutorial.kubebuilder.io/project/api/v1"
 )
 
-// +kubebuilder:docs-gen:collapse=Go imports
+// +kubebuilder:docs-gen:collapse=Imports
 
 /*
 Next, we'll setup a logger for the webhooks.
@@ -178,7 +178,7 @@ func validateCronJobName(cronjob *batchv1.CronJob) *field.Error {
 	return nil
 }
 
-// +kubebuilder:docs-gen:collapse=Validate object name`
+// +kubebuilder:docs-gen:collapse=validateCronJobName() Code Implementation`
 
 const fragmentForDefaultFields = `
 	// Default values for various CronJob fields

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
@@ -226,6 +226,7 @@ var _ = Describe("CronJob controller", func() {
 	})
 
 })
+// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
 
 /*
 	After writing all this code, you can run` + " `" + `go test ./...` + "`" + ` in your` + " `" + `controllers/` + "`" + ` directory again to run your new test!

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -120,6 +120,7 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
 
 /*
 Now that you have your controller running on a test cluster and a client ready to perform operations on your CronJob, we can start writing integration tests!

--- a/hack/docs/internal/multiversion-tutorial/cronjob_v1.go
+++ b/hack/docs/internal/multiversion-tutorial/cronjob_v1.go
@@ -60,7 +60,7 @@ const statusDesignComment = `/*
  serialization, as mentioned above.
 */`
 
-const boilerplateReplacement = `// +kubebuilder:docs-gen:collapse=old stuff
+const boilerplateReplacement = `// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_types.go
 
 /*
  Since we'll have more than one version, we'll need to mark a storage version.

--- a/hack/docs/internal/multiversion-tutorial/cronjob_v2.go
+++ b/hack/docs/internal/multiversion-tutorial/cronjob_v2.go
@@ -64,10 +64,9 @@ const cronjobSpecMore = `// startingDeadlineSeconds defines in seconds for start
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	FailedJobsHistoryLimit *int32 ` + "`json:\"failedJobsHistoryLimit,omitempty\"`" + `
-
-	// +kubebuilder:docs-gen:collapse=The rest of Spec
-
 }
+
+// +kubebuilder:docs-gen:collapse=CronJobSpec Full Code
 
 /*
 Next, we'll need to define a type to hold our schedule.

--- a/hack/docs/internal/multiversion-tutorial/hub.go
+++ b/hack/docs/internal/multiversion-tutorial/hub.go
@@ -73,7 +73,7 @@ const hubV2CovertTo = `sched := src.Spec.Schedule
 	dst.Status.Active = src.Status.Active
 	dst.Status.LastScheduleTime = src.Status.LastScheduleTime
 
-	// +kubebuilder:docs-gen:collapse=rote conversion`
+	// +kubebuilder:docs-gen:collapse=rest of conversion Code Implementation`
 
 const hubV2ConvertFromCode = `schedParts := strings.Split(src.Spec.Schedule, " ")
 	if len(schedParts) != 5 {
@@ -110,4 +110,4 @@ const hubV2ConvertFromCode = `schedParts := strings.Split(src.Spec.Schedule, " "
 	dst.Status.Active = src.Status.Active
 	dst.Status.LastScheduleTime = src.Status.LastScheduleTime
 
-	// +kubebuilder:docs-gen:collapse=rote conversion`
+	// +kubebuilder:docs-gen:collapse=rest of conversion Code Implementation`

--- a/testdata/project-v4/internal/controller/sailor_controller.go
+++ b/testdata/project-v4/internal/controller/sailor_controller.go
@@ -45,7 +45,7 @@ type SailorReconciler struct {
 // the user.
 //
 // For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.22.3/pkg/reconcile
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.22.4/pkg/reconcile
 func (r *SailorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = logf.FromContext(ctx)
 


### PR DESCRIPTION
The following changes impact mainly the tutorials.
To review see:
- https://deploy-preview-5175--kubebuilder.netlify.app/cronjob-tutorial/cronjob-tutorial
- https://deploy-preview-5175--kubebuilder.netlify.app/multiversion-tutorial/tutorial

## Documentation Improvements Summary

### Changes

**Content Cleanup:**
- Hidden Apache License and Import blocks
- Hidden closing braces in tests
- Removed duplicate collapse markers
- Fixed extra `}` appearing outside code blocks

**Label Updates:**
- "Clock" → "Clock Code Implementation"
- "Go imports" → "Imports"
- "Validate object name" → "validateCronJobName() Code Implementation"
- "old stuff" → "Remaining code from <filename>"
- "The rest of Spec" → "CronJobSpec Full Code"

**Related:** #4862