### PR TITLE
✨  (helm/v2alpha): Add support for parsing `imagePullSecrets` and including them in the generated chart

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -14,6 +14,9 @@ manager:
   # Environment variables
   env: []
 
+  # Image pull secrets
+  imagePullSecrets: []
+
   # Pod-level security settings
   podSecurityContext:
     runAsNonRoot: true

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -14,6 +14,9 @@ manager:
   # Environment variables
   env: []
 
+  # Image pull secrets
+  imagePullSecrets: []
+
   # Pod-level security settings
   podSecurityContext:
     runAsNonRoot: true

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -14,6 +14,9 @@ manager:
   # Environment variables
   env: []
 
+  # Image pull secrets
+  imagePullSecrets: []
+
   # Pod-level security settings
   podSecurityContext:
     runAsNonRoot: true

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -105,7 +105,7 @@ func (c *ChartConverter) ExtractDeploymentConfig() map[string]any {
 	}
 
 	extractPodSecurityContext(specMap, config)
-
+	extractImagePullSecrets(specMap, config)
 	container := firstManagerContainer(specMap)
 	if container == nil {
 		return config
@@ -133,6 +133,20 @@ func extractDeploymentSpec(deployment *unstructured.Unstructured) map[string]any
 	}
 
 	return specMap
+}
+
+func extractImagePullSecrets(specMap map[string]any, config map[string]any) {
+	imagePullSecrets, found, err := unstructured.NestedFieldNoCopy(specMap, "imagePullSecrets")
+	if !found || err != nil {
+		return
+	}
+
+	imagePullSecretsList, ok := imagePullSecrets.([]any)
+	if !ok || len(imagePullSecretsList) == 0 {
+		return
+	}
+
+	config["imagePullSecrets"] = imagePullSecretsList
 }
 
 func extractPodSecurityContext(specMap map[string]any, config map[string]any) {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -228,6 +228,25 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("  env: []\n\n")
 	}
 
+	// Add image pull secrets
+	if imagePullSecrets, exists := f.DeploymentConfig["imagePullSecrets"]; exists && imagePullSecrets != nil {
+		buf.WriteString("  # Image pull secrets\n")
+		buf.WriteString("  imagePullSecrets:\n")
+		if imagePullSecretsYaml, err := yaml.Marshal(imagePullSecrets); err == nil {
+			lines := bytes.SplitSeq(imagePullSecretsYaml, []byte("\n"))
+			for line := range lines {
+				if len(line) > 0 {
+					buf.WriteString("    ")
+					buf.Write(line)
+					buf.WriteString("\n")
+				}
+			}
+		}
+		buf.WriteString("\n")
+	} else {
+		f.addDefaultImagePullSecrets(buf)
+	}
+
 	// Add podSecurityContext
 	if podSecCtx, exists := f.DeploymentConfig["podSecurityContext"]; exists && podSecCtx != nil {
 		buf.WriteString("  # Pod-level security settings\n")
@@ -291,6 +310,7 @@ func (f *HelmValuesBasic) addDefaultDeploymentSections(buf *bytes.Buffer) {
 	buf.WriteString("  # Environment variables\n")
 	buf.WriteString("  env: []\n\n")
 
+	f.addDefaultImagePullSecrets(buf)
 	f.addDefaultPodSecurityContext(buf)
 	f.addDefaultSecurityContext(buf)
 	f.addDefaultResources(buf)
@@ -321,6 +341,12 @@ func (f *HelmValuesBasic) addArgsSection(buf *bytes.Buffer) {
 	}
 
 	buf.WriteString("  args: []\n\n")
+}
+
+// addDefaultImagePullSecrets adds default imagePullSecrets section
+func (f *HelmValuesBasic) addDefaultImagePullSecrets(buf *bytes.Buffer) {
+	buf.WriteString("  # Image pull secrets\n")
+	buf.WriteString("  imagePullSecrets: []\n\n")
 }
 
 // addDefaultPodSecurityContext adds default podSecurityContext section

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
@@ -55,6 +55,7 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("metrics:"))
 			Expect(content).To(ContainSubstring("prometheus:"))
 			Expect(content).To(ContainSubstring("rbacHelpers:"))
+			Expect(content).To(ContainSubstring("imagePullSecrets: []"))
 		})
 	})
 
@@ -84,6 +85,7 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("metrics:"))
 			Expect(content).To(ContainSubstring("prometheus:"))
 			Expect(content).To(ContainSubstring("rbacHelpers:"))
+			Expect(content).To(ContainSubstring("imagePullSecrets: []"))
 		})
 	})
 
@@ -159,6 +161,33 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("resources:"))
 			Expect(content).To(ContainSubstring("cpu: 100m"))
 			Expect(content).To(ContainSubstring("memory: 128Mi"))
+		})
+	})
+
+	Context("with multiple imagePullSecrets", func() {
+		BeforeEach(func() {
+			valuesTemplate = &HelmValuesBasic{
+				DeploymentConfig: map[string]any{
+					"imagePullSecrets": []any{
+						map[string]any{
+							"name": "test-secret",
+						},
+						map[string]any{
+							"name": "test-secret2",
+						},
+					},
+				},
+			}
+			valuesTemplate.InjectProjectName("test-private-project")
+			err := valuesTemplate.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should render multiple imagePullSecrets", func() {
+			content := valuesTemplate.GetBody()
+			Expect(content).To(ContainSubstring("imagePullSecrets:"))
+			Expect(content).To(ContainSubstring("- name: test-secret"))
+			Expect(content).To(ContainSubstring("- name: test-secret2"))
 		})
 	})
 

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -18,6 +18,9 @@ manager:
     - name: MEMCACHED_IMAGE
       value: memcached:1.6.26-alpine3.19
 
+  # Image pull secrets
+  imagePullSecrets: []
+
   # Pod-level security settings
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
The change is to bridge the gap of `helm/v2alpha` when using images in the private registry.
If users have private image and set `imagePullSecrets` in the original kustomize, it is not parsed and templated accordingly to helm. 

This update allows manager Helm chart to take `imagePullSecrets` into account and generate the template for it.

### Tests:
- I have read and followed CONTRIBUTING.md

1. Unit tests
```bash
go test ./pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize
ok  	sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize	0.256s
go test ./pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates
ok  	sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates	0.218s
```

2. Testdata
Rather than changing the `test/testdata/generate.sh`, just keep it as most users may not need `imagePullSecrets`.
For users who add `imagePullSecrets` in their kustomization under `config/manager/manager.yaml`, this will work nicely.
```diff
  spec:
    template:
      spec:
+       imagePullSecrets:
+         - name: ghcr-creds
        containers:
        - command:
          - /manager
```
This is validated with `make generate-charts` by applying a local change of `testdata/project-v4-with-plugins/config/manager/manager.yaml`

The resulting helm template of manager-deployment looks like:
```diff
+           {{- if .Values.manager.imagePullSecrets }}
+           imagePullSecrets:
+             {{- toYaml .Values.manager.imagePullSecrets | nindent 14 }}
+           {{- end }}
            securityContext:
              {{- if .Values.manager.podSecurityContext }}
              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
              {{- else }}
              {}
              {{- end }}
```

Closes #5241

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
