### PR TITLE
🐛 (helm/v2-alpha): Prevent Custom Resource instances from being added to extras directory

### DIFF
--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -121,7 +121,18 @@ The plugin creates a chart layout that matches your `config/`:
         └── my-config.yaml
 ```
 
-**Note:** The chart structure reflects the actual resources in your project. Resources that don't match the standard scaffold layout (custom Services, ConfigMaps, Secrets, etc.) are automatically placed in `templates/extras/` with proper Helm templating applied (namePrefix, labels, etc.) when present.
+<aside class="note">
+<H1>Chart Structure</H1>
+
+The chart structure mirrors your project's resources:
+
+- Standard resources (RBAC, manager, webhooks, CRDs) go into dedicated template directories
+- Other resources (Services, ConfigMaps, Secrets) go into `templates/extras/` with Helm templating
+- **Custom Resource instances** from `config/samples/` are **not included in the chart**
+
+By default, `make build-installer` does not include samples in `dist/install.yaml`. If you manually add CR instances to your kustomize output, the Helm plugin will ignore them.
+
+</aside>
 
 <aside class="note">
 <H1> Why CRDs are added under templates? </H1>
@@ -295,7 +306,7 @@ prometheus:
   enable: false
 ```
 
-### Installation Tip
+### Installation
 
 Install the chart into a namespace using Helm flags (the chart does not create namespaces):
 


### PR DESCRIPTION
After we added the logic to include any extra resources from `extra/` (when present), the goal was to allow bundling additional objects like ConfigMaps, Services, etc.

While `make build-installer` doesn’t include `config/samples` by default, users may customize their project (e.g., tweak the kustomization) or pass an `install.yaml` that includes samples (for example via the Helm plugin). With the current logic, those sample resources end up being ignored.

## Why it matters

If a user changes the default kustomize setup to include samples, installing the Helm chart can fail with an ownership/metadata error like, example:

```
Error: INSTALLATION FAILED: Unable to continue with install: CustomResourceDefinition "argocdcommitstatuses.promoter.argoproj.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "promoter"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "promoter-system"
```

## Important note about CRs (Custom Resources)

A key Helm limitation here is ordering:

- If a chart installs a CRD and also installs CRs of that type, Kubernetes needs the CRD to be registered first.
- Helm does not reliably guarantee “wait until the CRD is registered, then apply CRs”.

Because of that:
- Kubebuilder does not generate CRs in this plugin (it generates CRDs + controller/operator manifests).
- If users want to ship CRs in the same Helm chart, they typically need Helm hooks (e.g. post-install / post-upgrade) or a separate step to apply CRs after the chart is installed. A common approach is define the CRs in the Notes. 

Closes: https://github.com/kubernetes-sigs/kubebuilder/discussions/5386