### PR TITLE
📖 (docs): Add Go Reference badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/kubebuilder)](https://goreportcard.com/report/sigs.k8s.io/kubebuilder)
 [![Coverage Status](https://coveralls.io/repos/github/kubernetes-sigs/kubebuilder/badge.svg?branch=master)](https://coveralls.io/github/kubernetes-sigs/kubebuilder?branch=master)
 [![Latest release](https://img.shields.io/github/v/release/kubernetes-sigs/kubebuilder)](https://github.com/kubernetes-sigs/kubebuilder/releases)
+[![Go Reference](https://pkg.go.dev/badge/sigs.k8s.io/kubebuilder/v4.svg)](https://pkg.go.dev/sigs.k8s.io/kubebuilder/v4)
 
 ## Kubebuilder
 


### PR DESCRIPTION
This PR adds the Go Reference badge to the README file, which links to https://pkg.go.dev/sigs.k8s.io/kubebuilder/v4.

This is a common practice for Go projects that have packages indexed on pkg.go.dev. It will also make it easier for developers to explore the Kubebuilder API and its documentation.