### PR TITLE
✨ (go/v4): Add optional kubectl context locking for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ test-testdata: ## Run the tests of the testdata directory
 .PHONY: test-e2e-local
 test-e2e-local: ## Run the end-to-end tests locally
 	## To keep the same kind cluster between test runs, use `SKIP_KIND_CLEANUP=1 make test-e2e-local`
+	## To lock to a specific kubectl context, use `KUBE_CONTEXT=kind-test make test-e2e-local`
 	./test/e2e/local.sh
 
 .PHONY: test-e2e-ci

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -67,8 +67,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: project-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= project-test-e2e
 
 .PHONY: setup-test-e2e

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,7 +44,12 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
-// To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// Environment variables (see Makefile target 'test-e2e' for examples):
+// - KIND_CLUSTER: Name of the Kind cluster (default: kind)
+// - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+// - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+//
+// Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting project e2e test suite\n")
@@ -53,6 +59,13 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("Ensure that Prometheus is enabled")
 	_ = utils.UncommentCode("config/default/kustomization.yaml", "#- ../prometheus", "#")
+
+	// Display kubectl context being used
+	if kubectx := os.Getenv("KUBE_CONTEXT"); kubectx != "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", kubectx)
+	} else if currentCtx, err := getCurrentContext(); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", currentCtx)
+	}
 
 	By("building the manager image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
@@ -118,4 +131,14 @@ func teardownCertManager() {
 
 	By("uninstalling CertManager")
 	utils.UninstallCertManager()
+}
+
+// getCurrentContext returns the current kubectl context name
+func getCurrentContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "current-context")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -63,8 +63,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: project-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= project-test-e2e
 
 .PHONY: setup-test-e2e

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,7 +42,12 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
-// To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// Environment variables (see Makefile target 'test-e2e' for examples):
+// - KIND_CLUSTER: Name of the Kind cluster (default: kind)
+// - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+// - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+//
+// Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting project e2e test suite\n")
@@ -49,6 +55,13 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// Display kubectl context being used
+	if kubectx := os.Getenv("KUBE_CONTEXT"); kubectx != "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", kubectx)
+	} else if currentCtx, err := getCurrentContext(); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", currentCtx)
+	}
+
 	By("building the manager image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
 	_, err := utils.Run(cmd)
@@ -98,4 +111,14 @@ func teardownCertManager() {
 
 	By("uninstalling CertManager")
 	utils.UninstallCertManager()
+}
+
+// getCurrentContext returns the current kubectl context name
+func getCurrentContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "current-context")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -67,8 +67,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: project-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= project-test-e2e
 
 .PHONY: setup-test-e2e

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,7 +44,12 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
-// To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// Environment variables (see Makefile target 'test-e2e' for examples):
+// - KIND_CLUSTER: Name of the Kind cluster (default: kind)
+// - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+// - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+//
+// Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting project e2e test suite\n")
@@ -53,6 +59,13 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("Ensure that Prometheus is enabled")
 	_ = utils.UncommentCode("config/default/kustomization.yaml", "#- ../prometheus", "#")
+
+	// Display kubectl context being used
+	if kubectx := os.Getenv("KUBE_CONTEXT"); kubectx != "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", kubectx)
+	} else if currentCtx, err := getCurrentContext(); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", currentCtx)
+	}
 
 	By("building the manager image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
@@ -118,4 +131,14 @@ func teardownCertManager() {
 
 	By("uninstalling CertManager")
 	utils.UninstallCertManager()
+}
+
+// getCurrentContext returns the current kubectl context name
+func getCurrentContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "current-context")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -142,8 +142,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: {{ .ProjectName }}-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= {{ .ProjectName }}-test-e2e
 
 .PHONY: setup-test-e2e

--- a/test/e2e/utils/kubectl.go
+++ b/test/e2e/utils/kubectl.go
@@ -30,11 +30,20 @@ type Kubectl struct {
 	*CmdContext
 	Namespace      string
 	ServiceAccount string
+	KubeContext    string
+}
+
+// cmdOptionsWithContext prepends --context flag to kubectl commands if KubeContext is set
+func (k *Kubectl) cmdOptionsWithContext(cmdOptions ...string) []string {
+	if k.KubeContext != "" {
+		return append([]string{"--context", k.KubeContext}, cmdOptions...)
+	}
+	return cmdOptions
 }
 
 // Command is a general func to run kubectl commands
 func (k *Kubectl) Command(cmdOptions ...string) (string, error) {
-	cmd := exec.Command("kubectl", cmdOptions...)
+	cmd := exec.Command("kubectl", k.cmdOptionsWithContext(cmdOptions...)...)
 	output, err := k.Run(cmd)
 	return string(output), err
 }

--- a/test/e2e/utils/test_context.go
+++ b/test/e2e/utils/test_context.go
@@ -76,6 +76,8 @@ func NewTestContext(binaryName string, env ...string) (*TestContext, error) {
 		Namespace:      fmt.Sprintf("e2e-%s-system", testSuffix),
 		ServiceAccount: fmt.Sprintf("e2e-%s-controller-manager", testSuffix),
 		CmdContext:     cc,
+		// Optional context lock from env var
+		KubeContext: os.Getenv("KUBE_CONTEXT"),
 	}
 
 	// For test outside of cluster we do not need to have kubectl

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -63,8 +63,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: project-v4-multigroup-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= project-v4-multigroup-test-e2e
 
 .PHONY: setup-test-e2e

--- a/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,7 +42,12 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
-// To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// Environment variables (see Makefile target 'test-e2e' for examples):
+// - KIND_CLUSTER: Name of the Kind cluster (default: kind)
+// - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+// - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+//
+// Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting project-v4-multigroup e2e test suite\n")
@@ -49,6 +55,13 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// Display kubectl context being used
+	if kubectx := os.Getenv("KUBE_CONTEXT"); kubectx != "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", kubectx)
+	} else if currentCtx, err := getCurrentContext(); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", currentCtx)
+	}
+
 	By("building the manager image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
 	_, err := utils.Run(cmd)
@@ -98,4 +111,14 @@ func teardownCertManager() {
 
 	By("uninstalling CertManager")
 	utils.UninstallCertManager()
+}
+
+// getCurrentContext returns the current kubectl context name
+func getCurrentContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "current-context")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -63,8 +63,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: project-v4-with-plugins-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= project-v4-with-plugins-test-e2e
 
 .PHONY: setup-test-e2e

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,7 +42,12 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
-// To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// Environment variables (see Makefile target 'test-e2e' for examples):
+// - KIND_CLUSTER: Name of the Kind cluster (default: kind)
+// - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+// - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+//
+// Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting project-v4-with-plugins e2e test suite\n")
@@ -49,6 +55,13 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// Display kubectl context being used
+	if kubectx := os.Getenv("KUBE_CONTEXT"); kubectx != "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", kubectx)
+	} else if currentCtx, err := getCurrentContext(); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", currentCtx)
+	}
+
 	By("building the manager image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
 	_, err := utils.Run(cmd)
@@ -98,4 +111,14 @@ func teardownCertManager() {
 
 	By("uninstalling CertManager")
 	utils.UninstallCertManager()
+}
+
+// getCurrentContext returns the current kubectl context name
+func getCurrentContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "current-context")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -63,8 +63,11 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Environment variables:
+# - KIND_CLUSTER: Name of the Kind cluster (default: project-v4-test-e2e)
+# - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+# - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+# Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 KIND_CLUSTER ?= project-v4-test-e2e
 
 .PHONY: setup-test-e2e

--- a/testdata/project-v4/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,7 +42,12 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
-// To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
+// Environment variables (see Makefile target 'test-e2e' for examples):
+// - KIND_CLUSTER: Name of the Kind cluster (default: kind)
+// - KUBE_CONTEXT: Kubectl context to use (default: current-context)
+// - CERT_MANAGER_INSTALL_SKIP=true: Skip CertManager installation
+//
+// Note: When KIND_CLUSTER=my-cluster, the kubectl context will be "kind-my-cluster"
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting project-v4 e2e test suite\n")
@@ -49,6 +55,13 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// Display kubectl context being used
+	if kubectx := os.Getenv("KUBE_CONTEXT"); kubectx != "" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", kubectx)
+	} else if currentCtx, err := getCurrentContext(); err == nil {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Using context: %s\n", currentCtx)
+	}
+
 	By("building the manager image")
 	cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", managerImage))
 	_, err := utils.Run(cmd)
@@ -98,4 +111,14 @@ func teardownCertManager() {
 
 	By("uninstalling CertManager")
 	utils.UninstallCertManager()
+}
+
+// getCurrentContext returns the current kubectl context name
+func getCurrentContext() (string, error) {
+	cmd := exec.Command("kubectl", "config", "current-context")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }


### PR DESCRIPTION
E2E tests now support optional context locking via KUBE_CONTEXT environment
variable. When set, tests validate and lock to the specified kubectl context,
preventing context switching during execution.

Features:
- Display current kubectl context at test startup
- Validate context matches KUBE_CONTEXT if set
- Add --context flag to all kubectl commands when locked
- 100% backward compatible (opt-in feature)

Usage:
  KUBE_CONTEXT=kind-test make test-e2e

This addresses feedback from PR https://github.com/kubernetes-sigs/kubebuilder/pull/5329 about preventing inadvertent context
switching during test execution, while maintaining ease of use (works without
any env vars by default).


Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5335

Co-Author: @Sijoma 