### PR TITLE
WIP - Analyse/Test Ignore

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+- ../samples
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/samples/cronjob-sample.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/samples/cronjob-sample.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.samples.create }}
+apiVersion: batch.tutorial.kubebuilder.io/v1
+kind: CronJob
+metadata:
+    annotations:
+        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook-weight": "5"
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "project.resourceName" (dict "suffix" "cronjob-sample" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+spec:
+    concurrencyPolicy: Allow
+    jobTemplate:
+        spec:
+            template:
+                spec:
+                    containers:
+                        - args:
+                            - /bin/sh
+                            - -c
+                            - date; echo Hello from the Kubernetes cluster
+                          image: busybox
+                          name: hello
+                          securityContext:
+                            allowPrivilegeEscalation: false
+                            capabilities:
+                                drop:
+                                    - ALL
+                            readOnlyRootFilesystem: false
+                    restartPolicy: OnFailure
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        seccompProfile:
+                            type: RuntimeDefault
+    schedule: '*/1 * * * *'
+    startingDeadlineSeconds: 60
+{{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -102,6 +102,10 @@ webhook:
   # Webhook server port
   port: 9443
 
+## Deploy sample Custom Resources instances
+samples:
+  create: false
+
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4413,6 +4413,42 @@ spec:
         secret:
           secretName: webhook-server-cert
 ---
+apiVersion: batch.tutorial.kubebuilder.io/v1
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-sample
+  namespace: project-system
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+  schedule: '*/1 * * * *'
+  startingDeadlineSeconds: 60
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+- ../samples
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/samples/memcached-sample.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/samples/memcached-sample.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.samples.create }}
+apiVersion: cache.example.com/v1alpha1
+kind: Memcached
+metadata:
+    annotations:
+        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook-weight": "5"
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "project.resourceName" (dict "suffix" "memcached-sample" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+spec:
+    size: 1
+{{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -95,6 +95,10 @@ metrics:
 certManager:
   enable: false
 
+## Deploy sample Custom Resources instances
+samples:
+  create: false
+
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##

--- a/docs/book/src/getting-started/testdata/project/dist/install.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/install.yaml
@@ -477,3 +477,14 @@ spec:
       serviceAccountName: project-controller-manager
       terminationGracePeriodSeconds: 10
       volumes: []
+---
+apiVersion: cache.example.com/v1alpha1
+kind: Memcached
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-memcached-sample
+  namespace: project-system
+spec:
+  size: 1

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
+- ../samples
 # [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
 # Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
 # Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/samples/cronjob-sample.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/samples/cronjob-sample.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.samples.create }}
+apiVersion: batch.tutorial.kubebuilder.io/v2
+kind: CronJob
+metadata:
+    annotations:
+        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook-weight": "5"
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "project.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "project.resourceName" (dict "suffix" "cronjob-sample" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+spec:
+    concurrencyPolicy: Allow
+    jobTemplate:
+        spec:
+            template:
+                spec:
+                    containers:
+                        - args:
+                            - /bin/sh
+                            - -c
+                            - date; echo Hello from the Kubernetes cluster
+                          image: busybox
+                          name: hello
+                          securityContext:
+                            allowPrivilegeEscalation: false
+                            capabilities:
+                                drop:
+                                    - ALL
+                            readOnlyRootFilesystem: false
+                    restartPolicy: OnFailure
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        seccompProfile:
+                            type: RuntimeDefault
+    schedule:
+        minute: '*/1'
+    startingDeadlineSeconds: 60
+{{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -102,6 +102,10 @@ webhook:
   # Webhook server port
   port: 9443
 
+## Deploy sample Custom Resources instances
+samples:
+  create: false
+
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -8451,6 +8451,79 @@ spec:
         secret:
           secretName: webhook-server-cert
 ---
+apiVersion: batch.tutorial.kubebuilder.io/v1
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-sample
+  namespace: project-system
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+  schedule: '*/1 * * * *'
+  startingDeadlineSeconds: 60
+---
+apiVersion: batch.tutorial.kubebuilder.io/v2
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: project
+  name: project-cronjob-sample
+  namespace: project-system
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              readOnlyRootFilesystem: false
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+  schedule:
+    minute: '*/1'
+  startingDeadlineSeconds: 60
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -143,6 +143,20 @@ func (sp *Sample) CodeGen() {
 	_, err = sp.ctx.Run(cmd)
 	hackutils.CheckError("Failed to run make build-installer for cronjob tutorial", err)
 
+	// Add samples to kustomization for Helm chart generation
+	kustomizationPath := filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml")
+	err = pluginutil.InsertCode(
+		kustomizationPath,
+		"- metrics_service.yaml",
+		"\n- ../samples")
+	hackutils.CheckError("Failed to add samples to kustomization", err)
+
+	// Rebuild installer with samples
+	cmd = exec.Command("make", "build-installer")
+	cmd.Dir = sp.ctx.Dir
+	_, err = sp.ctx.Run(cmd)
+	hackutils.CheckError("Failed to rebuild installer with samples", err)
+
 	err = sp.ctx.EditHelmPlugin()
 	hackutils.CheckError("Failed to enable helm plugin", err)
 }

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -241,6 +241,20 @@ func (sp *Sample) CodeGen() {
 	_, err = sp.ctx.Run(cmd)
 	hackutils.CheckError("Failed to run make build-installer for getting started tutorial", err)
 
+	// Add samples to kustomization for Helm chart generation
+	kustomizationPath := filepath.Join(sp.ctx.Dir, "config/default/kustomization.yaml")
+	err = pluginutil.InsertCode(
+		kustomizationPath,
+		"- metrics_service.yaml",
+		"\n- ../samples")
+	hackutils.CheckError("Failed to add samples to kustomization", err)
+
+	// Rebuild installer with samples
+	cmd = exec.Command("make", "build-installer")
+	cmd.Dir = sp.ctx.Dir
+	_, err = sp.ctx.Run(cmd)
+	hackutils.CheckError("Failed to rebuild installer with samples", err)
+
 	err = sp.ctx.EditHelmPlugin()
 	hackutils.CheckError("Failed to enable helm plugin", err)
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/edit_kustomize.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/edit_kustomize.go
@@ -125,6 +125,7 @@ func (s *editKustomizeScaffolder) Scaffold() error {
 			// values.yaml with dynamic config
 			HasWebhooks:      hasWebhooks,
 			HasMetrics:       hasMetrics,
+			HasSamples:       len(resources.SampleResources) > 0,
 			DeploymentConfig: deploymentConfig,
 			OutputDir:        s.outputDir,
 			Force:            s.force,

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -45,6 +45,7 @@ type ChartConverter struct {
 func NewChartConverter(resources *ParsedResources, detectedPrefix, chartName, outputDir string) *ChartConverter {
 	organizer := NewResourceOrganizer(resources)
 	templater := NewHelmTemplater(detectedPrefix, chartName)
+	templater.SetCRDTypes(resources.definedCRDTypes)
 	writer := NewChartWriter(templater, outputDir)
 
 	return &ChartConverter{

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
@@ -111,7 +111,7 @@ func (w *ChartWriter) convertToYAML(resource *unstructured.Unstructured) string 
 func (w *ChartWriter) shouldSplitFiles(groupName string) bool {
 	return groupName == "crd" || groupName == "cert-manager" || groupName == "webhook" ||
 		groupName == "prometheus" || groupName == "rbac" || groupName == "metrics" ||
-		groupName == "extras"
+		groupName == "samples" || groupName == "extras"
 }
 
 // writeSplitFiles writes each resource in the group to its own file

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -716,6 +716,7 @@ spec:
 	Context("edge cases", func() {
 		It("should handle empty content", func() {
 			testResource := &unstructured.Unstructured{}
+			testResource.SetAPIVersion("v1")
 			testResource.SetKind("ConfigMap")
 
 			result := templater.ApplyHelmSubstitutions("", testResource)
@@ -741,6 +742,7 @@ metadata:
 
 		It("should handle malformed YAML gracefully", func() {
 			testResource := &unstructured.Unstructured{}
+			testResource.SetAPIVersion("v1")
 			testResource.SetKind("ConfigMap")
 
 			malformedContent := "not: valid: yaml: content:"

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/resource_organizer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/resource_organizer.go
@@ -78,6 +78,12 @@ func (o *ResourceOrganizer) OrganizeByFunction() map[string][]*unstructured.Unst
 		groups["prometheus"] = prometheusResources
 	}
 
+	// Samples - Custom Resource instances (from config/samples)
+	// These are example CRs for demonstration and testing purposes
+	if len(o.resources.SampleResources) > 0 {
+		groups["samples"] = o.resources.SampleResources
+	}
+
 	// Extras - Uncategorized resources (services, configmaps, secrets, etc. not fitting above categories)
 	// This includes both uncategorized services and all resources from the "Other" category
 	extrasResources := o.collectExtrasResources()

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -44,6 +44,8 @@ type HelmValuesBasic struct {
 	HasWebhooks bool
 	// HasMetrics is true when metrics service/monitor were found in the config
 	HasMetrics bool
+	// HasSamples is true when sample CRs were found in the config
+	HasSamples bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -198,6 +200,15 @@ webhook:
   port: %d
 
 `, webhookPort))
+	}
+
+	// Samples configuration - only if samples exist
+	if f.HasSamples {
+		buf.WriteString(`## Deploy sample Custom Resources instances
+samples:
+  create: false
+
+`)
 	}
 
 	// Prometheus configuration


### PR DESCRIPTION
Sample Custom Resources from config/samples/ are now automatically detected and placed in templates/samples/ with conditional rendering via .Values.samples.create (disabled by default). Detection uses CRD-based matching to ensure only CR instances of defined CRDs are categorized as samples.

Motivated by: https://kubernetes.slack.com/archives/CAR30FCJZ/p1767608032826149