### PR TITLE
🐛 fix(CLI/API) prevent --help from being validated as plugin name

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -53,6 +53,7 @@ func Run() {
 	gov4Bundle, _ := plugin.NewBundleWithOptions(plugin.WithName(golang.DefaultNameQualifier),
 		plugin.WithVersion(plugin.Version{Number: 4}),
 		plugin.WithPlugins(kustomizecommonv2.Plugin{}, golangv4.Plugin{}),
+		plugin.WithDescription("Default scaffold (go/v4 + kustomize/v2)"),
 	)
 
 	fs := machinery.Filesystem{

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl
 package cli
 
 import (
@@ -30,8 +31,7 @@ func (c CLI) newCreateAPICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Scaffold a Kubernetes API",
-		Long: `Scaffold a Kubernetes API.
-`,
+		Long:  `Scaffold a Kubernetes API.`,
 		RunE: errCmdFunc(
 			fmt.Errorf("api subcommand requires an existing project"),
 		),
@@ -62,6 +62,12 @@ func (c CLI) newCreateAPICmd() *cobra.Command {
 	}
 
 	c.applySubcommandHooks(cmd, subcommands, apiErrorMsg, false)
+
+	// Append plugin table after metadata updates
+	c.appendPluginTable(cmd, func(p plugin.Plugin) bool {
+		_, isValid := p.(plugin.CreateAPI)
+		return isValid
+	}, "Available plugins that support 'create api'")
 
 	return cmd
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -435,6 +435,23 @@ plugins:
 
 				Expect(c.getInfoFromFlags(false)).To(Succeed())
 			})
+
+			// When --plugins is followed by --help, --help is consumed as plugin value
+			// This should not trigger plugin validation errors
+			It("should not fail when `--plugins --help` is used together", func() {
+				os.Args = append(os.Args, "edit", "--plugins", "--help")
+
+				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(c.pluginKeys).To(BeEmpty())
+			})
+
+			// Same test for short help flag
+			It("should not fail when `--plugins -h` is used together", func() {
+				os.Args = append(os.Args, "edit", "--plugins", "-h")
+
+				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(c.pluginKeys).To(BeEmpty())
+			})
 		})
 	})
 

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -159,6 +159,13 @@ func (c *CLI) applySubcommandHooks(
 	cmd.PostRunE = factory.postRunEFunc()
 }
 
+// appendPluginTable appends a filtered plugin table to the command's Long description.
+// For subcommands, it excludes the default scaffold and its component plugins.
+func (c *CLI) appendPluginTable(cmd *cobra.Command, filter func(plugin.Plugin) bool, title string) {
+	pluginTable := c.getPluginTableFilteredForSubcommand(filter)
+	cmd.Long = fmt.Sprintf("%s\n%s:\n\n%s\n", cmd.Long, title, pluginTable)
+}
+
 // initializationHooks executes update metadata and bind flags plugin hooks.
 func initializationHooks(
 	cmd *cobra.Command,

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -17,14 +17,27 @@ limitations under the License.
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
-func (CLI) newCreateCmd() *cobra.Command {
+func (c CLI) newCreateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:        "create",
 		SuggestFor: []string{"new"},
 		Short:      "Scaffold a Kubernetes API or webhook",
-		Long:       `Scaffold a Kubernetes API or webhook.`,
+		Long: fmt.Sprintf(`Scaffold a Kubernetes API or webhook.
+
+Available plugins that support 'create' subcommands:
+
+%s
+`, c.getPluginTableFilteredForSubcommand(func(p plugin.Plugin) bool {
+			_, hasCreateAPI := p.(plugin.CreateAPI)
+			_, hasCreateWebhook := p.(plugin.CreateWebhook)
+			return hasCreateAPI || hasCreateWebhook
+		})),
 	}
 }

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl
 package cli
 
 import (
@@ -30,8 +31,7 @@ func (c CLI) newEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "Update the project configuration",
-		Long: `Edit the project configuration.
-`,
+		Long:  `Edit the project configuration.`,
 		RunE: errCmdFunc(
 			fmt.Errorf("project must be initialized"),
 		),
@@ -62,6 +62,12 @@ func (c CLI) newEditCmd() *cobra.Command {
 	}
 
 	c.applySubcommandHooks(cmd, subcommands, editErrorMsg, false)
+
+	// Append plugin table after metadata updates
+	c.appendPluginTable(cmd, func(p plugin.Plugin) bool {
+		_, isValid := p.(plugin.Edit)
+		return isValid
+	}, "Available plugins that support 'edit'")
 
 	return cmd
 }

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -72,6 +72,12 @@ For further help about a specific plugin, set --plugins.
 
 	c.applySubcommandHooks(cmd, subcommands, initErrorMsg, true)
 
+	// Append plugin table after metadata updates
+	c.appendPluginTable(cmd, func(p plugin.Plugin) bool {
+		_, isValid := p.(plugin.Init)
+		return isValid
+	}, "Available plugins that support 'init'")
+
 	return cmd
 }
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -17,19 +17,62 @@ limitations under the License.
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
-const (
-	pluginKeysHeader      = "Plugin keys"
-	projectVersionsHeader = "Supported project versions"
+var (
+	supportedPlatforms = []string{"darwin", "linux"}
+	// errHelpDisplayed is returned when help is displayed to prevent command execution
+	errHelpDisplayed = errors.New("help displayed")
 )
 
-var supportedPlatforms = []string{"darwin", "linux"}
+// isHelpFlag checks if the given string is a help flag
+func isHelpFlag(s string) bool {
+	return s == "--help" || s == "-h" || s == "help"
+}
+
+// getShortKey converts a full plugin key to a short display key
+// Example: "deploy-image.go.kubebuilder.io/v1-alpha" -> "deploy-image/v1-alpha"
+func getShortKey(fullKey string) string {
+	name, version := plugin.SplitKey(fullKey)
+
+	// Extract the short name (part before .kubebuilder.io or other domain)
+	shortName := name
+	if strings.Contains(name, ".kubebuilder.io") {
+		shortName = strings.TrimSuffix(name, ".kubebuilder.io")
+	} else if idx := strings.LastIndex(name, "."); idx > 0 {
+		// For external plugins, try to get a reasonable short name
+		// Keep the part before the last dot if it looks like a domain
+		parts := strings.Split(name, ".")
+		if len(parts) > 2 {
+			shortName = strings.Join(parts[:len(parts)-1], ".")
+		}
+	}
+
+	// Strip common suffixes for cleaner display
+	// e.g., "deploy-image.go" -> "deploy-image", "kustomize.common" -> "kustomize"
+	shortName = strings.TrimSuffix(shortName, ".go")
+	shortName = strings.TrimSuffix(shortName, ".common")
+
+	if version == "" {
+		return shortName
+	}
+	return shortName + "/" + version
+}
+
+// getPluginDescription returns a short description for a plugin key
+// This is a fallback for plugins that don't implement Describable interface
+func getPluginDescription(_ string) string {
+	// Fallback for external plugins that don't provide descriptions
+	return "External or custom plugin"
+}
 
 func (c CLI) newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -38,6 +81,23 @@ func (c CLI) newRootCmd() *cobra.Command {
 		Example: c.rootExamples(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Check if --plugins flag contains help flags (--help, -h, help)
+			// This handles cases like: kubebuilder init --plugins --help
+			if pluginKeys, err := cmd.Flags().GetStringSlice(pluginsFlag); err == nil {
+				for _, key := range pluginKeys {
+					key = strings.TrimSpace(key)
+					if isHelpFlag(key) {
+						// Help was requested, show help and stop execution
+						cmd.SilenceUsage = true
+						cmd.SilenceErrors = true
+						_ = cmd.Help()
+						return errHelpDisplayed
+					}
+				}
+			}
+			return nil
 		},
 	}
 
@@ -56,28 +116,28 @@ func (c CLI) newRootCmd() *cobra.Command {
 
 // rootExamples builds the examples string for the root command before resolving plugins
 func (c CLI) rootExamples() string {
-	str := fmt.Sprintf(`The first step is to initialize your project:
-    %[1]s init [--plugins=<PLUGIN KEYS> [--project-version=<PROJECT VERSION>]]
+	str := fmt.Sprintf(`Get started by initializing a new project:
 
-<PLUGIN KEYS> is a comma-separated list of plugin keys from the following table
-and <PROJECT VERSION> a supported project version for these plugins.
+    %[1]s init --domain <YOUR_DOMAIN>
+
+The default plugin scaffold includes everything you need. To use optional plugins:
+
+    %[1]s init --plugins=<PLUGIN_KEYS>
+
+Available plugins:
 
 %[2]s
 
-For more specific help for the init command of a certain plugins and project version
-configuration please run:
-    %[1]s init --help --plugins=<PLUGIN KEYS> [--project-version=<PROJECT VERSION>]
+To see which plugins support a specific command:
+
+    %[1]s <init|edit|create> --help
 `,
 		c.commandName, c.getPluginTable())
 
 	if len(c.defaultPlugins) != 0 {
 		if defaultPlugins, found := c.defaultPlugins[c.defaultProjectVersion]; found {
-			str += fmt.Sprintf("\nDefault plugin keys: %q\n", strings.Join(defaultPlugins, ","))
+			str += fmt.Sprintf("\nDefault plugin: %q\n", strings.Join(defaultPlugins, ","))
 		}
-	}
-
-	if c.defaultProjectVersion.Validate() == nil {
-		str += fmt.Sprintf("Default project version: %q\n", c.defaultProjectVersion)
 	}
 
 	return str
@@ -85,41 +145,109 @@ configuration please run:
 
 // getPluginTable returns an ASCII table of the available plugins and their supported project versions.
 func (c CLI) getPluginTable() string {
-	var (
-		maxPluginKeyLength      = len(pluginKeysHeader)
-		pluginKeys              = make([]string, 0, len(c.plugins))
-		maxProjectVersionLength = len(projectVersionsHeader)
-		projectVersions         = make(map[string]string, len(c.plugins))
-	)
+	return c.getPluginTableFiltered(nil)
+}
 
-	for pluginKey, plugin := range c.plugins {
-		if len(pluginKey) > maxPluginKeyLength {
-			maxPluginKeyLength = len(pluginKey)
-		}
-		pluginKeys = append(pluginKeys, pluginKey)
-		supportedProjectVersions := plugin.SupportedProjectVersions()
-		supportedProjectVersionStrs := make([]string, 0, len(supportedProjectVersions))
-		for _, version := range supportedProjectVersions {
-			supportedProjectVersionStrs = append(supportedProjectVersionStrs, version.String())
-		}
-		supportedProjectVersionsStr := strings.Join(supportedProjectVersionStrs, ", ")
-		if len(supportedProjectVersionsStr) > maxProjectVersionLength {
-			maxProjectVersionLength = len(supportedProjectVersionsStr)
-		}
-		projectVersions[pluginKey] = supportedProjectVersionsStr
+// getPluginTableFilteredForSubcommand returns a filtered list of plugins for subcommands,
+// excluding the default scaffold bundle and its component plugins.
+func (c CLI) getPluginTableFilteredForSubcommand(filter func(plugin.Plugin) bool) string {
+	return c.getPluginTableFilteredWithOptions(filter, true)
+}
+
+// getPluginTableFiltered returns a formatted list of plugins filtered by a predicate.
+// If filter is nil, all plugins are included.
+// Deprecated plugins are automatically excluded from help output.
+func (c CLI) getPluginTableFiltered(filter func(plugin.Plugin) bool) string {
+	return c.getPluginTableFilteredWithOptions(filter, false)
+}
+
+// getPluginTableFilteredWithOptions returns a formatted list of plugins with filtering options.
+func (c CLI) getPluginTableFilteredWithOptions(filter func(plugin.Plugin) bool, excludeDefaultScaffold bool) string {
+	type pluginInfo struct {
+		shortKey    string
+		fullKey     string
+		description string
+		versions    string
 	}
 
-	lines := make([]string, 0, len(c.plugins)+2)
-	lines = append(lines, fmt.Sprintf(" %[1]*[2]s | %[3]*[4]s",
-		maxPluginKeyLength, pluginKeysHeader, maxProjectVersionLength, projectVersionsHeader))
-	lines = append(lines, strings.Repeat("-", maxPluginKeyLength+2)+"+"+
-		strings.Repeat("-", maxProjectVersionLength+2))
+	plugins := make([]pluginInfo, 0, len(c.plugins))
 
-	slices.Sort(pluginKeys)
-	for _, pluginKey := range pluginKeys {
-		supportedProjectVersions := projectVersions[pluginKey]
-		lines = append(lines, fmt.Sprintf(" %[1]*[2]s | %[3]*[4]s",
-			maxPluginKeyLength, pluginKey, maxProjectVersionLength, supportedProjectVersions))
+	for pluginKey, p := range c.plugins {
+		// Skip deprecated plugins in help output
+		if deprecated, ok := p.(plugin.Deprecated); ok {
+			if deprecated.DeprecationWarning() != "" {
+				continue
+			}
+		}
+
+		// Apply filter if provided
+		if filter != nil && !filter(p) {
+			continue
+		}
+
+		// Skip base.go plugin to avoid duplication with go plugin
+		if strings.Contains(pluginKey, "base.go.kubebuilder.io") {
+			continue
+		}
+
+		// For subcommands, skip default scaffold and its component plugins
+		if excludeDefaultScaffold {
+			if pluginKey == "go.kubebuilder.io/v4" ||
+				pluginKey == "kustomize.common.kubebuilder.io/v2" {
+				continue
+			}
+		}
+
+		shortKey := getShortKey(pluginKey)
+
+		// Get description from plugin if it implements Describable, otherwise use fallback
+		var desc string
+		if describable, ok := p.(plugin.Describable); ok {
+			desc = describable.Description()
+		} else {
+			desc = getPluginDescription(pluginKey)
+		}
+
+		// Get supported project versions
+		supportedVersions := p.SupportedProjectVersions()
+		versionStrs := make([]string, 0, len(supportedVersions))
+		for _, ver := range supportedVersions {
+			versionStrs = append(versionStrs, ver.String())
+		}
+		versionsStr := strings.Join(versionStrs, ", ")
+
+		plugins = append(plugins, pluginInfo{
+			shortKey:    shortKey,
+			fullKey:     pluginKey,
+			description: desc,
+			versions:    versionsStr,
+		})
+	}
+
+	if len(plugins) == 0 {
+		return "No plugins available for this subcommand"
+	}
+
+	// Sort by short key for better readability
+	slices.SortFunc(plugins, func(a, b pluginInfo) int {
+		return strings.Compare(a.shortKey, b.shortKey)
+	})
+
+	// Calculate max width for KEY column
+	maxKeyWidth := len("KEY")
+	for _, p := range plugins {
+		if len(p.shortKey) > maxKeyWidth {
+			maxKeyWidth = len(p.shortKey)
+		}
+	}
+
+	// Build aligned column output
+	lines := make([]string, 0, len(plugins)+1)
+	// Header
+	lines = append(lines, fmt.Sprintf("  %-*s  %s", maxKeyWidth, "KEY", "DESCRIPTION"))
+	// Entries
+	for _, p := range plugins {
+		lines = append(lines, fmt.Sprintf("  %-*s  %s", maxKeyWidth, p.shortKey, p.description))
 	}
 
 	return strings.Join(lines, "\n")

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:dupl
 package cli
 
 import (
@@ -30,8 +31,7 @@ func (c CLI) newCreateWebhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "webhook",
 		Short: "Scaffold a webhook for an API resource",
-		Long: `Scaffold a webhook for an API resource.
-`,
+		Long:  `Scaffold a webhook for an API resource.`,
 		RunE: errCmdFunc(
 			fmt.Errorf("webhook subcommand requires an existing project"),
 		),
@@ -62,6 +62,12 @@ func (c CLI) newCreateWebhookCmd() *cobra.Command {
 	}
 
 	c.applySubcommandHooks(cmd, subcommands, webhookErrorMsg, false)
+
+	// Append plugin table after metadata updates
+	c.appendPluginTable(cmd, func(p plugin.Plugin) bool {
+		_, isValid := p.(plugin.CreateWebhook)
+		return isValid
+	}, "Available plugins that support 'create webhook'")
 
 	return cmd
 }

--- a/pkg/plugin/bundle.go
+++ b/pkg/plugin/bundle.go
@@ -23,9 +23,10 @@ import (
 )
 
 type bundle struct {
-	name    string
-	version Version
-	plugins []Plugin
+	name        string
+	version     Version
+	plugins     []Plugin
+	description string
 
 	supportedProjectVersions []config.Version
 	deprecateWarning         string
@@ -62,6 +63,13 @@ func WithDeprecationMessage(msg string) BundleOption {
 	}
 }
 
+// WithDescription allows setting a description for the bundle
+func WithDescription(desc string) BundleOption {
+	return func(opts *bundle) {
+		opts.description = desc
+	}
+}
+
 // NewBundleWithOptions creates a new Bundle with the provided BundleOptions.
 // The list of supported project versions is computed from the provided plugins in options.
 func NewBundleWithOptions(opts ...BundleOption) (Bundle, error) {
@@ -92,6 +100,7 @@ func NewBundleWithOptions(opts ...BundleOption) (Bundle, error) {
 		name:                     bundleOpts.name,
 		version:                  bundleOpts.version,
 		plugins:                  allPlugins,
+		description:              bundleOpts.description,
 		supportedProjectVersions: supportedProjectVersions,
 		deprecateWarning:         bundleOpts.deprecateWarning,
 	}, nil
@@ -115,6 +124,11 @@ func (b bundle) SupportedProjectVersions() []config.Version {
 // Plugins implements Bundle
 func (b bundle) Plugins() []Plugin {
 	return b.plugins
+}
+
+// Description implements Describable
+func (b bundle) Description() string {
+	return b.description
 }
 
 // DeprecationWarning return the warning message

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -41,6 +41,13 @@ type Deprecated interface {
 	DeprecationWarning() string
 }
 
+// Describable is an optional interface for plugins that provide a short description.
+// This description is shown in help output to explain what the plugin does.
+type Describable interface {
+	// Description returns a short description of the plugin (ideally one line).
+	Description() string
+}
+
 // Init is an interface for plugins that provide an `init` subcommand.
 type Init interface {
 	Plugin

--- a/pkg/plugins/common/kustomize/v2/plugin.go
+++ b/pkg/plugins/common/kustomize/v2/plugin.go
@@ -67,6 +67,11 @@ func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
 	return &p.createWebhookSubcommand
 }
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Scaffolds base Kustomize configuration"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return ""

--- a/pkg/plugins/golang/deploy-image/v1alpha1/plugin.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/plugin.go
@@ -71,6 +71,11 @@ type options struct {
 	RunAsUser        string `json:"runAsUser,omitempty"`
 }
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Scaffolds a CRD+controller to deploy an image-based Operand"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return ""

--- a/pkg/plugins/golang/v4/plugin.go
+++ b/pkg/plugins/golang/v4/plugin.go
@@ -64,6 +64,11 @@ func (p Plugin) GetCreateWebhookSubcommand() plugin.CreateWebhookSubcommand {
 // GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
 func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Default scaffold (go/v4 + kustomize/v2)"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return ""

--- a/pkg/plugins/optional/autoupdate/v1alpha/plugin.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/plugin.go
@@ -85,6 +85,11 @@ func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcom
 // GetInitSubcommand will return the subcommand which is responsible for init autoupdate plugin
 func (p Plugin) GetInitSubcommand() plugin.InitSubcommand { return &p.initSubcommand }
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Proposes Kubebuilder scaffold updates via GitHub Actions"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return ""

--- a/pkg/plugins/optional/grafana/v1alpha/plugin.go
+++ b/pkg/plugins/optional/grafana/v1alpha/plugin.go
@@ -56,6 +56,11 @@ func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcom
 
 type pluginConfig struct{}
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Generates Grafana Dashboards for metrics"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return ""

--- a/pkg/plugins/optional/helm/v1alpha/plugin.go
+++ b/pkg/plugins/optional/helm/v1alpha/plugin.go
@@ -52,6 +52,11 @@ func (Plugin) SupportedProjectVersions() []config.Version { return supportedProj
 // GetEditSubcommand will return the subcommand which is responsible for adding and/or edit a helm chart
 func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Generate Helm Chart (deprecated, use v2-alpha)"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return "helm/v1-alpha plugin is deprecated, use helm/v2-alpha instead which " +

--- a/pkg/plugins/optional/helm/v2alpha/plugin.go
+++ b/pkg/plugins/optional/helm/v2alpha/plugin.go
@@ -56,6 +56,11 @@ func (Plugin) SupportedProjectVersions() []config.Version { return supportedProj
 // GetEditSubcommand will return the subcommand which is responsible for adding and/or edit a helm chart
 func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
 
+// Description returns a short description of the plugin
+func (Plugin) Description() string {
+	return "Generates a Helm chart for project distribution"
+}
+
 // DeprecationWarning define the deprecation message or return empty when plugin is not deprecated
 func (p Plugin) DeprecationWarning() string {
 	return ""


### PR DESCRIPTION
- Add PersistentPreRunE hook to detect help flags in plugin values
- Filter help flags before plugin validation
- Show plugin descriptions instead of project versions
- Use short plugin keys (go/v4 vs go.kubebuilder.io/v4)
- Filter plugins by subcommand (init/edit/create)
- Hide deprecated plugins from help output
- Add documentation links for each plugin
- Improve root help wording for better getting-started experience

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5444

Example;

```
$ kubebuilder --plugins --help
CLI tool for building Kubernetes extensions and tools.

Usage:
  kubebuilder [flags]
  kubebuilder [command]

Examples:
Get started by initializing a new project:

    kubebuilder init --domain <YOUR_DOMAIN>

The default plugin scaffold includes everything you need. To use optional plugins:

    kubebuilder init --plugins=<PLUGIN_KEYS>

Available plugins:

  KEY                    DESCRIPTION
  autoupdate/v1-alpha    Proposes Kubebuilder scaffold updates via GitHub Actions
  deploy-image/v1-alpha  Scaffolds a CRD+controller to deploy an image-based Operand
  go/v4                  Default scaffold (go/v4 + kustomize/v2)
  grafana/v1-alpha       Generates Grafana Dashboards for metrics
  helm/v2-alpha          Generates a Helm chart for project distribution
  kustomize/v2           Scaffolds base Kustomize configuration

To see which plugins support a specific command:

    kubebuilder <init|edit|create> --help

Default plugin: "go.kubebuilder.io/v4"


Available Commands:
  alpha       Alpha-stage subcommands
  completion  Load completions for the specified shell
  create      Scaffold a Kubernetes API or webhook
  edit        Update the project configuration
  help        Help about any command
  init        Initialize a new project
  version     Print the kubebuilder version

Flags:
  -h, --help                     help for kubebuilder
      --plugins strings          plugin keys to be used for this subcommand execution
      --project-version string   project version (default "3")

Use "kubebuilder [command] --help" for more information about a command.
```

AND 


```
 $ kubebuilder create --plugins --help
Scaffold a Kubernetes API or webhook.

Available plugins that support 'create' subcommands:

  KEY                    DESCRIPTION
  deploy-image/v1-alpha  Scaffolds a CRD+controller to deploy an image-based Operand

Usage:
  kubebuilder create [command]

Available Commands:
  api         Scaffold a Kubernetes API
  webhook     Scaffold a webhook for an API resource

Flags:
  -h, --help   help for create

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution

Use "kubebuilder create [command] --help" for more information about a command.
```

AND

```
$ kubebuilder edit --plugins --help
Edit the project configuration.

Features:
  - Toggle multigroup layout (organize APIs by group).
  - Toggle namespaced layout (namespace-scoped vs cluster-scoped).

Namespaced layout (--namespaced):
  Changes namespace-scoped (watches specific namespaces) vs cluster-scoped (watches all namespaces).
  What changes automatically:
    - Updates PROJECT file (namespaced: true)
    - Scaffolds Role/RoleBinding instead of ClusterRole/ClusterRoleBinding
    - With --force: Regenerates config/manager/manager.yaml with WATCH_NAMESPACE env var
  What you must update manually:
    - Add namespace= to RBAC markers in existing controllers (new controllers get this automatically)
    - Update cmd/main.go to use namespace-scoped cache
    - Run: make manifests

Available plugins that support 'edit':

  KEY                  DESCRIPTION
  autoupdate/v1-alpha  Proposes Kubebuilder scaffold updates via GitHub Actions
  grafana/v1-alpha     Generates Grafana Dashboards for metrics
  helm/v2-alpha        Generates a Helm chart for project distribution

Usage:
  kubebuilder edit [flags]

Examples:
  # Enable multigroup layout
  kubebuilder edit --multigroup

  # Disable multigroup layout
  kubebuilder edit --multigroup=false

  # Enable namespaced layout (--force regenerates config/manager/manager.yaml with WATCH_NAMESPACE)
  kubebuilder edit --namespaced --force

  # Enable namespaced layout without force (manually update config/manager/manager.yaml)
  kubebuilder edit --namespaced

  # Disable namespaced layout (--force regenerates config/manager/manager.yaml without WATCH_NAMESPACE)
  kubebuilder edit --namespaced=false --force


Flags:
      --force        overwrite existing files (regenerates manager.yaml with WATCH_NAMESPACE)
  -h, --help         help for edit
      --multigroup   enable or disable multigroup layout
      --namespaced   enable or disable namespaced layout

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution
```