### PR TITLE
🐛 fix(alpha): respect custom project name in generate command

### DIFF
--- a/pkg/cli/alpha/internal/generate.go
+++ b/pkg/cli/alpha/internal/generate.go
@@ -436,6 +436,9 @@ func getInitArgs(s store.Store) []string {
 	if repo := s.Config().GetRepository(); repo != "" {
 		args = append(args, "--repo", repo)
 	}
+	if projectName := s.Config().GetProjectName(); projectName != "" {
+		args = append(args, "--project-name", projectName)
+	}
 	return args
 }
 

--- a/pkg/cli/alpha/internal/generate_test.go
+++ b/pkg/cli/alpha/internal/generate_test.go
@@ -36,6 +36,7 @@ type fakeConfig struct {
 	pluginChain []string
 	domain      string
 	repo        string
+	projectName string
 	multigroup  bool
 	resources   []resource.Resource
 	pluginErr   error
@@ -46,6 +47,7 @@ type fakeConfig struct {
 func (f *fakeConfig) GetPluginChain() []string { return f.pluginChain }
 func (f *fakeConfig) GetDomain() string        { return f.domain }
 func (f *fakeConfig) GetRepository() string    { return f.repo }
+func (f *fakeConfig) GetProjectName() string   { return f.projectName }
 func (f *fakeConfig) IsMultiGroup() bool       { return f.multigroup }
 func (f *fakeConfig) GetResources() ([]resource.Resource, error) {
 	if f.getResErr != nil {
@@ -376,6 +378,21 @@ var _ = Describe("generate: get-args-helpers", func() {
 					args := getInitArgs(store)
 					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
+				})
+			})
+
+			When("project name is set", func() {
+				It("returns correct args including project name", func() {
+					cfg := &fakeConfig{
+						pluginChain: []string{"go.kubebuilder.io/v4"},
+						domain:      "foo.com",
+						repo:        "bar",
+						projectName: "my-project",
+					}
+					store := &fakeStore{cfg: cfg}
+					args := getInitArgs(store)
+					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+						"--domain", "foo.com", "--repo", "bar", "--project-name", "my-project"))
 				})
 			})
 		})


### PR DESCRIPTION
## Problem

If a user creates a project with a custom name that differs from the directory name, that custom name is not used when re-generating the project via alpha generate or alpha update.

Here is visual example how I came across that issue

```bash
$ mkdir my-operator
$ cd my-operator
$ kubebuilder init --project-name zing-operator  # using Kubebuilder v4.10
$ kubebuilder create api ...                     # using Kubebuilder v4.10
...
$ kubebuilder alpha update                       # using Kubebuilder v4.11
```

and all `zing-operator` occurrences got renamed to `my-operator` after the directory name.

## Motivation

https://kubernetes.slack.com/archives/CAR30FCJZ/p1770038438744889