### PR TITLE
🐛 (alpha update): Fix --from-version Invalid SemVer error

### DIFF
--- a/pkg/cli/alpha/internal/update/prepare.go
+++ b/pkg/cli/alpha/internal/update/prepare.go
@@ -60,18 +60,22 @@ func (opts *Update) Prepare() error {
 
 // defineFromVersion will return the CLI version to be used for the update with the v prefix.
 func (opts *Update) defineFromVersion(config store.Store) (string, error) {
-	if len(opts.FromVersion) == 0 && len(config.Config().GetCliVersion()) == 0 {
+	fromVersion := opts.FromVersion
+
+	if len(fromVersion) == 0 {
+		fromVersion = config.Config().GetCliVersion()
+	}
+
+	if len(fromVersion) == 0 {
 		return "", fmt.Errorf("no version specified in PROJECT file. " +
 			"Please use --from-version flag to specify the version to update from")
 	}
 
-	if opts.FromVersion != "" {
-		if !strings.HasPrefix(opts.FromVersion, "v") {
-			return "v" + opts.FromVersion, nil
-		}
-		return opts.FromVersion, nil
+	if !strings.HasPrefix(fromVersion, "v") {
+		fromVersion = "v" + fromVersion
 	}
-	return "v" + config.Config().GetCliVersion(), nil
+
+	return fromVersion, nil
 }
 
 func (opts *Update) defineToVersion() string {

--- a/pkg/cli/alpha/internal/update/prepare_test.go
+++ b/pkg/cli/alpha/internal/update/prepare_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Prepare for internal update", func() {
 		projectFile = filepath.Join(tmpDir, yaml.DefaultPath)
 
 		config.Register(config.Version{Number: 3}, func() config.Config {
-			return &v3.Cfg{Version: config.Version{Number: 3}, CliVersion: "1.0.0"}
+			return &v3.Cfg{Version: config.Version{Number: 3}, CliVersion: "v1.0.0"}
 		})
 
 		gock.New("https://api.github.com").


### PR DESCRIPTION
Running `kubebuilder alpha update` without passing the `--from-version` as argument no longer adds a duplicate "v" prefix to the version extracted from the `PROJECT` file.

Fixes #5308