### PR TITLE
🐛 (helm/v2-alpha): wrap webhook resources with .Values.webhook.enable conditional

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -27,3 +28,4 @@ webhooks:
           resources:
             - cronjobs
       sideEffects: None
+{{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -27,3 +28,4 @@ webhooks:
           resources:
             - cronjobs
       sideEffects: None
+{{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     selector:
         app.kubernetes.io/name: {{ include "project.name" . }}
         control-plane: controller-manager
+{{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -47,3 +48,4 @@ webhooks:
           resources:
             - cronjobs
       sideEffects: None
+{{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -47,3 +48,4 @@ webhooks:
           resources:
             - cronjobs
       sideEffects: None
+{{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     selector:
         app.kubernetes.io/name: {{ include "project.name" . }}
         control-plane: controller-manager
+{{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -27,3 +28,4 @@ webhooks:
           resources:
             - memcacheds
       sideEffects: None
+{{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.webhook.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
     selector:
         app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
         control-plane: controller-manager
+{{- end }}


### PR DESCRIPTION
Webhook Service and Webhook Configurations (ValidatingWebhookConfiguration, MutatingWebhookConfiguration) are now only deployed when .Values.webhook.enable is true. Previously, these resources were always created regardless of the webhook.enable setting.
