### PR TITLE
📖 docs: add note on limitations to CRD validation markers reference

### DIFF
--- a/docs/book/src/reference/markers/crd-validation.md
+++ b/docs/book/src/reference/markers/crd-validation.md
@@ -17,5 +17,17 @@ The grouping ensures clarity by showing how the same marker can be reused for di
 
 </aside>
 
+<aside class="note">
+<h1>Schema & Validation</h1>
+
+Custom resources are validated using the generated OpenAPI v3 schema and must comply with Kubernetes structural schema rules.
+Only field types and constraints that can be represented in the CRD schema are enforced by the API server.
+
+Numeric types are constrained by [Kubernetes CRD OpenAPI v3 schema compatibility](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation).
+In practice, prefer Go types that map cleanly to the supported OpenAPI formats (for example, `int32` and `int64` for integers).
+For values that require decimal-like representation, use `resource.Quantity`.
+
+Use Kubebuilder validation markers to declare additional constraints — such as minimum and maximum values, length limits, patterns, enums, and list or map rules — so they are reflected in the generated CRD and validated at runtime.
+</aside>
 
 {{#markerdocs CRD validation}}


### PR DESCRIPTION
Adapted from the [API design tutorial](https://book.kubebuilder.io/cronjob-tutorial/api-design.html?highlight=numbers).
I came here because I was puzzled by the [Cilium API using `int32` for `EndPort` in `PortRange`](http://github.com/cilium/cilium/tree/main/pkg/policy/api/l4.go), but internally using the expected `uint16` type, and I was hinted on Kubebuilder's limitations when asking in their Slack, and then got confused again because this was only mentioned in a tutorial, but not in the reference. So here we are!

 :rabbit:
 :hole: 