### PR TITLE
🐛 fix(kustomize/v2): Add issuerRef replacement for cert-manager resources

### DIFF
--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -260,6 +260,32 @@ patches:
 #         delimiter: '/'
 #         index: 1
 #         create: true
+replacements:
+  - source:
+      kind: Issuer
+      group: cert-manager.io
+      version: v1
+      name: selfsigned-issuer
+      fieldPath: .metadata.name
+    targets:
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: serving-cert
+        fieldPaths:
+          - .spec.issuerRef.name
+        options:
+          create: true
+      - select:
+          kind: Certificate
+          group: cert-manager.io
+          version: v1
+          name: metrics-certs
+        fieldPaths:
+          - .spec.issuerRef.name
+        options:
+          create: true
 
 # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
 #     kind: Certificate


### PR DESCRIPTION
Description
This PR fixes #5280
 by introducing a Kustomize replacement in the kustomize/v2 plugin template. It ensures that Certificate resources dynamically reference the actual Issuer name after namePrefix is applied, preventing deployment failures due to mismatched names.

Problem
When using kustomize/v2 with cert-manager resources:

config/default/kustomization.yaml applies a namePrefix to all resources.

The Issuer name becomes: {project-name}-selfsigned-issuer.

Certificates still reference the hardcoded name selfsigned-issuer.

Result: Certificates fail to locate the Issuer, causing deployments to fail.

This issue is particularly critical for the helm/v2-alpha plugin, which converts Kustomize output to Helm templates, resulting in broken charts.

Solution
Added a Kustomize replacement to the kdefault/kustomization.go template that:

Sources the Issuer's actual name (.metadata.name) after namePrefix is applied.

Dynamically injects this name into the spec.issuerRef.name field of Certificate resources.

Follows the existing pattern used for webhook CA injection.

Changes Made

Modified: pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go

Added replacement block:
replacements:
- source:
    kind: Issuer
    group: cert-manager.io
    version: v1
    name: selfsigned-issuer
    fieldPath: .metadata.name
  targets:
    - select:
        kind: Certificate
        group: cert-manager.io
        version: v1
        name: serving-cert
      fieldPaths:
        - .spec.issuerRef.name
      options:
        create: true
    - select:
        kind: Certificate
        group: cert-manager.io
        version: v1
        name: metrics-certs
      fieldPaths:
        - .spec.issuerRef.name
      options:
        create: true


Testing

Build modified Kubebuilder binary:

make build


Scaffold new project:

mkdir test-project && cd test-project
$KB_BIN init --domain=test.com --repo=test.com/test
$KB_BIN create api --group test --version v1 --kind Test --resource --controller
$KB_BIN create webhook --group test --version v1 --kind Test --defaulting --programmatic-validation


Verify replacement exists:

grep -A15 "selfsigned-issuer" config/default/kustomization.yaml


Test with Helm plugin:

$KB_BIN edit --plugins=helm/v2-alpha
cd dist/chart
helm template . | grep -A3 "kind: Issuer"
helm template . | grep -A3 "issuerRef:"


Changing chart name should now correctly propagate to issuerRef.name.

Expected Result
Generated config/default/kustomization.yaml includes the issuerRef replacement, ensuring Certificates correctly reference the Issuer after namePrefix is applied. Helm charts generated via helm/v2-alpha are now consistent and deployable out of the box.

Fixes
Fixes #5280

Additional Context
This change ensures reliable, consistent cert-manager resource naming for projects scaffolded with Kustomize v2 and subsequently converted to Helm charts. Full testing was performed including rendering Helm templates and verifying dynamic name replacements.
<img width="1559" height="632" alt="image" src="https://github.com/user-attachments/assets/f794480a-9b2d-430d-9323-70dc6c9cb514" />
