### PR TITLE
✨ (alpha): Auto-migrate helm/v1-alpha to helm/v2-alpha in generate command

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -409,9 +409,10 @@ func getInitArgs(s store.Store) []string {
 
 	// Define outdated plugin versions that need replacement
 	outdatedPlugins := map[string]string{
-		"go.kubebuilder.io/v3":       "go.kubebuilder.io/v4",
-		"go.kubebuilder.io/v3-alpha": "go.kubebuilder.io/v4",
-		"go.kubebuilder.io/v2":       "go.kubebuilder.io/v4",
+		"go.kubebuilder.io/v3":         "go.kubebuilder.io/v4",
+		"go.kubebuilder.io/v3-alpha":   "go.kubebuilder.io/v4",
+		"go.kubebuilder.io/v2":         "go.kubebuilder.io/v4",
+		"helm.kubebuilder.io/v1-alpha": "helm.kubebuilder.io/v2-alpha",
 	}
 
 	// Replace outdated plugins and exit after the first replacement

--- a/pkg/cli/alpha/internal/generate_test.go
+++ b/pkg/cli/alpha/internal/generate_test.go
@@ -351,6 +351,21 @@ var _ = Describe("generate: get-args-helpers", func() {
 						"--domain", "foo.com", "--repo", "bar"))
 				})
 			})
+
+			When("helm v1-alpha plugin is used", func() {
+				It("should replace with helm v2-alpha", func() {
+					cfg := &fakeConfig{
+						pluginChain: []string{"go.kubebuilder.io/v4", "helm.kubebuilder.io/v1-alpha"},
+						domain:      "foo.com",
+						repo:        "bar",
+					}
+					store := &fakeStore{cfg: cfg}
+					args := getInitArgs(store)
+					Expect(args).To(ContainElements("--plugins", ContainSubstring("helm.kubebuilder.io/v2-alpha"),
+						"--domain", "foo.com", "--repo", "bar"))
+					Expect(args).NotTo(ContainElement(ContainSubstring("helm.kubebuilder.io/v1-alpha")))
+				})
+			})
 		})
 
 		Context("for latest plugins", func() {


### PR DESCRIPTION
When running `kubebuilder alpha generate` on projects using the deprecated helm.kubebuilder.io/v1-alpha plugin, automatically replace it with the current helm.kubebuilder.io/v2-alpha plugin, similar to existing go/v3 to go/v4 migration.

This ensures users with projects using the deprecated helm/v1-alpha plugin can seamlessly regenerate their projects with the newer helm/v2-alpha plugin without manual intervention.

