### PR TITLE
✨ (go/v4): Add autocomplete support in .devcontainer/post-install.sh

### DIFF
--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           subFolder: testdata/project-v4
           runCmd: |
+            # Source bash-completion for all tests
+            source /usr/share/bash-completion/bash_completion
+            
             # Verify Tools Installation
             echo "Verifying installed tools..."
             docker --version
@@ -32,6 +35,43 @@ jobs:
             kubectl version --client
             go version
             echo "All required tools are installed"
+            
+            # Verify common-utils feature is installed
+            echo "Verifying common-utils feature..."
+            if ! command -v zsh &> /dev/null; then
+              echo "ERROR: common-utils feature not installed (zsh missing)"
+              exit 1
+            fi
+            echo "common-utils feature is installed"
+            
+            # Verify bash-completion setup
+            echo "Verifying bash-completion configuration..."
+            if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc; then
+              echo "ERROR: bash-completion not configured in .bashrc"
+              exit 1
+            fi
+            echo "bash-completion is configured in .bashrc"
+            
+            # Verify completion files exist
+            echo "Verifying completion files..."
+            for cmd in kubectl kind kubebuilder docker; do
+              if [ ! -f "/usr/share/bash-completion/completions/${cmd}" ]; then
+                echo "ERROR: Completion file for ${cmd} not found"
+                exit 1
+              fi
+              echo "${cmd} completion file exists"
+            done
+            echo "All completion files are present"
+            
+            # Test bash-completion works
+            echo "Testing bash-completion functionality..."
+            # Bash-completion uses lazy-loading, so manually source completion to test
+            source /usr/share/bash-completion/completions/kubectl
+            if ! complete -p kubectl &> /dev/null; then
+              echo "ERROR: kubectl completions not loaded"
+              exit 1
+            fi
+            echo "Bash completions are working"
 
             # Test Docker-in-Docker
             echo "Testing Docker-in-Docker functionality..."

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/post-install.sh
@@ -3,29 +3,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/post-install.sh
@@ -3,29 +3,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/post-install.sh
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/post-install.sh
@@ -3,29 +3,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -38,7 +38,10 @@ const devContainerTemplate = `{
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],
@@ -69,29 +72,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/testdata/project-v4-multigroup/.devcontainer/post-install.sh
+++ b/testdata/project-v4-multigroup/.devcontainer/post-install.sh
@@ -3,29 +3,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do

--- a/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/testdata/project-v4-with-plugins/.devcontainer/post-install.sh
+++ b/testdata/project-v4-with-plugins/.devcontainer/post-install.sh
@@ -3,29 +3,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -6,7 +6,10 @@
       "moby": false,
       "dockerDefaultAddressPool": "base=172.30.0.0/16,size=24"
     },
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "upgradePackages": true
+    }
   },
 
   "runArgs": ["--privileged", "--init"],

--- a/testdata/project-v4/.devcontainer/post-install.sh
+++ b/testdata/project-v4/.devcontainer/post-install.sh
@@ -3,29 +3,65 @@ set -euo pipefail
 
 echo "Installing Kubebuilder development tools..."
 
-ARCH=$(go env GOARCH)
+# Verify running as root (required for installing to /usr/local/bin and /etc)
+if [ "$(id -u)" -ne 0 ]; then
+  echo "ERROR: This script must be run as root"
+  exit 1
+fi
+
+# Detect architecture using uname
+MACHINE=$(uname -m)
+case "${MACHINE}" in
+  x86_64)
+    ARCH="amd64"
+    ;;
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  *)
+    echo "WARNING: Unsupported architecture ${MACHINE}, defaulting to amd64"
+    ARCH="amd64"
+    ;;
+esac
+
+BASH_COMPLETIONS_DIR="/usr/share/bash-completion/completions"
+
+# Enable bash-completion in .bashrc
+if ! grep -q "source /usr/share/bash-completion/bash_completion" ~/.bashrc 2>/dev/null; then
+  echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc
+  echo "Added bash-completion to .bashrc"
+fi
 
 # Install kind
 if ! command -v kind &> /dev/null; then
-  curl -Lo ./kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
-  chmod +x ./kind
-  mv ./kind /usr/local/bin/kind
+  TMP_KIND=$(mktemp)
+  curl -Lo "${TMP_KIND}" "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  chmod +x "${TMP_KIND}"
+  mv "${TMP_KIND}" /usr/local/bin/kind
 fi
+kind completion bash > "${BASH_COMPLETIONS_DIR}/kind" 2>/dev/null || true
 
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
-  curl -L -o kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
-  chmod +x kubebuilder
-  mv kubebuilder /usr/local/bin/
+  TMP_KB=$(mktemp)
+  curl -L -o "${TMP_KB}" "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  chmod +x "${TMP_KB}"
+  mv "${TMP_KB}" /usr/local/bin/kubebuilder
 fi
+kubebuilder completion bash > "${BASH_COMPLETIONS_DIR}/kubebuilder" 2>/dev/null || true
 
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  chmod +x kubectl
-  mv kubectl /usr/local/bin/kubectl
+  TMP_KUBECTL=$(mktemp)
+  curl -Lo "${TMP_KUBECTL}" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  chmod +x "${TMP_KUBECTL}"
+  mv "${TMP_KUBECTL}" /usr/local/bin/kubectl
 fi
+kubectl completion bash > "${BASH_COMPLETIONS_DIR}/kubectl" 2>/dev/null || true
+
+# Docker completion
+docker completion bash > "${BASH_COMPLETIONS_DIR}/docker" 2>/dev/null || true
 
 # Wait for Docker to be ready
 for i in {1..30}; do


### PR DESCRIPTION
Add bash autocomplete for development tools (kind, kubebuilder, kubectl, docker) in the DevContainer post-install script to improve CLI usability during development.

Motivation: https://github.com/kubernetes-sigs/kubebuilder/pull/5144

Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/5144
