### PR TITLE
🐛 (alpha/update): update commit messages with conventional commit format

### DIFF
--- a/pkg/cli/alpha/internal/update/helpers/git_commands.go
+++ b/pkg/cli/alpha/internal/update/helpers/git_commands.go
@@ -57,3 +57,13 @@ func GitCmd(gitConfig []string, args ...string) *exec.Cmd {
 	gitArgs = append(gitArgs, args...)
 	return exec.Command("git", gitArgs...)
 }
+
+// MergeCommitMessage returns the commit message for a successful merge update
+func MergeCommitMessage(from, to string) string {
+	return fmt.Sprintf("chore(kubebuilder): update scaffold %s -> %s", from, to)
+}
+
+// ConflictCommitMessage returns the commit message for a merge update with conflicts
+func ConflictCommitMessage(from, to string) string {
+	return fmt.Sprintf("chore(kubebuilder): (:warning: manual conflict resolution required) update scaffold %s -> %s", from, to)
+}

--- a/pkg/cli/alpha/internal/update/integration_test.go
+++ b/pkg/cli/alpha/internal/update/integration_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update/helpers"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )
@@ -216,8 +217,7 @@ var _ = Describe("kubebuilder", func() {
 			By("checking commit message of the squashed branch")
 			msg, err := git("log", "-1", "--pretty=%B", prBranch)
 			Expect(err).NotTo(HaveOccurred(), string(msg))
-			expected := fmt.Sprintf(
-				":warning: (chore) [with conflicts] scaffold update: %s -> %s", fromVersion, toVersionWithConflict)
+			expected := helpers.ConflictCommitMessage(fromVersion, toVersionWithConflict)
 			Expect(string(msg)).To(ContainSubstring(expected))
 		})
 

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -713,9 +713,8 @@ func (opts *Update) mergeOriginalToUpgrade() (bool, error) {
 }
 
 func (opts *Update) getMergeMessage(hasConflicts bool) string {
-	base := fmt.Sprintf("scaffold update: %s -> %s", opts.FromVersion, opts.ToVersion)
 	if hasConflicts {
-		return fmt.Sprintf(":warning: (chore) [with conflicts] %s", base)
+		return helpers.ConflictCommitMessage(opts.FromVersion, opts.ToVersion)
 	}
-	return fmt.Sprintf("(chore) %s", base)
+	return helpers.MergeCommitMessage(opts.FromVersion, opts.ToVersion)
 }

--- a/pkg/cli/alpha/internal/update/update_test.go
+++ b/pkg/cli/alpha/internal/update/update_test.go
@@ -31,15 +31,6 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update/helpers"
 )
 
-// Helpers to keep lines short and consistent with production messages.
-func expNormalMsg(from, to string) string {
-	return fmt.Sprintf("(chore) scaffold update: %s -> %s", from, to)
-}
-
-func expConflictMsg(from, to string) string {
-	return fmt.Sprintf(":warning: (chore) [with conflicts] scaffold update: %s -> %s", from, to)
-}
-
 // Mock response for binary executables.
 func mockBinResponse(script, mockBin string) error {
 	err := os.WriteFile(mockBin, []byte(script), 0o755)
@@ -394,7 +385,7 @@ exit 1`
 				fmt.Sprintf("merge --no-edit --no-commit %s", opts.OriginalBranch),
 			))
 			Expect(s).To(ContainSubstring("add --all"))
-			Expect(s).To(ContainSubstring(expNormalMsg(opts.FromVersion, opts.ToVersion)))
+			Expect(s).To(ContainSubstring(helpers.MergeCommitMessage(opts.FromVersion, opts.ToVersion)))
 		})
 
 		It("fails when branch creation fails", func() {
@@ -439,7 +430,7 @@ exit 0`
 
 			s, _ := os.ReadFile(logFile)
 			Expect(string(s)).To(ContainSubstring(
-				expConflictMsg(opts.FromVersion, opts.ToVersion),
+				helpers.ConflictCommitMessage(opts.FromVersion, opts.ToVersion),
 			))
 		})
 	})
@@ -478,7 +469,7 @@ exit 0`
 
 			Expect(s).To(ContainSubstring(fmt.Sprintf("checkout %s -- .", opts.MergeBranch)))
 			Expect(s).To(ContainSubstring("add --all"))
-			Expect(s).To(ContainSubstring(expNormalMsg(opts.FromVersion, opts.ToVersion)))
+			Expect(s).To(ContainSubstring(helpers.MergeCommitMessage(opts.FromVersion, opts.ToVersion)))
 			Expect(s).To(ContainSubstring("commit --no-verify -m"))
 		})
 


### PR DESCRIPTION
Centralize the helper for the message and update the format to follow up conventions

Motivation: https://kubernetes.slack.com/archives/CAR30FCJZ/p1767008642660209