### PR TITLE
🌱 Add unit tests for CLI and external plugin helpers

### DIFF
--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -22,6 +22,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
 var _ = Describe("cmd_helpers", func() {
@@ -55,7 +59,6 @@ var _ = Describe("cmd_helpers", func() {
 			Expect(cmd.Long).To(ContainSubstring("test error"))
 			Expect(cmd.RunE).NotTo(BeNil())
 
-			// Execute the modified RunE to verify it returns the error
 			err := cmd.RunE(cmd, []string{})
 			Expect(err).To(Equal(testError))
 		})
@@ -70,4 +73,256 @@ var _ = Describe("cmd_helpers", func() {
 			Expect(err).To(Equal(testError))
 		})
 	})
+
+	Context("moveKeyToFront", func() {
+		It("should handle empty chain", func() {
+			result := moveKeyToFront([]string{}, "key1")
+			Expect(result).To(Equal([]string{"key1"}))
+		})
+
+		It("should not change chain when key is already at front", func() {
+			chain := []string{"key1", "key2", "key3"}
+			result := moveKeyToFront(chain, "key1")
+			Expect(result).To(Equal(chain))
+		})
+
+		It("should move key to front when it exists in chain", func() {
+			chain := []string{"key1", "key2", "key3"}
+			result := moveKeyToFront(chain, "key2")
+			Expect(result).To(Equal([]string{"key2", "key1", "key3"}))
+		})
+
+		It("should move key to front from end of chain", func() {
+			chain := []string{"key1", "key2", "key3"}
+			result := moveKeyToFront(chain, "key3")
+			Expect(result).To(Equal([]string{"key3", "key1", "key2"}))
+		})
+
+		It("should add key to front when not in chain", func() {
+			chain := []string{"key1", "key2"}
+			result := moveKeyToFront(chain, "key3")
+			Expect(result).To(Equal([]string{"key3", "key1", "key2"}))
+		})
+
+		It("should remove duplicate when moving key to front", func() {
+			chain := []string{"key1", "key2", "key2"}
+			result := moveKeyToFront(chain, "key2")
+			Expect(result).To(Equal([]string{"key2", "key1"}))
+		})
+	})
+
+	Context("equalStringSlices", func() {
+		It("should return true for equal slices", func() {
+			a := []string{"a", "b", "c"}
+			b := []string{"a", "b", "c"}
+			Expect(equalStringSlices(a, b)).To(BeTrue())
+		})
+
+		It("should return true for empty slices", func() {
+			Expect(equalStringSlices([]string{}, []string{})).To(BeTrue())
+		})
+
+		It("should return false for different lengths", func() {
+			a := []string{"a", "b"}
+			b := []string{"a", "b", "c"}
+			Expect(equalStringSlices(a, b)).To(BeFalse())
+		})
+
+		It("should return false for different content", func() {
+			a := []string{"a", "b", "c"}
+			b := []string{"a", "x", "c"}
+			Expect(equalStringSlices(a, b)).To(BeFalse())
+		})
+
+		It("should return false for different order", func() {
+			a := []string{"a", "b", "c"}
+			b := []string{"c", "b", "a"}
+			Expect(equalStringSlices(a, b)).To(BeFalse())
+		})
+
+		It("should handle nil slices", func() {
+			var a, b []string
+			Expect(equalStringSlices(a, b)).To(BeTrue())
+		})
+	})
+
+	Context("collectSubcommands", func() {
+		var (
+			testPlugin       *mockPluginWithSubcommand
+			testSubcommand   *mockTestSubcommand
+			testBundle       *mockPluginBundle
+			testNestedPlugin *mockPluginWithSubcommand
+		)
+
+		BeforeEach(func() {
+			testSubcommand = &mockTestSubcommand{}
+			testPlugin = newMockPluginWithSubcommand(
+				"test.plugin", []config.Version{{Number: 1}}, testSubcommand)
+			testNestedPlugin = newMockPluginWithSubcommand(
+				"nested.plugin", []config.Version{{Number: 1}}, &mockTestSubcommand{})
+			testBundle = newMockPluginBundle(
+				"test.bundle", []config.Version{{Number: 1}}, []plugin.Plugin{testNestedPlugin})
+		})
+
+		It("should return nil when filter returns false", func() {
+			filter := func(plugin.Plugin) bool { return false }
+			extract := func(plugin.Plugin) plugin.Subcommand { return testSubcommand }
+
+			result := collectSubcommands(testPlugin, "config.key", filter, extract)
+			Expect(result).To(BeNil())
+		})
+
+		It("should collect subcommand from single plugin", func() {
+			filter := func(plugin.Plugin) bool { return true }
+			extract := func(p plugin.Plugin) plugin.Subcommand {
+				if mp, ok := p.(*mockPluginWithSubcommand); ok {
+					return mp.subcommand
+				}
+				return nil
+			}
+
+			result := collectSubcommands(testPlugin, "config.key", filter, extract)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].key).To(Equal("test.plugin/v1"))
+			Expect(result[0].configKey).To(Equal("config.key"))
+			Expect(result[0].subcommand).To(Equal(testSubcommand))
+		})
+
+		It("should collect subcommands from bundle", func() {
+			filter := func(plugin.Plugin) bool { return true }
+			extract := func(p plugin.Plugin) plugin.Subcommand {
+				if mp, ok := p.(*mockPluginWithSubcommand); ok {
+					return mp.subcommand
+				}
+				return nil
+			}
+
+			result := collectSubcommands(testBundle, "bundle.key", filter, extract)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].key).To(Equal("nested.plugin/v1"))
+			Expect(result[0].configKey).To(Equal("bundle.key"))
+		})
+	})
+
+	Context("filterSubcommands", func() {
+		var (
+			cli            *CLI
+			testPlugin1    *mockPluginWithSubcommand
+			testPlugin2    *mockPluginWithSubcommand
+			testSubcommand *mockTestSubcommand
+		)
+
+		BeforeEach(func() {
+			testSubcommand = &mockTestSubcommand{}
+			testPlugin1 = newMockPluginWithSubcommand("plugin1", []config.Version{{Number: 1}}, testSubcommand)
+			testPlugin2 = newMockPluginWithSubcommand("plugin2", []config.Version{{Number: 1}}, testSubcommand)
+
+			cli = &CLI{
+				resolvedPlugins: []plugin.Plugin{testPlugin1, testPlugin2},
+			}
+		})
+
+		It("should filter and extract subcommands from all plugins", func() {
+			filter := func(p plugin.Plugin) bool {
+				return p.Name() == "plugin1"
+			}
+			extract := func(p plugin.Plugin) plugin.Subcommand {
+				if mp, ok := p.(*mockPluginWithSubcommand); ok {
+					return mp.subcommand
+				}
+				return nil
+			}
+
+			result := cli.filterSubcommands(filter, extract)
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].key).To(Equal("plugin1/v1"))
+		})
+
+		It("should return all subcommands when filter allows all", func() {
+			filter := func(plugin.Plugin) bool { return true }
+			extract := func(p plugin.Plugin) plugin.Subcommand {
+				if mp, ok := p.(*mockPluginWithSubcommand); ok {
+					return mp.subcommand
+				}
+				return nil
+			}
+
+			result := cli.filterSubcommands(filter, extract)
+			Expect(result).To(HaveLen(2))
+		})
+
+		It("should return empty when filter rejects all", func() {
+			filter := func(plugin.Plugin) bool { return false }
+			extract := func(plugin.Plugin) plugin.Subcommand { return testSubcommand }
+
+			result := cli.filterSubcommands(filter, extract)
+			Expect(result).To(BeEmpty())
+		})
+	})
 })
+
+type mockTestSubcommand struct{}
+
+func (m *mockTestSubcommand) Scaffold(machinery.Filesystem) error {
+	return nil
+}
+
+type mockPluginWithSubcommand struct {
+	name                     string
+	supportedProjectVersions []config.Version
+	subcommand               plugin.Subcommand
+}
+
+func newMockPluginWithSubcommand(
+	name string,
+	versions []config.Version,
+	subcommand plugin.Subcommand,
+) *mockPluginWithSubcommand {
+	return &mockPluginWithSubcommand{
+		name:                     name,
+		supportedProjectVersions: versions,
+		subcommand:               subcommand,
+	}
+}
+
+func (m *mockPluginWithSubcommand) Name() string {
+	return m.name
+}
+
+func (m *mockPluginWithSubcommand) Version() plugin.Version {
+	return plugin.Version{Number: 1}
+}
+
+func (m *mockPluginWithSubcommand) SupportedProjectVersions() []config.Version {
+	return m.supportedProjectVersions
+}
+
+type mockPluginBundle struct {
+	name                     string
+	supportedProjectVersions []config.Version
+	plugins                  []plugin.Plugin
+}
+
+func newMockPluginBundle(name string, versions []config.Version, plugins []plugin.Plugin) *mockPluginBundle {
+	return &mockPluginBundle{
+		name:                     name,
+		supportedProjectVersions: versions,
+		plugins:                  plugins,
+	}
+}
+
+func (m *mockPluginBundle) Name() string {
+	return m.name
+}
+
+func (m *mockPluginBundle) Version() plugin.Version {
+	return plugin.Version{Number: 1}
+}
+
+func (m *mockPluginBundle) SupportedProjectVersions() []config.Version {
+	return m.supportedProjectVersions
+}
+
+func (m *mockPluginBundle) Plugins() []plugin.Plugin {
+	return m.plugins
+}

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+)
+
+var _ = Describe("init", func() {
+	Context("getInitHelpExamples", func() {
+		It("should return help examples for available project versions", func() {
+			plugin1 := newMockPlugin("test.plugin", "3", config.Version{Number: 3})
+			plugin2 := newMockPlugin("another.plugin", "3", config.Version{Number: 3}, config.Version{Number: 4})
+
+			cli := CLI{
+				commandName: "kubebuilder",
+				plugins: map[string]plugin.Plugin{
+					plugin.KeyFor(plugin1): plugin1,
+					plugin.KeyFor(plugin2): plugin2,
+				},
+			}
+
+			examples := cli.getInitHelpExamples()
+
+			Expect(examples).To(ContainSubstring("kubebuilder init"))
+			Expect(examples).To(ContainSubstring("project-version"))
+			Expect(examples).To(ContainSubstring("-h"))
+		})
+
+		It("should handle multiple versions", func() {
+			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 2})
+			plugin2 := newMockPlugin("plugin2", "3", config.Version{Number: 3})
+
+			cli := CLI{
+				commandName: "kb",
+				plugins: map[string]plugin.Plugin{
+					plugin.KeyFor(plugin1): plugin1,
+					plugin.KeyFor(plugin2): plugin2,
+				},
+			}
+
+			examples := cli.getInitHelpExamples()
+
+			Expect(examples).To(ContainSubstring("kb init"))
+			Expect(examples).NotTo(HaveSuffix("\n\n"))
+		})
+
+		It("should return empty string when no plugins", func() {
+			cli := CLI{
+				commandName: "kubebuilder",
+				plugins:     map[string]plugin.Plugin{},
+			}
+
+			examples := cli.getInitHelpExamples()
+			Expect(examples).To(BeEmpty())
+		})
+	})
+
+	Context("getAvailableProjectVersions", func() {
+		It("should return unique project versions", func() {
+			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 3})
+			plugin2 := newMockPlugin("plugin2", "3", config.Version{Number: 3})
+			plugin3 := newMockPlugin("plugin3", "3", config.Version{Number: 4})
+
+			cli := CLI{
+				plugins: map[string]plugin.Plugin{
+					plugin.KeyFor(plugin1): plugin1,
+					plugin.KeyFor(plugin2): plugin2,
+					plugin.KeyFor(plugin3): plugin3,
+				},
+			}
+
+			versions := cli.getAvailableProjectVersions()
+
+			Expect(versions).To(ContainElement("\"3\""))
+			Expect(versions).To(ContainElement("\"4\""))
+			Expect(versions).To(HaveLen(2))
+		})
+
+		It("should exclude deprecated plugins", func() {
+			deprecatedPlugin := newMockDeprecatedPlugin("deprecated", "3", "use v4 instead", config.Version{Number: 2})
+			regularPlugin := newMockPlugin("regular", "3", config.Version{Number: 3})
+
+			cli := CLI{
+				plugins: map[string]plugin.Plugin{
+					plugin.KeyFor(deprecatedPlugin): deprecatedPlugin,
+					plugin.KeyFor(regularPlugin):    regularPlugin,
+				},
+			}
+
+			versions := cli.getAvailableProjectVersions()
+
+			Expect(versions).NotTo(ContainElement("\"2\""))
+			Expect(versions).To(ContainElement("\"3\""))
+		})
+
+		It("should return sorted versions", func() {
+			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 4})
+			plugin2 := newMockPlugin("plugin2", "3", config.Version{Number: 2})
+			plugin3 := newMockPlugin("plugin3", "3", config.Version{Number: 3})
+
+			cli := CLI{
+				plugins: map[string]plugin.Plugin{
+					plugin.KeyFor(plugin1): plugin1,
+					plugin.KeyFor(plugin2): plugin2,
+					plugin.KeyFor(plugin3): plugin3,
+				},
+			}
+
+			versions := cli.getAvailableProjectVersions()
+
+			Expect(versions).To(Equal([]string{"\"2\"", "\"3\"", "\"4\""}))
+		})
+
+		It("should return empty slice when no plugins", func() {
+			cli := CLI{
+				plugins: map[string]plugin.Plugin{},
+			}
+
+			versions := cli.getAvailableProjectVersions()
+			Expect(versions).To(BeEmpty())
+		})
+
+		It("should handle plugin with multiple supported versions", func() {
+			multiPlugin := newMockPlugin("multi", "3",
+				config.Version{Number: 2},
+				config.Version{Number: 3},
+				config.Version{Number: 4})
+
+			cli := CLI{
+				plugins: map[string]plugin.Plugin{
+					plugin.KeyFor(multiPlugin): multiPlugin,
+				},
+			}
+
+			versions := cli.getAvailableProjectVersions()
+
+			Expect(versions).To(HaveLen(3))
+			Expect(versions).To(ContainElement("\"2\""))
+			Expect(versions).To(ContainElement("\"3\""))
+			Expect(versions).To(ContainElement("\"4\""))
+		})
+	})
+})

--- a/pkg/cli/webhook_test.go
+++ b/pkg/cli/webhook_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("webhook", func() {
+	Context("constants", func() {
+		It("should have correct error message", func() {
+			Expect(webhookErrorMsg).To(Equal("failed to create webhook"))
+		})
+	})
+})

--- a/pkg/plugins/external/helpers_test.go
+++ b/pkg/plugins/external/helpers_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"
+)
+
+var _ = Describe("helpers", func() {
+	Context("isBooleanFlag", func() {
+		It("should return true when next arg starts with --", func() {
+			args := []string{"--flag1", "--flag2", "value"}
+			Expect(isBooleanFlag(0, args)).To(BeTrue())
+		})
+
+		It("should return true when at end of args", func() {
+			args := []string{"--flag1", "--flag2"}
+			Expect(isBooleanFlag(1, args)).To(BeTrue())
+		})
+
+		It("should return false when next arg is a value", func() {
+			args := []string{"--flag1", "value", "--flag2"}
+			Expect(isBooleanFlag(0, args)).To(BeFalse())
+		})
+
+		It("should return true for last argument", func() {
+			args := []string{"--flag"}
+			Expect(isBooleanFlag(0, args)).To(BeTrue())
+		})
+	})
+
+	Context("filterFlags", func() {
+		var testFlags []external.Flag
+
+		BeforeEach(func() {
+			testFlags = []external.Flag{
+				{Name: "group", Type: "string"},
+				{Name: "version", Type: "string"},
+				{Name: "kind", Type: "string"},
+				{Name: "custom", Type: "string"},
+				{Name: "help", Type: "bool"},
+			}
+		})
+
+		It("should filter flags based on single filter", func() {
+			filter := func(flag external.Flag) bool {
+				return flag.Name != "group"
+			}
+			result := filterFlags(testFlags, []externalFlagFilterFunc{filter})
+
+			Expect(result).To(HaveLen(4))
+			for _, flag := range result {
+				Expect(flag.Name).NotTo(Equal("group"))
+			}
+		})
+
+		It("should filter flags based on multiple filters", func() {
+			filter1 := func(flag external.Flag) bool {
+				return flag.Name != "group"
+			}
+			filter2 := func(flag external.Flag) bool {
+				return flag.Name != "help"
+			}
+			result := filterFlags(testFlags, []externalFlagFilterFunc{filter1, filter2})
+
+			Expect(result).To(HaveLen(3))
+			Expect(result).To(ContainElement(external.Flag{Name: "version", Type: "string"}))
+			Expect(result).To(ContainElement(external.Flag{Name: "kind", Type: "string"}))
+			Expect(result).To(ContainElement(external.Flag{Name: "custom", Type: "string"}))
+		})
+
+		It("should return empty when all flags filtered out", func() {
+			filter := func(_ external.Flag) bool {
+				return false
+			}
+			result := filterFlags(testFlags, []externalFlagFilterFunc{filter})
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should return all flags when no filters reject", func() {
+			filter := func(_ external.Flag) bool {
+				return true
+			}
+			result := filterFlags(testFlags, []externalFlagFilterFunc{filter})
+			Expect(result).To(Equal(testFlags))
+		})
+	})
+
+	Context("filterArgs", func() {
+		It("should filter args based on single filter", func() {
+			args := []string{"--group", "--version", "--custom", "--help"}
+			filter := func(arg string) bool {
+				return arg != "--group"
+			}
+			result := filterArgs(args, []argFilterFunc{filter})
+
+			Expect(result).To(Equal([]string{"--version", "--custom", "--help"}))
+		})
+
+		It("should filter args based on multiple filters", func() {
+			args := []string{"--group", "--version", "--custom"}
+			filter1 := func(arg string) bool {
+				return arg != "--group"
+			}
+			filter2 := func(arg string) bool {
+				return arg != "--version"
+			}
+			result := filterArgs(args, []argFilterFunc{filter1, filter2})
+
+			Expect(result).To(Equal([]string{"--custom"}))
+		})
+
+		It("should return empty when all args filtered out", func() {
+			args := []string{"--arg1", "--arg2"}
+			filter := func(_ string) bool {
+				return false
+			}
+			result := filterArgs(args, []argFilterFunc{filter})
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should return all args when no filters reject", func() {
+			args := []string{"--arg1", "--arg2"}
+			filter := func(_ string) bool {
+				return true
+			}
+			result := filterArgs(args, []argFilterFunc{filter})
+			Expect(result).To(Equal(args))
+		})
+	})
+
+	Context("gvkArgFilter", func() {
+		It("should filter out group flag", func() {
+			Expect(gvkArgFilter("group")).To(BeFalse())
+			Expect(gvkArgFilter("--group")).To(BeFalse())
+		})
+
+		It("should filter out version flag", func() {
+			Expect(gvkArgFilter("version")).To(BeFalse())
+			Expect(gvkArgFilter("--version")).To(BeFalse())
+		})
+
+		It("should filter out kind flag", func() {
+			Expect(gvkArgFilter("kind")).To(BeFalse())
+			Expect(gvkArgFilter("--kind")).To(BeFalse())
+		})
+
+		It("should allow other flags", func() {
+			Expect(gvkArgFilter("custom")).To(BeTrue())
+			Expect(gvkArgFilter("--custom")).To(BeTrue())
+			Expect(gvkArgFilter("domain")).To(BeTrue())
+		})
+	})
+
+	Context("gvkFlagFilter", func() {
+		It("should filter out group, version, kind flags", func() {
+			Expect(gvkFlagFilter(external.Flag{Name: "group"})).To(BeFalse())
+			Expect(gvkFlagFilter(external.Flag{Name: "version"})).To(BeFalse())
+			Expect(gvkFlagFilter(external.Flag{Name: "kind"})).To(BeFalse())
+		})
+
+		It("should allow other flags", func() {
+			Expect(gvkFlagFilter(external.Flag{Name: "custom"})).To(BeTrue())
+			Expect(gvkFlagFilter(external.Flag{Name: "domain"})).To(BeTrue())
+		})
+	})
+
+	Context("helpArgFilter", func() {
+		It("should filter out help flag", func() {
+			Expect(helpArgFilter("help")).To(BeFalse())
+			Expect(helpArgFilter("--help")).To(BeFalse())
+		})
+
+		It("should allow other flags", func() {
+			Expect(helpArgFilter("custom")).To(BeTrue())
+			Expect(helpArgFilter("--custom")).To(BeTrue())
+			Expect(helpArgFilter("helpful")).To(BeTrue())
+		})
+	})
+
+	Context("helpFlagFilter", func() {
+		It("should filter out help flag", func() {
+			Expect(helpFlagFilter(external.Flag{Name: "help"})).To(BeFalse())
+		})
+
+		It("should allow other flags", func() {
+			Expect(helpFlagFilter(external.Flag{Name: "custom"})).To(BeTrue())
+			Expect(helpFlagFilter(external.Flag{Name: "helpful"})).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
Adds test coverage for cmd_helpers.go, init.go, webhook.go, and external/helpers.go focusing on testable utility functions and filters.
