### PR TITLE
📖 : fix(docs): display copy button on codeblocks

### DIFF
--- a/docs/book/theme/css/markers.css
+++ b/docs/book/theme/css/markers.css
@@ -365,11 +365,6 @@ cite.literate-source > a::before {
     color: var(--fg);
 }
 
-/* hide the annoying "copy to clipboard" buttons */
-.literate pre > .buttons {
-    display: none;
-}
-
 /* add a bit of extra padding for readability */
 .literate pre code {
     padding-top: 0.75em;


### PR DESCRIPTION
This PR fixes the issue in which the copy button would not be displayed in code blocks generated by literate-go. 

Related to #4862 and #5175.

### Before:

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/2d3b2dad-2f2a-428c-a8ea-b6f50ccf6f70" />

### After:

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/ead060bb-9f8a-41da-a42a-cd5b6ba9fb25" />
