### PR TITLE
🐛 (helm/v2-alpha): Fix cross-namespace RBAC file naming and namespace handling

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/extras_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/extras_integration_test.go
@@ -21,6 +21,7 @@ package scaffolds
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -341,6 +342,639 @@ spec:
 			exists, err = afero.Exists(fs.FS, metricsDir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exists).To(BeTrue())
+		})
+	})
+
+	Context("RBAC resource placement", func() {
+		It("should ensure all RBAC resources go to rbac directory, never to extras", func() {
+			// Critical test: RBAC resources must NEVER end up in extras directory
+			kustomizeYAML := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-project-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-project-manager-role
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-leader-election-role
+  namespace: test-project-system
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-leader-election-rolebinding
+  namespace: test-project-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-config
+  namespace: test-project-system
+data:
+  key: value
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+`
+
+			kustomizeFile := filepath.Join(tmpDir, "install.yaml")
+			err := os.WriteFile(kustomizeFile, []byte(kustomizeYAML), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			parser := kustomize.NewParser(kustomizeFile)
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify parser correctly categorized RBAC resources
+			Expect(resources.ServiceAccount).NotTo(BeNil(), "ServiceAccount should be parsed")
+			Expect(resources.ClusterRoles).To(HaveLen(1), "should have 1 ClusterRole")
+			Expect(resources.Roles).To(HaveLen(1), "should have 1 Role")
+			Expect(resources.ClusterRoleBindings).To(HaveLen(1), "should have 1 ClusterRoleBinding")
+			Expect(resources.RoleBindings).To(HaveLen(1), "should have 1 RoleBinding")
+			Expect(resources.Other).To(HaveLen(1), "ConfigMap should be in Other")
+
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "dist")
+			err = converter.WriteChartFiles(fs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying rbac directory exists and contains all RBAC resources")
+			rbacDir := filepath.Join("dist", "chart", "templates", "rbac")
+			exists, err := afero.Exists(fs.FS, rbacDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "rbac directory must exist")
+
+			rbacFiles, err := afero.ReadDir(fs.FS, rbacDir)
+			Expect(err).NotTo(HaveOccurred())
+			// Should have: 1 ServiceAccount + 1 ClusterRole + 1 Role + 1 ClusterRoleBinding + 1 RoleBinding = 5 files
+			Expect(rbacFiles).To(HaveLen(5), "rbac directory should have exactly 5 RBAC files")
+
+			By("verifying NO RBAC resources in extras directory")
+			extrasDir := filepath.Join("dist", "chart", "templates", "extras")
+			exists, err = afero.Exists(fs.FS, extrasDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "extras directory should exist for ConfigMap")
+
+			extrasFiles, err := afero.ReadDir(fs.FS, extrasDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(extrasFiles).To(HaveLen(1), "extras should only have ConfigMap, not RBAC")
+
+			// Verify the extras file is the ConfigMap, not any RBAC resource
+			configMapFound := false
+			for _, f := range extrasFiles {
+				if strings.Contains(f.Name(), "custom-config") {
+					configMapFound = true
+				}
+				// Ensure no RBAC-related files
+				Expect(f.Name()).NotTo(ContainSubstring("role"), "no Role files in extras")
+				Expect(f.Name()).NotTo(ContainSubstring("rolebinding"), "no RoleBinding files in extras")
+				Expect(f.Name()).NotTo(ContainSubstring("serviceaccount"), "no ServiceAccount files in extras")
+			}
+			Expect(configMapFound).To(BeTrue(), "ConfigMap should be in extras")
+		})
+	})
+
+	Context("when converting namespace-scoped RBAC resources", func() {
+		It("should convert namespace-scoped Roles with explicit namespaces to Helm templates", func() {
+			// This test validates the scenario from issue where namespace-scoped Roles
+			// (used for cross-namespace permissions, leader election, etc.) must be
+			// included in the generated Helm chart, not just the ClusterRole.
+			kustomizeYAML := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+    control-plane: controller-manager
+  name: test-project-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-project-manager-role
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups: ["example.com"]
+  resources: ["myresources"]
+  verbs: ["get", "list", "watch", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-manager-role
+  namespace: infrastructure
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-leader-election-role
+  namespace: test-project-system
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-events-role
+  namespace: production
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+  namespace: infrastructure
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-leader-election-rolebinding
+  namespace: test-project-system
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-events-rolebinding
+  namespace: production
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-events-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+    control-plane: controller-manager
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+`
+
+			By("writing kustomize output to a file")
+			kustomizeFile := filepath.Join(tmpDir, "install.yaml")
+			err := os.WriteFile(kustomizeFile, []byte(kustomizeYAML), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("parsing the kustomize output")
+			parser := kustomize.NewParser(kustomizeFile)
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resources).NotTo(BeNil())
+
+			By("verifying parser correctly categorized all RBAC resources")
+			Expect(resources.ClusterRoles).To(HaveLen(1), "should have 1 ClusterRole")
+			Expect(resources.Roles).To(HaveLen(3), "should have 3 namespace-scoped Roles")
+			Expect(resources.ClusterRoleBindings).To(HaveLen(1), "should have 1 ClusterRoleBinding")
+			Expect(resources.RoleBindings).To(HaveLen(3), "should have 3 RoleBindings")
+
+			By("converting to Helm chart")
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "dist")
+			err = converter.WriteChartFiles(fs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying rbac directory was created")
+			rbacDir := filepath.Join("dist", "chart", "templates", "rbac")
+			exists, err := afero.Exists(fs.FS, rbacDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "rbac directory should exist")
+
+			By("verifying all RBAC files are present")
+			rbacFiles, err := afero.ReadDir(fs.FS, rbacDir)
+			Expect(err).NotTo(HaveOccurred())
+			// Should have: 1 ServiceAccount + 1 ClusterRole + 1 ClusterRoleBinding + 3 Roles + 3 RoleBindings = 9 files
+			Expect(rbacFiles).To(HaveLen(9), "should have 9 RBAC files total")
+
+			By("verifying ClusterRole file exists")
+			// ClusterRole has no namespace, so filename is just the name (with project prefix removed)
+			clusterRolePath := filepath.Join(rbacDir, "manager-role.yaml")
+			exists, err = afero.Exists(fs.FS, clusterRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "ClusterRole file should exist")
+
+			By("verifying infrastructure Role file exists")
+			// Role has namespace, so filename includes namespace suffix: name-namespace.yaml
+			infrastructureRolePath := filepath.Join(rbacDir, "manager-role-infrastructure.yaml")
+			exists, err = afero.Exists(fs.FS, infrastructureRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "infrastructure Role file should exist")
+
+			By("verifying project namespace Role file exists")
+			// Role in project namespace (test-project-system) should NOT have namespace suffix
+			projectRolePath := filepath.Join(rbacDir, "leader-election-role.yaml")
+			exists, err = afero.Exists(fs.FS, projectRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "project namespace Role file should exist without suffix")
+
+			By("verifying production Role file exists")
+			// Role in cross-namespace should have namespace suffix
+			productionRolePath := filepath.Join(rbacDir, "events-role-production.yaml")
+			exists, err = afero.Exists(fs.FS, productionRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "production Role file should exist with suffix")
+
+			By("verifying infrastructure RoleBinding file exists")
+			infrastructureBindingPath := filepath.Join(rbacDir, "manager-rolebinding-infrastructure.yaml")
+			exists, err = afero.Exists(fs.FS, infrastructureBindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "infrastructure RoleBinding file should exist")
+
+			By("verifying project namespace RoleBinding file exists")
+			// RoleBinding in project namespace should NOT have namespace suffix
+			projectBindingPath := filepath.Join(rbacDir, "leader-election-rolebinding.yaml")
+			exists, err = afero.Exists(fs.FS, projectBindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "project namespace RoleBinding file should exist without suffix")
+
+			By("verifying production RoleBinding file exists")
+			// RoleBinding in cross-namespace should have namespace suffix
+			productionBindingPath := filepath.Join(rbacDir, "events-rolebinding-production.yaml")
+			exists, err = afero.Exists(fs.FS, productionBindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "production RoleBinding file should exist with suffix")
+
+			By("verifying infrastructure Role has proper Helm templating")
+			roleContent, err := afero.ReadFile(fs.FS, infrastructureRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			roleContentStr := string(roleContent)
+
+			// Verify namespace is preserved (not templated to .Release.Namespace)
+			// because it's an explicit cross-namespace permission
+			Expect(roleContentStr).To(ContainSubstring("namespace: infrastructure"),
+				"Role should preserve explicit namespace for cross-namespace permissions")
+
+			// Verify standard Helm labels
+			Expect(roleContentStr).To(ContainSubstring(`app.kubernetes.io/name: {{ include "test-project.name" . }}`),
+				"Role should have templated app.kubernetes.io/name label")
+
+			// Verify name is templated
+			Expect(roleContentStr).To(ContainSubstring(`name: {{ include "test-project.resourceName"`),
+				"Role name should be templated")
+
+			// Verify rules are preserved
+			Expect(roleContentStr).To(ContainSubstring("apiGroups:"),
+				"Role rules should be preserved")
+			Expect(roleContentStr).To(ContainSubstring("- apps"),
+				"Role should have apps API group")
+			Expect(roleContentStr).To(ContainSubstring("- deployments"),
+				"Role should have deployments resource")
+
+			By("verifying project namespace Role has proper Helm templating")
+			projRoleContent, err := afero.ReadFile(fs.FS, projectRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			projRoleContentStr := string(projRoleContent)
+
+			// Verify namespace is templated to .Release.Namespace for project namespace
+			Expect(projRoleContentStr).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"Role in project namespace should template namespace to .Release.Namespace")
+			Expect(projRoleContentStr).NotTo(ContainSubstring("namespace: test-project-system"),
+				"Role should not have hardcoded project namespace")
+
+			// Verify leader election permissions
+			Expect(projRoleContentStr).To(ContainSubstring("- coordination.k8s.io"))
+			Expect(projRoleContentStr).To(ContainSubstring("- leases"))
+
+			By("verifying production Role has proper Helm templating")
+			prodRoleContent, err := afero.ReadFile(fs.FS, productionRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			prodRoleContentStr := string(prodRoleContent)
+
+			// Verify namespace is preserved for cross-namespace Role
+			Expect(prodRoleContentStr).To(ContainSubstring("namespace: production"),
+				"Role should preserve explicit namespace for cross-namespace permissions")
+
+			// Verify events permissions
+			Expect(prodRoleContentStr).To(ContainSubstring("- events"))
+
+			By("verifying infrastructure RoleBinding has proper Helm templating")
+			bindingContent, err := afero.ReadFile(fs.FS, infrastructureBindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			bindingContentStr := string(bindingContent)
+
+			// Verify namespace is preserved
+			Expect(bindingContentStr).To(ContainSubstring("namespace: infrastructure"),
+				"RoleBinding should preserve explicit namespace")
+
+			// Verify roleRef is templated
+			Expect(bindingContentStr).To(ContainSubstring(`name: {{ include "test-project.resourceName"`),
+				"RoleBinding roleRef should be templated")
+
+			// Verify subjects namespace is templated (references the controller namespace)
+			Expect(bindingContentStr).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"RoleBinding subject namespace should reference the release namespace")
+
+			By("verifying project namespace RoleBinding has proper Helm templating")
+			projBindingContent, err := afero.ReadFile(fs.FS, projectBindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			projBindingContentStr := string(projBindingContent)
+
+			// Verify namespace is templated for project namespace RoleBinding
+			Expect(projBindingContentStr).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"RoleBinding metadata namespace should be templated for project namespace")
+
+			// Verify standard Helm labels
+			Expect(projBindingContentStr).To(ContainSubstring(`app.kubernetes.io/name: {{ include "test-project.name" . }}`),
+				"RoleBinding should have templated labels")
+
+			By("verifying production RoleBinding has proper Helm templating")
+			prodBindingContent, err := afero.ReadFile(fs.FS, productionBindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			prodBindingContentStr := string(prodBindingContent)
+
+			// Verify namespace is preserved for cross-namespace RoleBinding
+			Expect(prodBindingContentStr).To(ContainSubstring("namespace: production"),
+				"RoleBinding should preserve explicit namespace for cross-namespace binding")
+
+			// Subject namespace should still be templated (references the controller namespace)
+			Expect(prodBindingContentStr).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"RoleBinding subject namespace should be templated to Release.Namespace")
+
+			By("verifying ClusterRole does not have namespace field")
+			clusterRoleContent, err := afero.ReadFile(fs.FS, clusterRolePath)
+			Expect(err).NotTo(HaveOccurred())
+			clusterRoleContentStr := string(clusterRoleContent)
+
+			// ClusterRole should not have namespace field
+			Expect(clusterRoleContentStr).NotTo(ContainSubstring("namespace:"),
+				"ClusterRole should not have namespace field")
+		})
+
+		It("should preserve ANY namespace field that differs from manager namespace", func() {
+			// This test validates that ANY namespace reference (metadata, subjects, etc.)
+			// that is NOT the manager namespace gets preserved exactly as-is
+			kustomizeYAML := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-project-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-sa
+  namespace: external-namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-cross-ns-binding
+  namespace: infrastructure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: some-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+- kind: ServiceAccount
+  name: external-sa
+  namespace: external-namespace
+- kind: ServiceAccount
+  name: another-sa
+  namespace: production
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      serviceAccountName: test-project-controller-manager
+      containers:
+      - name: manager
+        image: controller:latest
+`
+
+			kustomizeFile := filepath.Join(tmpDir, "install.yaml")
+			err := os.WriteFile(kustomizeFile, []byte(kustomizeYAML), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			parser := kustomize.NewParser(kustomizeFile)
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+
+			converter := kustomize.NewChartConverter(resources, "test-project", "test-project", "dist")
+			err = converter.WriteChartFiles(fs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying RoleBinding preserves all non-manager namespaces")
+			rbacDir := filepath.Join("dist", "chart", "templates", "rbac")
+			bindingPath := filepath.Join(rbacDir, "cross-ns-binding-infrastructure.yaml")
+			exists, err := afero.Exists(fs.FS, bindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(exists).To(BeTrue(), "RoleBinding file should exist")
+
+			bindingContent, err := afero.ReadFile(fs.FS, bindingPath)
+			Expect(err).NotTo(HaveOccurred())
+			bindingStr := string(bindingContent)
+
+			// Metadata namespace should be preserved (cross-namespace)
+			Expect(bindingStr).To(ContainSubstring("namespace: infrastructure"),
+				"metadata namespace should be preserved")
+
+			// Manager namespace in subjects should be templated
+			Expect(bindingStr).To(MatchRegexp(`kind: ServiceAccount\s+name:.*\s+namespace: \{\{ \.Release\.Namespace \}\}`),
+				"manager namespace in subject should be templated")
+
+			// External namespaces in subjects should be preserved
+			Expect(bindingStr).To(ContainSubstring("namespace: external-namespace"),
+				"external-namespace in subject should be preserved")
+			Expect(bindingStr).To(ContainSubstring("namespace: production"),
+				"production namespace in subject should be preserved")
+
+			// Count namespace occurrences
+			infrastructureCount := strings.Count(bindingStr, "namespace: infrastructure")
+			externalCount := strings.Count(bindingStr, "namespace: external-namespace")
+			productionCount := strings.Count(bindingStr, "namespace: production")
+			releaseNsCount := strings.Count(bindingStr, "namespace: {{ .Release.Namespace }}")
+
+			Expect(infrastructureCount).To(Equal(1), "should have 1 infrastructure namespace (metadata)")
+			Expect(externalCount).To(Equal(1), "should have 1 external-namespace (subject)")
+			Expect(productionCount).To(Equal(1), "should have 1 production namespace (subject)")
+			Expect(releaseNsCount).To(BeNumerically(">=", 1), "should have at least 1 templated namespace (manager subject)")
+
+			By("verifying external ServiceAccount preserves its namespace")
+			saFiles, err := afero.ReadDir(fs.FS, rbacDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			var externalSAFound bool
+			for _, f := range saFiles {
+				if strings.Contains(f.Name(), "external-sa") {
+					externalSAFound = true
+					saPath := filepath.Join(rbacDir, f.Name())
+					saContent, err := afero.ReadFile(fs.FS, saPath)
+					Expect(err).NotTo(HaveOccurred())
+					saStr := string(saContent)
+
+					// External SA namespace should be preserved
+					Expect(saStr).To(ContainSubstring("namespace: external-namespace"),
+						"external ServiceAccount namespace should be preserved")
+					Expect(saStr).NotTo(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+						"external ServiceAccount should not use Release.Namespace")
+				}
+			}
+			Expect(externalSAFound).To(BeTrue(), "external ServiceAccount file should exist")
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -43,9 +43,17 @@ type ChartConverter struct {
 
 // NewChartConverter creates a new chart converter with all necessary components
 func NewChartConverter(resources *ParsedResources, detectedPrefix, chartName, outputDir string) *ChartConverter {
+	// Extract manager namespace from Deployment, default to <prefix>-system
+	managerNamespace := detectedPrefix + "-system"
+	if resources.Deployment != nil {
+		if ns := resources.Deployment.GetNamespace(); ns != "" {
+			managerNamespace = ns
+		}
+	}
+
 	organizer := NewResourceOrganizer(resources)
-	templater := NewHelmTemplater(detectedPrefix, chartName)
-	writer := NewChartWriter(templater, outputDir)
+	templater := NewHelmTemplater(detectedPrefix, chartName, managerNamespace)
+	writer := NewChartWriter(templater, outputDir, managerNamespace)
 
 	return &ChartConverter{
 		resources:      resources,

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -356,10 +356,10 @@ var _ = Describe("ChartConverter", func() {
 			configMap.SetAPIVersion("v1")
 			configMap.SetKind("ConfigMap")
 			configMap.SetName("custom-config")
-			configMap.SetNamespace("test-project-system")
+			configMap.SetNamespace("test-system")
 			configMap.Object["metadata"] = map[string]any{
 				"name":      "custom-config",
-				"namespace": "test-project-system",
+				"namespace": "test-system",
 				"labels": map[string]any{
 					"app.kubernetes.io/name":       "test-project",
 					"app.kubernetes.io/managed-by": "kustomize",
@@ -443,10 +443,10 @@ var _ = Describe("ChartConverter", func() {
 			secret.SetAPIVersion("v1")
 			secret.SetKind("Secret")
 			secret.SetName("custom-secret")
-			secret.SetNamespace("test-project-system")
+			secret.SetNamespace("test-system")
 			secret.Object["metadata"] = map[string]any{
 				"name":      "custom-secret",
-				"namespace": "test-project-system",
+				"namespace": "test-system",
 				"labels": map[string]any{
 					"app.kubernetes.io/name":       "test-project",
 					"app.kubernetes.io/managed-by": "kustomize",

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -34,8 +34,9 @@ var _ = Describe("HelmTemplater", func() {
 
 	BeforeEach(func() {
 		templater = &HelmTemplater{
-			detectedPrefix: "test-project",
-			chartName:      "test-project",
+			detectedPrefix:   "test-project",
+			chartName:        "test-project",
+			managerNamespace: "test-project-system",
 		}
 	})
 
@@ -751,6 +752,648 @@ metadata:
 		})
 	})
 
+	Context("namespace-scoped RBAC resources", func() {
+		It("should preserve explicit namespace in Role for cross-namespace permissions", func() {
+			roleResource := &unstructured.Unstructured{}
+			roleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleResource.SetKind("Role")
+			roleResource.SetName("test-project-manager-role")
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-manager-role
+  namespace: infrastructure
+  labels:
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch`
+
+			result := templater.ApplyHelmSubstitutions(content, roleResource)
+
+			// Namespace should be preserved (not templated) for cross-namespace permissions
+			Expect(result).To(ContainSubstring("namespace: infrastructure"),
+				"explicit namespace should be preserved for cross-namespace Role")
+			Expect(result).NotTo(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"explicit namespace should NOT be templated to Release.Namespace")
+
+			// Labels should still be templated
+			Expect(result).To(ContainSubstring(`app.kubernetes.io/name: {{ include "test-project.name" . }}`))
+
+			// Name should be templated
+			Expect(result).To(ContainSubstring(`name: {{ include "test-project.resourceName"`))
+
+			// Rules should be preserved
+			Expect(result).To(ContainSubstring("- apps"))
+			Expect(result).To(ContainSubstring("- deployments"))
+		})
+
+		It("should preserve explicit namespace in Role for leader election", func() {
+			roleResource := &unstructured.Unstructured{}
+			roleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleResource.SetKind("Role")
+			roleResource.SetName("test-project-leader-election-role")
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-leader-election-role
+  namespace: production
+  labels:
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update`
+
+			result := templater.ApplyHelmSubstitutions(content, roleResource)
+
+			// Namespace should be preserved for cross-namespace leader election
+			Expect(result).To(ContainSubstring("namespace: production"),
+				"explicit namespace should be preserved for cross-namespace leader election Role")
+
+			// Verify leader election permissions
+			Expect(result).To(ContainSubstring("- coordination.k8s.io"))
+			Expect(result).To(ContainSubstring("- leases"))
+			Expect(result).To(ContainSubstring("- events"))
+		})
+
+		It("should preserve explicit namespace in RoleBinding metadata", func() {
+			roleBindingResource := &unstructured.Unstructured{}
+			roleBindingResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleBindingResource.SetKind("RoleBinding")
+			roleBindingResource.SetName("test-project-manager-rolebinding")
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+  namespace: infrastructure
+  labels:
+    app.kubernetes.io/name: test-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system`
+
+			result := templater.ApplyHelmSubstitutions(content, roleBindingResource)
+
+			// RoleBinding metadata namespace should be preserved
+			Expect(result).To(ContainSubstring("metadata:\n  name:"))
+			Expect(result).To(ContainSubstring("namespace: infrastructure"),
+				"RoleBinding metadata namespace should be preserved")
+
+			// Subject namespace should be templated (references the controller namespace)
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"subject namespace should be templated to Release.Namespace")
+
+			// Name references should be templated
+			Expect(result).To(ContainSubstring(`name: {{ include "test-project.resourceName"`))
+		})
+
+		It("should template Role namespace when it matches project namespace", func() {
+			roleResource := &unstructured.Unstructured{}
+			roleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleResource.SetKind("Role")
+			roleResource.SetName("test-project-leader-election-role")
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-leader-election-role
+  namespace: test-project-system
+  labels:
+    app.kubernetes.io/name: test-project
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete`
+
+			result := templater.ApplyHelmSubstitutions(content, roleResource)
+
+			// When namespace matches project namespace, it should be templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"Role namespace should be templated when it matches project namespace")
+			Expect(result).NotTo(ContainSubstring("namespace: test-project-system"),
+				"project namespace should be templated, not preserved")
+		})
+
+		It("should handle RoleBinding with multiple subjects correctly", func() {
+			roleBindingResource := &unstructured.Unstructured{}
+			roleBindingResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleBindingResource.SetKind("RoleBinding")
+			roleBindingResource.SetName("test-project-manager-rolebinding")
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+  namespace: infrastructure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+- kind: ServiceAccount
+  name: test-project-webhook
+  namespace: test-project-system`
+
+			result := templater.ApplyHelmSubstitutions(content, roleBindingResource)
+
+			// Both subject namespaces should be templated
+			subjectNamespaceCount := strings.Count(result, "namespace: {{ .Release.Namespace }}")
+			Expect(subjectNamespaceCount).To(BeNumerically(">=", 2),
+				"both subject namespaces should be templated")
+
+			// RoleBinding metadata namespace should be preserved
+			Expect(result).To(ContainSubstring("namespace: infrastructure"))
+		})
+
+		It("should preserve resource names when namespace appears as substring", func() {
+			// Critical: namespace "user" must NOT break resource name "users"
+			// This validates field-aware replacement prevents substring corruption
+			roleResource := &unstructured.Unstructured{}
+			roleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleResource.SetKind("ClusterRole")
+			roleResource.SetName("manager-role")
+
+			// Scenario: manager namespace is "user", CRD resource is "users"
+			customTemplater := &HelmTemplater{
+				detectedPrefix:   "test-project",
+				chartName:        "test-project",
+				managerNamespace: "user", // Short namespace that appears as substring
+			}
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-project-manager-role
+rules:
+- apiGroups:
+  - identity.example.com
+  resources:
+  - users
+  - users/finalizers
+  - users/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete`
+
+			result := customTemplater.ApplyHelmSubstitutions(content, roleResource)
+
+			// Critical: resource name "users" must NOT be replaced with "{{ .Release.Namespace }}s"
+			Expect(result).To(ContainSubstring("- users"),
+				"resource name 'users' should remain unchanged")
+			Expect(result).To(ContainSubstring("- users/finalizers"),
+				"resource name 'users/finalizers' should remain unchanged")
+			Expect(result).To(ContainSubstring("- users/status"),
+				"resource name 'users/status' should remain unchanged")
+
+			// Ensure we didn't create templated resource names
+			Expect(result).NotTo(ContainSubstring("- {{ .Release.Namespace }}s"),
+				"must NOT replace 'user' substring in resource names")
+			Expect(result).NotTo(MatchRegexp(`resources:\s*-\s*\{\{.*\}\}`),
+				"resource names must never be templated")
+		})
+
+		It("should handle edge case where namespace is substring of multiple fields", func() {
+			// Test more edge cases: namespace "app" appears in "applications", "apps", etc.
+			customTemplater := &HelmTemplater{
+				detectedPrefix:   "test-project",
+				chartName:        "test-project",
+				managerNamespace: "app",
+			}
+
+			roleBindingResource := &unstructured.Unstructured{}
+			roleBindingResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
+			roleBindingResource.SetKind("RoleBinding")
+			roleBindingResource.SetName("manager-rolebinding")
+
+			content := `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+  namespace: app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: app`
+
+			result := customTemplater.ApplyHelmSubstitutions(content, roleBindingResource)
+
+			// Namespace fields should be templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
+				"namespace fields should be templated")
+
+			// Verify we have exactly 2 namespace template substitutions (metadata + subject)
+			namespaceTemplateCount := strings.Count(result, "namespace: {{ .Release.Namespace }}")
+			Expect(namespaceTemplateCount).To(Equal(2),
+				"should have exactly 2 namespace field replacements")
+
+			// Verify apiGroup field is NOT affected (contains "app" in "rbac.authorization.k8s.io")
+			Expect(result).To(ContainSubstring("apiGroup: rbac.authorization.k8s.io"),
+				"apiGroup should not be affected by namespace replacement")
+		})
+
+		It("should handle ALL Kubernetes DNS patterns generically", func() {
+			// This test validates DNS replacement works for ANY K8s DNS pattern
+			configMapResource := &unstructured.Unstructured{}
+			configMapResource.SetAPIVersion("v1")
+			configMapResource.SetKind("ConfigMap")
+			configMapResource.SetName("dns-config")
+
+			content := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dns-config
+  namespace: test-project-system
+data:
+  # Standard service DNS
+  service-short: api.test-project-system.svc
+  service-full: api.test-project-system.svc.cluster.local
+  service-port: api.test-project-system.svc:8080
+  service-path: https://api.test-project-system.svc.cluster.local:443/v1
+  
+  # Pod DNS
+  pod-dns: my-pod.test-project-system.pod.cluster.local
+  
+  # Endpoints DNS  
+  endpoints-dns: my-service.test-project-system.endpoints.cluster.local
+  
+  # Headless service (StatefulSet)
+  stateful-0: app-0.app-headless.test-project-system.svc.cluster.local
+  stateful-1: app-1.app-headless.test-project-system.svc.cluster.local
+  
+  # External namespace should be preserved
+  external-svc: monitoring.monitoring-system.svc.cluster.local`
+
+			result := templater.ApplyHelmSubstitutions(content, configMapResource)
+
+			// Verify ALL manager namespace DNS patterns are templated
+			Expect(result).To(ContainSubstring("api.{{ .Release.Namespace }}.svc"))
+			Expect(result).To(ContainSubstring("api.{{ .Release.Namespace }}.svc.cluster.local"))
+			Expect(result).To(ContainSubstring("api.{{ .Release.Namespace }}.svc:8080"))
+			Expect(result).To(ContainSubstring("api.{{ .Release.Namespace }}.svc.cluster.local:443"))
+			Expect(result).To(ContainSubstring("my-pod.{{ .Release.Namespace }}.pod.cluster.local"))
+			Expect(result).To(ContainSubstring("my-service.{{ .Release.Namespace }}.endpoints.cluster.local"))
+			Expect(result).To(ContainSubstring("app-0.app-headless.{{ .Release.Namespace }}.svc.cluster.local"))
+			Expect(result).To(ContainSubstring("app-1.app-headless.{{ .Release.Namespace }}.svc.cluster.local"))
+
+			// Verify NO hardcoded manager namespace remains
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.pod"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.endpoints"))
+
+			// Verify external namespace is preserved
+			Expect(result).To(ContainSubstring("monitoring.monitoring-system.svc.cluster.local"))
+		})
+
+		It("should NOT replace namespace-like strings in non-DNS contexts", func() {
+			// Edge case: ensure we don't break strings that happen to contain the namespace
+			configMapResource := &unstructured.Unstructured{}
+			configMapResource.SetAPIVersion("v1")
+			configMapResource.SetKind("ConfigMap")
+			configMapResource.SetName("edge-cases")
+
+			// Using "app" as namespace to test substring issues
+			customTemplater := &HelmTemplater{
+				detectedPrefix:   "test",
+				chartName:        "test",
+				managerNamespace: "app",
+			}
+
+			content := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: edge-cases
+  namespace: app
+data:
+  # DNS patterns - should be templated
+  service-url: http://api.app.svc:8080
+  
+  # NOT DNS patterns - should be preserved
+  app-name: "my-application"
+  app-version: "v1.2.3"
+  mapping: "application-mapping"
+  labels: "app=frontend,app.kubernetes.io/name=myapp"
+  
+  # Tricky: "app" in various contexts
+  erapplication: "some-value"
+  wrapperapp: "another-value"`
+
+			result := customTemplater.ApplyHelmSubstitutions(content, configMapResource)
+
+			// DNS pattern should be templated
+			Expect(result).To(ContainSubstring("api.{{ .Release.Namespace }}.svc:8080"))
+
+			// Non-DNS occurrences should be preserved
+			Expect(result).To(ContainSubstring(`app-name: "my-application"`))
+			Expect(result).To(ContainSubstring("app-version"))
+			Expect(result).To(ContainSubstring("mapping: \"application-mapping\""))
+			Expect(result).To(ContainSubstring("app=frontend"))
+			Expect(result).To(ContainSubstring("app.kubernetes.io/name=myapp"))
+			Expect(result).To(ContainSubstring("erapplication"))
+			Expect(result).To(ContainSubstring("wrapperapp"))
+
+			// Namespace field should be templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+		})
+
+		It("should handle ANY resource type with namespace references (generic test)", func() {
+			// This test validates that namespace replacement is GENERIC and works
+			// for any resource type, including custom resources in extras/ directory
+
+			// Test with a custom ConfigMap (common in extras/)
+			configMapResource := &unstructured.Unstructured{}
+			configMapResource.SetAPIVersion("v1")
+			configMapResource.SetKind("ConfigMap")
+			configMapResource.SetName("custom-config")
+
+			content := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-config
+  namespace: test-project-system
+data:
+  service-url: http://api-service.test-project-system.svc.cluster.local:8080
+  webhook-endpoint: https://webhook.test-project-system.svc:9443/validate
+  annotation-ref: "test-project-system/my-resource"`
+
+			result := templater.ApplyHelmSubstitutions(content, configMapResource)
+
+			// 1. Namespace field should be templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+			Expect(result).NotTo(ContainSubstring("namespace: test-project-system"))
+
+			// 2. DNS names in data values should be templated
+			Expect(result).To(ContainSubstring("http://api-service.{{ .Release.Namespace }}.svc.cluster.local:8080"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc.cluster.local"))
+
+			// 3. DNS names with ports should be templated
+			Expect(result).To(ContainSubstring("https://webhook.{{ .Release.Namespace }}.svc:9443"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc:9443"))
+
+			// 4. Annotation-style references should be templated
+			Expect(result).To(ContainSubstring("{{ .Release.Namespace }}/my-resource"))
+			Expect(result).NotTo(ContainSubstring("test-project-system/my-resource"))
+		})
+
+		It("should handle Secret with namespace references", func() {
+			secretResource := &unstructured.Unstructured{}
+			secretResource.SetAPIVersion("v1")
+			secretResource.SetKind("Secret")
+			secretResource.SetName("app-secret")
+
+			content := `apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+  namespace: test-project-system
+  annotations:
+    source: test-project-system/config
+stringData:
+  database-url: postgresql://db.test-project-system.svc:5432/mydb
+  redis-url: redis://cache.test-project-system.svc.cluster.local:6379`
+
+			result := templater.ApplyHelmSubstitutions(content, secretResource)
+
+			// Namespace field templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+
+			// Annotation value templated
+			Expect(result).To(ContainSubstring("source: {{ .Release.Namespace }}/config"))
+
+			// DNS names in data templated
+			Expect(result).To(ContainSubstring("postgresql://db.{{ .Release.Namespace }}.svc:5432"))
+			Expect(result).To(ContainSubstring("redis://cache.{{ .Release.Namespace }}.svc.cluster.local:6379"))
+
+			// No hardcoded namespace remains
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc"))
+		})
+
+		It("should handle Ingress with namespace references", func() {
+			ingressResource := &unstructured.Unstructured{}
+			ingressResource.SetAPIVersion("networking.k8s.io/v1")
+			ingressResource.SetKind("Ingress")
+			ingressResource.SetName("app-ingress")
+
+			content := `apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  namespace: test-project-system
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://auth.test-project-system.svc.cluster.local/verify
+    cert-manager.io/issuer: test-project-system/letsencrypt
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: app-service
+            port:
+              number: 80`
+
+			result := templater.ApplyHelmSubstitutions(content, ingressResource)
+
+			// Namespace field templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+
+			// Annotation DNS templated
+			Expect(result).To(ContainSubstring("http://auth.{{ .Release.Namespace }}.svc.cluster.local/verify"))
+
+			// Annotation reference templated
+			Expect(result).To(ContainSubstring("cert-manager.io/issuer: {{ .Release.Namespace }}/letsencrypt"))
+
+			// No hardcoded namespace
+			Expect(result).NotTo(ContainSubstring("test-project-system/"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc"))
+		})
+
+		It("should handle PodMonitor with namespace references", func() {
+			podMonitorResource := &unstructured.Unstructured{}
+			podMonitorResource.SetAPIVersion("monitoring.coreos.com/v1")
+			podMonitorResource.SetKind("PodMonitor")
+			podMonitorResource.SetName("app-monitor")
+
+			content := `apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: app-monitor
+  namespace: test-project-system
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  podMetricsEndpoints:
+  - port: metrics
+    scheme: https
+    tlsConfig:
+      serverName: metrics.test-project-system.svc
+      ca:
+        configMap:
+          name: prometheus-ca
+          namespace: test-project-system`
+
+			result := templater.ApplyHelmSubstitutions(content, podMonitorResource)
+
+			// Namespace field templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+
+			// ServerName DNS templated
+			Expect(result).To(ContainSubstring("serverName: metrics.{{ .Release.Namespace }}.svc"))
+
+			// ConfigMap namespace reference templated
+			namespaceCount := strings.Count(result, "namespace: {{ .Release.Namespace }}")
+			Expect(namespaceCount).To(Equal(2), "both metadata and configMap namespace should be templated")
+
+			// No hardcoded namespace in DNS
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc"))
+		})
+
+		It("should handle custom CRD with multiple namespace contexts", func() {
+			customResource := &unstructured.Unstructured{}
+			customResource.SetAPIVersion("example.com/v1")
+			customResource.SetKind("Application")
+			customResource.SetName("my-app")
+
+			content := `apiVersion: example.com/v1
+kind: Application
+metadata:
+  name: my-app
+  namespace: test-project-system
+  annotations:
+    backup.velero.io/backup-volumes: test-project-system/pvc
+spec:
+  database:
+    host: postgres.test-project-system.svc.cluster.local
+    port: 5432
+  messaging:
+    brokerURL: amqp://rabbitmq.test-project-system.svc:5672
+  externalServices:
+    - name: external-api
+      url: https://api.external-namespace.svc/v1
+  references:
+    configMapRef: test-project-system/app-config
+    secretRef: test-project-system/app-secret`
+
+			result := templater.ApplyHelmSubstitutions(content, customResource)
+
+			// Namespace field templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+
+			// Annotation reference templated
+			Expect(result).To(ContainSubstring("{{ .Release.Namespace }}/pvc"))
+
+			// DNS names templated
+			Expect(result).To(ContainSubstring("postgres.{{ .Release.Namespace }}.svc.cluster.local"))
+			Expect(result).To(ContainSubstring("rabbitmq.{{ .Release.Namespace }}.svc:5672"))
+
+			// External namespace preserved (not manager namespace)
+			Expect(result).To(ContainSubstring("https://api.external-namespace.svc/v1"))
+
+			// ConfigMap/Secret refs templated
+			Expect(result).To(ContainSubstring("configMapRef: {{ .Release.Namespace }}/app-config"))
+			Expect(result).To(ContainSubstring("secretRef: {{ .Release.Namespace }}/app-secret"))
+
+			// No manager namespace remains
+			Expect(result).NotTo(ContainSubstring("test-project-system/"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc"))
+		})
+
+		It("should NOT replace namespace in non-manager context", func() {
+			// Critical: cross-namespace references must be preserved
+			customResource := &unstructured.Unstructured{}
+			customResource.SetAPIVersion("v1")
+			customResource.SetKind("ConfigMap")
+			customResource.SetName("federation-config")
+
+			content := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: federation-config
+  namespace: test-project-system
+data:
+  clusters: |
+    - name: cluster-a
+      apiserver: https://api.cluster-a-system.svc:6443
+    - name: cluster-b
+      apiserver: https://api.cluster-b-system.svc:6443
+  external-service: https://monitoring.monitoring-system.svc.cluster.local:9090
+  internal-service: https://internal.test-project-system.svc:8080`
+
+			result := templater.ApplyHelmSubstitutions(content, customResource)
+
+			// Manager namespace field templated
+			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
+			Expect(result).NotTo(ContainSubstring("namespace: test-project-system"))
+
+			// Manager namespace in DNS templated (appears once in internal-service)
+			Expect(result).To(ContainSubstring("internal.{{ .Release.Namespace }}.svc:8080"))
+			Expect(result).NotTo(ContainSubstring(".test-project-system.svc"))
+
+			// External namespaces preserved (these don't match manager namespace)
+			Expect(result).To(ContainSubstring("cluster-a-system.svc"))
+			Expect(result).To(ContainSubstring("cluster-b-system.svc"))
+			Expect(result).To(ContainSubstring("monitoring-system.svc"))
+		})
+	})
+
 	Context("templatePorts", func() {
 		It("should template webhook service ports", func() {
 			webhookService := &unstructured.Unstructured{}
@@ -1041,8 +1684,9 @@ spec:
 
 		It("should handle custom kustomize prefix", func() {
 			customPrefixTemplater := &HelmTemplater{
-				detectedPrefix: "ln",           // Custom short prefix from kustomize
-				chartName:      "test-project", // Chart/project name
+				detectedPrefix:   "ln",           // Custom short prefix from kustomize
+				chartName:        "test-project", // Chart/project name
+				managerNamespace: "ln-system",    // Manager namespace
 			}
 
 			issuer := &unstructured.Unstructured{}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_test.go
@@ -323,4 +323,191 @@ spec:
 			Expect(resources.EstimatePrefix("long-name")).To(Equal("ln"))
 		})
 	})
+
+	Context("with multiple namespace-scoped Roles", func() {
+		BeforeEach(func() {
+			// This test validates the parser correctly handles multiple Roles
+			// with explicit namespaces (for cross-namespace permissions, leader election, etc.)
+			yamlContent := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-project-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-project-manager-role
+rules:
+- apiGroups: ["example.com"]
+  resources: ["myresources"]
+  verbs: ["get", "list", "watch", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-manager-role
+  namespace: infrastructure
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-leader-election-role
+  namespace: production
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-project-leader-election-role
+  namespace: test-project-system
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-manager-rolebinding
+  namespace: infrastructure
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-leader-election-rolebinding
+  namespace: production
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-project-leader-election-rolebinding
+  namespace: test-project-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-project-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: test-project-controller-manager
+  namespace: test-project-system
+`
+			err := os.WriteFile(tempFile, []byte(yamlContent), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			parser = NewParser(tempFile)
+		})
+
+		It("should parse all Roles including those with explicit namespaces", func() {
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resources).NotTo(BeNil())
+
+			// Should parse all 3 namespace-scoped Roles
+			Expect(resources.Roles).To(HaveLen(3), "should have 3 namespace-scoped Roles")
+
+			// Should also parse the ClusterRole
+			Expect(resources.ClusterRoles).To(HaveLen(1), "should have 1 ClusterRole")
+
+			// Verify each Role has correct kind
+			for _, role := range resources.Roles {
+				Expect(role.GetKind()).To(Equal("Role"))
+			}
+
+			// Verify namespaces are preserved in the parsed objects
+			namespaces := make(map[string]bool)
+			for _, role := range resources.Roles {
+				ns := role.GetNamespace()
+				Expect(ns).NotTo(BeEmpty(), "Role should have namespace")
+				namespaces[ns] = true
+			}
+
+			// Should have Roles in 3 different namespaces
+			Expect(namespaces).To(HaveLen(3), "should have Roles in 3 different namespaces")
+			Expect(namespaces).To(HaveKey("infrastructure"))
+			Expect(namespaces).To(HaveKey("production"))
+			Expect(namespaces).To(HaveKey("test-project-system"))
+		})
+
+		It("should parse all RoleBindings including those with explicit namespaces", func() {
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should parse all 3 namespace-scoped RoleBindings
+			Expect(resources.RoleBindings).To(HaveLen(3), "should have 3 RoleBindings")
+
+			// Should also parse the ClusterRoleBinding
+			Expect(resources.ClusterRoleBindings).To(HaveLen(1), "should have 1 ClusterRoleBinding")
+
+			// Verify namespaces are preserved
+			namespaces := make(map[string]bool)
+			for _, rb := range resources.RoleBindings {
+				ns := rb.GetNamespace()
+				Expect(ns).NotTo(BeEmpty(), "RoleBinding should have namespace")
+				namespaces[ns] = true
+			}
+
+			Expect(namespaces).To(HaveLen(3), "should have RoleBindings in 3 different namespaces")
+		})
+
+		It("should correctly categorize RBAC resources separately from other resources", func() {
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+
+			// RBAC resources should be in their specific fields
+			Expect(resources.ServiceAccount).NotTo(BeNil())
+			Expect(resources.ClusterRoles).To(HaveLen(1))
+			Expect(resources.Roles).To(HaveLen(3))
+			Expect(resources.ClusterRoleBindings).To(HaveLen(1))
+			Expect(resources.RoleBindings).To(HaveLen(3))
+
+			// RBAC resources should NOT be in "Other"
+			Expect(resources.Other).To(BeEmpty(), "RBAC resources should not be in Other category")
+		})
+	})
 })


### PR DESCRIPTION
## What This Fixes

This PR fixes how the Helm plugin (v2-alpha) handles namespaces when converting your Kustomize project to a Helm chart.

### Problems Before This Fix

❌ **Missing RBAC Resources**  
If you used namespace-scoped Roles (like for leader election or cross-namespace permissions), they were ignored. Only ClusterRole was converted. Your Helm-deployed operator would fail with permission errors.

❌ **Broken Resource Names**  
If your namespace was `user` and you had a resource called `users`, it would break:
- Input: `users`
- Broken output: `{{ .Release.Namespace }}s` 😱

❌ **Incomplete DNS Replacement**  
Only `.svc` DNS names worked. Other patterns like `.pod`, `.svc.cluster.local`, or `.endpoints` were left with hardcoded namespaces.

❌ **File Name Collisions**  
Multiple Roles with the same name in different namespaces would overwrite each other.

❌ **Hardcoded Annotations**  
Things like `cert-manager.io/inject-ca-from: my-namespace/cert` stayed hardcoded.

---

## What This Fixes

✅ **All RBAC Resources Converted**  
Both ClusterRole AND namespace-scoped Roles/RoleBindings are now converted to Helm templates.

✅ **Safe Namespace Replacement**  
Resource names like `users`, `deployments`, `pods` are never touched. Only actual namespace fields are replaced.

✅ **All Kubernetes DNS Patterns**  
Every DNS format works: `.svc`, `.svc.cluster.local`, `.pod`, `.endpoints`, with ports, with paths, everything.

✅ **Smart Cross-Namespace Handling**  
- Your manager namespace (e.g., `myapp-system`) → `{{ .Release.Namespace }}`
- Other namespaces (e.g., `infrastructure`, `production`) → kept as-is

✅ **No More File Collisions**  
Files get unique names: `leader-election-role.yaml` vs `manager-role-infrastructure.yaml`

✅ **Complete Templating**  
Annotations, DNS names, resource references - everything that should be templated is templated.

---

## How It Works (Simple Explanation)

When you run `kubebuilder edit --plugins=helm/v2-alpha`, the plugin reads your Kustomize output and converts it to Helm templates.

### The Smart Rules

1. **If it's YOUR namespace** → Replace with `{{ .Release.Namespace }}`
2. **If it's SOMEONE ELSE'S namespace** → Keep it exactly as-is
3. **If it's a RESOURCE NAME** → Never touch it!

### Example: Your Namespace

```yaml
# Kustomize (input)
namespace: myapp-system

# Helm Chart (output)
namespace: {{ .Release.Namespace }}
```

When someone installs your chart:
```bash
helm install my-release ./chart --namespace production
```
It becomes: `namespace: production` ✅

### Example: External Namespace

```yaml
# Kustomize (input)
namespace: infrastructure

# Helm Chart (output)
namespace: infrastructure  # Kept as-is!
```

This is for cross-namespace permissions that must use a specific namespace.

---

## Real-World Examples

### Example 1: Leader Election Role

**What you write** (RBAC marker):
```go
//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
```

**What Kustomize generates**:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: myapp-leader-election-role
  namespace: myapp-system
rules:
- apiGroups: ["coordination.k8s.io"]
  resources: ["leases"]
  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```

**What the Helm plugin generates**:
- **File**: `dist/chart/templates/rbac/leader-election-role.yaml`
- **Content**:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: {{ include "myapp.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
  namespace: {{ .Release.Namespace }}  # ← Templated! Will use whatever namespace you install to
rules:
- apiGroups: ["coordination.k8s.io"]
  resources: ["leases"]               # ← NOT templated! Still "leases", not "lease{{ .Release.Namespace }}s"
  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
```

**Why this is important**: Your operator can now be installed in ANY namespace:
```bash
helm install prod ./chart --namespace production        # Works!
helm install staging ./chart --namespace staging        # Works!
helm install dev ./chart --namespace development        # Works!
```

---

### Example 2: Cross-Namespace Permissions

**What you write** (RBAC marker with explicit namespace):
```go
//+kubebuilder:rbac:groups=apps,namespace=infrastructure,resources=deployments,verbs=get;list;watch
```

**What Kustomize generates**:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: myapp-manager-role
  namespace: infrastructure  # Explicit namespace!
rules:
- apiGroups: ["apps"]
  resources: ["deployments"]
  verbs: ["get", "list", "watch"]
```

**What the Helm plugin generates**:
- **File**: `dist/chart/templates/rbac/manager-role-infrastructure.yaml` (note the `-infrastructure` suffix!)
- **Content**:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: {{ include "myapp.resourceName" (dict "suffix" "manager-role" "context" $) }}
  namespace: infrastructure  # ← NOT templated! Kept as "infrastructure" because it's not your manager namespace
rules:
- apiGroups: ["apps"]
  resources: ["deployments"]  # ← NOT templated! Still "deployments"
  verbs: ["get", "list", "watch"]
```

**Why this is important**: You can have permissions in specific namespaces:
```bash
# Your operator installs to "myapp-prod" but needs to watch deployments in "infrastructure"
helm install myapp ./chart --namespace myapp-prod

# Result:
# - Role created in "infrastructure" namespace (as specified)
# - Your operator runs in "myapp-prod" namespace (from --namespace)
```

---

### Example 3: ConfigMap with Service URLs

**What Kustomize generates**:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: app-config
  namespace: myapp-system
data:
  # Internal service (same namespace)
  database-url: "postgresql://db.myapp-system.svc:5432/mydb"
  
  # Internal service with full DNS
  redis-url: "redis://cache.myapp-system.svc.cluster.local:6379"
  
  # External service (different namespace)
  monitoring-url: "http://prometheus.monitoring-system.svc:9090"
  
  # Certificate reference
  tls-cert: "myapp-system/tls-cert"
```

**What the Helm plugin generates**:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: {{ include "myapp.resourceName" (dict "suffix" "app-config" "context" $) }}
  namespace: {{ .Release.Namespace }}  # ← Templated
data:
  # Internal services - namespace is templated
  database-url: "postgresql://db.{{ .Release.Namespace }}.svc:5432/mydb"
  redis-url: "redis://cache.{{ .Release.Namespace }}.svc.cluster.local:6379"
  
  # External service - namespace is PRESERVED
  monitoring-url: "http://prometheus.monitoring-system.svc:9090"
  
  # Reference - templated
  tls-cert: "{{ .Release.Namespace }}/tls-cert"
```

**Why this is important**: Your service URLs automatically work in any namespace:
```bash
helm install myapp ./chart --namespace staging

# Results in:
# database-url: "postgresql://db.staging.svc:5432/mydb"
# redis-url: "redis://cache.staging.svc.cluster.local:6379"
# monitoring-url: "http://prometheus.monitoring-system.svc:9090"  # Still points to monitoring-system!
```

---

### Example 4: The Substring Bug Fix

**Scenario**: Your namespace is `user` and you have a resource type called `users`.

**Before this fix** (BROKEN ❌):
```yaml
# Input
namespace: user
rules:
- resources:
  - users
  - users/finalizers

# Broken output (blind string replacement)
namespace: {{ .Release.Namespace }}
rules:
- resources:
  - {{ .Release.Namespace }}s        # BROKEN! 😱
  - {{ .Release.Namespace }}s/finalizers  # BROKEN! 😱
```

**After this fix** (CORRECT ✅):
```yaml
# Input
namespace: user
rules:
- resources:
  - users
  - users/finalizers

# Correct output (smart replacement)
namespace: {{ .Release.Namespace }}
rules:
- resources:
  - users              # ✅ Preserved!
  - users/finalizers   # ✅ Preserved!
```

**How it works**: The code uses smart patterns that only match actual namespaces:
- `namespace: user` → Has `namespace:` field, **replace it**
- `users` → Just a word, no namespace field, **keep it**

---

## What Gets Templated vs Preserved

### ✅ Gets Templated (Manager Namespace → `{{ .Release.Namespace }}`)

| Context | Example Input | Example Output |
|---------|---------------|----------------|
| Namespace field | `namespace: myapp-system` | `namespace: {{ .Release.Namespace }}` |
| Service DNS | `api.myapp-system.svc` | `api.{{ .Release.Namespace }}.svc` |
| Full DNS | `api.myapp-system.svc.cluster.local` | `api.{{ .Release.Namespace }}.svc.cluster.local` |
| DNS with port | `api.myapp-system.svc:8080` | `api.{{ .Release.Namespace }}.svc:8080` |
| Pod DNS | `pod.myapp-system.pod.cluster.local` | `pod.{{ .Release.Namespace }}.pod.cluster.local` |
| Annotation refs | `myapp-system/my-cert` | `{{ .Release.Namespace }}/my-cert` |
| ConfigMap refs | `configMapRef: myapp-system/config` | `configMapRef: {{ .Release.Namespace }}/config` |

### ✅ Gets Preserved (External Namespaces)

| Context | Example | Why |
|---------|---------|-----|
| Cross-namespace Role | `namespace: infrastructure` | Explicit namespace for cross-namespace permissions |
| External service | `.monitoring-system.svc` | Service in another namespace |
| External reference | `external-namespace/resource` | Reference to resource in another namespace |

### ✅ Never Touched (Resource Names)

| Context | Example | Why |
|---------|---------|-----|
| Resource types | `users`, `deployments`, `pods` | These are Kubernetes resource types, not namespaces |
| Labels | `app: frontend` | Labels are not namespaces |
| Arbitrary strings | `my-application` | Just regular strings |

---

## File Organization

### RBAC Files Go to `rbac/` Directory

**All** RBAC resources are organized in `dist/chart/templates/rbac/`:

```
dist/chart/templates/rbac/
├── controller-manager.yaml           (ServiceAccount)
├── manager-role.yaml                 (ClusterRole)
├── manager-rolebinding.yaml          (ClusterRoleBinding)
├── leader-election-role.yaml         (Role in manager namespace)
├── leader-election-rolebinding.yaml  (RoleBinding in manager namespace)
├── manager-role-infrastructure.yaml  (Role in "infrastructure" namespace)
├── manager-rolebinding-infrastructure.yaml (RoleBinding in "infrastructure")
└── ...
```

**Note**: They're **never** in `extras/`, even custom ServiceAccounts.

### Filename Rules

| Resource Type | Namespace | Example Filename |
|---------------|-----------|------------------|
| ClusterRole | (none) | `manager-role.yaml` |
| Role | Manager namespace | `leader-election-role.yaml` |
| Role | Cross-namespace | `manager-role-infrastructure.yaml` |
| RoleBinding | Manager namespace | `leader-election-rolebinding.yaml` |
| RoleBinding | Cross-namespace | `manager-rolebinding-infrastructure.yaml` |

The `-<namespace>` suffix prevents file collisions when you have multiple Roles with the same name in different namespaces.

---

## Before vs After Comparison

### Before This Fix

```bash
$ kubebuilder edit --plugins=helm/v2-alpha
$ ls dist/chart/templates/rbac/
manager-role.yaml              # ← Only ClusterRole
manager-rolebinding.yaml       # ← Only ClusterRoleBinding
# WHERE IS MY LEADER ELECTION ROLE?? 😱

$ helm install myapp dist/chart/ --namespace production
# Result: Deployment fails with "forbidden: User cannot get leases" 💥
```

### After This Fix

```bash
$ kubebuilder edit --plugins=helm/v2-alpha
$ ls dist/chart/templates/rbac/
controller-manager.yaml
manager-role.yaml
manager-rolebinding.yaml
leader-election-role.yaml              # ← NOW INCLUDED! ✅
leader-election-rolebinding.yaml       # ← NOW INCLUDED! ✅
manager-role-infrastructure.yaml       # ← Cross-namespace roles too! ✅
manager-rolebinding-infrastructure.yaml

$ helm install myapp dist/chart/ --namespace production
# Result: Everything works! ✅
```

---

## Technical Details (For the Curious)

### Why Regex Instead of YAML Parsing?

**Short answer**: The content has Helm templates mixed with YAML, which breaks YAML parsers.

**Long answer**: By the time we need to replace namespaces, the content looks like this:

```yaml
metadata:
  name: {{ include "chart.name" . }}    # ← Helm template (not valid YAML!)
  namespace: myapp-system                # ← We need to replace this
  {{- if .Values.certManager.enable }}  # ← Helm conditional (not valid YAML!)
  annotations:
    cert-manager: enabled
  {{- end }}
```

If we try to parse this as YAML:
```go
yaml.Unmarshal(yamlContent, &data)
// Error: "could not find expected ':'"
```

So we use **smart regex patterns** that only match what we want:

1. **Namespace fields**: `namespace: myapp-system` (only if it's on its own line)
2. **DNS names**: `.myapp-system.svc` (only if there are dots on both sides)
3. **References**: `myapp-system/cert` (only if followed by `/`)

### Safety Guarantees

Each pattern is designed to prevent false matches:

| Pattern | What It Matches | What It Skips |
|---------|----------------|---------------|
| `(?m)^(\s*)namespace:\s+<value>\s*$` | `namespace: myapp-system` | `message: "namespace: myapp-system"` (in string) |
| `\b<value>/` | `myapp-system/cert` | `https://example.com/myapp-system/docs` (URL) |
| `\.<value>\.` | `.myapp-system.svc` | `users` (no dots), `app=myapp-system` (no dots on both sides) |

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5354

