### PR TITLE
✨ (helm/v2-alpha): Add Helm chart tests and call in the GitHub action to validate the chart

### DIFF
--- a/.github/workflows/test-helm-book.yml
+++ b/.github/workflows/test-helm-book.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Verify Helm installation
         run: helm version
 
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
+
       - name: Lint Helm chart
         run: |
           helm lint ${{ matrix.folder }}/dist/chart
@@ -100,4 +105,8 @@ jobs:
         working-directory: ${{ matrix.folder }}
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test ${{ steps.project.outputs.name}} --namespace ${{ steps.project.outputs.name}}-system
 

--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -71,8 +71,13 @@ jobs:
         run: |
           cd testdata/project-v4-with-plugins/
           go mod tidy
-          make docker-build IMG=project-v4-with-plugins:v0.1.0
-          kind load docker-image project-v4-with-plugins:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Install Prometheus Operator CRDs
         run: |
@@ -98,12 +103,16 @@ jobs:
       - name: Deploy manager via Helm
         working-directory: testdata/project-v4-with-plugins
         run: |
-          make helm-deploy IMG=project-v4-with-plugins:v0.1.0 HELM_EXTRA_ARGS="--set prometheus.enable=true"
+          make helm-deploy IMG=controller:latest HELM_EXTRA_ARGS="--set prometheus.enable=true"
 
       - name: Check Helm release status
         working-directory: testdata/project-v4-with-plugins
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test project-v4-with-plugins --namespace project-v4-with-plugins-system
 
       - name: Delete kind cluster
         if: always()
@@ -161,8 +170,13 @@ jobs:
       - name: Build and load Docker image
         working-directory: test-helm-no-webhooks
         run: |
-          make docker-build IMG=test-helm-no-webhooks:v0.1.0
-          kind load docker-image test-helm-no-webhooks:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Lint Helm chart
         working-directory: test-helm-no-webhooks
@@ -171,12 +185,17 @@ jobs:
       - name: Deploy manager via Helm
         working-directory: test-helm-no-webhooks
         run: |
-          make helm-deploy IMG=test-helm-no-webhooks:v0.1.0
+          make helm-deploy IMG=controller:latest
 
       - name: Verify deployment is working
         working-directory: test-helm-no-webhooks
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        working-directory: test-helm-no-webhooks
+        run: |
+          helm test test-helm-no-webhooks --namespace test-helm-no-webhooks-system
 
       - name: Delete kind cluster
         if: always()

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Prepare project
         run: |
           go mod tidy
-          make docker-build IMG=project:v0.1.0
-          kind load docker-image project:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Install Helm
         run: |
@@ -72,3 +77,7 @@ jobs:
       - name: Check Helm release status
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test project --namespace project-system

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  {{- if .Values.certManager.enable }}
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  containers:
+    - name: test
+      image: bitnami/kubectl:latest
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          echo "=================================="
+          echo "Helm Chart Deployment Test"
+          echo "=================================="
+          echo "Release: {{ .Release.Name }}"
+          echo "Namespace: {{ .Release.Namespace }}"
+          echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
+          echo ""
+
+          {{- if .Values.certManager.enable }}
+          echo "Step 1/3: Validating cert-manager certificates..."
+          if ! kubectl wait --for=condition=Ready certificate --all \
+            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
+            echo "Warning: No certificates found or certificates not ready"
+            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          else
+            echo "SUCCESS: Certificates are ready"
+          fi
+          echo ""
+          {{- else }}
+          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
+          echo ""
+          {{- end }}
+
+          echo "Step 2/3: Verifying manager deployment is available..."
+          if ! kubectl wait --for=condition=Available deployment \
+            -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} --timeout=5m; then
+            echo "ERROR: Manager deployment failed to become available"
+            echo ""
+            echo "Deployment status:"
+            kubectl get deployments -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager deployment is available"
+          echo ""
+
+          echo "Step 3/3: Verifying manager pod is running..."
+          POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          
+          if [ -z "$POD_STATUS" ]; then
+            echo "ERROR: No manager pod found"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+
+          if [ "$POD_STATUS" != "Running" ]; then
+            echo "ERROR: Manager pod is not running (status: $POD_STATUS)"
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod logs:"
+            kubectl logs -n {{ .Release.Namespace }} -l control-plane=controller-manager --tail=50 || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager pod is running"
+          echo ""
+
+          echo "=================================="
+          echo "All tests passed successfully!"
+          echo "=================================="
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test-chart.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Prepare project
         run: |
           go mod tidy
-          make docker-build IMG=project:v0.1.0
-          kind load docker-image project:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Install Helm
         run: |
@@ -72,3 +77,7 @@ jobs:
       - name: Check Helm release status
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test project --namespace project-system

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  {{- if .Values.certManager.enable }}
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  containers:
+    - name: test
+      image: bitnami/kubectl:latest
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          echo "=================================="
+          echo "Helm Chart Deployment Test"
+          echo "=================================="
+          echo "Release: {{ .Release.Name }}"
+          echo "Namespace: {{ .Release.Namespace }}"
+          echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
+          echo ""
+
+          {{- if .Values.certManager.enable }}
+          echo "Step 1/3: Validating cert-manager certificates..."
+          if ! kubectl wait --for=condition=Ready certificate --all \
+            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
+            echo "Warning: No certificates found or certificates not ready"
+            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          else
+            echo "SUCCESS: Certificates are ready"
+          fi
+          echo ""
+          {{- else }}
+          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
+          echo ""
+          {{- end }}
+
+          echo "Step 2/3: Verifying manager deployment is available..."
+          if ! kubectl wait --for=condition=Available deployment \
+            -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} --timeout=5m; then
+            echo "ERROR: Manager deployment failed to become available"
+            echo ""
+            echo "Deployment status:"
+            kubectl get deployments -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager deployment is available"
+          echo ""
+
+          echo "Step 3/3: Verifying manager pod is running..."
+          POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          
+          if [ -z "$POD_STATUS" ]; then
+            echo "ERROR: No manager pod found"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+
+          if [ "$POD_STATUS" != "Running" ]; then
+            echo "ERROR: Manager pod is not running (status: $POD_STATUS)"
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod logs:"
+            kubectl logs -n {{ .Release.Namespace }} -l control-plane=controller-manager --tail=50 || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager pod is running"
+          echo ""
+
+          echo "=================================="
+          echo "All tests passed successfully!"
+          echo "=================================="
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Prepare project
         run: |
           go mod tidy
-          make docker-build IMG=project:v0.1.0
-          kind load docker-image project:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Install Helm
         run: |
@@ -72,3 +77,7 @@ jobs:
       - name: Check Helm release status
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test project --namespace project-system

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  {{- if .Values.certManager.enable }}
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  containers:
+    - name: test
+      image: bitnami/kubectl:latest
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          echo "=================================="
+          echo "Helm Chart Deployment Test"
+          echo "=================================="
+          echo "Release: {{ .Release.Name }}"
+          echo "Namespace: {{ .Release.Namespace }}"
+          echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
+          echo ""
+
+          {{- if .Values.certManager.enable }}
+          echo "Step 1/3: Validating cert-manager certificates..."
+          if ! kubectl wait --for=condition=Ready certificate --all \
+            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
+            echo "Warning: No certificates found or certificates not ready"
+            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          else
+            echo "SUCCESS: Certificates are ready"
+          fi
+          echo ""
+          {{- else }}
+          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
+          echo ""
+          {{- end }}
+
+          echo "Step 2/3: Verifying manager deployment is available..."
+          if ! kubectl wait --for=condition=Available deployment \
+            -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} --timeout=5m; then
+            echo "ERROR: Manager deployment failed to become available"
+            echo ""
+            echo "Deployment status:"
+            kubectl get deployments -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager deployment is available"
+          echo ""
+
+          echo "Step 3/3: Verifying manager pod is running..."
+          POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          
+          if [ -z "$POD_STATUS" ]; then
+            echo "ERROR: No manager pod found"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+
+          if [ "$POD_STATUS" != "Running" ]; then
+            echo "ERROR: Manager pod is not running (status: $POD_STATUS)"
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod logs:"
+            kubectl logs -n {{ .Release.Namespace }} -l control-plane=controller-manager --tail=50 || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager pod is running"
+          echo ""
+
+          echo "=================================="
+          echo "All tests passed successfully!"
+          echo "=================================="
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -30,8 +30,9 @@ The **helm/v2-alpha** plugin converts the bundle (`dist/install.yaml`) into a He
 - **Preserves Customizations**: Keeps env vars, labels, annotations, and patches.
 - **Structured Output**: Templates follow your `config/` directory layout.
 - **Smart Values**: `values.yaml` includes only actual configurable parameters.
-- **File Preservation**: `Chart.yaml` is never overwritten. Without `--force`, `values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, and `.github/workflows/test-chart.yml` are preserved.
+- **File Preservation**: `Chart.yaml` is never overwritten. Without `--force`, `values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `templates/tests/test-manager-ready.yaml` and `.github/workflows/test-chart.yml` are preserved.
 - **Handles Custom Resources**: Resources not matching standard layout (custom Services, ConfigMaps, etc.) are placed in `templates/extras/` with proper templating.
+- **Built-in Tests**: Includes Helm test templates to validate deployment health.
 
 ## When to Use It
 
@@ -118,6 +119,8 @@ The plugin creates a chart layout that matches your `config/`:
     │   └── webhook-service.yaml
     ├── monitoring/
     │   └── servicemonitor.yaml
+    ├── tests/
+    │   └── test-manager-ready.yaml
     └── extras/                  # Custom resources (if any)
         ├── my-service.yaml
         └── my-config.yaml
@@ -340,13 +343,27 @@ helm install my-release ./dist/chart \
 
 The Makefile targets use sensible defaults extracted from your project configuration (namespace from manifests, release name from project name, chart directory from `--output-dir` flag).
 
+### Testing
+
+The generated chart includes Helm tests to verify deployment health:
+
+```shell
+# Run tests after installation
+helm test my-release --namespace my-project-system
+```
+
+Tests verify:
+- Manager deployment is available
+- Manager pod is running
+- Cert-manager certificates are ready (if cert-manager is enabled)
+
 ## Flags
 
 | Flag                | Description                                                                 |
 |---------------------|-----------------------------------------------------------------------------|
 | **--manifests**     | Path to YAML file containing Kubernetes manifests (default: `dist/install.yaml`) |
 | **--output-dir** string | Output directory for chart (default: `dist`)                                |
-| **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`) |
+| **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-manager-ready.yaml`, `test-chart.yml`) |
 
 <aside class="note">
 <H1> Examples </H1>

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -81,9 +81,10 @@ distribution of your project. When enabled, adds Helm helpers targets to Makefil
   %[1]s edit --plugins=%[2]s  # Generate/update Helm chart in dist/chart/
 
 **NOTE**: Chart.yaml is never overwritten (contains user-managed version info).
-Without --force, the plugin also preserves values.yaml, NOTES.txt, _helpers.tpl, .helmignore, and
-.github/workflows/test-chart.yml. All template files in templates/ are always regenerated
-to match your current kustomize output. Use --force to regenerate all files except Chart.yaml.
+Without --force, the plugin also preserves values.yaml, NOTES.txt, _helpers.tpl, .helmignore,
+templates/tests/test-manager-ready.yaml, and .github/workflows/test-chart.yml.
+All other template files in templates/ are always regenerated to match your current
+kustomize output. Use --force to regenerate all files except Chart.yaml.
 
 The generated chart structure mirrors your config/ directory:
 <output>/chart/
@@ -96,6 +97,7 @@ The generated chart structure mirrors your config/ directory:
     ├── rbac/
     ├── manager/
     ├── webhook/
+    ├── tests/
     └── ...
 `, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/edit_kustomize.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/edit_kustomize.go
@@ -152,6 +152,11 @@ func (s *editKustomizeScaffolder) Scaffold() error {
 			OutputDir: s.outputDir,
 			Force:     s.force,
 		},
+		&charttemplates.TestManagerReady{
+			HasWebhooks: hasWebhooks,
+			OutputDir:   s.outputDir,
+			Force:       s.force,
+		},
 	}
 
 	// Only scaffold the generic ServiceMonitor when the project does NOT already

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/consts.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/consts.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+const defaultOutputDir = "dist"

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -23,8 +23,6 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
-const defaultOutputDir = "dist"
-
 var _ machinery.Template = &ServiceMonitor{}
 
 // ServiceMonitor scaffolds a ServiceMonitor for Prometheus monitoring in the Helm chart

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/test_manager_ready.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/test_manager_ready.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &TestManagerReady{}
+
+// TestManagerReady scaffolds a Helm test that verifies the manager deployment is healthy.
+//
+// The test validates deployment readiness in three steps:
+//  1. Cert-manager certificates are Ready (if cert-manager is enabled)
+//  2. Manager deployment is Available (waits up to 5 minutes)
+//  3. Manager pod is Running (validates pod actually started)
+//
+// The test pod uses a dedicated ServiceAccount, Role, and RoleBinding
+// and follows security best practices with a restrictive security context.
+type TestManagerReady struct {
+	machinery.TemplateMixin
+	machinery.ProjectNameMixin
+
+	// OutputDir specifies the output directory for the chart
+	OutputDir string
+
+	// HasWebhooks is currently unused but reserved for future webhook-specific test enhancements
+	HasWebhooks bool
+
+	// Force if true allows overwriting the scaffolded file
+	Force bool
+}
+
+// SetTemplateDefaults implements machinery.Template
+func (f *TestManagerReady) SetTemplateDefaults() error {
+	if f.Path == "" {
+		outputDir := f.OutputDir
+		if outputDir == "" {
+			outputDir = defaultOutputDir
+		}
+		f.Path = filepath.Join(outputDir, "chart", "templates", "tests", "test-manager-ready.yaml")
+	}
+
+	prefix := f.ProjectName
+	f.TemplateBody = fmt.Sprintf(testManagerReadyTemplate,
+		prefix, prefix, // ServiceAccount metadata (name, resourceName)
+		prefix, prefix, // Role metadata (name, resourceName)
+		prefix, prefix, prefix, prefix, // RoleBinding (name, resourceName, roleRef, subject)
+		prefix, prefix, prefix, // Pod (name, resourceName, serviceAccountName)
+	)
+
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
+
+	return nil
+}
+
+const testManagerReadyTemplate = `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ "{{ .Release.Service }}" }}
+    app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+    helm.sh/chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version | replace \"+\" \"_\" }}" }}
+    app.kubernetes.io/instance: {{ "{{ .Release.Name }}" }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ "{{ .Release.Service }}" }}
+    app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+    helm.sh/chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version | replace \"+\" \"_\" }}" }}
+    app.kubernetes.io/instance: {{ "{{ .Release.Name }}" }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  {{ "{{- if .Values.certManager.enable }}" }}
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+  {{ "{{- end }}" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ "{{ .Release.Service }}" }}
+    app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+    helm.sh/chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version | replace \"+\" \"_\" }}" }}
+    app.kubernetes.io/instance: {{ "{{ .Release.Name }}" }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+    namespace: {{ "{{ .Release.Namespace }}" }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ "{{ .Release.Service }}" }}
+    app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+    helm.sh/chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version | replace \"+\" \"_\" }}" }}
+    app.kubernetes.io/instance: {{ "{{ .Release.Name }}" }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+  containers:
+    - name: test
+      image: bitnami/kubectl:latest
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          echo "=================================="
+          echo "Helm Chart Deployment Test"
+          echo "=================================="
+          echo "Release: {{ "{{ .Release.Name }}" }}"
+          echo "Namespace: {{ "{{ .Release.Namespace }}" }}"
+          echo "Chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version }}" }}"
+          echo ""
+
+          {{ "{{- if .Values.certManager.enable }}" }}
+          echo "Step 1/3: Validating cert-manager certificates..."
+          if ! kubectl wait --for=condition=Ready certificate --all \
+            -n {{ "{{ .Release.Namespace }}" }} --timeout=3m 2>/dev/null; then
+            echo "Warning: No certificates found or certificates not ready"
+            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          else
+            echo "SUCCESS: Certificates are ready"
+          fi
+          echo ""
+          {{ "{{- else }}" }}
+          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
+          echo ""
+          {{ "{{- end }}" }}
+
+          echo "Step 2/3: Verifying manager deployment is available..."
+          if ! kubectl wait --for=condition=Available deployment \
+            -l control-plane=controller-manager \
+            -n {{ "{{ .Release.Namespace }}" }} --timeout=5m; then
+            echo "ERROR: Manager deployment failed to become available"
+            echo ""
+            echo "Deployment status:"
+            kubectl get deployments -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager deployment is available"
+          echo ""
+
+          echo "Step 3/3: Verifying manager pod is running..."
+          POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
+            -n {{ "{{ .Release.Namespace }}" }} \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          
+          if [ -z "$POD_STATUS" ]; then
+            echo "ERROR: No manager pod found"
+            kubectl get pods -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+
+          if [ "$POD_STATUS" != "Running" ]; then
+            echo "ERROR: Manager pod is not running (status: $POD_STATUS)"
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod logs:"
+            kubectl logs -n {{ "{{ .Release.Namespace }}" }} -l control-plane=controller-manager --tail=50 || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager pod is running"
+          echo ""
+
+          echo "=================================="
+          echo "All tests passed successfully!"
+          echo "=================================="
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+`

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
@@ -84,8 +84,13 @@ jobs:
       - name: Prepare {{ .ProjectName }}
         run: |
           go mod tidy
-          make docker-build IMG={{ .ProjectName }}:v0.1.0
-          kind load docker-image {{ .ProjectName }}:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Install Helm
         run: |
@@ -124,4 +129,8 @@ jobs:
       - name: Check Helm release status
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test {{ .ProjectName }} --namespace {{ .ProjectName }}-system
 `

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -73,6 +73,7 @@ function test_cluster {
   # Pull images for the correct platform
   docker pull --platform ${kind_platform} memcached:1.6.26-alpine3.19
   docker pull --platform ${kind_platform} busybox:1.36.1
+  docker pull --platform ${kind_platform} bitnami/kubectl:latest
 
   # Load images directly with ctr to avoid kind's --all-platforms issue
   # kind load docker-image uses --all-platforms internally which breaks with multi-platform manifests
@@ -84,4 +85,6 @@ function test_cluster {
   fi
 
   go test $(dirname "$0")/all $flags -timeout 40m
+
+  docker save bitnami/kubectl:latest | docker exec -i $KIND_CLUSTER-control-plane ctr --namespace=k8s.io images import /dev/stdin
 }

--- a/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
@@ -32,8 +32,13 @@ jobs:
       - name: Prepare project-v4-with-plugins
         run: |
           go mod tidy
-          make docker-build IMG=project-v4-with-plugins:v0.1.0
-          kind load docker-image project-v4-with-plugins:v0.1.0
+          make docker-build IMG=controller:latest
+          kind load docker-image controller:latest
+
+      - name: Pre-load kubectl image for Helm tests
+        run: |
+          docker pull bitnami/kubectl:latest
+          kind load docker-image bitnami/kubectl:latest
 
       - name: Install Helm
         run: |
@@ -72,3 +77,7 @@ jobs:
       - name: Check Helm release status
         run: |
           make helm-status
+
+      - name: Run Helm tests
+        run: |
+          helm test project-v4-with-plugins --namespace project-v4-with-plugins-system

--- a/testdata/project-v4-with-plugins/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/tests/test-manager-ready.yaml
@@ -1,0 +1,187 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  {{- if .Values.certManager.enable }}
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  containers:
+    - name: test
+      image: bitnami/kubectl:latest
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          echo "=================================="
+          echo "Helm Chart Deployment Test"
+          echo "=================================="
+          echo "Release: {{ .Release.Name }}"
+          echo "Namespace: {{ .Release.Namespace }}"
+          echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
+          echo ""
+
+          {{- if .Values.certManager.enable }}
+          echo "Step 1/3: Validating cert-manager certificates..."
+          if ! kubectl wait --for=condition=Ready certificate --all \
+            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
+            echo "Warning: No certificates found or certificates not ready"
+            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          else
+            echo "SUCCESS: Certificates are ready"
+          fi
+          echo ""
+          {{- else }}
+          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
+          echo ""
+          {{- end }}
+
+          echo "Step 2/3: Verifying manager deployment is available..."
+          if ! kubectl wait --for=condition=Available deployment \
+            -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} --timeout=5m; then
+            echo "ERROR: Manager deployment failed to become available"
+            echo ""
+            echo "Deployment status:"
+            kubectl get deployments -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager deployment is available"
+          echo ""
+
+          echo "Step 3/3: Verifying manager pod is running..."
+          POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
+            -n {{ .Release.Namespace }} \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
+          
+          if [ -z "$POD_STATUS" ]; then
+            echo "ERROR: No manager pod found"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            exit 1
+          fi
+
+          if [ "$POD_STATUS" != "Running" ]; then
+            echo "ERROR: Manager pod is not running (status: $POD_STATUS)"
+            echo ""
+            echo "Pod status:"
+            kubectl get pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod details:"
+            kubectl describe pods -n {{ .Release.Namespace }} -l control-plane=controller-manager || true
+            echo ""
+            echo "Pod logs:"
+            kubectl logs -n {{ .Release.Namespace }} -l control-plane=controller-manager --tail=50 || true
+            exit 1
+          fi
+          echo "SUCCESS: Manager pod is running"
+          echo ""
+
+          echo "=================================="
+          echo "All tests passed successfully!"
+          echo "=================================="
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
This commit adds built-in Helm tests to validate deployment health in
scaffolded Helm charts. Tests automatically verify that the manager
deployment, services, and certificates are properly configured and ready.

The test Pod uses bitnami/kubectl image and includes proper RBAC permissions
to check deployments, services, and certificates. Tests are automatically
cleaned up after completion via helm.sh/hook-delete-policy annotation.

This improves CI/CD reliability by catching deployment issues early and
provides a standardized testing approach for Helm chart validation.