### PR TITLE
🌱 chore: Move to maintained yaml library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/mod v0.29.0
 	golang.org/x/text v0.30.0
 	golang.org/x/tools v0.38.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.0
 	k8s.io/apimachinery v0.34.1
 	sigs.k8s.io/yaml v1.6.0
@@ -36,7 +36,6 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )


### PR DESCRIPTION
gopkg.in/yaml is not maintained anymore, https://github.com/yaml/go-yaml is used by https://github.com/kubernetes-sigs/yaml and probably a good drop-in replacement.