### PR TITLE
🐛 (helm/v2-alpha): add Helm standard labels to resources

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -31,13 +31,10 @@ Always uses the Helm release namespace.
 {{ .Release.Namespace }}
 {{- end }}
 
-
-
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
 Takes a dict with .suffix (resource name suffix) and .context (template context).
 Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.
-Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project.resourceName" -}}
 {{- $fullname := include "project.fullname" .context -}}
@@ -48,29 +45,4 @@ Generic helper that works for any resource type (Service, Role, Certificate, etc
 {{- else -}}
 {{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end }}
-
-{{/*
-Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
-*/}}
-{{- define "project.labels" -}}
-{{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-{{- if .Chart.Version }}
-helm.sh/chart: {{ .Chart.Version | quote }}
-{{- end }}
-app.kubernetes.io/name: {{ include "project.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels for matching pods and services.
-Only includes name and instance for consistent selection.
-*/}}
-{{- define "project.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "project.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "metrics-certs" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}
@@ -19,6 +21,9 @@ spec:
                 kubectl.kubernetes.io/default-container: manager
             labels:
                 app.kubernetes.io/name: {{ include "project.name" . }}
+                helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+                app.kubernetes.io/instance: {{ .Release.Name }}
+                app.kubernetes.io/managed-by: {{ .Release.Service }}
                 control-plane: controller-manager
         spec:
             {{- with .Values.manager.tolerations }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -4,5 +4,7 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "cronjob-admin-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "cronjob-editor-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "cronjob-viewer-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-role.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
     namespace: {{ .Release.Namespace }}
 rules:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
     namespace: {{ .Release.Namespace }}
 roleRef:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "webhook-service" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
@@ -31,13 +31,10 @@ Always uses the Helm release namespace.
 {{ .Release.Namespace }}
 {{- end }}
 
-
-
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
 Takes a dict with .suffix (resource name suffix) and .context (template context).
 Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.
-Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project.resourceName" -}}
 {{- $fullname := include "project.fullname" .context -}}
@@ -48,29 +45,4 @@ Generic helper that works for any resource type (Service, Role, Certificate, etc
 {{- else -}}
 {{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end }}
-
-{{/*
-Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
-*/}}
-{{- define "project.labels" -}}
-{{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-{{- if .Chart.Version }}
-helm.sh/chart: {{ .Chart.Version | quote }}
-{{- end }}
-app.kubernetes.io/name: {{ include "project.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels for matching pods and services.
-Only includes name and instance for consistent selection.
-*/}}
-{{- define "project.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "project.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}
@@ -19,6 +21,9 @@ spec:
                 kubectl.kubernetes.io/default-container: manager
             labels:
                 app.kubernetes.io/name: {{ include "project.name" . }}
+                helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+                app.kubernetes.io/instance: {{ .Release.Name }}
+                app.kubernetes.io/managed-by: {{ .Release.Service }}
                 control-plane: controller-manager
         spec:
             {{- with .Values.manager.tolerations }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/monitoring/servicemonitor.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/monitoring/servicemonitor.yaml
@@ -3,9 +3,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    {{- include "{{ .Chart.Name }}.labels" . | nindent 4 }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
-  name: {{ include "{{ .Chart.Name }}.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
+  name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
@@ -15,7 +18,7 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         {{- if .Values.certManager.enable }}
-        serverName: {{ include "{{ .Chart.Name }}.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
+        serverName: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
         # Apply secure TLS configuration with cert-manager
         insecureSkipVerify: false
         ca:
@@ -35,5 +38,6 @@ spec:
         {{- end }}
   selector:
     matchLabels:
+      app.kubernetes.io/name: {{ include "project.name" . }}
       control-plane: controller-manager
 {{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -4,5 +4,7 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/leader-election-role.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
     namespace: {{ .Release.Namespace }}
 rules:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
     namespace: {{ .Release.Namespace }}
 roleRef:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-admin-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-admin-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "memcached-admin-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-editor-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-editor-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "memcached-editor-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-viewer-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-viewer-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "memcached-viewer-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -31,13 +31,10 @@ Always uses the Helm release namespace.
 {{ .Release.Namespace }}
 {{- end }}
 
-
-
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
 Takes a dict with .suffix (resource name suffix) and .context (template context).
 Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.
-Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project.resourceName" -}}
 {{- $fullname := include "project.fullname" .context -}}
@@ -48,29 +45,4 @@ Generic helper that works for any resource type (Service, Role, Certificate, etc
 {{- else -}}
 {{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end }}
-
-{{/*
-Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
-*/}}
-{{- define "project.labels" -}}
-{{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-{{- if .Chart.Version }}
-helm.sh/chart: {{ .Chart.Version | quote }}
-{{- end }}
-app.kubernetes.io/name: {{ include "project.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels for matching pods and services.
-Only includes name and instance for consistent selection.
-*/}}
-{{- define "project.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "project.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "metrics-certs" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}
@@ -19,6 +21,9 @@ spec:
                 kubectl.kubernetes.io/default-container: manager
             labels:
                 app.kubernetes.io/name: {{ include "project.name" . }}
+                helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+                app.kubernetes.io/instance: {{ .Release.Name }}
+                app.kubernetes.io/managed-by: {{ .Release.Service }}
                 control-plane: controller-manager
         spec:
             {{- with .Values.manager.tolerations }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -4,5 +4,7 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "cronjob-admin-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "cronjob-editor-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "cronjob-viewer-role" "context" $) }}
 rules:
     - apiGroups:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-role.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
     namespace: {{ .Release.Namespace }}
 rules:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
     namespace: {{ .Release.Namespace }}
 roleRef:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project.resourceName" (dict "suffix" "webhook-service" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -44,8 +44,6 @@ func (f *HelmHelpers) SetTemplateDefaults() error {
 		f.Path = filepath.Join(outputDir, "chart", "templates", "_helpers.tpl")
 	}
 
-	// Use project name as template prefix to avoid collisions when chart is used as dependency
-	// This follows the pattern used by Bitnami, cert-manager, and other production Helm charts
 	f.TemplateBody = f.generateHelpersTemplate()
 
 	f.IfExistsAction = machinery.SkipFile
@@ -60,7 +58,7 @@ func (f *HelmHelpers) generateHelpersTemplate() string {
 	// preventing collisions when chart is used as a Helm dependency
 	prefix := f.ProjectName
 
-	return fmt.Sprintf(helmHelpersTemplate, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix)
+	return fmt.Sprintf(helmHelpersTemplate, prefix, prefix, prefix, prefix, prefix)
 }
 
 const helmHelpersTemplate = `{{` + "`" + `{{/*
@@ -96,13 +94,10 @@ Always uses the Helm release namespace.
 {{` + "`" + `{{ .Release.Namespace }}` + "`" + `}}
 {{` + "`" + `{{- end }}` + "`" + `}}
 
-
-
 {{` + "`" + `{{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
 Takes a dict with .suffix (resource name suffix) and .context (template context).
 Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.
-Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}` + "`" + `}}
 {{` + "`" + `{{- define "%s.resourceName" -}}` + "`" + `}}
 {{` + "`" + `{{- $fullname := include "%s.fullname" .context -}}` + "`" + `}}
@@ -114,30 +109,5 @@ Generic helper that works for any resource type (Service, Role, Certificate, etc
 {{` + "`" + `{{- else -}}` + "`" + `}}
 {{` + "`" + `{{- printf "%%s-%%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}` + "`" + `}}
 {{` + "`" + `{{- end -}}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-{{` + "`" + `{{/*
-Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.labels" -}}` + "`" + `}}
-{{` + "`" + `{{- if .Chart.AppVersion -}}` + "`" + `}}
-app.kubernetes.io/version: {{` + "`" + `{{ .Chart.AppVersion | quote }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-{{` + "`" + `{{- if .Chart.Version }}` + "`" + `}}
-helm.sh/chart: {{` + "`" + `{{ .Chart.Version | quote }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-app.kubernetes.io/name: {{` + "`" + `{{ include "%s.name" . }}` + "`" + `}}
-app.kubernetes.io/instance: {{` + "`" + `{{ .Release.Name }}` + "`" + `}}
-app.kubernetes.io/managed-by: {{` + "`" + `{{ .Release.Service }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-{{` + "`" + `{{/*
-Selector labels for matching pods and services.
-Only includes name and instance for consistent selection.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.selectorLabels" -}}` + "`" + `}}
-app.kubernetes.io/name: {{` + "`" + `{{ include "%s.name" . }}` + "`" + `}}
-app.kubernetes.io/instance: {{` + "`" + `{{ .Release.Name }}` + "`" + `}}
 {{` + "`" + `{{- end }}` + "`" + `}}
 `

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -31,13 +31,10 @@ Always uses the Helm release namespace.
 {{ .Release.Namespace }}
 {{- end }}
 
-
-
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
 Takes a dict with .suffix (resource name suffix) and .context (template context).
 Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.
-Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project-v4-with-plugins.resourceName" -}}
 {{- $fullname := include "project-v4-with-plugins.fullname" .context -}}
@@ -48,29 +45,4 @@ Generic helper that works for any resource type (Service, Role, Certificate, etc
 {{- else -}}
 {{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- end }}
-
-{{/*
-Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
-*/}}
-{{- define "project-v4-with-plugins.labels" -}}
-{{- if .Chart.AppVersion -}}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-{{- if .Chart.Version }}
-helm.sh/chart: {{ .Chart.Version | quote }}
-{{- end }}
-app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels for matching pods and services.
-Only includes name and instance for consistent selection.
-*/}}
-{{- define "project-v4-with-plugins.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "metrics-certs" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}
@@ -19,6 +21,9 @@ spec:
                 kubectl.kubernetes.io/default-container: manager
             labels:
                 app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+                helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+                app.kubernetes.io/instance: {{ .Release.Name }}
+                app.kubernetes.io/managed-by: {{ .Release.Service }}
                 control-plane: controller-manager
         spec:
             {{- with .Values.manager.tolerations }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/monitoring/servicemonitor.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/monitoring/servicemonitor.yaml
@@ -3,9 +3,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    {{- include "{{ .Chart.Name }}.labels" . | nindent 4 }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
-  name: {{ include "{{ .Chart.Name }}.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
@@ -15,7 +18,7 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         {{- if .Values.certManager.enable }}
-        serverName: {{ include "{{ .Chart.Name }}.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
+        serverName: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
         # Apply secure TLS configuration with cert-manager
         insecureSkipVerify: false
         ca:
@@ -35,5 +38,6 @@ spec:
         {{- end }}
   selector:
     matchLabels:
+      app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
       control-plane: controller-manager
 {{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-admin-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-admin-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "busybox-admin-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-editor-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-editor-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "busybox-editor-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-viewer-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-viewer-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "busybox-viewer-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
@@ -4,5 +4,7 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader-election-role.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
     namespace: {{ .Release.Namespace }}
 rules:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
     namespace: {{ .Release.Namespace }}
 roleRef:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
 roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-admin-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-admin-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "memcached-admin-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-editor-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-editor-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "memcached-editor-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-viewer-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-viewer-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "memcached-viewer-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-admin-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-admin-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "wordpress-admin-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-editor-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-editor-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "wordpress-editor-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-viewer-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-viewer-role.yaml
@@ -5,6 +5,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "wordpress-viewer-role" "context" $) }}
 rules:
     - apiGroups:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
@@ -4,6 +4,8 @@ metadata:
     labels:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "webhook-service" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
## What Changed

Added missing Helm standard labels to all generated chart resources:
- `helm.sh/chart` - Chart name and version
- `app.kubernetes.io/instance` - Release name

These labels are recommended by Helm best practices but were missing 
from dynamically generated templates.

## How It Works

Labels are added after `app.kubernetes.io/name` with proper indentation:

# Before
```yaml
metadata:
  labels:
    app.kubernetes.io/name: {{ include "chart.name" . }}
    app.kubernetes.io/managed-by: {{ .Release.Service }}
```

# After  

```yaml
metadata:
  labels:
    app.kubernetes.io/name: {{ include "chart.name" . }}
    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
    app.kubernetes.io/instance: {{ .Release.Name }}
    app.kubernetes.io/managed-by: {{ .Release.Service }}## Cleanup
```

Removed unused `chart.selectorLabels` helper from `_helpers.tpl`.

## Reference

Follows https://helm.sh/docs/chart_best_practices/labels/#standard-labels

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5304