### PR TITLE
📖 : remove misleading comment from install script

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -66,7 +66,6 @@ case ${os} in
 esac
 
 # grab mdbook
-# we hardcode linux/amd64 since rust uses a different naming scheme and it's a pain to tran
 MDBOOK_VERSION="v0.5.2"
 MDBOOK_BASENAME="mdBook-${MDBOOK_VERSION}-${arch}-${target}"
 MDBOOK_URL="https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/${MDBOOK_BASENAME}.${ext}"


### PR DESCRIPTION
The system and architecture are not hardcoded, and the translation (this sentence was unfinished, maybe lost before committing?) was already provided above and still is.

It might make sense to `cargo install mdbook`, avoiding all the case handling, just like for the other tools, `go install` is used. :thinking: At least that's what I did, though I have both toolchains anyway. :)