### PR TITLE
🐛 (autoupdate/v1-alpha): Make GitHub Models opt-in to prevent 403 errors

### DIFF
--- a/docs/book/src/getting-started/testdata/project/.github/workflows/auto_update.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/auto_update.yml
@@ -1,14 +1,13 @@
 name: Auto Update
 
-# The 'kubebuilder alpha update 'command requires write access to the repository to create a branch
+# The 'kubebuilder alpha update' command requires write access to the repository to create a branch
 # with the update files and allow you to open a pull request using the link provided in the issue.
 # The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
 # To protect your codebase, please ensure that you have branch protection rules configured for your 
 # main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
 permissions:
-  contents: write
-  issues: write
-  models: read
+  contents: write  # Create and push the update branch
+  issues: write    # Create GitHub Issue with PR link
 
 on:
   workflow_dispatch:
@@ -21,27 +20,27 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # Step 1: Checkout the repository.
+    # Checkout the repository.
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
-    
-    # Step 2: Configure Git to create commits with the GitHub Actions bot.
+
+    # Configure Git to create commits with the GitHub Actions bot.
     - name: Configure Git
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-    # Step 3: Set up Go environment.
+    # Set up Go environment.
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: stable
 
-    # Step 4: Install Kubebuilder.
+    # Install Kubebuilder.
     - name: Install Kubebuilder
       run: |
         curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
@@ -49,13 +48,7 @@ jobs:
         sudo mv kubebuilder /usr/local/bin/
         kubebuilder version
 
-    # Step 5: Install Models extension for GitHub CLI
-    - name: Install/upgrade gh-models extension
-      run: |
-        gh extension install github/gh-models --force
-        gh models --help >/dev/null
-
-    # Step 6: Run the Kubebuilder alpha update command.
+    # Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
       # Executes the update command with specified flags.
@@ -63,12 +56,14 @@ jobs:
       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
-      # --use-gh-models: Adds an AI-generated comment to the created Issue with
-      #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
+      #
+      # WARNING: This workflow does not use GitHub Models AI summary by default.
+      # To enable AI-generated summaries in GitHub issues, you need permissions to use GitHub Models.
+      # If you have the required permissions, re-run:
+      #   kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
       run: |
         kubebuilder alpha update \
           --force \
           --push \
           --restore-path .github/workflows \
-          --open-gh-issue \
-          --use-gh-models
+          --open-gh-issue

--- a/docs/book/src/plugins/available/autoupdate-v1-alpha.md
+++ b/docs/book/src/plugins/available/autoupdate-v1-alpha.md
@@ -8,7 +8,7 @@ This automation uses the [`kubebuilder alpha update`][alpha-update-command] comm
 refresh your project scaffold, and wraps it in a GitHub Actions workflow that opens an **Issue** with a **Pull Request compare link** so you can create the PR and review it.
 
 <aside class="warning">
-<h1>Protect your branches</h1>
+<h3>Protect your branches</h3>
 
 This workflow by default **only** creates and pushes the merged files to a branch
 called `kubebuilder-update-from-<from-version>-to-<to-version>`.
@@ -20,17 +20,16 @@ changes aren't pushed or merged without proper review.
 
 ## When to Use It
 
-- When you don’t deviate too much from the default scaffold — ensure that you see the note about customization [here](https://book.kubebuilder.io/versions_compatibility_supportability#project-customizations).
+
 - When you want to reduce the burden of keeping the project updated and well-maintained.
-- When you want to guidance and help from AI to know what changes are needed to keep your project up to date
-as to solve conflicts.
+- When you want guidance and help from AI to know what changes are needed to keep your project up to date and to solve conflicts (requires `--use-gh-models` flag and GitHub Models permissions).
 
 ## How to Use It
 
 - If you want to add the `autoupdate` plugin to your project:
 
 ```shell
-kubebuilder edit --plugins="autoupdate.kubebuilder.io/v1-alpha"
+kubebuilder edit --plugins="autoupdate/v1-alpha"
 ```
 
 - If you want to create a new project with the `autoupdate` plugin:
@@ -39,43 +38,135 @@ kubebuilder edit --plugins="autoupdate.kubebuilder.io/v1-alpha"
 kubebuilder init --plugins=go/v4,autoupdate/v1-alpha
 ```
 
+### Optional: GitHub Models AI Summary
+
+By default, the workflow works without GitHub Models to avoid permission errors.
+If you want AI-generated summaries in your update issues:
+
+```shell
+kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
+```
+
+<aside class="note">
+<h1>Permissions required to use GitHub Models in GitHub Actions</h1>
+
+To use GitHub Models in your workflows, organization and repository administrators must grant this permission.
+
+**If you have admin access:**
+
+1. Go to **Settings → Code and automation → Models**
+2. Enable GitHub Models for your repository
+
+**Don't see the Models option?**
+
+Your organization or enterprise may have disabled it. Contact your administrator:
+
+- Organization admins: [Managing Models in your organization][manage-org-models]
+- Enterprise admins: [Managing Models at enterprise scale][manage-models-at-scale]
+
+</aside>
+
 ## How It Works
 
-This will scaffold a GitHub Actions workflow that runs the [kubebuilder alpha update][alpha-update-command] command.
-Whenever a new Kubebuilder release is available, the workflow will automatically open an **Issue** with a Pull Request compare link so you can easily create the PR and review it, such as:
+The plugin scaffolds a GitHub Actions workflow that checks for new Kubebuilder releases every week. When an update is available, it:
+
+1. Creates a new branch with the merged changes
+2. Opens a GitHub Issue with a PR compare link
+
+**Example Issue:**
 
 <img width="638" height="482" alt="Example Issue" src="https://github.com/user-attachments/assets/589fd16b-7709-4cd5-b169-fd53d69790d4" />
 
-By default, the workflow scaffolded uses `--use-gh-model` the flag to leverage in [AI models][ai-models] to help you understand
-what changes are needed. You'll get a concise list of changed files to streamline the review, for example:
+**With GitHub Models enabled** (optional), you also get AI-generated summaries:
 
-<img width="582" height="646" alt="Screenshot 2025-08-26 at 13 40 53" src="https://github.com/user-attachments/assets/d460a5af-5ca4-4dd5-afb8-7330dd6de148" />
+<img width="582" height="646" alt="AI Summary" src="https://github.com/user-attachments/assets/d460a5af-5ca4-4dd5-afb8-7330dd6de148" />
 
-If conflicts arise, AI-generated comments call them out and provide next steps, such as:
+**Conflict help** (when needed):
 
 <img width="600" height="188" alt="Conflicts" src="https://github.com/user-attachments/assets/2142887a-730c-499a-94df-c717f09ab600" />
 
-### Workflow details
+## Troubleshooting
 
-The workflow will check once a week for new releases, and if there are any, it will create an Issue with a Pull Request compare link so you can create the PR and review it.
-The command called by the workflow is:
+#### If you get the 403 Forbidden Error
+
+**Error message:**
+```
+ERROR Update failed error=failed to open GitHub issue: gh models run failed: exit status 1
+Error: unexpected response from the server: 403 Forbidden
+```
+
+**Quick fix:** Disable GitHub Models (works for everyone)
 
 ```shell
-	# More info: https://kubebuilder.io/reference/commands/alpha_update
-    - name: Run kubebuilder alpha update
-      run: |
-		# Executes the update command with specified flags.
-		# --force: Completes the merge even if conflicts occur, leaving conflict markers.
-		# --push: Automatically pushes the resulting output branch to the 'origin' remote.
-		# --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
-		# --open-gh-models: Adds an AI-generated comment to the created Issue with
-		#   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
-        kubebuilder alpha update \
-          --force \
-          --push \
-          --restore-path .github/workflows \
-          --open-gh-issue \
-          --use-gh-models
+kubebuilder edit --plugins="autoupdate/v1-alpha"
+```
+
+This regenerates the workflow without GitHub Models:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  # No models: read permission
+
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v4
+    # ... other setup steps
+
+  - name: Run kubebuilder alpha update
+    # WARNING: This workflow does not use GitHub Models AI summary by default.
+    # To enable AI-generated summaries, you need permissions to use GitHub Models.
+    # If you have the required permissions, re-run:
+    #   kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
+    run: |
+      kubebuilder alpha update \
+        --force \
+        --push \
+        --restore-path .github/workflows \
+        --open-gh-issue
+```
+
+The workflow continues to work—just without AI summaries.
+
+**To enable GitHub Models instead:**
+
+1. Ask your GitHub administrator to enable Models (see links below)
+2. Enable it in **Settings → Code and automation → Models**
+3. Re-run with:
+
+```shell
+kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
+```
+
+This regenerates the workflow WITH GitHub Models:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  models: read  # Added for GitHub Models
+
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@v4
+    # ... other setup steps
+
+  - name: Install gh-models extension
+    run: |
+      gh extension install github/gh-models --force
+      gh models --help >/dev/null
+
+  - name: Run kubebuilder alpha update
+    # --use-gh-models: Adds an AI-generated comment to the Issue with
+    #   a summary of scaffold changes and conflict-resolution guidance (if any).
+    run: |
+      kubebuilder alpha update \
+        --force \
+        --push \
+        --restore-path .github/workflows \
+        --open-gh-issue \
+        --use-gh-models
 ```
 
 ## Demonstration
@@ -84,3 +175,5 @@ The command called by the workflow is:
 
 [alpha-update-command]: ./../../reference/commands/alpha_update.md
 [ai-models]: https://docs.github.com/en/github-models/about-github-models
+[manage-models-at-scale]: https://docs.github.com/en/github-models/github-models-at-scale/manage-models-at-scale
+[manage-org-models]: https://docs.github.com/en/organizations/managing-organization-settings/managing-or-restricting-github-models-for-your-organization

--- a/pkg/cli/alpha/internal/generate_test.go
+++ b/pkg/cli/alpha/internal/generate_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
+	autoupdatev1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
 
@@ -53,7 +54,7 @@ func (f *fakeConfig) GetResources() ([]resource.Resource, error) {
 	return f.resources, nil
 }
 
-func (f *fakeConfig) DecodePluginConfig(key string, _ any) error {
+func (f *fakeConfig) DecodePluginConfig(key string, dst any) error {
 	if len(f.plugins) == 0 {
 		return config.PluginKeyNotFoundError{Key: key}
 	}
@@ -61,8 +62,23 @@ func (f *fakeConfig) DecodePluginConfig(key string, _ any) error {
 		return f.pluginErr
 	}
 	// Check if the specific key exists
-	if _, exists := f.plugins[key]; !exists {
+	val, exists := f.plugins[key]
+	if !exists {
 		return config.PluginKeyNotFoundError{Key: key}
+	}
+	// If the value is a struct, copy its fields to dst
+	if val != nil && dst != nil {
+		// Handle different plugin config types
+		switch d := dst.(type) {
+		case *autoupdatev1alpha.PluginConfig:
+			if v, ok := val.(autoupdatev1alpha.PluginConfig); ok {
+				*d = v
+			}
+		case *deployimagev1alpha1.PluginConfig:
+			if v, ok := val.(deployimagev1alpha1.PluginConfig); ok {
+				*d = v
+			}
+		}
 	}
 	return nil
 }
@@ -812,7 +828,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("skips migration as AutoUpdate plugin not found", func() {
 			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: "autoupdate.kubebuilder.io/v1-alpha"}}
 			store := &fakeStore{cfg: cfg}
-			Expect(migrateGrafanaPlugin(store, "src", "dest")).To(Succeed())
+			Expect(migrateAutoUpdatePlugin(store)).To(Succeed())
 		})
 
 		It("returns error if failed to decode Auto Update plugin", func() {
@@ -824,8 +840,22 @@ var _ = Describe("generate: migrate-plugins", func() {
 			Expect(migrateAutoUpdatePlugin(store)).NotTo(Succeed())
 		})
 
-		It("migrates Auto Update plugin successfully", func() {
-			cfg := &fakeConfig{plugins: map[string]any{"autoupdate.kubebuilder.io/v1-alpha": true}}
+		It("migrates Auto Update plugin successfully without UseGHModels", func() {
+			cfg := &fakeConfig{
+				plugins: map[string]any{
+					"autoupdate.kubebuilder.io/v1-alpha": autoupdatev1alpha.PluginConfig{UseGHModels: false},
+				},
+			}
+			store := &fakeStore{cfg: cfg}
+			Expect(migrateAutoUpdatePlugin(store)).To(Succeed())
+		})
+
+		It("migrates Auto Update plugin successfully with UseGHModels enabled", func() {
+			cfg := &fakeConfig{
+				plugins: map[string]any{
+					"autoupdate.kubebuilder.io/v1-alpha": autoupdatev1alpha.PluginConfig{UseGHModels: true},
+				},
+			}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateAutoUpdatePlugin(store)).To(Succeed())
 		})

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -117,6 +117,12 @@ type Update struct {
 // Update a project using a default three-way Git merge.
 // This helps apply new scaffolding changes while preserving custom code.
 func (opts *Update) Update() error {
+	// Inform users about GitHub Models if they're opening an issue but not using AI summary
+	if opts.OpenGhIssue && !opts.UseGhModels {
+		log.Info("Consider enabling GitHub Models to get an AI summary to help with the update")
+		log.Info("Use the --use-gh-models flag if your project/organization has permission to use GitHub Models")
+	}
+
 	log.Info("Checking out base branch", "branch", opts.FromBranch)
 	checkoutCmd := helpers.GitCmd(opts.GitConfig, "checkout", opts.FromBranch)
 	if err := checkoutCmd.Run(); err != nil {

--- a/pkg/plugins/optional/autoupdate/v1alpha/init.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/init.go
@@ -18,6 +18,9 @@ package v1alpha
 
 import (
 	"fmt"
+	log "log/slog"
+
+	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -28,7 +31,8 @@ import (
 var _ plugin.InitSubcommand = &initSubcommand{}
 
 type initSubcommand struct {
-	config config.Config
+	config      config.Config
+	useGHModels bool
 }
 
 func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -36,7 +40,15 @@ func (p *initSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 
 	subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a common project with this plugin
   %[1]s init --plugins=%[2]s
+
+  # Initialize with GitHub Models enabled (requires repo permissions)
+  %[1]s init --plugins=%[2]s --use-gh-models
 `, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
+}
+
+func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&p.useGHModels, "use-gh-models", false,
+		"enable GitHub Models AI summary in the scaffolded workflow (requires GitHub Models permissions)")
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) error {
@@ -45,15 +57,24 @@ func (p *initSubcommand) InjectConfig(c config.Config) error {
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
-	if err := insertPluginMetaToConfig(p.config, pluginConfig{}); err != nil {
+	if err := insertPluginMetaToConfig(p.config, PluginConfig{UseGHModels: p.useGHModels}); err != nil {
 		return fmt.Errorf("error inserting project plugin meta to configuration: %w", err)
 	}
 
-	scaffolder := scaffolds.NewInitScaffolder()
+	scaffolder := scaffolds.NewInitScaffolder(p.useGHModels)
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {
 		return fmt.Errorf("error scaffolding init subcommand: %w", err)
 	}
 
+	return nil
+}
+
+func (p *initSubcommand) PostScaffold() error {
+	// Inform users about GitHub Models if they didn't enable it
+	if !p.useGHModels {
+		log.Info("Consider enabling GitHub Models to get an AI summary to help with the update")
+		log.Info("Use the --use-gh-models flag if your project/organization has permission to use GitHub Models")
+	}
 	return nil
 }

--- a/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/init.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/init.go
@@ -33,11 +33,16 @@ type initScaffolder struct {
 
 	// fs is the filesystem that will be used by the scaffolder
 	fs machinery.Filesystem
+
+	// useGHModels determines if GitHub Models AI summary should be enabled
+	useGHModels bool
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder() plugins.Scaffolder {
-	return &initScaffolder{}
+func NewInitScaffolder(useGHModels bool) plugins.Scaffolder {
+	return &initScaffolder{
+		useGHModels: useGHModels,
+	}
 }
 
 // InjectFS implements cmdutil.Scaffolder
@@ -54,7 +59,7 @@ func (s *initScaffolder) Scaffold() error {
 	)
 
 	err := scaffold.Execute(
-		&github.AutoUpdate{},
+		&github.AutoUpdate{UseGHModels: s.useGHModels},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute init scaffold: %w", err)

--- a/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github/auto_update.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github/auto_update.go
@@ -28,6 +28,9 @@ var _ machinery.Template = &AutoUpdate{}
 type AutoUpdate struct {
 	machinery.TemplateMixin
 	machinery.BoilerplateMixin
+
+	// UseGHModels indicates whether to enable GitHub Models AI summary
+	UseGHModels bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -37,22 +40,22 @@ func (f *AutoUpdate) SetTemplateDefaults() error {
 	}
 
 	f.TemplateBody = autoUpdateTemplate
-	f.IfExistsAction = machinery.SkipFile
+	f.IfExistsAction = machinery.OverwriteFile
 
 	return nil
 }
 
 const autoUpdateTemplate = `name: Auto Update
 
-# The 'kubebuilder alpha update 'command requires write access to the repository to create a branch
+# The 'kubebuilder alpha update' command requires write access to the repository to create a branch
 # with the update files and allow you to open a pull request using the link provided in the issue.
 # The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
 # To protect your codebase, please ensure that you have branch protection rules configured for your 
 # main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
 permissions:
-  contents: write
-  issues: write
-  models: read
+  contents: write  # Create and push the update branch
+  issues: write    # Create GitHub Issue with PR link{{ if .UseGHModels }}
+  models: read     # Use GitHub Models for AI summaries{{ end }}
 
 on:
   workflow_dispatch:
@@ -65,55 +68,60 @@ jobs:
     env:
       GH_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
 
-    # Step 1: Checkout the repository.
+    # Checkout the repository.
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         token: {{ "${{ secrets.GITHUB_TOKEN }}" }}
         fetch-depth: 0
-    
-    # Step 2: Configure Git to create commits with the GitHub Actions bot.
+
+    # Configure Git to create commits with the GitHub Actions bot.
     - name: Configure Git
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-    # Step 3: Set up Go environment.
+    # Set up Go environment.
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: stable
 
-    # Step 4: Install Kubebuilder.
+    # Install Kubebuilder.
     - name: Install Kubebuilder
       run: |
         curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
         chmod +x kubebuilder
         sudo mv kubebuilder /usr/local/bin/
         kubebuilder version
-
-    # Step 5: Install Models extension for GitHub CLI
-    - name: Install/upgrade gh-models extension
+{{ if .UseGHModels }}
+    # Install Models extension for GitHub CLI.
+    - name: Install gh-models extension
       run: |
         gh extension install github/gh-models --force
         gh models --help >/dev/null
-
-    # Step 6: Run the Kubebuilder alpha update command.
+{{ end }}
+    # Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
       # Executes the update command with specified flags.
       # --force: Completes the merge even if conflicts occur, leaving conflict markers.
       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
-      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
+      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.{{ if .UseGHModels }}
       # --use-gh-models: Adds an AI-generated comment to the created Issue with
-      #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
+      #   a short overview of the scaffold changes and conflict-resolution guidance (if any).{{ else }}
+      #
+      # WARNING: This workflow does not use GitHub Models AI summary by default.
+      # To enable AI-generated summaries in GitHub issues, you need permissions to use GitHub Models.
+      # If you have the required permissions, re-run:
+      #   kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models{{ end }}
       run: |
         kubebuilder alpha update \
           --force \
           --push \
           --restore-path .github/workflows \
-          --open-gh-issue \
-          --use-gh-models
+          --open-gh-issue{{ if .UseGHModels }} \
+          --use-gh-models{{ end }}
 `

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -119,7 +119,7 @@ function scaffold_test_project {
     $kb edit --plugins=helm.kubebuilder.io/v2-alpha
 
     header_text 'Editing project with Auto Update plugin ...'
-    $kb edit --plugins=autoupdate.kubebuilder.io/v1-alpha
+    $kb edit --plugins=autoupdate.kubebuilder.io/v1-alpha --use-gh-models
   fi
 
   # To avoid conflicts

--- a/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
@@ -1,14 +1,14 @@
 name: Auto Update
 
-# The 'kubebuilder alpha update 'command requires write access to the repository to create a branch
+# The 'kubebuilder alpha update' command requires write access to the repository to create a branch
 # with the update files and allow you to open a pull request using the link provided in the issue.
 # The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
 # To protect your codebase, please ensure that you have branch protection rules configured for your 
 # main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
 permissions:
-  contents: write
-  issues: write
-  models: read
+  contents: write  # Create and push the update branch
+  issues: write    # Create GitHub Issue with PR link
+  models: read     # Use GitHub Models for AI summaries
 
 on:
   workflow_dispatch:
@@ -21,27 +21,27 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    # Step 1: Checkout the repository.
+    # Checkout the repository.
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
-    
-    # Step 2: Configure Git to create commits with the GitHub Actions bot.
+
+    # Configure Git to create commits with the GitHub Actions bot.
     - name: Configure Git
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-    # Step 3: Set up Go environment.
+    # Set up Go environment.
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: stable
 
-    # Step 4: Install Kubebuilder.
+    # Install Kubebuilder.
     - name: Install Kubebuilder
       run: |
         curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)"
@@ -49,13 +49,13 @@ jobs:
         sudo mv kubebuilder /usr/local/bin/
         kubebuilder version
 
-    # Step 5: Install Models extension for GitHub CLI
-    - name: Install/upgrade gh-models extension
+    # Install Models extension for GitHub CLI.
+    - name: Install gh-models extension
       run: |
         gh extension install github/gh-models --force
         gh models --help >/dev/null
 
-    # Step 6: Run the Kubebuilder alpha update command.
+    # Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
       # Executes the update command with specified flags.
@@ -64,7 +64,7 @@ jobs:
       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
       # --use-gh-models: Adds an AI-generated comment to the created Issue with
-      #   a short overview of the scaffold changes and conflict-resolution guidance (If Any).
+      #   a short overview of the scaffold changes and conflict-resolution guidance (if any).
       run: |
         kubebuilder alpha update \
           --force \

--- a/testdata/project-v4-with-plugins/PROJECT
+++ b/testdata/project-v4-with-plugins/PROJECT
@@ -7,7 +7,8 @@ domain: testproject.org
 layout:
 - go.kubebuilder.io/v4
 plugins:
-  autoupdate.kubebuilder.io/v1-alpha: {}
+  autoupdate.kubebuilder.io/v1-alpha:
+    useGHModels: true
   deploy-image.go.kubebuilder.io/v1-alpha:
     resources:
     - domain: testproject.org


### PR DESCRIPTION
Default scaffold now works without GitHub Models permissions, preventing
403 Forbidden errors for most users. AI summaries remain available as an
opt-in feature.

**Changes:**
- Remove `--use-gh-models` from default workflow scaffold
- Add `--use-gh-models` flag to `init` and `edit` commands
- Track `useGHModels` preference in PROJECT file (like helm/v2-alpha)
- Add runtime warning when `alpha update` runs without GH Models enabled
- Update `alpha generate` to preserve user's GH Models preference
- Update the documentation accordingly
- Add support to reenarate the projects with this option