### PR TITLE
📖 docs: show only relevant webhook sections in kustomization tutorial

### DIFF
--- a/docs/book/src/cronjob-tutorial/running-webhook.md
+++ b/docs/book/src/cronjob-tutorial/running-webhook.md
@@ -31,10 +31,21 @@ To know more, see: [Using Kind For Development Purposes and CI](./../reference/k
 ## Deploy Webhooks
 
 You need to enable the webhook and cert manager configuration through kustomize.
-`config/default/kustomization.yaml` should now look like the following:
+`config/default/kustomization.yaml` should have the following webhook-related sections uncommented:
 
+**Resources** - Add the webhook and cert-manager resources:
 ```yaml
-{{#include ./testdata/project/config/default/kustomization.yaml}}
+{{#include ./testdata/project/config/default/kustomization.yaml:webhook-resources}}
+```
+
+**Patches** - Add the webhook manager patch:
+```yaml
+{{#include ./testdata/project/config/default/kustomization.yaml:webhook-patch}}
+```
+
+**Replacements** - Add the webhook certificate replacements:
+```yaml
+{{#include ./testdata/project/config/default/kustomization.yaml:webhook-replacements}}
 ```
 
 And `config/crd/kustomization.yaml` should now look like the following:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -18,11 +18,13 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+# ANCHOR: webhook-resources
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
+# ANCHOR_END: webhook-resources
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -48,11 +50,13 @@ patches:
   target:
     kind: Deployment
 
+# ANCHOR: webhook-patch
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - path: manager_webhook_patch.yaml
   target:
     kind: Deployment
+# ANCHOR_END: webhook-patch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
@@ -117,6 +121,7 @@ replacements:
          index: 1
          create: true
 
+ # ANCHOR: webhook-replacements
  - source: # Uncomment the following block if you have any webhook
      kind: Service
      version: v1
@@ -215,6 +220,7 @@ replacements:
          delimiter: '/'
          index: 1
          create: true
+# ANCHOR_END: webhook-replacements
 
 # - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
 #     kind: Certificate

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -18,11 +18,13 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+# ANCHOR: webhook-resources
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 - ../certmanager
+# ANCHOR_END: webhook-resources
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -48,11 +50,13 @@ patches:
   target:
     kind: Deployment
 
+# ANCHOR: webhook-patch
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - path: manager_webhook_patch.yaml
   target:
     kind: Deployment
+# ANCHOR_END: webhook-patch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
@@ -117,6 +121,7 @@ replacements:
          index: 1
          create: true
 
+ # ANCHOR: webhook-replacements
  - source: # Uncomment the following block if you have any webhook
      kind: Service
      version: v1
@@ -215,6 +220,7 @@ replacements:
          delimiter: '/'
          index: 1
          create: true
+# ANCHOR_END: webhook-replacements
 
  - source: # Uncomment the following block if you have a ConversionWebhook (--conversion)
      kind: Certificate

--- a/hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go
+++ b/hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go
@@ -44,7 +44,7 @@ func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
 	}
 	if cronJob.Spec.FailedJobsHistoryLimit == nil {
 		cronJob.Spec.FailedJobsHistoryLimit = new(int32)
-		*cronJob.Spec	.FailedJobsHistoryLimit = d.DefaultFailedJobsHistoryLimit
+		*cronJob.Spec.FailedJobsHistoryLimit = d.DefaultFailedJobsHistoryLimit
 	}
 }
 `


### PR DESCRIPTION
# 📖 (docs): Show only relevant webhook sections in kustomization tutorial
Fixes #5227

## Problem
The [running-webhook.md](file:///home/badis/Desktop/codebase/kubebuilder/docs/book/src/cronjob-tutorial/running-webhook.md) page in the cronjob tutorial was showing the entire 235-line [config/default/kustomization.yaml](file:///home/badis/Desktop/codebase/kubebuilder/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml) file instead of only webhook related parts.

## Root Cause
The documentation used `{{#include ...}}` to include the entire file contents.

## Changes 

### 1. File: [hack/docs/internal/cronjob-tutorial/generate_cronjob.go](file:///home/badis/Desktop/codebase/kubebuilder/hack/docs/internal/cronjob-tutorial/generate_cronjob.go)
**[updateKustomization()](file:///home/badis/Desktop/codebase/kubebuilder/hack/docs/internal/cronjob-tutorial/generate_cronjob.go#610-701) function**:
- Added `ANCHOR` markers to the generated [kustomization.yaml](file:///home/badis/Desktop/codebase/kubebuilder/docs/book/src/cronjob-tutorial/testdata/project/config/crd/kustomization.yaml) to wrap webhook-related sections:
  - `# ANCHOR: webhook-resources` ... `# ANCHOR_END: webhook-resources`
  - `# ANCHOR: webhook-patch` ... `# ANCHOR_END: webhook-patch`
  - `# ANCHOR: webhook-replacements` ... `# ANCHOR_END: webhook-replacements`
  
This introduces the usage of mdBook anchors to the project documentation

### 2. File: [docs/book/src/cronjob-tutorial/running-webhook.md](file:///home/badis/Desktop/codebase/kubebuilder/docs/book/src/cronjob-tutorial/running-webhook.md)
- Updated the file to use anchored includes (e.g., `{{#include ...:webhook-resources}}`) instead of including the full file.
- Split the configuration display into logical sections (Resources, Patches, Replacements) for better readability.

### 3. File: [docs/book/src/multiversion-tutorial/webhook_v2_implementaton.go](file:///home/badis/Desktop/codebase/kubebuilder/docs/book/src/multiversion-tutorial/webhook_v2_implementaton.go)
- Removed extra space at line 47 multiversion-tutorial/webhook_v2_implementaton.go that was mistakenly commited in  PR #5372    .

## Result


**[running-webhook.md](file:///home/badis/Desktop/codebase/kubebuilder/docs/book/src/cronjob-tutorial/running-webhook.md) now shows focused snippets:**
- **Resources**: Only the `../webhook` and `../certmanager` entries
- **Patches**: Only the `manager_webhook_patch.yaml` entry
- **Replacements**: Only the cert-manager certificate and service replacements

<img width="984" height="841" alt="Screenshot from 2026-01-19 20-07-42" src="https://github.com/user-attachments/assets/f47cb380-2582-4367-9db2-d70ff8d4a922" />

