### PR TITLE
✨ (go/v4): add --license-file flag and preserve boilerplate in alpha generate

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -67,6 +67,7 @@
   - [Generating CRDs](./reference/generating-crd.md)
   - [Using Finalizers](./reference/using-finalizers.md)
   - [Good Practices](./reference/good-practices.md)
+  - [License Header](./reference/license-header.md)
   - [Raising Events](./reference/raising-events.md)
   - [Watching Resources](./reference/watching-resources.md)
     - [Owned Resources](./reference/watching-resources/secondary-owned-resources.md)

--- a/docs/book/src/reference/license-header.md
+++ b/docs/book/src/reference/license-header.md
@@ -1,0 +1,256 @@
+# License Header
+
+## What is it?
+
+Kubebuilder creates a file at `hack/boilerplate.go.txt` that contains your license header. This header is automatically added to all generated Go files.
+
+The boilerplate file is used by:
+- Kubebuilder when creating new files (`create api`, `create webhook`, etc.)
+- `controller-gen` when generating code (DeepCopy methods, etc.)
+- `make generate` and `make manifests` commands
+
+By default, Kubebuilder uses the Apache 2.0 license.
+
+<aside class="warning" role="note">
+<p class="note-title">Boilerplate is a Template</p>
+
+`hack/boilerplate.go.txt` is a **template** used when generating or regenerating files. Changing this file does **not** automatically update existing files.
+
+**To apply changes to existing files:**
+- Run `make generate && make manifests` to update generated code
+- Run `kubebuilder alpha generate` to regenerate the entire project
+- Or create new files - they'll use the updated template
+
+</aside>
+
+## How to Customize
+
+### Option 1: Use Built-in Licenses
+
+Use the `--license` flag during initialization or to update an existing project:
+
+```bash
+# During initialization
+kubebuilder init --domain example.com --license apache2 --owner "Your Name"
+
+# After initialization (update existing project)
+kubebuilder edit --license apache2 --owner "Your Company"
+```
+
+Available license values:
+- `apache2` - Apache 2.0 License (default)
+- `copyright` - Copyright notice only (no license text)
+- `none` - No license header
+
+### Option 2: Use a Custom License File
+
+Provide your own license header from a file. Kubebuilder will read the content from your file and copy it to `hack/boilerplate.go.txt`:
+
+```bash
+# During initialization
+kubebuilder init --domain example.com --license-file ./my-header.txt
+
+# After initialization
+kubebuilder edit --license-file ./my-header.txt
+```
+
+**How it works:**
+1. Kubebuilder reads your custom license file (can be any path)
+2. Copies the content to `hack/boilerplate.go.txt`
+
+<aside class="note" role="note">
+<p class="note-title">License File Override</p>
+
+The `--license-file` flag overrides the `--license` flag. If you provide `--license-file`, a boilerplate will always be created, even if you also specify `--license none`.
+
+</aside>
+
+Use this when you need:
+- A license not available in the built-in templates
+- A specific company license format
+- Custom copyright notices
+
+### Option 3: Edit the File Directly
+
+After initialization, you can edit `hack/boilerplate.go.txt` directly:
+
+```bash
+vim hack/boilerplate.go.txt
+```
+
+## Custom License File Format
+
+Your custom license file must include Go comment delimiters (`/*` and `*/`).
+
+**Example** (`my-license-header.txt`):
+
+```go
+/*
+Copyright YEAR Your Company Name.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license text.
+*/
+```
+
+<aside class="warning" role="note">
+<p class="note-title">Automatic Year Updates</p>
+
+Use `YEAR` in your boilerplate and it will be automatically replaced with the current year:
+
+```go
+/*
+Copyright YEAR Your Company.
+*/
+```
+
+**How it works:**
+- **Kubebuilder** replaces `YEAR` when creating files (`create api`, `create webhook`, etc.)
+- **Controller-gen** replaces `YEAR` when generating code (`make generate`)
+
+The Makefile passes the year to controller-gen:
+
+```makefile
+YEAR ?= $(shell date +%Y)
+
+.PHONY: generate
+generate:
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
+```
+
+Both automatically use the current year, so your boilerplate stays up-to-date.
+
+</aside>
+
+## Applying License Changes to Existing Files
+
+After updating `hack/boilerplate.go.txt`, choose how to apply the changes:
+
+**Regenerate Generated Code (Recommended):**
+```bash
+make generate  # Update DeepCopy methods
+make manifests # Update CRDs, RBAC, webhooks
+```
+This updates generated code but keeps your hand-written files unchanged.
+
+**Regenerate Entire Project:**
+```bash
+kubebuilder alpha generate
+```
+<aside class="warning" role="note">
+<p class="note-title">Commit First</p>
+
+This overwrites all scaffolded files. Commit your changes before running.
+
+</aside>
+
+**New Files Only:**
+New files will automatically use the updated template:
+```bash
+kubebuilder create api --group myapp --version v1 --kind MyNewKind
+```
+
+**Manual Updates:**
+For hand-written files, manually update headers using `hack/boilerplate.go.txt` as a reference.
+
+## How It's Used
+
+`hack/boilerplate.go.txt` is used when generating or regenerating files:
+
+- `kubebuilder create api` and `create webhook` - new files
+- `make generate` - DeepCopy methods, etc.
+- `make manifests` - CRDs, RBAC, webhooks
+- `kubebuilder alpha generate` - entire project
+
+All tools automatically reference `hack/boilerplate.go.txt`. The Makefile is already configured - no changes needed.
+
+## Examples
+
+### Example 1: Apache 2.0 License (Default)
+
+Use the built-in Apache 2.0 license:
+
+```bash
+kubebuilder init --domain example.com --license apache2 --owner "Your Company"
+```
+
+This generates:
+
+```go
+/*
+Copyright YEAR Your Company.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+```
+
+### Example 2: Copyright Only
+
+Use the built-in `copyright` license for just a copyright notice:
+
+```bash
+kubebuilder init --domain example.com --license copyright --owner "Your Company"
+```
+
+This generates:
+
+```go
+/*
+Copyright YEAR Your Company.
+*/
+```
+
+### Example 3: Custom License (MIT)
+
+For licenses not built-in, create a custom file `mit-header.txt`:
+
+```go
+/*
+Copyright YEAR Your Name.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+```
+
+Then initialize your project:
+
+```bash
+kubebuilder init --domain example.com --license-file ./mit-header.txt
+```
+
+**What happens:**
+1. Kubebuilder reads the content from `./mit-header.txt`
+2. Creates `hack/boilerplate.go.txt` with that content
+3. `hack/boilerplate.go.txt` becomes the source of truth for all generated files
+
+## Related
+
+- [Good Practices](./good-practices.md) - Best practices for project structure
+- [Generating CRDs](./generating-crd.md) - How CRDs are generated with headers
+- [controller-gen CLI](./controller-gen.md) - Details on code generation

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -54,6 +54,31 @@ func (opts *Generate) Generate() error {
 		return fmt.Errorf("error loading project config: %v", err)
 	}
 
+	// Save existing boilerplate before cleanup so we can restore it
+	var preservedBoilerplate []byte
+	var boilerplateFileExists bool
+	boilerplatePath := filepath.Join(opts.InputDir, "hack", "boilerplate.go.txt")
+	if _, statErr := os.Stat(boilerplatePath); statErr == nil {
+		boilerplateFileExists = true
+		preservedBoilerplate, err = os.ReadFile(boilerplatePath)
+		if err != nil {
+			return fmt.Errorf("failed to read existing boilerplate file %q: %w", boilerplatePath, err)
+		}
+
+		// Warn if boilerplate isn't a valid Go comment block, but don't fail
+		if len(preservedBoilerplate) > 0 {
+			content := strings.TrimSpace(string(preservedBoilerplate))
+			if !strings.HasPrefix(content, "/*") || !strings.HasSuffix(content, "*/") {
+				slog.Warn(
+					"Existing boilerplate file is not a valid Go comment block; preserving it as-is for regeneration",
+					"path", boilerplatePath,
+				)
+			}
+		}
+
+		slog.Info("Preserving existing license header file for regeneration")
+	}
+
 	if opts.OutputDir == "" {
 		cwd, getWdErr := os.Getwd()
 		if getWdErr != nil {
@@ -96,7 +121,29 @@ func (opts *Generate) Generate() error {
 		return fmt.Errorf("error changing working directory %q: %w", opts.OutputDir, err)
 	}
 
-	if err = kubebuilderInit(projectConfig, opts); err != nil {
+	// Create temp file with preserved boilerplate to pass to init
+	var tempLicenseFile string
+	if boilerplateFileExists {
+		tempFile, createErr := os.CreateTemp("", "kubebuilder-license-*.txt")
+		if createErr != nil {
+			return fmt.Errorf("failed to create temporary license file: %w", createErr)
+		}
+		defer func() {
+			_ = os.Remove(tempFile.Name())
+		}()
+
+		if len(preservedBoilerplate) > 0 {
+			if _, writeErr := tempFile.Write(preservedBoilerplate); writeErr != nil {
+				return fmt.Errorf("failed to write temporary license file: %w", writeErr)
+			}
+		}
+		_ = tempFile.Close()
+
+		tempLicenseFile = tempFile.Name()
+		slog.Info("Created temporary license file for init", "path", tempLicenseFile)
+	}
+
+	if err = kubebuilderInit(projectConfig, opts, tempLicenseFile); err != nil {
 		return fmt.Errorf("error initializing project config: %w", err)
 	}
 
@@ -187,8 +234,8 @@ func changeWorkingDirectory(outputDir string) error {
 }
 
 // Initializes the project with Kubebuilder.
-func kubebuilderInit(s store.Store, opts *Generate) error {
-	args := append([]string{"init"}, getInitArgs(s, opts)...)
+func kubebuilderInit(s store.Store, opts *Generate, tempLicenseFile string) error {
+	args := append([]string{"init"}, getInitArgs(s, opts, tempLicenseFile)...)
 	execPath, err := getExecutablePathFunc()
 	if err != nil {
 		return err
@@ -396,7 +443,7 @@ func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) err
 }
 
 // Helper function to get Init arguments for Kubebuilder.
-func getInitArgs(s store.Store, opts *Generate) []string {
+func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string {
 	var args []string
 
 	if opts.SkipGoVersionCheck {
@@ -442,6 +489,13 @@ func getInitArgs(s store.Store, opts *Generate) []string {
 	}
 	if s.Config().IsNamespaced() {
 		args = append(args, "--namespaced")
+	}
+
+	// Use preserved boilerplate if it existed, otherwise --license none
+	if tempLicenseFile != "" {
+		args = append(args, "--license-file", tempLicenseFile)
+	} else {
+		args = append(args, "--license", "none")
 	}
 	return args
 }

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -340,7 +340,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 				It("should return correct args for plugins, domain, repo", func() {
 					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3"}, domain: "foo.com", repo: "bar"}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
 				})
@@ -350,7 +350,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 				It("should return correct args for plugins, domain, repo", func() {
 					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3-alpha"}, domain: "foo.com", repo: "bar"}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
 				})
@@ -364,7 +364,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 						repo:        "bar",
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements(
 						"--skip-go-version-check",
 						"--plugins", ContainSubstring("helm.kubebuilder.io/v2-alpha"),
@@ -379,7 +379,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 				It("returns correct args for plugins, domain, repo", func() {
 					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v4"}, domain: "foo.com", repo: "bar"}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
 				})
@@ -394,7 +394,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 						projectName: "my-project",
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--project-name", "my-project"))
 				})
@@ -409,7 +409,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 						multigroup:  true,
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--multigroup"))
 				})
@@ -424,7 +424,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 						namespaced:  true,
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--namespaced"))
 				})
@@ -440,7 +440,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 						namespaced:  true,
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--multigroup", "--namespaced"))
 				})
@@ -451,7 +451,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 			It("does not include --skip-go-version-check", func() {
 				cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v4"}, domain: "foo.com", repo: "bar"}
 				store := &fakeStore{cfg: cfg}
-				args := getInitArgs(store, &Generate{SkipGoVersionCheck: false})
+				args := getInitArgs(store, &Generate{SkipGoVersionCheck: false}, "")
 				Expect(args).NotTo(ContainElement("--skip-go-version-check"))
 				Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 					"--domain", "foo.com", "--repo", "bar"))
@@ -781,7 +781,7 @@ var _ = Describe("generate: kubebuilder", func() {
 				repo:        "github.com/example/repo",
 			}
 			store := &fakeStore{cfg: cfg}
-			Expect(kubebuilderInit(store, &Generate{SkipGoVersionCheck: true})).To(Succeed())
+			Expect(kubebuilderInit(store, &Generate{SkipGoVersionCheck: true}, "")).To(Succeed())
 		})
 	})
 
@@ -837,6 +837,74 @@ var _ = Describe("generate: hasHelmPlugin", func() {
 		hasPlugin, isV2Alpha := hasHelmPlugin(store)
 		Expect(hasPlugin).To(BeFalse())
 		Expect(isV2Alpha).To(BeFalse())
+	})
+})
+
+var _ = Describe("generate: boilerplate preservation", func() {
+	Describe("getInitArgs with boilerplate handling", func() {
+		It("should include --license none when no boilerplate exists", func() {
+			cfg := &fakeConfig{
+				pluginChain: []string{"go.kubebuilder.io/v4"},
+				domain:      "example.com",
+				repo:        "github.com/example/repo",
+			}
+			store := &fakeStore{cfg: cfg}
+			args := getInitArgs(store, &Generate{}, "") // tempLicenseFile = "" (no boilerplate)
+
+			Expect(args).To(ContainElement("--license"))
+			// Find --license and verify next element is "none"
+			foundLicenseNone := false
+			for i, arg := range args {
+				if arg == "--license" && i+1 < len(args) && args[i+1] == "none" {
+					foundLicenseNone = true
+					break
+				}
+			}
+			Expect(foundLicenseNone).To(BeTrue(), "Expected --license none when no boilerplate exists")
+		})
+
+		It("should use --license-file when temp file is provided", func() {
+			cfg := &fakeConfig{
+				pluginChain: []string{"go.kubebuilder.io/v4"},
+				domain:      "example.com",
+				repo:        "github.com/example/repo",
+			}
+			store := &fakeStore{cfg: cfg}
+			args := getInitArgs(store, &Generate{}, "/tmp/preserved-license.txt") // tempLicenseFile provided
+
+			// Should have --license-file flag (not --license none)
+			Expect(args).To(ContainElement("--license-file"))
+			Expect(args).To(ContainElement("/tmp/preserved-license.txt"))
+
+			// Should NOT have --license none
+			foundLicenseNone := false
+			for i, arg := range args {
+				if arg == "--license" && i+1 < len(args) && args[i+1] == "none" {
+					foundLicenseNone = true
+					break
+				}
+			}
+			Expect(foundLicenseNone).To(BeFalse(), "Should not use --license none when temp file is provided")
+		})
+
+		It("should always include either --license-file or --license none", func() {
+			cfg := &fakeConfig{
+				pluginChain: []string{"go.kubebuilder.io/v4"},
+				domain:      "example.com",
+				repo:        "github.com/example/repo",
+			}
+			store := &fakeStore{cfg: cfg}
+
+			// With temp file: should have --license-file
+			argsWithFile := getInitArgs(store, &Generate{}, "/tmp/custom-license.txt")
+			Expect(argsWithFile).To(ContainElement("--license-file"))
+			Expect(argsWithFile).To(ContainElement("/tmp/custom-license.txt"))
+
+			// Without temp file: should have --license none
+			argsWithoutFile := getInitArgs(store, &Generate{}, "")
+			Expect(argsWithoutFile).To(ContainElement("--license"))
+			Expect(argsWithoutFile).To(ContainElement("none"))
+		})
 	})
 })
 

--- a/pkg/plugins/golang/v4/edit.go
+++ b/pkg/plugins/golang/v4/edit.go
@@ -18,6 +18,8 @@ package v4
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -32,9 +34,12 @@ var _ plugin.EditSubcommand = &editSubcommand{}
 type editSubcommand struct {
 	config config.Config
 
-	multigroup bool
-	namespaced bool
-	force      bool
+	multigroup  bool
+	namespaced  bool
+	force       bool
+	licenseFile string
+	license     string
+	owner       string
 
 	// fs stores the FlagSet to check if flags were explicitly set
 	fs *pflag.FlagSet
@@ -86,6 +91,12 @@ Note: To add optional plugins after initialization, use 'kubebuilder edit --plug
 
   # Enable/disable multiple settings
   %[1]s edit --multigroup --namespaced --force
+
+  # Update license header from custom file
+  %[1]s edit --license-file ./my-header.txt
+
+  # Update license header to built-in apache2
+  %[1]s edit --license apache2 --owner "Your Company"
 `, cliMeta.CommandName)
 }
 
@@ -94,6 +105,12 @@ func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.multigroup, "multigroup", false, "enable or disable multigroup layout")
 	fs.BoolVar(&p.namespaced, "namespaced", false, "enable or disable namespace-scoped deployment")
 	fs.BoolVar(&p.force, "force", false, "overwrite scaffolded files to apply changes (manual edits may be lost)")
+	fs.StringVar(&p.licenseFile, "license-file", "",
+		"path to custom license file; content copied to hack/boilerplate.go.txt")
+	fs.StringVar(&p.license, "license", "",
+		"license header to use for boilerplate "+
+			"(see: https://book.kubebuilder.io/reference/license-header)")
+	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {
@@ -103,20 +120,51 @@ func (p *editSubcommand) InjectConfig(c config.Config) error {
 }
 
 func (p *editSubcommand) PreScaffold(machinery.Filesystem) error {
+	// Trim whitespace from license file path
+	p.licenseFile = strings.TrimSpace(p.licenseFile)
+
+	// Validate license file before scaffolding to prevent errors mid-operation
+	if p.licenseFile != "" {
+		if _, err := os.Stat(p.licenseFile); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("license file %q does not exist", p.licenseFile)
+			}
+			return fmt.Errorf("failed to access license file %q: %w", p.licenseFile, err)
+		}
+
+		// Check that the license file is a valid Go comment block
+		content, err := os.ReadFile(p.licenseFile)
+		if err != nil {
+			return fmt.Errorf("failed to read license file %q: %w", p.licenseFile, err)
+		}
+
+		// Empty files are allowed, only validate format if file has content
+		if len(content) > 0 {
+			contentStr := strings.TrimSpace(string(content))
+			if !strings.HasPrefix(contentStr, "/*") || !strings.HasSuffix(contentStr, "*/") {
+				return fmt.Errorf("license file %q must be a valid Go comment block (start with /* and end with */)", p.licenseFile)
+			}
+		}
+	}
+
 	// If flags were not explicitly set, preserve existing PROJECT file values
 	// This prevents one flag from clearing another when using default values
-	if !p.fs.Changed("multigroup") {
-		p.multigroup = p.config.IsMultiGroup()
-	}
-	if !p.fs.Changed("namespaced") {
-		p.namespaced = p.config.IsNamespaced()
+	// Only when FlagSet was bound (e.g. from CLI); tests may call PreScaffold without BindFlags
+	if p.fs != nil {
+		if !p.fs.Changed("multigroup") {
+			p.multigroup = p.config.IsMultiGroup()
+		}
+		if !p.fs.Changed("namespaced") {
+			p.namespaced = p.config.IsNamespaced()
+		}
 	}
 
 	return nil
 }
 
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewEditScaffolder(p.config, p.multigroup, p.namespaced, p.force)
+	scaffolder := scaffolds.NewEditScaffolder(p.config, p.multigroup, p.namespaced, p.force,
+		p.license, p.owner, p.licenseFile)
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {
 		return fmt.Errorf("failed to edit scaffold: %w", err)

--- a/pkg/plugins/golang/v4/edit_test.go
+++ b/pkg/plugins/golang/v4/edit_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v4
 
 import (
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
@@ -25,6 +28,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds"
 )
 
 var _ = Describe("editSubcommand", func() {
@@ -132,6 +136,392 @@ var _ = Describe("editSubcommand", func() {
 
 			Expect(subCmd.multigroup).To(BeTrue(), "multigroup should be preserved from PROJECT file")
 			Expect(subCmd.namespaced).To(BeTrue(), "namespaced should be preserved from PROJECT file")
+		})
+	})
+
+	Context("Boilerplate update", func() {
+		var (
+			fs     machinery.Filesystem
+			tmpDir string
+		)
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "test-edit-boilerplate")
+			Expect(err).NotTo(HaveOccurred())
+
+			fs = machinery.Filesystem{
+				FS: afero.NewBasePathFs(afero.NewOsFs(), tmpDir),
+			}
+
+			// Create necessary files for edit to work
+			err = os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte("FROM golang:1.23"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				_ = os.RemoveAll(tmpDir)
+			})
+		})
+
+		It("should update boilerplate with custom license file", func() {
+			// Create a custom license header file
+			customLicensePath := filepath.Join(tmpDir, "new-header.txt")
+			customContent := `/*
+Copyright 2026 New Company.
+
+Updated License Header.
+*/`
+			err := os.WriteFile(customLicensePath, []byte(customContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create scaffolder with custom license file
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewEditScaffolder(testCfg, false, false, false, "", "", customLicensePath)
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was created/updated with custom content
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customContent))
+		})
+
+		It("should update boilerplate with license flag", func() {
+			// Create scaffolder with license flag
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewEditScaffolder(testCfg, false, false, false, "apache2", "New Owner", "")
+			scaffolder.InjectFS(fs)
+			err := scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was created with Apache 2.0 license
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("Apache License"))
+			Expect(string(content)).To(ContainSubstring("New Owner"))
+		})
+
+		It("should not update boilerplate when neither license nor license-file is set", func() {
+			// Create scaffolder without license or license file
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewEditScaffolder(testCfg, false, false, false, "", "", "")
+			scaffolder.InjectFS(fs)
+			err := scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was not created
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			_, err = os.Stat(boilerplatePath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("should handle empty license file", func() {
+			// Create an empty license file
+			customLicensePath := filepath.Join(tmpDir, "empty-header.txt")
+			err := os.WriteFile(customLicensePath, []byte(""), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewEditScaffolder(testCfg, false, false, false, "apache2", "Test Owner", customLicensePath)
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was created (even if empty)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(""), "Empty license file should create empty boilerplate")
+		})
+
+		It("should ignore owner flag when using license-file", func() {
+			// Create a custom license file
+			customLicensePath := filepath.Join(tmpDir, "custom-no-owner.txt")
+			customContent := `/*
+Copyright 2026.
+
+Fixed License Header.
+*/`
+			err := os.WriteFile(customLicensePath, []byte(customContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			// Pass owner flag - it should be ignored when license-file is provided
+			scaffolder := scaffolds.NewEditScaffolder(
+				testCfg, false, false, false, "apache2", "Ignored Owner", customLicensePath)
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify content matches custom file exactly (owner flag was ignored)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customContent), "Owner flag should be ignored when license-file is provided")
+			Expect(string(content)).NotTo(ContainSubstring("Ignored Owner"))
+		})
+
+		It("should overwrite existing boilerplate when running edit with license-file", func() {
+			// Scenario: User has existing Apache 2.0 boilerplate and wants to change to custom license
+			// This is the bug reported in https://github.com/kubernetes-sigs/kubebuilder/pull/5559#discussion_r1972085438
+
+			// Given: an existing boilerplate.go.txt file with Apache 2.0 license
+			hackDir := filepath.Join(tmpDir, "hack")
+			err := os.MkdirAll(hackDir, 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			existingBoilerplatePath := filepath.Join(hackDir, "boilerplate.go.txt")
+			existingContent := `/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/`
+			err = os.WriteFile(existingBoilerplatePath, []byte(existingContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// And: a custom license file with different content
+			customLicensePath := filepath.Join(tmpDir, "my-custom-header.txt")
+			customContent := `/*
+this is my license
+*/`
+			err = os.WriteFile(customLicensePath, []byte(customContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// When: running `kubebuilder edit --license-file my-custom-header.txt`
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewEditScaffolder(testCfg, false, false, false, "", "", customLicensePath)
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Then: the boilerplate.go.txt should be overwritten with the custom content
+			content, err := os.ReadFile(existingBoilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customContent), "Existing boilerplate should be overwritten with custom license")
+			Expect(string(content)).NotTo(ContainSubstring("Apache License"), "Old Apache license should be replaced")
+			Expect(string(content)).To(ContainSubstring("this is my license"), "New custom license should be present")
+		})
+
+		It("should overwrite existing boilerplate when running edit with license flag", func() {
+			// Scenario: User has existing custom boilerplate and wants to change to Apache 2.0
+
+			// Given: an existing boilerplate.go.txt file with custom license
+			hackDir := filepath.Join(tmpDir, "hack")
+			err := os.MkdirAll(hackDir, 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			existingBoilerplatePath := filepath.Join(hackDir, "boilerplate.go.txt")
+			existingContent := `/*
+Custom License Header
+*/`
+			err = os.WriteFile(existingBoilerplatePath, []byte(existingContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// When: running `kubebuilder edit --license apache2 --owner "New Company"`
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewEditScaffolder(testCfg, false, false, false, "apache2", "New Company", "")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Then: the boilerplate.go.txt should be overwritten with Apache 2.0 license
+			content, err := os.ReadFile(existingBoilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("Apache License"), "New Apache license should be present")
+			Expect(string(content)).To(ContainSubstring("New Company"), "New owner should be present")
+			Expect(string(content)).NotTo(ContainSubstring("Custom License Header"), "Old custom license should be replaced")
+		})
+	})
+
+	Context("PreScaffold validation", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "test-edit-prescaffold")
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				_ = os.RemoveAll(tmpDir)
+			})
+
+			// Initialize subcommand with config
+			subCmd = &editSubcommand{
+				license: "apache2",
+				owner:   "Test Owner",
+			}
+			cfg = cfgv3.New()
+			err = subCmd.InjectConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail early when license file does not exist", func() {
+			subCmd.licenseFile = "/nonexistent/license.txt"
+
+			// PreScaffold should fail before any updates
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("license file"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("should succeed when license file exists", func() {
+			customLicensePath := filepath.Join(tmpDir, "valid-license.txt")
+			err := os.WriteFile(customLicensePath, []byte("/*\nValid License\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = customLicensePath
+
+			// PreScaffold should succeed
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed when no license file is specified", func() {
+			subCmd.licenseFile = ""
+
+			// PreScaffold should succeed
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should treat whitespace-only license file as empty", func() {
+			subCmd.licenseFile = "   "
+
+			// PreScaffold should succeed and trim the whitespace (treating as empty)
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subCmd.licenseFile).To(Equal(""), "Whitespace-only path should be trimmed to empty string")
+		})
+
+		It("should trim whitespace from license file path", func() {
+			customLicensePath := filepath.Join(tmpDir, "valid-license.txt")
+			err := os.WriteFile(customLicensePath, []byte("/*\nValid License\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = "  " + customLicensePath + "  "
+
+			// PreScaffold should succeed and trim the whitespace
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subCmd.licenseFile).To(Equal(customLicensePath), "Whitespace should be trimmed from path")
+		})
+
+		It("should fail when trimmed license file path does not exist", func() {
+			// Path with whitespace that doesn't exist even after trimming
+			subCmd.licenseFile = "  /nonexistent/file.txt  "
+
+			// PreScaffold should fail with trimmed path
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("license file"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+			// Verify the error message shows the trimmed path
+			Expect(err.Error()).To(ContainSubstring("/nonexistent/file.txt"))
+			Expect(subCmd.licenseFile).To(Equal("/nonexistent/file.txt"), "Path should be trimmed before validation")
+		})
+
+		It("should fail when license file is missing Go comment delimiters", func() {
+			// Create a license file without proper Go comment delimiters
+			invalidLicensePath := filepath.Join(tmpDir, "invalid-no-delimiters.txt")
+			err := os.WriteFile(invalidLicensePath, []byte("Copyright 2026 Test Company"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = invalidLicensePath
+
+			// PreScaffold should fail
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be a valid Go comment block"))
+			Expect(err.Error()).To(ContainSubstring("start with /* and end with */"))
+		})
+
+		It("should fail when license file does not start with opening delimiter", func() {
+			// Create a license file that doesn't start with /*
+			invalidLicensePath := filepath.Join(tmpDir, "invalid-no-opening.txt")
+			err := os.WriteFile(invalidLicensePath, []byte("Copyright 2026 Test Company\n/*\nSome text\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = invalidLicensePath
+
+			// PreScaffold should fail
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be a valid Go comment block"))
+		})
+
+		It("should fail when license file does not end with closing delimiter", func() {
+			// Create a license file that doesn't end with */
+			invalidLicensePath := filepath.Join(tmpDir, "invalid-no-closing.txt")
+			err := os.WriteFile(invalidLicensePath, []byte("/*\nCopyright 2026 Test Company\n*/\nExtra text"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = invalidLicensePath
+
+			// PreScaffold should fail
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be a valid Go comment block"))
+		})
+
+		It("should succeed when license file has proper Go comment delimiters", func() {
+			// Create a valid license file with proper delimiters
+			validLicensePath := filepath.Join(tmpDir, "valid-with-delimiters.txt")
+			err := os.WriteFile(validLicensePath, []byte("/*\nCopyright 2026 Test Company\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = validLicensePath
+
+			// PreScaffold should succeed
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow empty license file without requiring delimiters", func() {
+			// Create an empty license file
+			emptyLicensePath := filepath.Join(tmpDir, "empty-license.txt")
+			err := os.WriteFile(emptyLicensePath, []byte(""), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = emptyLicensePath
+
+			// PreScaffold should succeed (empty files are allowed)
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -48,8 +48,9 @@ type initSubcommand struct {
 	commandName string
 
 	// boilerplate options
-	license string
-	owner   string
+	license     string
+	owner       string
+	licenseFile string
 
 	// go config options
 	repo string
@@ -115,6 +116,15 @@ Note: Layout settings can be changed later with 'kubebuilder edit'.
 
   # Initialize with all options combined
   %[1]s init --plugins go/v4,autoupdate/v1-alpha --domain example.org --multigroup --namespaced
+
+  # Initialize with specific project version
+  %[1]s init --plugins go/v4 --project-version 3
+
+  # Initialize with custom license header from file
+  %[1]s init --plugins go/v4 --domain example.org --license-file ./my-header.txt
+
+  # Initialize with built-in license (apache2, none)
+  %[1]s init --plugins go/v4 --domain example.org --license apache2
 `, cliMeta.CommandName)
 }
 
@@ -127,8 +137,11 @@ func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 
 	// boilerplate args
 	fs.StringVar(&p.license, "license", "apache2",
-		"license header to use (apache2 or none)")
-	fs.StringVar(&p.owner, "owner", "", "copyright owner for license headers")
+		"license header to use for boilerplate "+
+			"(see: https://book.kubebuilder.io/reference/license-header)")
+	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
+	fs.StringVar(&p.licenseFile, "license-file", "",
+		"path to custom license file; content copied to hack/boilerplate.go.txt (overrides --license)")
 
 	// project args
 	fs.StringVar(&p.repo, "repo", "", "Go module name (e.g., github.com/user/repo); "+
@@ -178,12 +191,39 @@ func (p *initSubcommand) PreScaffold(machinery.Filesystem) error {
 		}
 	}
 
+	// Trim whitespace from license file path
+	p.licenseFile = strings.TrimSpace(p.licenseFile)
+
+	// Validate license file before scaffolding to prevent broken state
+	if p.licenseFile != "" {
+		if _, err := os.Stat(p.licenseFile); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("license file %q does not exist", p.licenseFile)
+			}
+			return fmt.Errorf("failed to access license file %q: %w", p.licenseFile, err)
+		}
+
+		// Check that the license file is a valid Go comment block
+		content, err := os.ReadFile(p.licenseFile)
+		if err != nil {
+			return fmt.Errorf("failed to read license file %q: %w", p.licenseFile, err)
+		}
+
+		// Empty files are allowed, only validate format if file has content
+		if len(content) > 0 {
+			contentStr := strings.TrimSpace(string(content))
+			if !strings.HasPrefix(contentStr, "/*") || !strings.HasSuffix(contentStr, "*/") {
+				return fmt.Errorf("license file %q must be a valid Go comment block (start with /* and end with */)", p.licenseFile)
+			}
+		}
+	}
+
 	// Check if the current directory has no files or directories which does not allow to init the project
 	return checkDir()
 }
 
 func (p *initSubcommand) Scaffold(fs machinery.Filesystem) error {
-	scaffolder := scaffolds.NewInitScaffolder(p.config, p.license, p.owner, p.commandName)
+	scaffolder := scaffolds.NewInitScaffolder(p.config, p.license, p.owner, p.licenseFile, p.commandName)
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {
 		return fmt.Errorf("error scaffolding init plugin: %w", err)

--- a/pkg/plugins/golang/v4/init_test.go
+++ b/pkg/plugins/golang/v4/init_test.go
@@ -22,9 +22,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds"
 )
 
 const testRepo = "github.com/example/test"
@@ -164,6 +167,432 @@ var _ = Describe("initSubcommand", func() {
 			err = checkDir()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("already initialized"))
+		})
+	})
+
+	Context("Boilerplate customization", func() {
+		var (
+			fs     machinery.Filesystem
+			tmpDir string
+		)
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "test-boilerplate")
+			Expect(err).NotTo(HaveOccurred())
+
+			fs = machinery.Filesystem{
+				FS: afero.NewBasePathFs(afero.NewOsFs(), tmpDir),
+			}
+
+			DeferCleanup(func() {
+				_ = os.RemoveAll(tmpDir)
+			})
+		})
+
+		It("should use custom license file when provided", func() {
+			// Create a custom license header file
+			customLicensePath := filepath.Join(tmpDir, "custom-header.txt")
+			customContent := `/*
+Copyright 2026 Test Company.
+
+Custom License Header.
+*/`
+			err := os.WriteFile(customLicensePath, []byte(customContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create scaffolder with custom license file
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Test Owner", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was created with custom content
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customContent))
+		})
+
+		It("should use default license when no custom license file is provided", func() {
+			// Create scaffolder without custom license file
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Test Owner", "", "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err := scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was created with Apache 2.0 license
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("Apache License"))
+			Expect(string(content)).To(ContainSubstring("Test Owner"))
+		})
+
+		It("should handle none license option", func() {
+			// Create scaffolder with none license
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "none", "", "", "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err := scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was not created
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			_, err = os.Stat(boilerplatePath)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("should fail when custom license file does not exist", func() {
+			// Create scaffolder with non-existent license file
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Test Owner", "/nonexistent/file.txt", "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err := scaffolder.Scaffold()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read license file"))
+		})
+
+		It("should preserve exact content from license file with no modifications", func() {
+			// Create a custom license file with specific formatting
+			customLicensePath := filepath.Join(tmpDir, "exact-header.txt")
+			// Include various formatting: multiple spaces, newlines, special characters
+			exactContent := `/*
+Copyright 2026 Test Company.
+  Indented line here.
+
+Double newline above.
+Special chars: @#$%
+*/`
+			err := os.WriteFile(customLicensePath, []byte(exactContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create scaffolder with custom license file
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Test Owner", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify content is EXACTLY the same (byte-for-byte)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			actualContent, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(actualContent)).To(Equal(exactContent), "Content should be preserved exactly with no modifications")
+		})
+
+		It("should handle license file with no trailing newline", func() {
+			// Create a license file without trailing newline
+			customLicensePath := filepath.Join(tmpDir, "no-newline.txt")
+			contentNoNewline := "/*\nCopyright 2026.\n*/"
+			err := os.WriteFile(customLicensePath, []byte(contentNoNewline), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify exact content preservation
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			actualContent, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(actualContent)).To(Equal(contentNoNewline))
+		})
+
+		It("should create boilerplate when --license-file is provided even with --license none", func() {
+			// Create a custom license header file
+			customLicensePath := filepath.Join(tmpDir, "custom-header.txt")
+			customContent := `/*
+Copyright 2026 My Company.
+
+My Custom License.
+*/`
+			err := os.WriteFile(customLicensePath, []byte(customContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create scaffolder with --license none BUT --license-file provided
+			// Expected: --license-file should override --license none
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "none", "", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file WAS created with custom content (--license-file overrides --license none)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customContent))
+		})
+
+		It("should handle empty license file", func() {
+			// Create an empty license file
+			customLicensePath := filepath.Join(tmpDir, "empty-header.txt")
+			err := os.WriteFile(customLicensePath, []byte(""), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Test Owner", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify boilerplate file was created (even if empty)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(""), "Empty license file should create empty boilerplate")
+		})
+
+		It("should ignore owner flag when using license-file", func() {
+			// Create a custom license file without owner placeholder
+			customLicensePath := filepath.Join(tmpDir, "custom-no-owner.txt")
+			customContent := `/*
+Copyright 2026.
+
+Fixed License Header.
+*/`
+			err := os.WriteFile(customLicensePath, []byte(customContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			// Pass owner flag - it should be ignored when license-file is provided
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Ignored Owner", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify content matches custom file exactly (owner flag was ignored)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customContent), "Owner flag should be ignored when license-file is provided")
+			Expect(string(content)).NotTo(ContainSubstring("Ignored Owner"), "Owner from flag should not appear in boilerplate")
+		})
+
+		It("should handle license file with only whitespace content", func() {
+			// Create a license file with only whitespace
+			customLicensePath := filepath.Join(tmpDir, "whitespace-content.txt")
+			whitespaceContent := "   \n\t\n   "
+			err := os.WriteFile(customLicensePath, []byte(whitespaceContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			testCfg := cfgv3.New()
+			_ = testCfg.SetRepository("github.com/test/repo")
+			_ = testCfg.SetDomain("test.io")
+
+			scaffolder := scaffolds.NewInitScaffolder(testCfg, "apache2", "Test Owner", customLicensePath, "kubebuilder")
+			scaffolder.InjectFS(fs)
+			err = scaffolder.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify content is preserved exactly (whitespace not trimmed)
+			boilerplatePath := filepath.Join(tmpDir, "hack", "boilerplate.go.txt")
+			content, err := os.ReadFile(boilerplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(whitespaceContent), "Whitespace content should be preserved as-is")
+		})
+	})
+
+	Context("PreScaffold validation", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "test-prescaffold")
+			Expect(err).NotTo(HaveOccurred())
+
+			originalDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				_ = os.Chdir(originalDir)
+				_ = os.RemoveAll(tmpDir)
+			})
+
+			err = os.Chdir(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Initialize subcommand with config
+			subCmd = &initSubcommand{
+				license:            "apache2",
+				owner:              "Test Owner",
+				repo:               "github.com/test/repo",
+				skipGoVersionCheck: true,
+			}
+			cfg = cfgv3.New()
+			err = subCmd.InjectConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail early when license file does not exist", func() {
+			subCmd.licenseFile = "/nonexistent/license.txt"
+
+			// PreScaffold should fail before any files are created
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("license file"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+
+			// Verify NO files were created (project not in broken state)
+			entries, err := os.ReadDir(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(BeEmpty(), "No files should be created when PreScaffold fails")
+		})
+
+		It("should succeed when license file exists", func() {
+			customLicensePath := filepath.Join(tmpDir, "valid-license.txt")
+			err := os.WriteFile(customLicensePath, []byte("/*\nValid License\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = customLicensePath
+
+			// PreScaffold should succeed
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed when no license file is specified", func() {
+			subCmd.licenseFile = ""
+
+			// PreScaffold should succeed (using built-in license)
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should treat whitespace-only license file as empty", func() {
+			subCmd.licenseFile = "   "
+
+			// PreScaffold should succeed and trim the whitespace (treating as empty)
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subCmd.licenseFile).To(Equal(""), "Whitespace-only path should be trimmed to empty string")
+		})
+
+		It("should trim whitespace from license file path", func() {
+			customLicensePath := filepath.Join(tmpDir, "valid-license.txt")
+			err := os.WriteFile(customLicensePath, []byte("/*\nValid License\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = "  " + customLicensePath + "  "
+
+			// PreScaffold should succeed and trim the whitespace
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(subCmd.licenseFile).To(Equal(customLicensePath), "Whitespace should be trimmed from path")
+		})
+
+		It("should fail when trimmed license file path does not exist", func() {
+			// Path with whitespace that doesn't exist even after trimming
+			subCmd.licenseFile = "  /nonexistent/file.txt  "
+
+			// PreScaffold should fail with trimmed path
+			err := subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("license file"))
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+			// Verify the error message shows the trimmed path (not the original with spaces)
+			Expect(err.Error()).To(ContainSubstring("/nonexistent/file.txt"))
+			Expect(subCmd.licenseFile).To(Equal("/nonexistent/file.txt"), "Path should be trimmed before validation")
+		})
+
+		It("should fail when license file is missing Go comment delimiters", func() {
+			// Create a license file without proper Go comment delimiters
+			invalidLicensePath := filepath.Join(tmpDir, "invalid-no-delimiters.txt")
+			err := os.WriteFile(invalidLicensePath, []byte("Copyright 2026 Test Company"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = invalidLicensePath
+
+			// PreScaffold should fail
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be a valid Go comment block"))
+			Expect(err.Error()).To(ContainSubstring("start with /* and end with */"))
+		})
+
+		It("should fail when license file does not start with opening delimiter", func() {
+			// Create a license file that doesn't start with /*
+			invalidLicensePath := filepath.Join(tmpDir, "invalid-no-opening.txt")
+			err := os.WriteFile(invalidLicensePath, []byte("Copyright 2026 Test Company\n/*\nSome text\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = invalidLicensePath
+
+			// PreScaffold should fail
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be a valid Go comment block"))
+		})
+
+		It("should fail when license file does not end with closing delimiter", func() {
+			// Create a license file that doesn't end with */
+			invalidLicensePath := filepath.Join(tmpDir, "invalid-no-closing.txt")
+			err := os.WriteFile(invalidLicensePath, []byte("/*\nCopyright 2026 Test Company\n*/\nExtra text after"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = invalidLicensePath
+
+			// PreScaffold should fail
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be a valid Go comment block"))
+		})
+
+		It("should succeed when license file has proper Go comment delimiters", func() {
+			// Create a valid license file with proper delimiters
+			validLicensePath := filepath.Join(tmpDir, "valid-with-delimiters.txt")
+			err := os.WriteFile(validLicensePath, []byte("/*\nCopyright 2026 Test Company\n*/"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = validLicensePath
+
+			// PreScaffold should succeed
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow empty license file without requiring delimiters", func() {
+			// Create an empty license file
+			emptyLicensePath := filepath.Join(tmpDir, "empty-license.txt")
+			err := os.WriteFile(emptyLicensePath, []byte(""), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			subCmd.licenseFile = emptyLicensePath
+
+			// PreScaffold should succeed (empty files are allowed)
+			err = subCmd.PreScaffold(machinery.Filesystem{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/plugins/golang/v4/scaffolds/edit.go
+++ b/pkg/plugins/golang/v4/scaffolds/edit.go
@@ -19,6 +19,7 @@ package scaffolds
 import (
 	"fmt"
 	log "log/slog"
+	"os"
 
 	"github.com/spf13/afero"
 
@@ -26,27 +27,36 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins"
 	kustomizecommonv2 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/common/kustomize/v2/scaffolds"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
 )
 
 var _ plugins.Scaffolder = &editScaffolder{}
 
 type editScaffolder struct {
-	config     config.Config
-	multigroup bool
-	namespaced bool
-	force      bool
+	config      config.Config
+	multigroup  bool
+	namespaced  bool
+	force       bool
+	license     string
+	owner       string
+	licenseFile string
 
 	// fs is the filesystem that will be used by the scaffolder
 	fs machinery.Filesystem
 }
 
 // NewEditScaffolder returns a new Scaffolder for configuration edit operations
-func NewEditScaffolder(cfg config.Config, multigroup bool, namespaced bool, force bool) plugins.Scaffolder {
+func NewEditScaffolder(cfg config.Config, multigroup bool, namespaced bool, force bool,
+	license, owner, licenseFile string,
+) plugins.Scaffolder {
 	return &editScaffolder{
-		config:     cfg,
-		multigroup: multigroup,
-		namespaced: namespaced,
-		force:      force,
+		config:      cfg,
+		multigroup:  multigroup,
+		namespaced:  namespaced,
+		force:       force,
+		license:     license,
+		owner:       owner,
+		licenseFile: licenseFile,
 	}
 }
 
@@ -63,6 +73,14 @@ func (s *editScaffolder) Scaffold() error {
 		return fmt.Errorf("error reading %q: %w", filename, err)
 	}
 	str := string(bs)
+
+	// Update boilerplate if license flags are provided.
+	// This allows users to change the license header after project initialization.
+	if s.license != "" || s.licenseFile != "" {
+		if updateErr := s.updateBoilerplate(); updateErr != nil {
+			return fmt.Errorf("failed to update boilerplate: %w", updateErr)
+		}
+	}
 
 	// Track if we're toggling namespaced mode
 	wasNamespaced := s.config.IsNamespaced()
@@ -180,4 +198,56 @@ func (s *editScaffolder) hasWebhooks() bool {
 		}
 	}
 	return false
+}
+
+func (s *editScaffolder) updateBoilerplate() error {
+	// Remove boilerplate file if --license none
+	if s.license == "none" {
+		boilerplatePath := hack.DefaultBoilerplatePath
+		if err := s.fs.FS.Remove(boilerplatePath); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to remove boilerplate file: %w", err)
+			}
+		}
+		log.Info("Removed license header file (--license none)", "path", boilerplatePath)
+		return nil
+	}
+
+	scaffold := machinery.NewScaffold(s.fs,
+		machinery.WithConfig(s.config),
+	)
+
+	bpFile := &hack.Boilerplate{
+		License: s.license,
+		Owner:   s.owner,
+	}
+
+	// Overwrite existing boilerplate
+	bpFile.IfExistsAction = machinery.OverwriteFile
+
+	// Use custom license file content if provided
+	if s.licenseFile != "" {
+		content, err := afero.ReadFile(afero.NewOsFs(), s.licenseFile)
+		if err != nil {
+			return fmt.Errorf("failed to read license file %q: %w", s.licenseFile, err)
+		}
+		bpFile.CustomBoilerplateContent = string(content)
+		bpFile.HasCustomBoilerplate = true
+		log.Info("Updating boilerplate with custom license file", "file", s.licenseFile)
+	} else if s.license != "" {
+		log.Info("Updating boilerplate with license", "license", s.license)
+	}
+
+	bpFile.Path = hack.DefaultBoilerplatePath
+	if err := scaffold.Execute(bpFile); err != nil {
+		return fmt.Errorf("failed to update boilerplate: %w", err)
+	}
+
+	if s.licenseFile != "" {
+		log.Info("Copied custom license file to boilerplate",
+			"file", s.licenseFile, "boilerplate", hack.DefaultBoilerplatePath)
+	}
+
+	log.Info("License header updated successfully", "path", hack.DefaultBoilerplatePath)
+	return nil
 }

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -57,6 +57,7 @@ type initScaffolder struct {
 	boilerplatePath string
 	license         string
 	owner           string
+	licenseFile     string
 	commandName     string
 
 	// fs is the filesystem that will be used by the scaffolder
@@ -64,12 +65,13 @@ type initScaffolder struct {
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(cfg config.Config, license, owner, commandName string) plugins.Scaffolder {
+func NewInitScaffolder(cfg config.Config, license, owner, licenseFile, commandName string) plugins.Scaffolder {
 	return &initScaffolder{
 		config:          cfg,
 		boilerplatePath: hack.DefaultBoilerplatePath,
 		license:         license,
 		owner:           owner,
+		licenseFile:     licenseFile,
 		commandName:     commandName,
 	}
 }
@@ -104,14 +106,32 @@ func (s *initScaffolder) Scaffold() error {
 		machinery.WithConfig(s.config),
 	)
 
-	if s.license != "none" {
+	// Create boilerplate unless --license none
+	if s.licenseFile != "" || s.license != "none" {
 		bpFile := &hack.Boilerplate{
 			License: s.license,
 			Owner:   s.owner,
 		}
+
+		// Use custom license file content if provided
+		if s.licenseFile != "" {
+			content, err := afero.ReadFile(afero.NewOsFs(), s.licenseFile)
+			if err != nil {
+				return fmt.Errorf("failed to read license file %q: %w", s.licenseFile, err)
+			}
+			bpFile.CustomBoilerplateContent = string(content)
+			bpFile.HasCustomBoilerplate = true
+			log.Info("Using custom license header file", "file", s.licenseFile)
+		}
+
 		bpFile.Path = s.boilerplatePath
 		if err := scaffold.Execute(bpFile); err != nil {
 			return fmt.Errorf("failed to execute boilerplate: %w", err)
+		}
+
+		if s.licenseFile != "" {
+			log.Info("Copied custom license file to boilerplate",
+				"file", s.licenseFile, "boilerplate", s.boilerplatePath)
 		}
 
 		boilerplate, err := afero.ReadFile(s.fs.FS, s.boilerplatePath)

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate.go
@@ -41,10 +41,21 @@ type Boilerplate struct {
 
 	// Owner is the copyright owner - e.g. "The Kubernetes Authors"
 	Owner string
+
+	// CustomBoilerplateContent is the content from a custom boilerplate file
+	CustomBoilerplateContent string
+
+	// HasCustomBoilerplate indicates whether a custom boilerplate file was explicitly provided
+	HasCustomBoilerplate bool
 }
 
 // Validate implements file.RequiresValidation
 func (f *Boilerplate) Validate() error {
+	// Skip validation if using custom boilerplate content (--license-file overrides --license)
+	if f.HasCustomBoilerplate {
+		return nil
+	}
+
 	if f.License != "" {
 		if _, foundKnown := knownLicenses[f.License]; !foundKnown {
 			if _, found := f.Licenses[f.License]; !found {
@@ -73,6 +84,13 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 		if _, hasLicense := f.Licenses[key]; !hasLicense {
 			f.Licenses[key] = value
 		}
+	}
+
+	// Custom boilerplate file content takes precedence (even if empty)
+	// HasCustomBoilerplate is set when --license-file is explicitly provided
+	if f.HasCustomBoilerplate {
+		f.TemplateBody = f.CustomBoilerplateContent
+		return nil
 	}
 
 	// Boilerplate given


### PR DESCRIPTION
We are either adding the docs to explain how to work with the license headers as custom those values.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5447