### PR TITLE
✨  (helm/v2-alpha): improve _helper generator readability

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -28,10 +28,8 @@ Namespace for generated references.
 Always uses the Helm release namespace.
 */}}
 {{- define "project.namespaceName" -}}
-{{ .Release.Namespace }}
+{{- .Release.Namespace }}
 {{- end }}
-
-
 
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
@@ -40,14 +38,14 @@ Dynamically calculates safe truncation length based on suffix to ensure total <=
 Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project.resourceName" -}}
-{{- $fullname := include "project.fullname" .context -}}
-{{- $suffix := .suffix -}}
-{{- $maxLen := sub 62 (len $suffix) | int -}}
-{{- if gt (len $fullname) $maxLen -}}
-{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- $fullname := include "project.fullname" .context }}
+{{- $suffix := .suffix }}
+{{- $maxLen := sub 62 (len $suffix) | int }}
+{{- if gt (len $fullname) $maxLen }}
+{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
@@ -28,10 +28,8 @@ Namespace for generated references.
 Always uses the Helm release namespace.
 */}}
 {{- define "project.namespaceName" -}}
-{{ .Release.Namespace }}
+{{- .Release.Namespace }}
 {{- end }}
-
-
 
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
@@ -40,14 +38,14 @@ Dynamically calculates safe truncation length based on suffix to ensure total <=
 Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project.resourceName" -}}
-{{- $fullname := include "project.fullname" .context -}}
-{{- $suffix := .suffix -}}
-{{- $maxLen := sub 62 (len $suffix) | int -}}
-{{- if gt (len $fullname) $maxLen -}}
-{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- $fullname := include "project.fullname" .context }}
+{{- $suffix := .suffix }}
+{{- $maxLen := sub 62 (len $suffix) | int }}
+{{- if gt (len $fullname) $maxLen }}
+{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -28,10 +28,8 @@ Namespace for generated references.
 Always uses the Helm release namespace.
 */}}
 {{- define "project.namespaceName" -}}
-{{ .Release.Namespace }}
+{{- .Release.Namespace }}
 {{- end }}
-
-
 
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
@@ -40,14 +38,14 @@ Dynamically calculates safe truncation length based on suffix to ensure total <=
 Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project.resourceName" -}}
-{{- $fullname := include "project.fullname" .context -}}
-{{- $suffix := .suffix -}}
-{{- $maxLen := sub 62 (len $suffix) | int -}}
-{{- if gt (len $fullname) $maxLen -}}
-{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- $fullname := include "project.fullname" .context }}
+{{- $suffix := .suffix }}
+{{- $maxLen := sub 62 (len $suffix) | int }}
+{{- if gt (len $fullname) $maxLen }}
+{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -17,8 +17,8 @@ limitations under the License.
 package charttemplates
 
 import (
-	"fmt"
 	"path/filepath"
+	"strings"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -53,91 +53,85 @@ func (f *HelmHelpers) SetTemplateDefaults() error {
 	return nil
 }
 
-// generateHelpersTemplate creates the _helpers.tpl content with project-specific template names
 func (f *HelmHelpers) generateHelpersTemplate() string {
-	// Use project name as prefix (e.g., "project-v4-with-plugins")
-	// This creates templates like "project-v4-with-plugins.name" instead of generic "chart.name"
-	// preventing collisions when chart is used as a Helm dependency
-	prefix := f.ProjectName
+	escape := func(s string) string {
+		return "{{`" + s + "`}}"
+	}
 
-	return fmt.Sprintf(helmHelpersTemplate, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix)
+	return strings.Join([]string{
+		escape("{{/*"),
+		"Expand the name of the chart.",
+		escape("*/}}"),
+		escape("{{- define \"") + f.ProjectName + escape(".name\" -}}"),
+		escape("{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix \"-\" }}"),
+		escape("{{- end }}"),
+		"",
+		escape("{{/*"),
+		"Create a default fully qualified app name.",
+		"We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).",
+		"If release name contains chart name it will be used as a full name.",
+		escape("*/}}"),
+		escape("{{- define \"") + f.ProjectName + escape(".fullname\" -}}"),
+		escape("{{- if .Values.fullnameOverride }}"),
+		escape("{{- .Values.fullnameOverride | trunc 63 | trimSuffix \"-\" }}"),
+		escape("{{- else }}"),
+		escape("{{- $name := default .Chart.Name .Values.nameOverride }}"),
+		escape("{{- if contains $name .Release.Name }}"),
+		escape("{{- .Release.Name | trunc 63 | trimSuffix \"-\" }}"),
+		escape("{{- else }}"),
+		escape("{{- printf \"%s-%s\" .Release.Name $name | trunc 63 | trimSuffix \"-\" }}"),
+		escape("{{- end }}"),
+		escape("{{- end }}"),
+		escape("{{- end }}"),
+		"",
+		escape("{{/*"),
+		"Namespace for generated references.",
+		"Always uses the Helm release namespace.",
+		escape("*/}}"),
+		escape("{{- define \"") + f.ProjectName + escape(".namespaceName\" -}}"),
+		escape("{{- .Release.Namespace }}"),
+		escape("{{- end }}"),
+		"",
+		escape("{{/*"),
+		"Resource name with proper truncation for Kubernetes 63-character limit.",
+		"Takes a dict with .suffix (resource name suffix) and .context (template context).",
+		"Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.",
+		"Generic helper that works for any resource type (Service, Role, Certificate, etc.).",
+		escape("*/}}"),
+		escape("{{- define \"") + f.ProjectName + escape(".resourceName\" -}}"),
+		escape("{{- $fullname := include \"") + f.ProjectName + escape(".fullname\" .context }}"),
+		escape("{{- $suffix := .suffix }}"),
+		escape("{{- $maxLen := sub 62 (len $suffix) | int }}"),
+		escape("{{- if gt (len $fullname) $maxLen }}"),
+		escape("{{- printf \"%s-%s\" (trunc $maxLen $fullname | trimSuffix \"-\") $suffix | trunc 63 | trimSuffix \"-\" }}"),
+		escape("{{- else }}"),
+		escape("{{- printf \"%s-%s\" $fullname $suffix | trunc 63 | trimSuffix \"-\" }}"),
+		escape("{{- end }}"),
+		escape("{{- end }}"),
+		"",
+		escape("{{/*"),
+		"Common labels for Helm charts.",
+		"Includes app version, chart version, app name, instance, and managed-by labels.",
+		escape("*/}}"),
+		escape("{{- define \"") + f.ProjectName + escape(".labels\" -}}"),
+		escape("{{- if .Chart.AppVersion -}}"),
+		escape("app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}"),
+		escape("{{- end }}"),
+		escape("{{- if .Chart.Version }}"),
+		escape("helm.sh/chart: {{ .Chart.Version | quote }}"),
+		escape("{{- end }}"),
+		escape("app.kubernetes.io/name: {{ include \"") + f.ProjectName + escape(".name\" . }}"),
+		escape("app.kubernetes.io/instance: {{ .Release.Name }}"),
+		escape("app.kubernetes.io/managed-by: {{ .Release.Service }}"),
+		escape("{{- end }}"),
+		"",
+		escape("{{/*"),
+		"Selector labels for matching pods and services.",
+		"Only includes name and instance for consistent selection.",
+		escape("*/}}"),
+		escape("{{- define \"") + f.ProjectName + escape(".selectorLabels\" -}}"),
+		escape("app.kubernetes.io/name: {{ include \"") + f.ProjectName + escape(".name\" . }}"),
+		escape("app.kubernetes.io/instance: {{ .Release.Name }}"),
+		escape("{{- end }}"),
+	}, "\n") + "\n" // Add EOF new line
 }
-
-const helmHelpersTemplate = `{{` + "`" + `{{/*
-Expand the name of the chart.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.name" -}}` + "`" + `}}
-{{` + "`" + `{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-{{` + "`" + `{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.fullname" -}}` + "`" + `}}
-{{` + "`" + `{{- if .Values.fullnameOverride }}` + "`" + `}}
-{{` + "`" + `{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}` + "`" + `}}
-{{` + "`" + `{{- else }}` + "`" + `}}
-{{` + "`" + `{{- $name := default .Chart.Name .Values.nameOverride }}` + "`" + `}}
-{{` + "`" + `{{- if contains $name .Release.Name }}` + "`" + `}}
-{{` + "`" + `{{- .Release.Name | trunc 63 | trimSuffix "-" }}` + "`" + `}}
-{{` + "`" + `{{- else }}` + "`" + `}}
-{{` + "`" + `{{- printf "%%s-%%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-{{` + "`" + `{{/*
-Namespace for generated references.
-Always uses the Helm release namespace.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.namespaceName" -}}` + "`" + `}}
-{{` + "`" + `{{ .Release.Namespace }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-
-
-{{` + "`" + `{{/*
-Resource name with proper truncation for Kubernetes 63-character limit.
-Takes a dict with .suffix (resource name suffix) and .context (template context).
-Dynamically calculates safe truncation length based on suffix to ensure total <= 63 chars.
-Generic helper that works for any resource type (Service, Role, Certificate, etc.).
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.resourceName" -}}` + "`" + `}}
-{{` + "`" + `{{- $fullname := include "%s.fullname" .context -}}` + "`" + `}}
-{{` + "`" + `{{- $suffix := .suffix -}}` + "`" + `}}
-{{` + "`" + `{{- $maxLen := sub 62 (len $suffix) | int -}}` + "`" + `}}
-{{` + "`" + `{{- if gt (len $fullname) $maxLen -}}` + "`" + `}}
-{{` + "`" + `{{- printf "%%s-%%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix ` +
-	`| trunc 63 | trimSuffix "-" -}}` + "`" + `}}
-{{` + "`" + `{{- else -}}` + "`" + `}}
-{{` + "`" + `{{- printf "%%s-%%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}` + "`" + `}}
-{{` + "`" + `{{- end -}}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-{{` + "`" + `{{/*
-Common labels for Helm charts.
-Includes app version, chart version, app name, instance, and managed-by labels.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.labels" -}}` + "`" + `}}
-{{` + "`" + `{{- if .Chart.AppVersion -}}` + "`" + `}}
-app.kubernetes.io/version: {{` + "`" + `{{ .Chart.AppVersion | quote }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-{{` + "`" + `{{- if .Chart.Version }}` + "`" + `}}
-helm.sh/chart: {{` + "`" + `{{ .Chart.Version | quote }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-app.kubernetes.io/name: {{` + "`" + `{{ include "%s.name" . }}` + "`" + `}}
-app.kubernetes.io/instance: {{` + "`" + `{{ .Release.Name }}` + "`" + `}}
-app.kubernetes.io/managed-by: {{` + "`" + `{{ .Release.Service }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-
-{{` + "`" + `{{/*
-Selector labels for matching pods and services.
-Only includes name and instance for consistent selection.
-*/}}` + "`" + `}}
-{{` + "`" + `{{- define "%s.selectorLabels" -}}` + "`" + `}}
-app.kubernetes.io/name: {{` + "`" + `{{ include "%s.name" . }}` + "`" + `}}
-app.kubernetes.io/instance: {{` + "`" + `{{ .Release.Name }}` + "`" + `}}
-{{` + "`" + `{{- end }}` + "`" + `}}
-`

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -28,10 +28,8 @@ Namespace for generated references.
 Always uses the Helm release namespace.
 */}}
 {{- define "project-v4-with-plugins.namespaceName" -}}
-{{ .Release.Namespace }}
+{{- .Release.Namespace }}
 {{- end }}
-
-
 
 {{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
@@ -40,14 +38,14 @@ Dynamically calculates safe truncation length based on suffix to ensure total <=
 Generic helper that works for any resource type (Service, Role, Certificate, etc.).
 */}}
 {{- define "project-v4-with-plugins.resourceName" -}}
-{{- $fullname := include "project-v4-with-plugins.fullname" .context -}}
-{{- $suffix := .suffix -}}
-{{- $maxLen := sub 62 (len $suffix) | int -}}
-{{- if gt (len $fullname) $maxLen -}}
-{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- $fullname := include "project-v4-with-plugins.fullname" .context }}
+{{- $suffix := .suffix }}
+{{- $maxLen := sub 62 (len $suffix) | int }}
+{{- if gt (len $fullname) $maxLen }}
+{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Rework the way the _helper.tpl file is generated for helm chart. It makes it more readable and probably easier to maintain.

Closes #5356 


