### PR TITLE
📖 (doc): Move section Versions Compatibility and Supportability for references

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -8,7 +8,6 @@
 
 [Getting Started](./getting-started.md)
 
-[Versions Compatibility and Supportability](./versions_compatibility_supportability.md)
 ---
 
 - [Tutorial: Building CronJob](cronjob-tutorial/cronjob-tutorial.md)
@@ -114,6 +113,7 @@
     - [Reference](./reference/metrics-reference.md)
 
   - [Project config](./reference/project-config.md)
+  - [Versions Compatibility and Supportability](./versions_compatibility_supportability.md)
 
 ---
 


### PR DESCRIPTION
We must to provide this info.
However, it is not first info that new users should need to check.
So, it was moved to references since seems more appropriate. 