### PR TITLE
🐛 (helm/v2-alpha): Fix force option to overwriten all files less Chart.yaml

### DIFF
--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -30,7 +30,7 @@ The **helm/v2-alpha** plugin converts the bundle (`dist/install.yaml`) into a He
 - **Preserves Customizations**: Keeps env vars, labels, annotations, and patches.
 - **Structured Output**: Templates follow your `config/` directory layout.
 - **Smart Values**: `values.yaml` includes only actual configurable parameters.
-- **File Preservation**: Manual edits in `values.yaml`, `Chart.yaml`, `_helpers.tpl` are kept unless `--force` is used.
+- **File Preservation**: `Chart.yaml` is never overwritten. Without `--force`, `values.yaml`, `_helpers.tpl`, `.helmignore`, and `.github/workflows/test-chart.yml` are preserved.
 - **Handles Custom Resources**: Resources not matching standard layout (custom Services, ConfigMaps, etc.) are placed in `templates/extras/` with proper templating.
 
 ## When to Use It
@@ -55,7 +55,7 @@ make build-installer IMG=<registry>/<project:tag>
 # Create Helm chart from kustomize output
 kubebuilder edit --plugins=helm/v2-alpha
 
-# Overwrite preserved files if needed
+# Regenerate preserved files (Chart.yaml never overwritten)
 kubebuilder edit --plugins=helm/v2-alpha --force
 ```
 
@@ -274,7 +274,7 @@ helm install my-release ./dist/chart \
 |---------------------|-----------------------------------------------------------------------------|
 | **--manifests**     | Path to YAML file containing Kubernetes manifests (default: `dist/install.yaml`) |
 | **--output-dir** string | Output directory for chart (default: `dist`)                                |
-| **--force**         | Overwrites preserved files (`values.yaml`, `Chart.yaml`, `_helpers.tpl`)    |
+| **--force**         | Regenerates preserved files except `Chart.yaml` (values.yaml, _helpers.tpl, .helmignore, test-chart.yml) |
 
 <aside class="note">
 <H1> Examples </H1>

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -77,8 +77,10 @@ The chart structure mirrors your config/ directory organization for easy mainten
   make build-installer  # Generate dist/install.yaml with latest changes
   %[1]s edit --plugins=%[2]s  # Generate/update Helm chart in dist/chart/
 
-**NOTE**: The plugin preserves customizations in values.yaml, Chart.yaml, _helpers.tpl, and .helmignore
-unless --force is used. All template files are regenerated to match your current kustomize output.
+**NOTE**: Chart.yaml is never overwritten (contains user-managed version info). 
+Without --force, the plugin also preserves values.yaml, _helpers.tpl, .helmignore, and 
+.github/workflows/test-chart.yml. All template files in templates/ are always regenerated 
+to match your current kustomize output. Use --force to regenerate all files except Chart.yaml.
 
 The generated chart structure mirrors your config/ directory:
 <output>/chart/

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/chart_never_overwrite_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/chart_never_overwrite_test.go
@@ -1,0 +1,189 @@
+//go:build integration
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("Chart.yaml Never Overwrite Test", func() {
+	var (
+		fs            machinery.Filesystem
+		tmpDir        string
+		manifestsFile string
+		outputDir     string
+		projectConfig config.Config
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "helm-chart-never-overwrite-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.Chdir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		fs = machinery.Filesystem{
+			FS: afero.NewBasePathFs(afero.NewOsFs(), tmpDir),
+		}
+
+		projectConfig = cfgv3.New()
+		projectConfig.SetProjectName("test-project")
+		projectConfig.SetDomain("example.io")
+
+		manifestsFile = filepath.Join(tmpDir, "dist", "install.yaml")
+		outputDir = "dist"
+
+		// Create minimal kustomize output
+		kustomizeYAML := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-project-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+`
+
+		err = os.MkdirAll(filepath.Dir(manifestsFile), 0o755)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.WriteFile(manifestsFile, []byte(kustomizeYAML), 0o644)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if tmpDir != "" {
+			_ = os.RemoveAll(tmpDir)
+		}
+	})
+
+	It("should NEVER overwrite Chart.yaml even with --force=true", func() {
+		scaffolder := &editKustomizeScaffolder{
+			config:        projectConfig,
+			fs:            fs,
+			force:         false,
+			manifestsFile: manifestsFile,
+			outputDir:     outputDir,
+		}
+
+		// First scaffold
+		err := scaffolder.Scaffold()
+		Expect(err).NotTo(HaveOccurred())
+
+		chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")
+
+		// Read initial Chart.yaml
+		initialContent, err := os.ReadFile(chartPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(initialContent)).To(ContainSubstring("name: test-project"))
+		Expect(string(initialContent)).To(ContainSubstring("version: 0.1.0"))
+
+		// Customize Chart.yaml with user version
+		customChartYAML := `apiVersion: v2
+name: test-project
+description: My custom description
+type: application
+version: 1.2.3
+appVersion: "1.2.3"
+icon: "https://mycompany.com/icon.png"
+maintainers:
+  - name: John Doe
+    email: john@example.com
+`
+		err = os.WriteFile(chartPath, []byte(customChartYAML), 0o644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Scaffold again WITHOUT force
+		err = scaffolder.Scaffold()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify Chart.yaml was NOT overwritten
+		content, err := os.ReadFile(chartPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal(customChartYAML), "Chart.yaml should not be overwritten without --force")
+		Expect(string(content)).To(ContainSubstring("version: 1.2.3"))
+		Expect(string(content)).To(ContainSubstring("John Doe"))
+
+		// Scaffold again WITH force=true
+		scaffolder.force = true
+		err = scaffolder.Scaffold()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify Chart.yaml STILL was NOT overwritten (never overwritten even with force)
+		content, err = os.ReadFile(chartPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal(customChartYAML), "Chart.yaml should NEVER be overwritten, even with --force")
+		Expect(string(content)).To(ContainSubstring("version: 1.2.3"))
+		Expect(string(content)).To(ContainSubstring("John Doe"))
+		Expect(string(content)).To(ContainSubstring("My custom description"))
+	})
+
+	It("should preserve Chart.yaml on initial scaffold if file already exists", func() {
+		// Create Chart.yaml before any scaffolding
+		chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")
+		err := os.MkdirAll(filepath.Dir(chartPath), 0o755)
+		Expect(err).NotTo(HaveOccurred())
+
+		preexistingChart := `apiVersion: v2
+name: my-existing-chart
+version: 99.99.99
+`
+		err = os.WriteFile(chartPath, []byte(preexistingChart), 0o644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// First scaffold with force=true
+		scaffolder := &editKustomizeScaffolder{
+			config:        projectConfig,
+			fs:            fs,
+			force:         true,
+			manifestsFile: manifestsFile,
+			outputDir:     outputDir,
+		}
+
+		err = scaffolder.Scaffold()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify Chart.yaml was preserved even on first scaffold with force
+		content, err := os.ReadFile(chartPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal(preexistingChart), "Chart.yaml should be preserved even on first scaffold with --force")
+		Expect(string(content)).To(ContainSubstring("my-existing-chart"))
+		Expect(string(content)).To(ContainSubstring("99.99.99"))
+	})
+})
+

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/edit_kustomize.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/edit_kustomize.go
@@ -119,8 +119,8 @@ func (s *editKustomizeScaffolder) Scaffold() error {
 
 	// Define the standard Helm chart files to generate
 	chartFiles := []machinery.Builder{
-		&github.HelmChartCI{},                        // GitHub Actions workflow for chart testing
-		&templates.HelmChart{OutputDir: s.outputDir}, // Chart.yaml metadata
+		&github.HelmChartCI{Force: s.force},                          // GitHub Actions workflow for chart testing
+		&templates.HelmChart{OutputDir: s.outputDir, Force: s.force}, // Chart.yaml metadata
 		&templates.HelmValuesBasic{
 			// values.yaml with dynamic config
 			HasWebhooks:      hasWebhooks,
@@ -129,8 +129,8 @@ func (s *editKustomizeScaffolder) Scaffold() error {
 			OutputDir:        s.outputDir,
 			Force:            s.force,
 		},
-		&templates.HelmIgnore{OutputDir: s.outputDir},       // .helmignore file
-		&charttemplates.HelmHelpers{OutputDir: s.outputDir}, // _helpers.tpl template functions
+		&templates.HelmIgnore{OutputDir: s.outputDir, Force: s.force},       // .helmignore file
+		&charttemplates.HelmHelpers{OutputDir: s.outputDir, Force: s.force}, // _helpers.tpl template functions
 	}
 
 	// Only scaffold the generic ServiceMonitor when the project does NOT already
@@ -149,6 +149,7 @@ func (s *editKustomizeScaffolder) Scaffold() error {
 		chartFiles = append(chartFiles, &charttemplates.ServiceMonitor{
 			OutputDir:   s.outputDir,
 			ServiceName: metricsServiceName,
+			Force:       s.force,
 		})
 	}
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/force_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/force_integration_test.go
@@ -1,0 +1,333 @@
+//go:build integration
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("Force Flag Integration Test", func() {
+	var (
+		fs             machinery.Filesystem
+		tmpDir         string
+		manifestsFile  string
+		outputDir      string
+		projectConfig  config.Config
+		scaffolderBase *editKustomizeScaffolder
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "helm-force-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.Chdir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		fs = machinery.Filesystem{
+			FS: afero.NewBasePathFs(afero.NewOsFs(), tmpDir),
+		}
+
+		// Create PROJECT file
+		projectConfig = cfgv3.New()
+		projectConfig.SetProjectName("test-project")
+		projectConfig.SetDomain("example.io")
+
+		// Setup directories - use absolute path for manifestsFile since parser uses os.Open
+		manifestsFile = filepath.Join(tmpDir, "dist", "install.yaml")
+		outputDir = "dist"
+
+		// Create minimal kustomize output file using real OS filesystem (parser uses os.Open)
+		kustomizeYAML := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+    control-plane: controller-manager
+  name: test-project-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: test-project
+    control-plane: controller-manager
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - /manager
+        args:
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        env:
+        - name: TEST_ENV
+          value: "test-value"
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+`
+
+		// Use OS filesystem to write manifests file since Parser uses os.Open
+		err = os.MkdirAll(filepath.Dir(manifestsFile), 0o755)
+		Expect(err).NotTo(HaveOccurred())
+		err = os.WriteFile(manifestsFile, []byte(kustomizeYAML), 0o644)
+		Expect(err).NotTo(HaveOccurred())
+
+		scaffolderBase = &editKustomizeScaffolder{
+			config:        projectConfig,
+			fs:            fs,
+			manifestsFile: manifestsFile,
+			outputDir:     outputDir,
+		}
+	})
+
+	AfterEach(func() {
+		if tmpDir != "" {
+			_ = os.RemoveAll(tmpDir)
+		}
+	})
+
+	Context("when --force flag is NOT used", func() {
+		It("should NOT overwrite existing Chart.yaml, values.yaml, .helmignore, _helpers.tpl, and test-chart.yml", func() {
+			// First generation with force=false
+			scaffolderBase.force = false
+			err := scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Define file paths (absolute paths for OS filesystem)
+			chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")
+			valuesPath := filepath.Join(tmpDir, outputDir, "chart", "values.yaml")
+			helmignorePath := filepath.Join(tmpDir, outputDir, "chart", ".helmignore")
+			helpersPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "_helpers.tpl")
+			testChartPath := filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml")
+
+			// Verify files exist
+			_, err = os.ReadFile(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = os.ReadFile(helmignorePath)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = os.ReadFile(helpersPath)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = os.ReadFile(testChartPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Modify all protected files
+			customChartContent := "# CUSTOM CHART YAML\nversion: 999.0.0\n"
+			customValuesContent := "# CUSTOM VALUES YAML\ncustom: value\n"
+			customHelmignoreContent := "# CUSTOM HELMIGNORE\n*.custom\n"
+			customHelpersContent := "# CUSTOM HELPERS TPL\n{{/* custom helper */}}\n"
+			customTestChartContent := "# CUSTOM TEST CHART\nname: Custom Workflow\n"
+
+			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(valuesPath, []byte(customValuesContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(helmignorePath, []byte(customHelmignoreContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(helpersPath, []byte(customHelpersContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(testChartPath, []byte(customTestChartContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second generation with force=false
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify all protected files were NOT overwritten
+			chartContent, err := os.ReadFile(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(chartContent)).To(Equal(customChartContent), "Chart.yaml should not be overwritten without --force")
+
+			valuesContent, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(valuesContent)).To(Equal(customValuesContent), "values.yaml should not be overwritten without --force")
+
+			helmignoreContent, err := os.ReadFile(helmignorePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(helmignoreContent)).To(Equal(customHelmignoreContent), ".helmignore should not be overwritten without --force")
+
+			helpersContent, err := os.ReadFile(helpersPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(helpersContent)).To(Equal(customHelpersContent), "_helpers.tpl should not be overwritten without --force")
+
+			testChartContent, err := os.ReadFile(testChartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(testChartContent)).To(Equal(customTestChartContent), "test-chart.yml should not be overwritten without --force")
+		})
+	})
+
+	Context("when --force flag IS used", func() {
+		It("should overwrite all files EXCEPT Chart.yaml (which is never overwritten)", func() {
+			// First generation with force=false
+			scaffolderBase.force = false
+			err := scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Define file paths (absolute paths for OS filesystem)
+			chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")
+			valuesPath := filepath.Join(tmpDir, outputDir, "chart", "values.yaml")
+			helmignorePath := filepath.Join(tmpDir, outputDir, "chart", ".helmignore")
+			helpersPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "_helpers.tpl")
+			testChartPath := filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml")
+
+			// Modify all protected files with custom content
+			customChartContent := "# CUSTOM CHART YAML\nversion: 999.0.0\n"
+			customValuesContent := "# CUSTOM VALUES YAML\ncustom: value\n"
+			customHelmignoreContent := "# CUSTOM HELMIGNORE\n*.custom\n"
+			customHelpersContent := "# CUSTOM HELPERS TPL\n{{/* custom helper */}}\n"
+			customTestChartContent := "# CUSTOM TEST CHART\nname: Custom Workflow\n"
+
+			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(valuesPath, []byte(customValuesContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(helmignorePath, []byte(customHelmignoreContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(helpersPath, []byte(customHelpersContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(testChartPath, []byte(customTestChartContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Second generation with force=true
+			scaffolderBase.force = true
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify Chart.yaml was NOT overwritten (never overwritten, even with --force)
+			chartContent, err := os.ReadFile(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(chartContent)).To(Equal(customChartContent), "Chart.yaml should NEVER be overwritten, even with --force")
+
+			valuesContent, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(valuesContent)).NotTo(Equal(customValuesContent), "values.yaml should be overwritten with --force")
+			Expect(string(valuesContent)).To(ContainSubstring("manager:"), "values.yaml should contain manager section")
+
+			helmignoreContent, err := os.ReadFile(helmignorePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(helmignoreContent)).NotTo(Equal(customHelmignoreContent), ".helmignore should be overwritten with --force")
+			Expect(string(helmignoreContent)).To(ContainSubstring(".DS_Store"), ".helmignore should contain default patterns")
+
+			helpersContent, err := os.ReadFile(helpersPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(helpersContent)).NotTo(Equal(customHelpersContent), "_helpers.tpl should be overwritten with --force")
+			Expect(string(helpersContent)).To(ContainSubstring("test-project.name"), "_helpers.tpl should contain template helpers")
+
+			testChartContent, err := os.ReadFile(testChartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(testChartContent)).NotTo(Equal(customTestChartContent), "test-chart.yml should be overwritten with --force")
+			Expect(string(testChartContent)).To(ContainSubstring("Test Chart"), "test-chart.yml should contain workflow name")
+		})
+
+		It("should overwrite files on first run when force=true", func() {
+			// Create pre-existing custom files before any scaffold run (absolute paths)
+			chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")
+			valuesPath := filepath.Join(tmpDir, outputDir, "chart", "values.yaml")
+
+			err := os.MkdirAll(filepath.Dir(chartPath), 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			customChartContent := "# PRE-EXISTING CHART\nversion: 0.0.1\n"
+			customValuesContent := "# PRE-EXISTING VALUES\nold: data\n"
+
+			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(valuesPath, []byte(customValuesContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// First generation with force=true should overwrite
+			scaffolderBase.force = true
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify Chart.yaml was NOT overwritten (never overwritten, even on first run with force)
+			chartContent, err := os.ReadFile(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(chartContent)).To(Equal(customChartContent), "Chart.yaml should NEVER be overwritten, even on first run with --force")
+
+			// Verify values.yaml WAS overwritten
+			valuesContent, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(valuesContent)).NotTo(Equal(customValuesContent), "values.yaml should be overwritten on first run with --force")
+			Expect(string(valuesContent)).To(ContainSubstring("manager:"))
+		})
+	})
+
+	Context("when template files are modified", func() {
+		It("should verify template files exist in templates/ directory", func() {
+			// First generation
+			scaffolderBase.force = false
+			err := scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify that template directory was created with files
+			templatesDir := filepath.Join(tmpDir, outputDir, "chart", "templates")
+			info, err := os.Stat(templatesDir)
+			Expect(err).NotTo(HaveOccurred(), "Templates directory should be created")
+			Expect(info.IsDir()).To(BeTrue(), "Templates should be a directory")
+
+			// At minimum, _helpers.tpl should exist
+			helpersPath := filepath.Join(templatesDir, "_helpers.tpl")
+			_, err = os.Stat(helpersPath)
+			Expect(err).NotTo(HaveOccurred(), "_helpers.tpl should exist in templates/")
+		})
+	})
+})
+

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -32,6 +32,8 @@ type HelmHelpers struct {
 
 	// OutputDir specifies the output directory for the chart
 	OutputDir string
+	// Force if true allows overwriting the scaffolded file
+	Force bool
 }
 
 // SetTemplateDefaults sets the default template configuration
@@ -46,7 +48,11 @@ func (f *HelmHelpers) SetTemplateDefaults() error {
 
 	f.TemplateBody = f.generateHelpersTemplate()
 
-	f.IfExistsAction = machinery.SkipFile
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
 
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -37,6 +37,8 @@ type ServiceMonitor struct {
 
 	// OutputDir specifies the output directory for the chart
 	OutputDir string
+	// Force if true allows overwriting the scaffolded file
+	Force bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -49,7 +51,6 @@ func (f *ServiceMonitor) SetTemplateDefaults() error {
 		f.Path = filepath.Join(outputDir, "chart", "templates", "monitoring", "servicemonitor.yaml")
 	}
 
-	// Replace {{ .Chart.Name }} placeholders with actual project name
 	chartName := f.ProjectName
 	f.TemplateBody = fmt.Sprintf(serviceMonitorTemplate, chartName, chartName, chartName, chartName)
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart.go
@@ -33,6 +33,8 @@ type HelmChart struct {
 
 	// OutputDir specifies the output directory for the chart
 	OutputDir string
+	// Force if true allows overwriting the scaffolded file
+	Force bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -47,6 +49,7 @@ func (f *HelmChart) SetTemplateDefaults() error {
 
 	f.TemplateBody = helmChartTemplate
 
+	// Chart.yaml is never overwritten as it contains user-managed version info
 	f.IfExistsAction = machinery.SkipFile
 
 	return nil

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
@@ -28,6 +28,9 @@ var _ machinery.Template = &HelmChartCI{}
 type HelmChartCI struct {
 	machinery.TemplateMixin
 	machinery.ProjectNameMixin
+
+	// Force if true allows overwriting the scaffolded file
+	Force bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -38,7 +41,11 @@ func (f *HelmChartCI) SetTemplateDefaults() error {
 
 	f.TemplateBody = testChartTemplate
 
-	f.IfExistsAction = machinery.SkipFile
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
 
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/helmignore.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/helmignore.go
@@ -30,6 +30,8 @@ type HelmIgnore struct {
 
 	// OutputDir specifies the output directory for the chart
 	OutputDir string
+	// Force if true allows overwriting the scaffolded file
+	Force bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -44,7 +46,11 @@ func (f *HelmIgnore) SetTemplateDefaults() error {
 
 	f.TemplateBody = helmIgnoreTemplate
 
-	f.IfExistsAction = machinery.SkipFile
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
 
 	return nil
 }


### PR DESCRIPTION
Chart.yaml contains user-managed version metadata and should never be overwritten, even with --force. The --force flag now regenerates all other preserved files (values.yaml, _helpers.tpl, .helmignore, test-chart.yml) while respecting Chart.yaml.

Added integration tests to verify force flag behavior and Chart.yaml preservation.

