### PR TITLE
📖 (docs): Show webhook configuration in cronjob tutorial 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -240,5 +240,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-// +kubebuilder:docs-gen:collapse=Remaining code from main.go

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -367,15 +367,6 @@ CronJob controller's`+" `"+`SetupWithManager`+"`"+` method.
 		os.Exit(1)
 	}`, mainEnableWebhook)
 	hackutils.CheckError("fixing main.go", err)
-
-	err = pluginutil.InsertCode(
-		filepath.Join(sp.ctx.Dir, "cmd/main.go"),
-		`setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
-}`, `
-// +kubebuilder:docs-gen:collapse=Remaining code from main.go`)
-	hackutils.CheckError("fixing main.go", err)
 }
 
 func (sp *Sample) updateMakefile() {

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -682,24 +682,6 @@ CronJob controller's `+"`SetupWithManager`"+` method.
 	*/`,
 	)
 	hackutils.CheckError("replace webhook setup explanation main.go", err)
-
-	err = pluginutil.InsertCode(
-		filepath.Join(sp.ctx.Dir, path),
-		`setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
-}`, `
-// +kubebuilder:docs-gen:collapse=Remaining code from main.go`,
-	)
-	hackutils.CheckError("update main.go with final collapse marker", err)
-
-	err = pluginutil.ReplaceInFile(
-		filepath.Join(sp.ctx.Dir, path),
-		`// +kubebuilder:docs-gen:collapse=Remaining code from main.go
-
-// +kubebuilder:docs-gen:collapse=Remaining code from main.go`, ``,
-	)
-	hackutils.CheckError("update main.go to remove final collapses", err)
 }
 
 func (sp *Sample) updateAPIV2() {


### PR DESCRIPTION
# 📖 (docs): Show webhook configuration in cronjob tutorial

Fixes #5238

## Problem

The webhook setup code in `cmd/main.go` was hidden in the cronjob tutorial's `main-revisited` page.

## Root Cause

The cronjob tutorial generator was adding a collapse marker at the end of `cmd/main.go` (lines 371-380), which collapsed everything after the controller setup, including the webhook configuration that users needed to see.

## Discovery: Multiversion Dependency

Found that multiversion tutorial has interdependent code:

Line 79 in `generate_multiversion.go`:
```go
cmd := exec.Command("cp", "./../../../cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go", ...)
```

**The multiversion tutorial copies files from cronjob, then has logic expecting certain markers to exist.** This dependency required changes to both files.

## Changes Made

### File 1: `hack/docs/internal/cronjob-tutorial/generate_cronjob.go`

**Function:** `updateMain()`  
**Lines deleted:** 371-380

**Code removed:**
```go
err = pluginutil.InsertCode(
    filepath.Join(sp.ctx.Dir, "cmd/main.go"),
    `setupLog.Error(err, "problem running manager")
    os.Exit(1)
}
}`, `
// +kubebuilder:docs-gen:collapse=Remaining code from main.go`)
hackutils.CheckError("fixing main.go", err)
```

**Why:** This code was inserting a collapse marker at the end of `main.go`:
```go
// +kubebuilder:docs-gen:collapse=Remaining code from main.go
```

This marker collapsed everything from controller setup to the end of file, hiding the webhook configuration (issue 5238).

---

### File 2: `hack/docs/internal/multiversion-tutorial/generate_multiversion.go`

**Function:** `updateMain()`  
**Lines deleted:** 686-703 (two blocks)

#### Block 1 (lines 686-694)

**Code removed:**
```go
err = pluginutil.InsertCode(
    filepath.Join(sp.ctx.Dir, path),
    `setupLog.Error(err, "problem running manager")
    os.Exit(1)
}
}`, `
// +kubebuilder:docs-gen:collapse=Remaining code from main.go`,
)
hackutils.CheckError("update main.go with final collapse marker", err)
```

**What it did:** Added the same collapse marker in multiversion's `main.go`

#### Block 2 (lines 696-703)

**Code removed:**
```go
err = pluginutil.ReplaceInFile(
    filepath.Join(sp.ctx.Dir, path),
    `// +kubebuilder:docs-gen:collapse=Remaining code from main.go

// +kubebuilder:docs-gen:collapse=Remaining code from main.go`, ``,
)
hackutils.CheckError("update main.go to remove final collapses", err)
```

**What it did:** Searched for and removed duplicate collapse markers (two consecutive identical markers)

---

## Why Both Multiversion Blocks Were Removed

**The problem:** Block 2 expected to find duplicate markers (one from cronjob, one from Block 1). After removing the cronjob marker, this pattern no longer exists, causing build error: `"unable to find the content to be replaced"`

**Three options considered:**

1. **Keep both blocks** → Fixes the issue but build fails (Block 2 can't find duplicates).
2. **Remove only Block 2** →Fixes the issue but block 1 hides webhooks in multiversion .  
3. **Remove both blocks** → Fixes the issue and prevent changes on multiversion.
---

## Result

The webhook configuration is now visible in main-revisited page : 
Multiversion tutorial remains unchanged

![Screenshot showing webhook configuration now visible](https://github.com/user-attachments/assets/9f57328f-d19b-4d42-91dd-883d1e9edc53)