### PR TITLE
📖 (docs): Fix duplicate content and collapse markers in writing tests tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -208,8 +208,6 @@ var _ = Describe("CronJob controller", func() {
 
 })
 
-// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
-
 /*
 	After writing all this code, you can run `go test ./...` in your `controllers/` directory again to run your new test!
 */

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -170,8 +170,6 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
-// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
-
 /*
 Now that you have your controller running on a test cluster and a client ready to perform operations on your CronJob, we can start writing integration tests!
 */

--- a/docs/book/src/cronjob-tutorial/writing-tests.md
+++ b/docs/book/src/cronjob-tutorial/writing-tests.md
@@ -9,31 +9,6 @@ The basic approach is that, in your generated `suite_test.go` file, you will use
 
 If you want to tinker with how your envtest cluster is configured, see section [Configuring envtest for integration tests](../reference/envtest.md) as well as the [`envtest docs`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc).
 
-## Test Environment Setup
-
-{{#literatego ../cronjob-tutorial/testdata/project/internal/controller/suite_test.go}}
-
-## Testing your Controller's Behavior
-
-{{#literatego ../cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go}}
-
-This Status update example above demonstrates a general testing strategy for a custom Kind with downstream objects. By this point, you hopefully have learned the following methods for testing your controller behavior:
-
-* Setting up your controller to run on an envtest cluster
-* Writing stubs for creating test objects
-* Isolating changes to an object to test specific controller behavior
-
-# Writing controller tests
-
-Testing Kubernetes controllers is a big subject, and the boilerplate testing
-files generated for you by kubebuilder are fairly minimal.
-
-To walk you through integration testing patterns for Kubebuilder-generated controllers, we will revisit the CronJob we built in our first tutorial and write a simple test for it.
-
-The basic approach is that, in your generated `suite_test.go` file, you will use envtest to create a local Kubernetes API server, instantiate and run your controllers, and then write additional `*_test.go` files to test it using [Ginkgo](http://onsi.github.io/ginkgo).
-
-If you want to tinker with how your envtest cluster is configured, see section [Configuring envtest for integration tests](../reference/envtest.md) as well as the [`envtest docs`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest?tab=doc).
-
 <aside class="note">
 <h1>Other Examples</h1>
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -208,8 +208,6 @@ var _ = Describe("CronJob controller", func() {
 
 })
 
-// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
-
 /*
 	After writing all this code, you can run `go test ./...` in your `controllers/` directory again to run your new test!
 */

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -170,8 +170,6 @@ var _ = AfterSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 })
 
-// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
-
 /*
 Now that you have your controller running on a test cluster and a client ready to perform operations on your CronJob, we can start writing integration tests!
 */

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
@@ -226,7 +226,6 @@ var _ = Describe("CronJob controller", func() {
 	})
 
 })
-// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
 
 /*
 	After writing all this code, you can run` + " `" + `go test ./...` + "`" + ` in your` + " `" + `controllers/` + "`" + ` directory again to run your new test!

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -120,7 +120,6 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
-// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
 
 /*
 Now that you have your controller running on a test cluster and a client ready to perform operations on your CronJob, we can start writing integration tests!


### PR DESCRIPTION
# 📖 (docs): Fix duplicate content and collapse markers in writing tests tutorial

**Fixes #5239**

## Problem

**Duplicate Content**: The page is being rendered twice, showing identical sections
**Collapse Markers**: Test code explanations and final instructions were hidden behind collapse markers

## Root Cause

### Duplicate Content
The markdown template file `docs/book/src/cronjob-tutorial/writing-tests.md` contained duplicate sections (lines 1-25) that were identical to the rest of the page causing the `{{#literatego}}` directives to be processed twice.

### Collapse Markers
Two generation scripts were inserting collapse markers that hide content from the test page:


## Changes Made

### File 1: `docs/book/src/cronjob-tutorial/writing-tests.md`
**Lines deleted**: 0-25 (pre build)

**Why**: Lines 1-25 were an older duplicate of page content that must be removed.

---

### File 2: `hack/docs/internal/cronjob-tutorial/writing_tests_env.go`
**Constant**: `suiteTestCleanup`  
**Line deleted**: 123

**Code removed**:
```go
// +kubebuilder:docs-gen:collapse=Remaining code from suite_test.go
```

**Why**: This collapse marker hides the transition comment  .

---

### File 3: `hack/docs/internal/cronjob-tutorial/writing_tests_controller.go`
**Constant**: `controllerTest`  
**Line deleted**: 229

**Code removed**:
```go
// +kubebuilder:docs-gen:collapse=Remaining code from cronjob_controller_test.go
```

**Why**: This collapse marker hides the final instructions about how to run tests with `go test ./...`. 

---
### Shared Generation Code

Multiversion tutorial uses the **same generation constants** from `writing_tests_controller.go`:

**Line 19 in `hack/docs/internal/cronjob-tutorial/writing_tests_controller.go`**:
```go
const controllerTest = `/*
```

Both tutorials generate their controller test files independently using the same source constant. This means changes to the generation scripts affect both tutorials identically.


## Result

**No duplicate content in the writing tests**

**First Marker**
was hiding section ( `Kubebuilder also generates ... `) 

<img width="804" height="467" alt="Test execution instructions visible" src="https://github.com/user-attachments/assets/9f49f4bf-fd73-4bc2-bc97-800a6a2a3c3b" />

**Second Marker**
was hiding section ( `Adding this Job to our test CronJob ... `) 

<img width="796" height="438" alt="Cleanup code explanation visible" src="https://github.com/user-attachments/assets/095002fd-ac1c-4592-80d3-8910193682a6" />






