### PR TITLE
📖 (docs): Limit code rendering to relevant sections in multiversion webhook tutorial

### DIFF
--- a/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
@@ -121,6 +121,8 @@ func main() {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}
 
+	// +kubebuilder:docs-gen:collapse=Manager Setup
+
 	// Initial webhook TLS options
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook.go
@@ -37,6 +37,8 @@ import (
 	batchv2 "tutorial.kubebuilder.io/project/api/v2"
 )
 
+// +kubebuilder:docs-gen:collapse=Imports
+
 // nolint:unused
 // log is for logging in this package.
 var cronjoblog = logf.Log.WithName("cronjob-resource")
@@ -156,6 +158,8 @@ func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
 		*cronJob.Spec.FailedJobsHistoryLimit = d.DefaultFailedJobsHistoryLimit
 	}
 }
+
+// +kubebuilder:docs-gen:collapse=Webhook Setup and Defaulting
 
 // validateCronJob validates the fields of a CronJob object.
 func validateCronJob(cronjob *batchv2.CronJob) error {

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -354,6 +354,16 @@ func (sp *Sample) updateWebhookV2() {
 	)
 	hackutils.CheckError("replacing imports in v2", err)
 
+	// Add collapse marker after the import block to hide imports
+	err = pluginutil.InsertCode(
+		filepath.Join(sp.ctx.Dir, path),
+		`batchv2 "tutorial.kubebuilder.io/project/api/v2"
+)`,
+		`
+
+// +kubebuilder:docs-gen:collapse=Imports`)
+	hackutils.CheckError("adding imports collapse marker to webhook v2", err)
+
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, path),
 		`// TODO(user): Add more fields as needed for defaulting`,
@@ -493,17 +503,14 @@ CronJob controller's `+"`SetupWithManager`"+` method.
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, path),
-		`if err := (&controller.CronJobReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "CronJob")
-		os.Exit(1)
+		`if !enableHTTP2 {
+		tlsOpts = append(tlsOpts, disableHTTP2)
 	}`,
 		`
- `,
+
+	// +kubebuilder:docs-gen:collapse=Manager Setup`,
 	)
-	hackutils.CheckError("insert doc marker existing setup main.go", err)
+	hackutils.CheckError("adding manager setup collapse marker main.go", err)
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, path),

--- a/hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go
+++ b/hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go
@@ -44,12 +44,14 @@ func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
 	}
 	if cronJob.Spec.FailedJobsHistoryLimit == nil {
 		cronJob.Spec.FailedJobsHistoryLimit = new(int32)
-		*cronJob.Spec.FailedJobsHistoryLimit = d.DefaultFailedJobsHistoryLimit
+		*cronJob.Spec	.FailedJobsHistoryLimit = d.DefaultFailedJobsHistoryLimit
 	}
 }
 `
 
 const cronJobValidationFunction = `
+// +kubebuilder:docs-gen:collapse=Webhook Setup and Defaulting
+
 // validateCronJob validates the fields of a CronJob object.
 func validateCronJob(cronjob *batchv2.CronJob) error {
 	var allErrs field.ErrorList


### PR DESCRIPTION
# 📖 (docs): Limit code rendering to relevant sections in multiversion webhook tutorial


Fixes #5232

### Problem
The multiversion webhook tutorial was showing entire file contents instead of only the relevant code sections:
- **Webhook v2**: The entire webhook file was rendered, including imports, defaulting logic, and webhook setup
- **main.go**: Too much boilerplate was visible instead of focusing on the relevant setup sections

### Root Cause
The generation scripts in `hack/docs/internal/multiversion-tutorial/` were missing collapse markers to hide non-essential code from the rendered documentation.

### Changes Made

#### File 1: `hack/docs/internal/multiversion-tutorial/generate_multiversion.go`

**updateWebhookV2() function** - Added imports collapse marker:

```go
	// Add collapse marker after the import block to hide imports
	err = pluginutil.InsertCode(
		filepath.Join(sp.ctx.Dir, path),
		`batchv2 "tutorial.kubebuilder.io/project/api/v2"
)`,
		`

// +kubebuilder:docs-gen:collapse=Imports`)
	hackutils.CheckError("adding imports collapse marker to webhook v2", err)
```

**updateMain() function** - Added Manager Setup collapse marker (Lin:

```go
	err = pluginutil.InsertCode(
		filepath.Join(sp.ctx.Dir, path),
		`if !enableHTTP2 {
		tlsOpts = append(tlsOpts, disableHTTP2)
	}`,
		`

	// +kubebuilder:docs-gen:collapse=Manager Setup`,
	)
	hackutils.CheckError("adding manager setup collapse marker main.go", err)
```

**updateMain() function** - Removed existing setup doc marker insertion :

```go
	err = pluginutil.InsertCode(
		filepath.Join(sp.ctx.Dir, path),
		`if err := (&controller.CronJobReconciler{
		Client: mgr.GetClient(),
		Scheme: mgr.GetScheme(),
	}).SetupWithManager(mgr); err != nil {
		setupLog.Error(err, "unable to create controller", "controller", "CronJob")
		os.Exit(1)
	}`,
		`
 `,
	)
	hackutils.CheckError("insert doc marker existing setup main.go", err)
```

---

#### File 2: `hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go`

**cronJobValidationFunction constant** - Added collapse marker before validation functions :

```go
 const cronJobValidationFunction = `
+// +kubebuilder:docs-gen:collapse=Webhook Setup and Defaulting

 // validateCronJob validates the fields of a CronJob object.
 func validateCronJob(cronjob *batchv2.CronJob) error {
```


### Result

#### Webhook v2 (`cronjob_webhook.go`)
- **Collapsed**: Apache License, Imports, Webhook Setup and Defaulting
- **Visible**: Only validation functions (`validateCronJob`, `validateCronJobName`, `validateCronJobSpec`, `validateScheduleFormat`)


<img width="872" height="781" alt="Screenshot from 2026-01-14 21-26-23" src="https://github.com/user-attachments/assets/ef1f343c-ce73-4095-989d-d9130715e1f9" />

#### main.go
- **Collapsed**: Apache License, Imports, existing setup, Manager Setup (flags and HTTP2 config)
- **Visible**: Webhook TLS options, metrics server options, manager creation, controller setup, and webhook registration




<img width="872" height="781" alt="Screenshot from 2026-01-14 21-25-26" src="https://github.com/user-attachments/assets/381c799b-1692-44cf-8991-7bb1f9231098" />

