### PR TITLE
🌱 Fix test-coverage to include only directories where are covered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test-unit: ## Run the unit tests
 .PHONY: test-coverage
 test-coverage: ## Run unit tests creating the output to report coverage
 	- rm -rf *.out  # Remove all coverage files if exists
-	go test -race -failfast -tags=integration -coverprofile=coverage-all.out -coverpkg="./pkg/cli/...,./pkg/config/...,./pkg/internal/...,./pkg/machinery/...,./pkg/model/...,./pkg/plugin/...,./pkg/plugins/..." $(TEST_PKGS)
+	go test -race -failfast -tags=integration -coverprofile=coverage-all.out -coverpkg="./pkg/cli/...,./pkg/config/...,./pkg/internal/...,./pkg/machinery/...,./pkg/model/...,./pkg/plugin/...,./pkg/plugins/golang/...,./pkg/plugins/external/...,./pkg/plugins/optional/grafana/...,./pkg/plugins/optional/helm/v2alpha/..." $(TEST_PKGS)
 
 .PHONY: test-features
 test-features: ## Run the integration tests


### PR DESCRIPTION
## Description

This PR fixes the `test-coverage` target in the Makefile to properly cover the plugin directories that have tests.

## Problem

In PR #5197, the coverage configuration was inadvertently changed from specific plugin paths to `./pkg/plugins/...`, which includes all plugins indiscriminately. This is problematic because:
- It includes deprecated plugins (e.g., `helm/v1-alpha`) that shouldn't be covered
- It includes plugins without test files (e.g., `common/kustomize/v2`, `optional/autoupdate`); We might can revisit it. If would make sense cover those with "unit tests"
- It was missing the `external` plugin which has tests

## Solution

Updated the `-coverpkg` parameter to explicitly include only plugin directories with tests:
- `./pkg/plugins/golang/...` - Core golang plugin with multiple test files
- `./pkg/plugins/external/...` - External plugin support (was missing)
- `./pkg/plugins/optional/grafana/...` - Has scaffold tests that validate dashboard generation
- `./pkg/plugins/optional/helm/v2-alpha/...` - Active helm plugin with tests (excluding deprecated v1-alpha)

This provides more accurate coverage reporting and focuses on the plugins we actively maintain and test.

## Related

- Fixes the regression introduced in #5197