### PR TITLE
📖 Recommend options of migrations

### DIFF
--- a/docs/book/src/migrations.md
+++ b/docs/book/src/migrations.md
@@ -41,7 +41,11 @@ For further information on the project layout, see [What's in a basic project?][
 
 ## Migration Options
 
-### Automated Updates via GitHub Actions
+
+> [!TIP]
+> To reduce effort, we recommend enabling the [AutoUpdate Plugin][autoupdate-v1-alpha] (GitHub Actions). You can also run [alpha update](./reference/commands/alpha_update.md) locally—both use the same update logic. Use the other options mainly for older projects that do not have `cliVersion` in the `PROJECT` file as a one-time step to reach a supported version; after that, use these workflows for future updates (older versions cannot use these automation features).
+
+###  **(Recommended)** AutoUpdate/GitHub Action: Get Notified of New Kubebuilder Releases via Issues with a PR Link to Review and Upgrade
 
 The [AutoUpdate Plugin][autoupdate-v1-alpha] scaffolds an action that automatically monitors for new Kubebuilder releases and
 opens a GitHub Issue with a Pull Request compare link when updates are available. This is ideal for
@@ -65,7 +69,7 @@ kubebuilder edit --plugins="autoupdate/v1-alpha"
 
 See the [AutoUpdate Plugin documentation][autoupdate-v1-alpha] for complete details.
 
-### Using Alpha Update Locally
+### **(Recommended)** Use `alpha update` to Upgrade Without Losing Customisations (Logic Behind AutoUpdate/GitHub Action)
 
 If you prefer to run updates locally instead of relying on GitHub Actions, you can use the same logic
 as the [AutoUpdate Plugin][autoupdate-v1-alpha] directly from your command line.


### PR DESCRIPTION
Since there are multiple (at least four) migration options, users may
appreciate guidance on which is the recommended one, especially for
straightforward cases.

----

Although the [How to contribute to docs](https://github.com/kubernetes-sigs/kubebuilder/blob/master/CONTRIBUTING.md#how-to-contribute-to-docs) section refers to the Kubernetes docs style guide, I decided to follow [the pre-existing convention](https://github.com/kubernetes-sigs/kubebuilder/blob/66bfbc11338c8ead832f5583b5ade892dbb16134/docs/book/src/introduction.md?plain=1#L1-L2) presenting a tip note as it seems the Kubebuilder documenation does not use the [Hugo Shortcodes](https://kubernetes.io/docs/contribute/style/style-guide/#shortcodes) anywhere.

----

This PR stems from discussion [thread I opened on the Slack](https://kubernetes.slack.com/archives/CAR30FCJZ/p1768737780914779) where @camilamacedo86 kindly (and patiently) addressed my questions about the migrations guide.
