### PR TITLE
🐛 bugfix: Prevent Unintended Cert-Manager Removal from Production Clusters

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -65,7 +65,7 @@ var (
 	// These variables are useful if CertManager is already installed, avoiding
 	// re-installation and conflicts.
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
-	// certManagerWasInstalledByTest will be set true is installed during the test.
+	// certManagerWasInstalledByTest will be set true if installed during test.
 	certManagerWasInstalledByTest = false
 
 	// projectImage is the name of the image which will be build and loaded


### PR DESCRIPTION
## Bug Fix: Prevent Unintended Cert-Manager Removal from Production Clusters

**Problem:**
The current implementation has a critical race condition that can delete cert-manager from real clusters. When `BeforeSuite` is interrupted (Ctrl-C, timeout, etc.) before setting `isCertManagerAlreadyInstalled = true`, the variable remains `false` by default. `AfterSuite` then executes cleanup and **uninstalls cert-manager even though the test never installed it**.

This has caused production outages.

**Root Cause:**
We're using `isCertManagerAlreadyInstalled` (what existed before) as a proxy for `certManagerWasInstalledByTest` (what we actually need to know). These are fundamentally different states with different default values when interrupted.

**The Fix:**
Track what the test *actually did* (installed cert-manager), not what it *discovered* (cert-manager was already there). Set the flag **after successful installation**, not after discovery.

**Safety Improvement:**
- **Before:** Interruption → defaults to `false` → **deletes cert-manager from your cluster**
- **After:** Interruption → defaults to `false` → **skips cleanup, leaving your cluster untouched**

The worst case is now failing to clean up our own installation (safe) instead of removing infrastructure from production (catastrophic).

**Variable Rename Rationale:**
While I can keep the variable name if strongly preferred, `certManagerWasInstalledByTest` more accurately represents what we're tracking and makes the safety logic self-documenting for future maintainers. The semantic difference matters when reasoning about defaults and failure modes.

This addresses issues like: https://github.com/kubernetes-sigs/kubebuilder/issues/4391 and others.
