### PR TITLE
🌱 Fix cmd version to keep value used by vendor

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -40,7 +40,7 @@ const (
 // information in the release process
 var (
 	kubeBuilderVersion      = unknown
-	kubernetesVendorVersion = "1.35.0"
+	kubernetesVendorVersion = "1.34.1"
 	goos                    = unknown
 	goarch                  = unknown
 	gitCommit               = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)


### PR DESCRIPTION
We cannot update this value yet.
Just after we bump controller-runtime.