### PR TITLE
🐛 Downgrade Go to 1.24.6 and standardize version across codebase

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/README.md
+++ b/docs/book/src/cronjob-tutorial/testdata/project/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/cronjob-tutorial/testdata/project/go.mod
+++ b/docs/book/src/cronjob-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/getting-started/testdata/project/Dockerfile
+++ b/docs/book/src/getting-started/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/getting-started/testdata/project/README.md
+++ b/docs/book/src/getting-started/testdata/project/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/getting-started/testdata/project/go.mod
+++ b/docs/book/src/getting-started/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module example.com/memcached
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/README.md
+++ b/docs/book/src/multiversion-tutorial/testdata/project/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/multiversion-tutorial/testdata/project/go.mod
+++ b/docs/book/src/multiversion-tutorial/testdata/project/go.mod
@@ -1,6 +1,6 @@
 module tutorial.kubebuilder.io/project
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -9,7 +9,7 @@ This Quick Start guide will cover:
 
 ## Prerequisites
 
-- [go](https://go.dev/dl/) version v1.24.5+
+- [go](https://go.dev/dl/) version v1.24.6+
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
+++ b/docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1/go.mod
@@ -1,6 +1,6 @@
 module v1
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/spf13/pflag v1.0.10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/v4
 
-go 1.25.0
+go 1.24.6
 
 require (
 	github.com/gobuffalo/flect v1.0.3

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -22,7 +22,7 @@ import (
 
 const devContainerTemplate = `{
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/gomod.go
@@ -45,7 +45,7 @@ func (f *GoMod) SetTemplateDefaults() error {
 
 const goModTemplate = `module {{ .Repo }}
 
-go 1.24.5
+go 1.24.6
 
 require (
 	sigs.k8s.io/controller-runtime {{ .ControllerRuntimeVersion }}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/readme.go
@@ -73,7 +73,7 @@ const readmeFileTemplate = `# {{ .ProjectName }}
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup/README.md
+++ b/testdata/project-v4-multigroup/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4-multigroup/go.mod
+++ b/testdata/project-v4-multigroup/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/cert-manager/cert-manager v1.18.2

--- a/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4-with-plugins/Dockerfile
+++ b/testdata/project-v4-with-plugins/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-plugins/README.md
+++ b/testdata/project-v4-with-plugins/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4-with-plugins/go.mod
+++ b/testdata/project-v4-with-plugins/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v4-with-plugins
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.25",
+  "image": "golang:1.24",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4/README.md
+++ b/testdata/project-v4/README.md
@@ -7,7 +7,7 @@
 ## Getting Started
 
 ### Prerequisites
-- go version v1.24.0+
+- go version v1.24.6+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/testdata/project-v4/go.mod
+++ b/testdata/project-v4/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kubebuilder/testdata/project-v4
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/cert-manager/cert-manager v1.18.2


### PR DESCRIPTION
### Summary
This PR downgrades the Go version to **1.24.6** and ensures consistent usage across all modules and build configurations.

### Motivation
- **Security:** Go **1.24.6** includes important fixes that address a known CVE affecting earlier patch releases in the 1.24 series.  
- **Compatibility:** The latest versions of **Kubernetes APIs**, **controller-runtime**, and **controller-tools** are still built and tested against Go **1.24.x**, so maintaining this version ensures full compatibility and avoids potential build or runtime issues.
