### PR TITLE
Fix cert-manager naming: consistent Issuer and Certificate names

### DIFF
--- a/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.certManager.enable .Values.metrics.enable }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ .Release.Name }}
+    name: {{ include "chart.name" . }}-metrics-certs
+    namespace: {{ .Release.Namespace }}
+spec:
+    dnsNames:
+        - {{ include "chart.serviceName" (dict "suffix" "controller-manager-metrics-service" "context" .) }}.{{ include "chart.namespaceName" . }}.svc
+        - {{ include "chart.serviceName" (dict "suffix" "controller-manager-metrics-service" "context" .) }}.{{ include "chart.namespaceName" . }}.svc.cluster.local
+    issuerRef:
+        kind: Issuer
+        name: {{ include "chart.name" . }}-selfsigned-issuer
+    secretName: metrics-server-cert
+{{- end }}

--- a/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ .Release.Name }}
+    name: {{ include "chart.name" . }}-selfsigned-issuer
+    namespace: {{ .Release.Namespace }}
+spec:
+    selfSigned: {}
+{{- end }}

--- a/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ .Release.Name }}
+    name: {{ include "chart.name" . }}-serving-cert
+    namespace: {{ .Release.Namespace }}
+spec:
+    dnsNames:
+        - {{ include "chart.name" . }}-webhook-service.{{ .Release.Namespace }}.svc
+        - {{ include "chart.name" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+    issuerRef:
+        kind: Issuer
+        name: {{ include "chart.name" . }}-selfsigned-issuer
+    secretName: webhook-server-cert
+{{- end }}


### PR DESCRIPTION
✨ Fix cert-manager naming: make Issuer and Certificates names consistent

Description of the change:
This PR fixes an issue in the Kubebuilder Helm chart where the cert-manager resources (Issuer and Certificates) had inconsistent naming.

Previously:

The Issuer name was hardcoded as test-project-selfsigned-issuer in selfsigned-issuer.yaml.

The Certificates referred to the Issuer using Helm templates ({{ include "chart.name" . }}-selfsigned-issuer).

This mismatch caused deployment failures whenever the Helm chart was renamed, because the Issuer name did not match what the Certificates expected.

Changes introduced in this PR:

Updated all cert-manager templates (metrics-certs.yaml, selfsigned-issuer.yaml, serving-cert.yaml) to use the Helm template function {{ include "chart.name" . }} for generating names dynamically.

Ensured that:

Issuer names are consistent with all Certificates that reference them (issuerRef.name).

dnsNames and any service references in Certificates are using the templated chart name, avoiding hard-coded project names.

Metadata labels now consistently reference .Release.Name to align with Helm best practices.

No other templates (webhook templates or values.yaml) were modified.

The Helm chart now fully supports renaming without breaking cert-manager resources.

Motivation for the change:

Avoid deployment failures caused by hard-coded Issuer names.

Make the Helm chart flexible and maintainable for projects that rename their charts.

Ensure that cert-manager resources follow Helm best practices by using template-based naming consistently.

Reduce the chance of human error when copying or renaming Helm charts in downstream projects.

What issue it fixes:

Fixes #5280 – Missing name substitution in the cert-manager resources, which led to inconsistent naming between Issuers and Certificates.

Verification / Testing done:

1. Verified that no hard-coded test-project names remain in the dist/chart/templates/cert-manager/ directory:

2. Checked all issuerRef.name references to ensure consistency with the Issuer.

3. Verified Helm template syntax is correct and renders expected names for Issuer and Certificates.

4. Confirmed that renaming the chart does not break cert-manager resources.


![Verification Screenshot](https://github.com/user-attachments/assets/cb97f324-0391-4ca4-82e1-676f9bbc08d2)



