### PR TITLE
🐛 (go/v4;deploy-image/v1-alpha): Remove omitempty from nested struct JSON tags in API scaffolds

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -192,7 +192,7 @@ type CronJob struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of CronJob
 	// +required
@@ -200,7 +200,7 @@ type CronJob struct {
 
 	// status defines the observed state of CronJob
 	// +optional
-	Status CronJobStatus `json:"status,omitempty,omitzero"`
+	Status CronJobStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -208,7 +208,7 @@ type CronJob struct {
 // CronJobList contains a list of CronJob
 type CronJobList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []CronJob `json:"items"`
 }
 

--- a/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
+++ b/docs/book/src/getting-started/testdata/project/api/v1alpha1/memcached_types.go
@@ -75,7 +75,7 @@ type Memcached struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Memcached
 	// +required
@@ -83,7 +83,7 @@ type Memcached struct {
 
 	// status defines the observed state of Memcached
 	// +optional
-	Status MemcachedStatus `json:"status,omitempty,omitzero"`
+	Status MemcachedStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -91,7 +91,7 @@ type Memcached struct {
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Memcached `json:"items"`
 }
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v1/cronjob_types.go
@@ -156,7 +156,7 @@ type CronJob struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of CronJob
 	// +required
@@ -164,7 +164,7 @@ type CronJob struct {
 
 	// status defines the observed state of CronJob
 	// +optional
-	Status CronJobStatus `json:"status,omitempty,omitzero"`
+	Status CronJobStatus `json:"status,omitzero"`
 }
 
 /*
@@ -175,7 +175,7 @@ type CronJob struct {
 // CronJobList contains a list of CronJob
 type CronJobList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []CronJob `json:"items"`
 }
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/api/v2/cronjob_types.go
@@ -186,7 +186,7 @@ type CronJob struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of CronJob
 	// +required
@@ -194,7 +194,7 @@ type CronJob struct {
 
 	// status defines the observed state of CronJob
 	// +optional
-	Status CronJobStatus `json:"status,omitempty,omitzero"`
+	Status CronJobStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -202,7 +202,7 @@ type CronJob struct {
 // CronJobList contains a list of CronJob
 type CronJobList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []CronJob `json:"items"`
 }
 

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/api/types.go
@@ -126,7 +126,7 @@ type {{ .Resource.Kind }} struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty,omitzero"` + "`" + `
+	metav1.ObjectMeta ` + "`" + `json:"metadata,omitzero"` + "`" + `
 
 	// spec defines the desired state of {{ .Resource.Kind }}
 	// +required
@@ -134,7 +134,7 @@ type {{ .Resource.Kind }} struct {
 
 	// status defines the observed state of {{ .Resource.Kind }}
 	// +optional
-	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty,omitzero"` + "`" + `
+	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitzero"` + "`" + `
 }
 
 // +kubebuilder:object:root=true
@@ -142,7 +142,7 @@ type {{ .Resource.Kind }} struct {
 // {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}List struct {
 	metav1.TypeMeta ` + "`" + `json:",inline"` + "`" + `
-	metav1.ListMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
+	metav1.ListMeta ` + "`" + `json:"metadata,omitzero"` + "`" + `
 	Items           []{{ .Resource.Kind }} ` + "`" + `json:"items"` + "`" + `
 }
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -124,7 +124,7 @@ type {{ .Resource.Kind }} struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta ` + "`" + `json:"metadata,omitempty,omitzero"` + "`" + `
+	metav1.ObjectMeta ` + "`" + `json:"metadata,omitzero"` + "`" + `
 
 	// spec defines the desired state of {{ .Resource.Kind }}
 	// +required
@@ -132,7 +132,7 @@ type {{ .Resource.Kind }} struct {
 
 	// status defines the observed state of {{ .Resource.Kind }}
 	// +optional
-	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitempty,omitzero"` + "`" + `
+	Status {{ .Resource.Kind }}Status ` + "`" + `json:"status,omitzero"` + "`" + `
 }
 
 // +kubebuilder:object:root=true
@@ -140,7 +140,7 @@ type {{ .Resource.Kind }} struct {
 // {{ .Resource.Kind }}List contains a list of {{ .Resource.Kind }}
 type {{ .Resource.Kind }}List struct {
 	metav1.TypeMeta ` + "`" + `json:",inline"` + "`" + `
-	metav1.ListMeta ` + "`" + `json:"metadata,omitempty"` + "`" + `
+	metav1.ListMeta ` + "`" + `json:"metadata,omitzero"` + "`" + `
 	Items           []{{ .Resource.Kind }} ` + "`" + `json:"items"` + "`" + `
 }
 

--- a/testdata/project-v4-multigroup/api/crew/v1/captain_types.go
+++ b/testdata/project-v4-multigroup/api/crew/v1/captain_types.go
@@ -67,7 +67,7 @@ type Captain struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Captain
 	// +required
@@ -75,7 +75,7 @@ type Captain struct {
 
 	// status defines the observed state of Captain
 	// +optional
-	Status CaptainStatus `json:"status,omitempty,omitzero"`
+	Status CaptainStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Captain struct {
 // CaptainList contains a list of Captain
 type CaptainList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Captain `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v1/wordpress_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1/wordpress_types.go
@@ -68,7 +68,7 @@ type Wordpress struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Wordpress
 	// +required
@@ -76,7 +76,7 @@ type Wordpress struct {
 
 	// status defines the observed state of Wordpress
 	// +optional
-	Status WordpressStatus `json:"status,omitempty,omitzero"`
+	Status WordpressStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type Wordpress struct {
 // WordpressList contains a list of Wordpress
 type WordpressList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Wordpress `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/busybox_types.go
@@ -66,7 +66,7 @@ type Busybox struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Busybox
 	// +required
@@ -74,7 +74,7 @@ type Busybox struct {
 
 	// status defines the observed state of Busybox
 	// +optional
-	Status BusyboxStatus `json:"status,omitempty,omitzero"`
+	Status BusyboxStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -82,7 +82,7 @@ type Busybox struct {
 // BusyboxList contains a list of Busybox
 type BusyboxList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Busybox `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v1alpha1/memcached_types.go
@@ -70,7 +70,7 @@ type Memcached struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Memcached
 	// +required
@@ -78,7 +78,7 @@ type Memcached struct {
 
 	// status defines the observed state of Memcached
 	// +optional
-	Status MemcachedStatus `json:"status,omitempty,omitzero"`
+	Status MemcachedStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -86,7 +86,7 @@ type Memcached struct {
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Memcached `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/example.com/v2/wordpress_types.go
+++ b/testdata/project-v4-multigroup/api/example.com/v2/wordpress_types.go
@@ -67,7 +67,7 @@ type Wordpress struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Wordpress
 	// +required
@@ -75,7 +75,7 @@ type Wordpress struct {
 
 	// status defines the observed state of Wordpress
 	// +optional
-	Status WordpressStatus `json:"status,omitempty,omitzero"`
+	Status WordpressStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Wordpress struct {
 // WordpressList contains a list of Wordpress
 type WordpressList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Wordpress `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/fiz/v1/bar_types.go
+++ b/testdata/project-v4-multigroup/api/fiz/v1/bar_types.go
@@ -67,7 +67,7 @@ type Bar struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Bar
 	// +required
@@ -75,7 +75,7 @@ type Bar struct {
 
 	// status defines the observed state of Bar
 	// +optional
-	Status BarStatus `json:"status,omitempty,omitzero"`
+	Status BarStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Bar struct {
 // BarList contains a list of Bar
 type BarList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Bar `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/foo.policy/v1/healthcheckpolicy_types.go
+++ b/testdata/project-v4-multigroup/api/foo.policy/v1/healthcheckpolicy_types.go
@@ -67,7 +67,7 @@ type HealthCheckPolicy struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of HealthCheckPolicy
 	// +required
@@ -75,7 +75,7 @@ type HealthCheckPolicy struct {
 
 	// status defines the observed state of HealthCheckPolicy
 	// +optional
-	Status HealthCheckPolicyStatus `json:"status,omitempty,omitzero"`
+	Status HealthCheckPolicyStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type HealthCheckPolicy struct {
 // HealthCheckPolicyList contains a list of HealthCheckPolicy
 type HealthCheckPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []HealthCheckPolicy `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/foo/v1/bar_types.go
+++ b/testdata/project-v4-multigroup/api/foo/v1/bar_types.go
@@ -67,7 +67,7 @@ type Bar struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Bar
 	// +required
@@ -75,7 +75,7 @@ type Bar struct {
 
 	// status defines the observed state of Bar
 	// +optional
-	Status BarStatus `json:"status,omitempty,omitzero"`
+	Status BarStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Bar struct {
 // BarList contains a list of Bar
 type BarList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Bar `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/kraken_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta1/kraken_types.go
@@ -67,7 +67,7 @@ type Kraken struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Kraken
 	// +required
@@ -75,7 +75,7 @@ type Kraken struct {
 
 	// status defines the observed state of Kraken
 	// +optional
-	Status KrakenStatus `json:"status,omitempty,omitzero"`
+	Status KrakenStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Kraken struct {
 // KrakenList contains a list of Kraken
 type KrakenList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Kraken `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/leviathan_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1beta2/leviathan_types.go
@@ -67,7 +67,7 @@ type Leviathan struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Leviathan
 	// +required
@@ -75,7 +75,7 @@ type Leviathan struct {
 
 	// status defines the observed state of Leviathan
 	// +optional
-	Status LeviathanStatus `json:"status,omitempty,omitzero"`
+	Status LeviathanStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Leviathan struct {
 // LeviathanList contains a list of Leviathan
 type LeviathanList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Leviathan `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/ship/v1/destroyer_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v1/destroyer_types.go
@@ -68,7 +68,7 @@ type Destroyer struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Destroyer
 	// +required
@@ -76,7 +76,7 @@ type Destroyer struct {
 
 	// status defines the observed state of Destroyer
 	// +optional
-	Status DestroyerStatus `json:"status,omitempty,omitzero"`
+	Status DestroyerStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type Destroyer struct {
 // DestroyerList contains a list of Destroyer
 type DestroyerList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Destroyer `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v1beta1/frigate_types.go
@@ -67,7 +67,7 @@ type Frigate struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Frigate
 	// +required
@@ -75,7 +75,7 @@ type Frigate struct {
 
 	// status defines the observed state of Frigate
 	// +optional
-	Status FrigateStatus `json:"status,omitempty,omitzero"`
+	Status FrigateStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Frigate struct {
 // FrigateList contains a list of Frigate
 type FrigateList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Frigate `json:"items"`
 }
 

--- a/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_types.go
+++ b/testdata/project-v4-multigroup/api/ship/v2alpha1/cruiser_types.go
@@ -68,7 +68,7 @@ type Cruiser struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Cruiser
 	// +required
@@ -76,7 +76,7 @@ type Cruiser struct {
 
 	// status defines the observed state of Cruiser
 	// +optional
-	Status CruiserStatus `json:"status,omitempty,omitzero"`
+	Status CruiserStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type Cruiser struct {
 // CruiserList contains a list of Cruiser
 type CruiserList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Cruiser `json:"items"`
 }
 

--- a/testdata/project-v4-with-plugins/api/v1/wordpress_types.go
+++ b/testdata/project-v4-with-plugins/api/v1/wordpress_types.go
@@ -68,7 +68,7 @@ type Wordpress struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Wordpress
 	// +required
@@ -76,7 +76,7 @@ type Wordpress struct {
 
 	// status defines the observed state of Wordpress
 	// +optional
-	Status WordpressStatus `json:"status,omitempty,omitzero"`
+	Status WordpressStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type Wordpress struct {
 // WordpressList contains a list of Wordpress
 type WordpressList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Wordpress `json:"items"`
 }
 

--- a/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/busybox_types.go
@@ -66,7 +66,7 @@ type Busybox struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Busybox
 	// +required
@@ -74,7 +74,7 @@ type Busybox struct {
 
 	// status defines the observed state of Busybox
 	// +optional
-	Status BusyboxStatus `json:"status,omitempty,omitzero"`
+	Status BusyboxStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -82,7 +82,7 @@ type Busybox struct {
 // BusyboxList contains a list of Busybox
 type BusyboxList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Busybox `json:"items"`
 }
 

--- a/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
+++ b/testdata/project-v4-with-plugins/api/v1alpha1/memcached_types.go
@@ -70,7 +70,7 @@ type Memcached struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Memcached
 	// +required
@@ -78,7 +78,7 @@ type Memcached struct {
 
 	// status defines the observed state of Memcached
 	// +optional
-	Status MemcachedStatus `json:"status,omitempty,omitzero"`
+	Status MemcachedStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -86,7 +86,7 @@ type Memcached struct {
 // MemcachedList contains a list of Memcached
 type MemcachedList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Memcached `json:"items"`
 }
 

--- a/testdata/project-v4-with-plugins/api/v2/wordpress_types.go
+++ b/testdata/project-v4-with-plugins/api/v2/wordpress_types.go
@@ -67,7 +67,7 @@ type Wordpress struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Wordpress
 	// +required
@@ -75,7 +75,7 @@ type Wordpress struct {
 
 	// status defines the observed state of Wordpress
 	// +optional
-	Status WordpressStatus `json:"status,omitempty,omitzero"`
+	Status WordpressStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Wordpress struct {
 // WordpressList contains a list of Wordpress
 type WordpressList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Wordpress `json:"items"`
 }
 

--- a/testdata/project-v4/api/v1/admiral_types.go
+++ b/testdata/project-v4/api/v1/admiral_types.go
@@ -68,7 +68,7 @@ type Admiral struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Admiral
 	// +required
@@ -76,7 +76,7 @@ type Admiral struct {
 
 	// status defines the observed state of Admiral
 	// +optional
-	Status AdmiralStatus `json:"status,omitempty,omitzero"`
+	Status AdmiralStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type Admiral struct {
 // AdmiralList contains a list of Admiral
 type AdmiralList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Admiral `json:"items"`
 }
 

--- a/testdata/project-v4/api/v1/captain_types.go
+++ b/testdata/project-v4/api/v1/captain_types.go
@@ -67,7 +67,7 @@ type Captain struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Captain
 	// +required
@@ -75,7 +75,7 @@ type Captain struct {
 
 	// status defines the observed state of Captain
 	// +optional
-	Status CaptainStatus `json:"status,omitempty,omitzero"`
+	Status CaptainStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Captain struct {
 // CaptainList contains a list of Captain
 type CaptainList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Captain `json:"items"`
 }
 

--- a/testdata/project-v4/api/v1/firstmate_types.go
+++ b/testdata/project-v4/api/v1/firstmate_types.go
@@ -68,7 +68,7 @@ type FirstMate struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of FirstMate
 	// +required
@@ -76,7 +76,7 @@ type FirstMate struct {
 
 	// status defines the observed state of FirstMate
 	// +optional
-	Status FirstMateStatus `json:"status,omitempty,omitzero"`
+	Status FirstMateStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -84,7 +84,7 @@ type FirstMate struct {
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []FirstMate `json:"items"`
 }
 

--- a/testdata/project-v4/api/v1/sailor_types.go
+++ b/testdata/project-v4/api/v1/sailor_types.go
@@ -67,7 +67,7 @@ type Sailor struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of Sailor
 	// +required
@@ -75,7 +75,7 @@ type Sailor struct {
 
 	// status defines the observed state of Sailor
 	// +optional
-	Status SailorStatus `json:"status,omitempty,omitzero"`
+	Status SailorStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type Sailor struct {
 // SailorList contains a list of Sailor
 type SailorList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []Sailor `json:"items"`
 }
 

--- a/testdata/project-v4/api/v2/firstmate_types.go
+++ b/testdata/project-v4/api/v2/firstmate_types.go
@@ -67,7 +67,7 @@ type FirstMate struct {
 
 	// metadata is a standard object metadata
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty,omitzero"`
+	metav1.ObjectMeta `json:"metadata,omitzero"`
 
 	// spec defines the desired state of FirstMate
 	// +required
@@ -75,7 +75,7 @@ type FirstMate struct {
 
 	// status defines the observed state of FirstMate
 	// +optional
-	Status FirstMateStatus `json:"status,omitempty,omitzero"`
+	Status FirstMateStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true
@@ -83,7 +83,7 @@ type FirstMate struct {
 // FirstMateList contains a list of FirstMate
 type FirstMateList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata,omitzero"`
 	Items           []FirstMate `json:"items"`
 }
 


### PR DESCRIPTION
Remove 'omitempty' from JSON tags on nested struct fields (metav1.ObjectMeta, Status, and metav1.ListMeta) in API type scaffolds. The 'omitempty' tag has no effect on nested structs in Go and triggers linter warnings.

For Go 1.24+, 'omitzero' correctly handles nested structs and omits them when empty, making 'omitempty' redundant and misleading. The '// +optional' markers already indicate optional fields for CRD schema generation.

Updated JSON tags:
- metav1.ObjectMeta: json:"metadata,omitempty,omitzero" → json:"metadata,omitzero"
- Status fields: json:"status,omitempty,omitzero" → json:"status,omitzero"
- metav1.ListMeta: json:"metadata,omitempty" → json:"metadata,omitzero"

This resolves linter warnings from gopls modernise analyser and kube-api-linter while maintaining correct behaviour for projects using Go 1.24+.

Closes https://github.com/kubernetes-sigs/kubebuilder/issues/5205 