### PR TITLE
📖 (docs/ui): better format for warnings

### DIFF
--- a/docs/book/src/cronjob-tutorial/running-webhook.md
+++ b/docs/book/src/cronjob-tutorial/running-webhook.md
@@ -62,9 +62,9 @@ kubectl create -f config/samples/batch_v1_cronjob.yaml
 You can also try to create an invalid CronJob (e.g. use an ill-formatted
 schedule field). You should see a creation failure with a validation error.
 
-<aside class="note warning">
+<aside class="warning">
 
-<h1>The Bootstrapping Problem</h1>
+<h3>The Bootstrapping Problem</h3>
 
 If you are deploying a webhook for pods in the same cluster, be
 careful about the bootstrapping problem, since the creation request of the

--- a/docs/book/src/migration/legacy/manually_migration_guide_v2_v3.md
+++ b/docs/book/src/migration/legacy/manually_migration_guide_v2_v3.md
@@ -326,8 +326,8 @@ config version to the latest supported by your target plugin version before upgr
 
 The following steps describe the manual changes required to modify the project's layout enabling your project to use the `go/v3` plugin. These steps will not help you address all the bug fixes of the already generated scaffolds.
 
-<aside class="note warning">
-<h1> Deprecated APIs </h1>
+<aside class="warning">
+    <h3> Deprecated APIs </h3>
 
 The following steps will not migrate the API versions which are deprecated `apiextensions.k8s.io/v1beta1`, `admissionregistration.k8s.io/v1beta1`, `cert-manager.io/v1alpha2`.
 
@@ -500,8 +500,8 @@ You can check all changes applied to the Makefile by looking in the samples proj
 
 #### Update your controllers
 
-<aside class="note warning">
-<h1>Controller-runtime version updated has breaking changes</h1>
+<aside class="warning">
+    <h3>Controller-runtime version updated has breaking changes</h3>
 
 Check [sigs.k8s.io/controller-runtime release docs from 0.7.0+ version][controller-releases] for breaking changes.
 
@@ -524,8 +524,8 @@ func (r *<MyKind>Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 #### Update your controller and webhook test suite
 
-<aside class="note warning">
-<h1>Ginkgo V2 version update has breaking changes</h1>
+<aside class="warning">
+    <h3>Ginkgo V2 version update has breaking changes</h3>
 
 Check [Ginkgo V2 Migration Guide](https://onsi.github.io/ginkgo/MIGRATING_TO_V2) for breaking changes.
 
@@ -703,8 +703,8 @@ version: "3"
 
 You can try to re-create the APIS(CRDs) and Webhooks manifests by using the `--force` flag.
 
-<aside class="note warning">
-<h1>Before re-create</h1>
+<aside class="warning">
+    <h3>Before re-create</h3>
 
 Note, however, that the tool will re-scaffold the files which means that you will lose their content.
 

--- a/docs/book/src/migration/legacy/migration_guide_v2tov3.md
+++ b/docs/book/src/migration/legacy/migration_guide_v2tov3.md
@@ -109,8 +109,8 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	log := r.Log.WithValues("cronjob", req.NamespacedName)
 ```
 
-<aside class="note warning">
-<h1>Controller-runtime version updated has breaking changes</h1>
+<aside class="warning">
+    <h3>Controller-runtime version updated has breaking changes</h3>
 
 Check [sigs.k8s.io/controller-runtime release docs from 0.8.0+ version][controller-runtime] for breaking changes.
 

--- a/docs/book/src/migration/legacy/v2vsv3.md
+++ b/docs/book/src/migration/legacy/v2vsv3.md
@@ -49,8 +49,8 @@ Projects scaffolded with Kubebuilder v3 will use the `go.kubebuilder.io/v3` plug
   * Required Envtest binaries are automatically downloaded
   * The minimum Go version is now `1.18` (previously it was `1.13`).
 
-<aside class="note warning">
-<h1>Project customizations</h1>
+<aside class="warning">
+    <h3>Project customizations</h3>
 
 After using the CLI to create your project, you are free to customise how you see fit. Bear in mind, that it is not recommended to deviate from the proposed layout unless you know what you are doing.
 
@@ -62,8 +62,8 @@ For example, you should refrain from moving the scaffolded files, doing so will 
 
 So you want to upgrade your scaffolding to use the latest and greatest features then, follow up the following guide which will cover the steps in the most straightforward way to allow you to upgrade your project to get all latest changes and improvements.
 
-<aside class="note warning">
-<h1> Apple Silicon (M1) </h1>
+<aside class="warning">
+    <h3> Apple Silicon (M1) </h3>
 
 The current scaffold done by the CLI (`go/v3`) uses [kubernetes-sigs/kustomize][kustomize] v3 which does not provide
 a valid binary for Apple Silicon (`darwin/arm64`). Therefore, you can use the `go/v4` plugin

--- a/docs/book/src/migration/migration_guide_gov3_to_gov4.md
+++ b/docs/book/src/migration/migration_guide_gov3_to_gov4.md
@@ -10,8 +10,8 @@ The recommended way to migrate a `go/v3` project is to create a new `go/v4` proj
 copy over the API and the reconciliation code. The conversion will end up with a
 project that looks like a native go/v4 project layout (latest version).
 
-<aside class="note warning">
-<h1>Your Upgrade Assistant: The `alpha generate` command</h1>
+<aside class="warning">
+    <h3>Your Upgrade Assistant: The `alpha generate` command</h3>
 
 To upgrade your project you might want to use the command `kubebuilder alpha generate [OPTIONS]`.
 This command will re-scaffold the project using the current Kubebuilder version.

--- a/docs/book/src/migration/multi-group.md
+++ b/docs/book/src/migration/multi-group.md
@@ -1,8 +1,8 @@
 # Single Group to Multi-Group
 
-<aside class="note warning">
+<aside class="warning">
 
-<h1>Note</h1>
+<h3>Note</h3>
 
 While Kubebuilder will not scaffold out a project structure compatible
 with multiple API groups in the same repository by default, it's possible
@@ -14,8 +14,8 @@ Note that the process mainly is to ensure that your  API(s) and controller(s) wi
 
 Let's migrate the [CronJob example][cronjob-tutorial].
 
-<aside class="note warning">
-<h1>Instructions vary per project layout</h1>
+<aside class="warning">
+    <h3>Instructions vary per project layout</h3>
 
 You can verify the version by looking at the PROJECT file. The currently default and
 recommended version is go/v4.

--- a/docs/book/src/migration/v3vsv4.md
+++ b/docs/book/src/migration/v3vsv4.md
@@ -34,8 +34,8 @@ Further details can be found in the [go/v4 plugin section][go/v4-doc]
 
 **_More details on this can be found at [here][kb-releases], but for the highlights, check below_**
 
-<aside class="note warning">
-<h1>Project customizations</h1>
+<aside class="warning">
+    <h3>Project customizations</h3>
 
 After using the CLI to create your project, you are free to customize how you see fit. Bear in mind, that it is not recommended to deviate from the proposed layout unless you know what you are doing.
 

--- a/docs/book/src/migrations.md
+++ b/docs/book/src/migrations.md
@@ -29,8 +29,8 @@ The traditional process involves:
 All inputs used by Kubebuilder are tracked in the [PROJECT][project-config] file.
 If you use the CLI to generate your scaffolds, this file will record the project's configuration and metadata.
 
-<aside class="note warning">
-<h1>Project customizations</h1>
+<aside class="warning">
+    <h3>Project customizations</h3>
 
 After using the CLI to create your project, you are free to customise how you see fit.
 Bear in mind, that it is not recommended to deviate from the proposed layout unless you know what you are doing.
@@ -46,8 +46,8 @@ the doc [What's in a basic project?][basic-project-doc]
 
 Kubebuilder provides alpha commands to assist with project upgrades.
 
-<aside class="note warning">
-<h1>Automation process will involve deleting all files to regenerate</h1>
+<aside class="warning">
+<h3>Automation process will involve deleting all files to regenerate</h3>
 Deletes all files except `.git` and `PROJECT`.
 </aside>
 

--- a/docs/book/src/reference/alpha_commands.md
+++ b/docs/book/src/reference/alpha_commands.md
@@ -6,8 +6,8 @@ project migration and scaffold regeneration.
 These commands are designed to simplify tasks that were previously manual and error-prone
 by automating or partially automating the process.
 
-<aside class="note warning">
-<h1>Alpha commands are experimental</h1>
+<aside class="warning">
+    <h3>Alpha commands are experimental</h3>
 
 Alpha commands are under active development and may change or be removed in future releases.
 They make local changes to your project and may delete files during execution.

--- a/docs/book/src/reference/artifacts.md
+++ b/docs/book/src/reference/artifacts.md
@@ -26,8 +26,8 @@ of its tooling. Additionally, you can find more information by reviewing the Kub
 </aside>
 
 
-<aside class="note warning">
-<h1>IMPORTANT: Action Required: Ensure that you no longer use https://storage.googleapis.com/kubebuilder-tools </h1>
+<aside class="warning">
+    <h3>IMPORTANT: Action Required: Ensure that you no longer use https://storage.googleapis.com/kubebuilder-tools </h3>
 
 **Artifacts provided under [https://storage.googleapis.com/kubebuilder-tools](https://storage.googleapis.com/kubebuilder-tools) are deprecated and Kubebuilder maintainers are no longer able to support, build, or ensure the promotion of these artifacts.**
 

--- a/docs/book/src/reference/commands/alpha_generate.md
+++ b/docs/book/src/reference/commands/alpha_generate.md
@@ -12,8 +12,8 @@ in newer Kubebuilder releases.
 You may choose to re-scaffold the project in-place (overwriting existing files) or in a separate
 directory for diff-based inspection and manual integration.
 
-<aside class="note warning">
-<h1>Deletes files during scaffold regeneration</h1>
+<aside class="warning">
+    <h3>Deletes files during scaffold regeneration</h3>
 When executed in-place, this command deletes all files except `.git` and `PROJECT`.
 
 Always back up your project or use version control before running this command.

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -208,8 +208,8 @@ kubebuilder alpha update \
   --git-config rerere.enabled=true
 ```
 
-<aside class="note warning">
-<h1>You might need to upgrade your project first</h1>
+<aside class="warning">
+    <h3>You might need to upgrade your project first</h3>
 
 This command uses `kubebuilder alpha generate` under the hood.
 We support projects created with <strong>v4.5.0+</strong>.

--- a/docs/book/src/reference/markers/scaffold.md
+++ b/docs/book/src/reference/markers/scaffold.md
@@ -5,8 +5,8 @@ files where additional code will be injected as new resources (such as controlle
 This enables Kubebuilder to seamlessly integrate newly generated components into the project without affecting
 user-defined code.
 
-<aside class="note warning">
-<H1>If you delete or change the `+kubebuilder:scaffold` markers</H1>
+<aside class="warning">
+    <h3>If you delete or change the `+kubebuilder:scaffold` markers</h3>
 
 The Kubebuilder CLI specifically looks for these markers in expected
 files during code generation. If the marker is moved or removed, the CLI will
@@ -109,8 +109,8 @@ properly registered with the manager, so that the controller can reconcile the r
 | `+kubebuilder:scaffold:manifestskustomizesamples` | `config/samples`           | Marks where Kustomize sample manifests are injected.                            |
 | `+kubebuilder:scaffold:e2e-webhooks-checks` | `test/e2e`                   | Adds e2e checks for webhooks depending on the types of webhooks scaffolded.      |
 
-<aside class="note warning">
-<h1> **(No longer supported)** `+kubebuilder:scaffold:crdkustomizecainjectionpatch` </h1>
+<aside class="warning">
+    <h3> **(No longer supported)** `+kubebuilder:scaffold:crdkustomizecainjectionpatch` </h3>
 
 If you find this marker in your code please:
 

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -4,8 +4,8 @@ By default, controller-runtime builds a global prometheus registry and
 publishes [a collection of performance metrics](/reference/metrics-reference.md) for each controller.
 
 
-<aside class="note warning">
-<h1>IMPORTANT: If you are using `kube-rbac-proxy`</h1>
+<aside class="warning">
+    <h3>IMPORTANT: If you are using `kube-rbac-proxy`</h3>
 
 Please stop using the image `gcr.io/kubebuilder/kube-rbac-proxy` as soon as possible.
 Your projects will be affected and may fail to work if the image cannot be pulled.

--- a/docs/book/src/reference/pprof-tutorial.md
+++ b/docs/book/src/reference/pprof-tutorial.md
@@ -2,8 +2,8 @@
 
 [Pprof][github], a Go profiling tool, helps identify performance bottlenecks in areas like CPU and memory usage. It's integrated with the controller-runtime library's HTTP server, enabling profiling via HTTP endpoints. You can visualize the data using go tool pprof. Since [Pprof][github] is built into controller-runtime, no separate installation is needed. [Manager options][manager-options-doc] make it easy to enable pprof and gather runtime metrics to optimize controller performance.
 
-<aside class="note warning">
-<h1>Not Recommended for Production</h1>
+<aside class="warning">
+    <h3>Not Recommended for Production</h3>
 
 While [Pprof][github] is an excellent tool for profiling and debugging, it is not recommended to leave it enabled in production environments. The primary reasons are:
 

--- a/docs/book/src/reference/submodule-layouts.md
+++ b/docs/book/src/reference/submodule-layouts.md
@@ -29,8 +29,8 @@ They introduce however multiple caveats into typical projects which is one of th
 - There is always the possibility to extract your APIs into a new repository and arguably also have more control over the release process in a project spanning multiple repos relying on the same API types.
 - It requires at least one [replace directive][replace-directives] either through `go.work` which is at least 2 more files plus an environment variable for build environments without GO_WORK or through `go.mod` replace, which has to be manually dropped and added for every release.
 
-<aside class="note warning">
-<h1>Implications on Maintenance efforts</h1>
+<aside class="warning">
+    <h3>Implications on Maintenance efforts</h3>
 
 When deciding to deviate from the standard kubebuilder `PROJECT` setup or the extended layouts offered by its plugins, it can result in increased maintenance overhead as there can be breaking changes in upstream that could break with the custom module structure described here.
 
@@ -133,8 +133,8 @@ go mod tidy
 Note that we used the placeholder version `v0.0.0` of the API Module. In case you already released your API module once,
 you can use the real version as well. However this will only work if the API Module is already available in the VCS.
 
-<aside class="note warning">
-<h1>Implications on controller releases</h1>
+<aside class="warning">
+    <h3>Implications on controller releases</h3>
 
 Since the main `go.mod` file now has a replace directive, it is important to drop it again before releasing your controller module.
 To achieve this you can simply run

--- a/docs/book/src/versions_compatibility_supportability.md
+++ b/docs/book/src/versions_compatibility_supportability.md
@@ -33,8 +33,8 @@ Currently, Kubebuilder officially supports macOS and Linux platforms. If you are
 
 Contributions towards supporting Windows are not planned.
 
-<aside class="note warning">
-<h1>Project customizations</h1>
+<aside class="warning">
+    <h3>Project customizations</h3>
 
 After using the CLI to create your project, you are free to customize how
 you see fit. Bear in mind, that it is not recommended to deviate from


### PR DESCRIPTION
This PR fixes the styles in warnings in several elements in the book.

Related to #4862.

### Before

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/75106e9d-f044-41d3-a7de-5ec80293d7d6" />

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/39c68fbe-de94-4450-bbcc-953aa46df881" />

### After

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/8a81b924-e135-456f-adad-ec44ad622cd3" />

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/b1fa704f-23ee-4081-8271-f43e67c50524" />