### PR TITLE
🐛 Fix Go module download failure caused by invalid filename

### DIFF
--- a/.github/*.instructions.md
+++ b/.github/*.instructions.md
@@ -1,1 +1,0 @@
-See [AGENTS.md](../AGENTS.md) for AI agent guidelines.

--- a/.github/instructions/kubebuilder.instructions.md
+++ b/.github/instructions/kubebuilder.instructions.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](../../AGENTS.md) for AI agent guidelines.

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ go-apidiff:
 ##@ Tests
 
 .PHONY: test
-test: test-unit test-integration test-testdata test-book test-license ## Run the unit and integration tests (used in the CI)
+test: test-unit test-integration test-testdata test-book test-license test-gomod ## Run the unit and integration tests (used in the CI)
 
 .PHONY: test-unit
 TEST_PKGS := ./pkg/... ./test/e2e/utils/...
@@ -187,6 +187,10 @@ test-book: ## Run the cronjob tutorial's unit tests to make sure we don't break 
 .PHONY: test-license
 test-license:  ## Run the license check
 	./test/check-license.sh
+
+.PHONY: test-gomod
+test-gomod:  ## Run the Go module compatibility check
+	./test/check-gomod.sh
 
 .PHONY: test-external-plugin
 test-external-plugin: install  ## Run tests for external plugin

--- a/test/check-gomod.sh
+++ b/test/check-gomod.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Checking for Go module compatibility (invalid filename characters)..."
+
+# Go modules don't allow certain characters in file paths when creating archives
+# Reference: https://go.dev/ref/mod#zip-files
+# Invalid characters include: *, ?, [, ], \, and others that are shell wildcards or special characters
+
+# Get all tracked files in git (this will include all files that would be part of the go module)
+allfiles=$(git ls-files)
+invalidFiles=""
+
+for file in $allfiles; do
+  # Check if the filename (not the full path) contains invalid characters
+  filename=$(basename "$file")
+  
+  # Check for wildcard characters that are invalid in Go module archives
+  # Note: We check for *, ?, [, ], and \ (backslash)
+  if echo "$filename" | grep -qE '[*?[]|\\'; then
+    invalidFiles="${invalidFiles}\n  ${file} (contains invalid character in filename: ${filename})"
+  fi
+done
+
+if [ -n "${invalidFiles}" ]; then
+  echo -e "Go module compatibility check failed. The following files contain invalid characters:"
+  echo -e "${invalidFiles}"
+  echo ""
+  echo "Go modules cannot include files with wildcard characters (*, ?, [, ], \\) in their names."
+  echo "This will cause 'go get' and 'go mod download' to fail."
+  echo "Please rename these files to use only alphanumeric characters, hyphens, underscores, and dots."
+  exit 255
+fi
+
+echo "Go module compatibility check passed."
+


### PR DESCRIPTION
Fix issue where `go get sigs.k8s.io/kubebuilder/v4@v4.10.0` failed with: "malformed file path .github/*.instructions.md: invalid char '*'"

Go modules do not allow wildcard characters (*, ?, [, ], \) in filenames when creating module archives.

Changes:
- Remove .github/*.instructions.md (invalid filename with asterisk)
- Add .github/instructions/kubebuilder.instructions.md (proper location)
- Add test/check-gomod.sh to validate Go module compatibility
- Update Makefile to include test-gomod in CI test suite

This test will prevent similar issues in future releases by catching invalid filenames during development.

Fixes the issue introduced in f3d4ca0

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5211
