### PR TITLE
🐛 fix(go.mod): Retract v4.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/kubebuilder/v4
 
 go 1.24.6
 
+retract v4.10.0 // invalid filename causes go get/install failure (#5211)
+
 require (
 	github.com/gobuffalo/flect v1.0.3
 	github.com/h2non/gock v1.2.0


### PR DESCRIPTION
`v4.10.0` has a malformed filename that causes failure when trying to `go install` any version. 

I believe just fixing the invalid filename won't solve this issue. 

We need to retract the broken version in `go.mod` and release a patch, as already suggested by @chappjc in [his comment](https://github.com/kubernetes-sigs/kubebuilder/pull/5213#issuecomment-3536669942) on #5213. 

```
$ go install sigs.k8s.io/kubebuilder/v4@latest
go: downloading sigs.k8s.io/kubebuilder/v4 v4.10.0
go: sigs.k8s.io/kubebuilder/v4@latest: create zip: .github/*.instructions.md: malformed file path ".github/*.instructions.md": invalid char '*'

$ go install sigs.k8s.io/kubebuilder/v4@v4.9.0
go: downloading sigs.k8s.io/kubebuilder/v4 v4.9.0
go: sigs.k8s.io/kubebuilder/v4@v4.9.0: loading deprecation for sigs.k8s.io/kubebuilder/v4: sigs.k8s.io/kubebuilder/v4@v4.10.0: verifying go.mod: sigs.k8s.io/kubebuilder/v4@v4.10.0/go.mod: reading https://sum.golang.org/lookup/sigs.k8s.io/kubebuilder/v4@v4.10.0: 404 Not Found
	server response: not found: create zip: .github/*.instructions.md: malformed file path ".github/*.instructions.md": invalid char '*'

$ go install sigs.k8s.io/kubebuilder/v4@v4.8.0
go: downloading sigs.k8s.io/kubebuilder/v4 v4.8.0
go: sigs.k8s.io/kubebuilder/v4@v4.8.0: loading deprecation for sigs.k8s.io/kubebuilder/v4: sigs.k8s.io/kubebuilder/v4@v4.10.0: verifying go.mod: sigs.k8s.io/kubebuilder/v4@v4.10.0/go.mod: reading https://sum.golang.org/lookup/sigs.k8s.io/kubebuilder/v4@v4.10.0: 404 Not Found
	server response: not found: create zip: .github/*.instructions.md: malformed file path ".github/*.instructions.md": invalid char '*'

$ go install sigs.k8s.io/kubebuilder/v4@v4.7.1
go: downloading sigs.k8s.io/kubebuilder/v4 v4.7.1
go: sigs.k8s.io/kubebuilder/v4@v4.7.1: loading deprecation for sigs.k8s.io/kubebuilder/v4: sigs.k8s.io/kubebuilder/v4@v4.10.0: verifying go.mod: sigs.k8s.io/kubebuilder/v4@v4.10.0/go.mod: reading https://sum.golang.org/lookup/sigs.k8s.io/kubebuilder/v4@v4.10.0: 404 Not Found
	server response: not found: create zip: .github/*.instructions.md: malformed file path ".github/*.instructions.md": invalid char '*'

$ go install sigs.k8s.io/kubebuilder/v4@v4.7.0
go: downloading sigs.k8s.io/kubebuilder/v4 v4.7.0
go: sigs.k8s.io/kubebuilder/v4@v4.7.0: loading deprecation for sigs.k8s.io/kubebuilder/v4: sigs.k8s.io/kubebuilder/v4@v4.10.0: verifying go.mod: sigs.k8s.io/kubebuilder/v4@v4.10.0/go.mod: reading https://sum.golang.org/lookup/sigs.k8s.io/kubebuilder/v4@v4.10.0: 404 Not Found
	server response: not found: create zip: .github/*.instructions.md: malformed file path ".github/*.instructions.md": invalid char '*'
```
Fixes #5211