### PR TITLE
🐛 (go/v4): Re-add e2e cert-manager logs

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -91,11 +91,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -110,6 +112,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
@@ -71,11 +71,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -90,6 +92,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -91,11 +91,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -110,6 +112,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -99,11 +99,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -118,6 +120,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 

--- a/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
@@ -71,11 +71,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -90,6 +92,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
@@ -71,11 +71,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -90,6 +92,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 

--- a/testdata/project-v4/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4/test/e2e/e2e_suite_test.go
@@ -71,11 +71,13 @@ var _ = AfterSuite(func() {
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.
 func setupCertManager() {
 	if os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true" {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager installation (CERT_MANAGER_INSTALL_SKIP=true)\n")
 		return
 	}
 
 	By("checking if CertManager is already installed")
 	if utils.IsCertManagerCRDsInstalled() {
+		_, _ = fmt.Fprintf(GinkgoWriter, "CertManager is already installed. Skipping installation.\n")
 		return
 	}
 
@@ -90,6 +92,7 @@ func setupCertManager() {
 // This ensures we only remove what we installed.
 func teardownCertManager() {
 	if !shouldCleanupCertManager {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Skipping CertManager cleanup (not installed by this suite)\n")
 		return
 	}
 


### PR DESCRIPTION
Follow-up to #5329 - restore informative logging for setup/teardown steps.
