### PR TITLE
✨ (helm/v2-alpha) add tolerations, nodeselector and affinity

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -21,6 +21,15 @@ spec:
                 app.kubernetes.io/name: project
                 control-plane: controller-manager
         spec:
+            {{- with .Values.manager.tolerations }}
+            tolerations: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.affinity }}
+            affinity: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.nodeSelector }}
+            nodeSelector: {{ toYaml . | nindent 16 }}
+            {{- end }}
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -40,6 +40,15 @@ manager:
         cpu: 10m
         memory: 64Mi
 
+  # Manager pod's affinity
+  affinity: {}
+
+  # Manager pod's node selector
+  nodeSelector: {}
+
+  # Manager pod's tolerations
+  tolerations: []
+
 # Essential RBAC permissions (required for controller operation)
 # These include ServiceAccount, controller permissions, leader election, and metrics access
 # Note: Essential RBAC is always enabled as it's required for the controller to function

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -21,6 +21,15 @@ spec:
                 app.kubernetes.io/name: project
                 control-plane: controller-manager
         spec:
+            {{- with .Values.manager.tolerations }}
+            tolerations: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.affinity }}
+            affinity: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.nodeSelector }}
+            nodeSelector: {{ toYaml . | nindent 16 }}
+            {{- end }}
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -40,6 +40,15 @@ manager:
         cpu: 10m
         memory: 64Mi
 
+  # Manager pod's affinity
+  affinity: {}
+
+  # Manager pod's node selector
+  nodeSelector: {}
+
+  # Manager pod's tolerations
+  tolerations: []
+
 # Essential RBAC permissions (required for controller operation)
 # These include ServiceAccount, controller permissions, leader election, and metrics access
 # Note: Essential RBAC is always enabled as it's required for the controller to function

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -21,6 +21,15 @@ spec:
                 app.kubernetes.io/name: project
                 control-plane: controller-manager
         spec:
+            {{- with .Values.manager.tolerations }}
+            tolerations: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.affinity }}
+            affinity: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.nodeSelector }}
+            nodeSelector: {{ toYaml . | nindent 16 }}
+            {{- end }}
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -40,6 +40,15 @@ manager:
         cpu: 10m
         memory: 64Mi
 
+  # Manager pod's affinity
+  affinity: {}
+
+  # Manager pod's node selector
+  nodeSelector: {}
+
+  # Manager pod's tolerations
+  tolerations: []
+
 # Essential RBAC permissions (required for controller operation)
 # These include ServiceAccount, controller permissions, leader election, and metrics access
 # Note: Essential RBAC is always enabled as it's required for the controller to function

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -188,6 +188,35 @@ controllerManager:
       cpu: 10m
       memory: 64Mi
 
+  # Manager pod's affinity
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+
+  # Manager pod's node selector
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  # Manager pod's tolerations
+  tolerations:
+    - key: "node.kubernetes.io/unreachable"
+      operator: "Exists"
+      effect: "NoExecute"
+      tolerationSeconds: 6000
+
 # Essential RBAC permissions (required for controller operation)
 # These include ServiceAccount, controller permissions, leader election, and metrics access
 # Note: Essential RBAC is always enabled as it's required for the controller to function

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -106,6 +106,10 @@ func (c *ChartConverter) ExtractDeploymentConfig() map[string]any {
 
 	extractPodSecurityContext(specMap, config)
 	extractImagePullSecrets(specMap, config)
+	extractPodNodeSelector(specMap, config)
+	extractPodTolerations(specMap, config)
+	extractPodAffinity(specMap, config)
+
 	container := firstManagerContainer(specMap)
 	if container == nil {
 		return config
@@ -161,6 +165,48 @@ func extractPodSecurityContext(specMap map[string]any, config map[string]any) {
 	}
 
 	config["podSecurityContext"] = podSecurityContext
+}
+
+func extractPodNodeSelector(specMap map[string]any, config map[string]any) {
+	raw, found, err := unstructured.NestedFieldNoCopy(specMap, "nodeSelector")
+	if !found || err != nil {
+		return
+	}
+
+	result, ok := raw.(map[string]any)
+	if !ok || len(result) == 0 {
+		return
+	}
+
+	config["podNodeSelector"] = result
+}
+
+func extractPodTolerations(specMap map[string]any, config map[string]any) {
+	raw, found, err := unstructured.NestedFieldNoCopy(specMap, "tolerations")
+	if !found || err != nil {
+		return
+	}
+
+	result, ok := raw.([]any)
+	if !ok || len(result) == 0 {
+		return
+	}
+
+	config["podTolerations"] = result
+}
+
+func extractPodAffinity(specMap map[string]any, config map[string]any) {
+	raw, found, err := unstructured.NestedFieldNoCopy(specMap, "affinity")
+	if !found || err != nil {
+		return
+	}
+
+	result, ok := raw.(map[string]any)
+	if !ok || len(result) == 0 {
+		return
+	}
+
+	config["podAffinity"] = result
 }
 
 func firstManagerContainer(specMap map[string]any) map[string]any {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -210,15 +210,7 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("  # Environment variables\n")
 		buf.WriteString("  env:\n")
 		if envYaml, err := yaml.Marshal(env); err == nil {
-			// Indent the YAML properly
-			lines := bytes.SplitSeq(envYaml, []byte("\n"))
-			for line := range lines {
-				if len(line) > 0 {
-					buf.WriteString("    ")
-					buf.Write(line)
-					buf.WriteString("\n")
-				}
-			}
+			f.IndentYamlProperly(buf, envYaml)
 		} else {
 			buf.WriteString("    []\n")
 		}
@@ -252,14 +244,7 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("  # Pod-level security settings\n")
 		buf.WriteString("  podSecurityContext:\n")
 		if secYaml, err := yaml.Marshal(podSecCtx); err == nil {
-			lines := bytes.SplitSeq(secYaml, []byte("\n"))
-			for line := range lines {
-				if len(line) > 0 {
-					buf.WriteString("    ")
-					buf.Write(line)
-					buf.WriteString("\n")
-				}
-			}
+			f.IndentYamlProperly(buf, secYaml)
 		}
 		buf.WriteString("\n")
 	} else {
@@ -271,14 +256,7 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("  # Container-level security settings\n")
 		buf.WriteString("  securityContext:\n")
 		if secYaml, err := yaml.Marshal(secCtx); err == nil {
-			lines := bytes.SplitSeq(secYaml, []byte("\n"))
-			for line := range lines {
-				if len(line) > 0 {
-					buf.WriteString("    ")
-					buf.Write(line)
-					buf.WriteString("\n")
-				}
-			}
+			f.IndentYamlProperly(buf, secYaml)
 		}
 		buf.WriteString("\n")
 	} else {
@@ -290,18 +268,58 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("  # Resource limits and requests\n")
 		buf.WriteString("  resources:\n")
 		if resYaml, err := yaml.Marshal(resources); err == nil {
-			lines := bytes.SplitSeq(resYaml, []byte("\n"))
-			for line := range lines {
-				if len(line) > 0 {
-					buf.WriteString("    ")
-					buf.Write(line)
-					buf.WriteString("\n")
-				}
-			}
+			f.IndentYamlProperly(buf, resYaml)
 		}
 		buf.WriteString("\n")
 	} else {
 		f.addDefaultResources(buf)
+	}
+
+	buf.WriteString("  # Manager pod's affinity\n")
+	if affinity, exists := f.DeploymentConfig["podAffinity"]; exists && affinity != nil {
+		buf.WriteString("  affinity:\n")
+		if affYaml, err := yaml.Marshal(affinity); err == nil {
+			f.IndentYamlProperly(buf, affYaml)
+		}
+		buf.WriteString("\n")
+	} else {
+		buf.WriteString("  affinity: {}\n")
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString("  # Manager pod's node selector\n")
+	if nodeSelector, exists := f.DeploymentConfig["podNodeSelector"]; exists && nodeSelector != nil {
+		buf.WriteString("  nodeSelector:\n")
+		if nodYaml, err := yaml.Marshal(nodeSelector); err == nil {
+			f.IndentYamlProperly(buf, nodYaml)
+		}
+		buf.WriteString("\n")
+	} else {
+		buf.WriteString("  nodeSelector: {}\n")
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString("  # Manager pod's tolerations\n")
+	if tolerations, exists := f.DeploymentConfig["podTolerations"]; exists && tolerations != nil {
+		buf.WriteString("  tolerations:\n")
+		if tolYaml, err := yaml.Marshal(tolerations); err == nil {
+			f.IndentYamlProperly(buf, tolYaml)
+		}
+		buf.WriteString("\n")
+	} else {
+		buf.WriteString("  tolerations: []\n")
+		buf.WriteString("\n")
+	}
+}
+
+func (f *HelmValuesBasic) IndentYamlProperly(buf *bytes.Buffer, envYaml []byte) {
+	lines := bytes.SplitSeq(envYaml, []byte("\n"))
+	for line := range lines {
+		if len(line) > 0 {
+			buf.WriteString("    ")
+			buf.Write(line)
+			buf.WriteString("\n")
+		}
 	}
 }
 

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -21,6 +21,15 @@ spec:
                 app.kubernetes.io/name: project-v4-with-plugins
                 control-plane: controller-manager
         spec:
+            {{- with .Values.manager.tolerations }}
+            tolerations: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.affinity }}
+            affinity: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.nodeSelector }}
+            nodeSelector: {{ toYaml . | nindent 16 }}
+            {{- end }}
             containers:
                 - args:
                     {{- if .Values.metrics.enable }}

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -44,6 +44,15 @@ manager:
         cpu: 10m
         memory: 64Mi
 
+  # Manager pod's affinity
+  affinity: {}
+
+  # Manager pod's node selector
+  nodeSelector: {}
+
+  # Manager pod's tolerations
+  tolerations: []
+
 # Essential RBAC permissions (required for controller operation)
 # These include ServiceAccount, controller permissions, leader election, and metrics access
 # Note: Essential RBAC is always enabled as it's required for the controller to function


### PR DESCRIPTION
Adds nodeSelector, affinity and tolerations to the manager deployment template and values of the helm chart (v2-alpha).

Related issue: #5246
