### PR TITLE
🐛 fix(cli): format version subcommand output

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -102,5 +102,16 @@ func (v *Version) applyVCSMetadata(settings []debug.BuildSetting) {
 }
 
 func (v Version) PrintVersion() string {
-	return fmt.Sprintf("Version: %#v", v)
+	return fmt.Sprintf(`KubeBuilder:          %s
+Kubernetes:           %s
+Git Commit:           %s
+Build Date:           %s
+Go OS/Arch:           %s/%s`,
+		v.KubeBuilderVersion,
+		v.KubernetesVendor,
+		v.GitCommit,
+		v.BuildDate,
+		v.GoOs,
+		v.GoArch,
+	)
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -172,3 +172,27 @@ func TestApplyVCSMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestPrintVersion(t *testing.T) {
+	v := Version{
+		KubeBuilderVersion: "v9.99.9",
+		KubernetesVendor:   "9.99.9",
+		GitCommit:          "9990f08847dd1",
+		BuildDate:          "1970-01-12T12:12:12Z",
+		GoOs:               "linux",
+		GoArch:             "amd64",
+	}
+
+	expectedOutput := `KubeBuilder:          v9.99.9
+Kubernetes:           9.99.9
+Git Commit:           9990f08847dd1
+Build Date:           1970-01-12T12:12:12Z
+Go OS/Arch:           linux/amd64`
+
+	actualOutput := v.PrintVersion()
+
+	if actualOutput != expectedOutput {
+		t.Errorf("different output in version subcommand.\nexpected:\n%v\ngot:\n%v",
+			expectedOutput, actualOutput)
+	}
+}


### PR DESCRIPTION
This PR changes the `version` subcommand output to a human-readable table format:
- Current:
```
$ kubebuilder version
Version: cmd.version{KubeBuilderVersion:"v4.10.1", KubernetesVendor:"1.34.1", GitCommit:"$Format:%H$", BuildDate:"1970-01-01T00:00:00Z", GoOs:"unknown", GoArch:"unknown"}
```
- After:
```
$ kubebuilder version
KubeBuilder:        v4.10.1
Kubernetes:         1.34.1
Git Commit:         c7b5b17b8e1dc4f0fdaf0910464a4d44000365bf
Build Date:         2025-12-24T01:25:15Z
Go OS/Arch:         linux/amd64
```
