### PR TITLE
✨ feat(cli): add short description to tab completion in bash

### DIFF
--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -37,7 +37,7 @@ MacOS:
   $ %[1]s completion bash > /usr/local/etc/bash_completion.d/%[1]s
 `, c.commandName),
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Root().GenBashCompletion(os.Stdout)
+			return cmd.Root().GenBashCompletionV2(os.Stdout, true)
 		},
 	}
 }


### PR DESCRIPTION
This PR enhances the tab completion in `bash` with a short description for all available subcommands and flags, similar to `kubectl` and `docker` tab completion.

### Current completion in bash:
```
$ kubebuilder
alpha       completion  create      edit        help        init        version

$ kubebuilder init --
--domain                 --license                --owner=                 --project-name           --project-version=       --skip-go-version-check
--domain=                --license=               --plugins                --project-name=          --repo
--fetch-deps             --owner                  --plugins=               --project-version        --repo=
```
### New completion in bash:
```
$ kubebuilder
alpha       (Alpha-stage subcommands)                   help        (Help about any command)
completion  (Load completions for the specified shell)  init        (Initialize a new project)
create      (Scaffold a Kubernetes API or webhook)      version     (Print the kubebuilder version)
edit        (Update the project configuration)

$ kubebuilder init --
--domain                 (domain for groups)
--fetch-deps             (ensure dependencies are downloaded)
--help                   (help for init)
--license                (license to use to boilerplate, may be one of 'apache2', 'none')
--owner                  (owner to add to the copyright)
--plugins                (plugin keys to be used for this subcommand execution)
--project-name           (name of this project)
--project-version        (project version)
--repo                   (name to use for go module (e.g., github.com/user/repo), defaults to the go package of the current working directory.)
--skip-go-version-check  (if specified, skip checking the Go version)
```
This greatly improves the UX and allows us to add examples to the short descriptions in follow-ups.