### PR TITLE
🐛 (helm/v2-alpha): Fix crd.keep to correctly add the helm.sh/resource-policy: keep annotation to generated CRDs

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     annotations:
+        {{- if .Values.crd.keep }}
+        "helm.sh/resource-policy": keep
+        {{- end }}
         controller-gen.kubebuilder.io/version: v0.20.0
     name: cronjobs.batch.tutorial.kubebuilder.io
 spec:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/crd/memcacheds.cache.example.com.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/crd/memcacheds.cache.example.com.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     annotations:
+        {{- if .Values.crd.keep }}
+        "helm.sh/resource-policy": keep
+        {{- end }}
         controller-gen.kubebuilder.io/version: v0.20.0
     name: memcacheds.cache.example.com
 spec:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     annotations:
+        {{- if .Values.crd.keep }}
+        "helm.sh/resource-policy": keep
+        {{- end }}
         cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
         controller-gen.kubebuilder.io/version: v0.20.0
     name: cronjobs.batch.tutorial.kubebuilder.io

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/busyboxes.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/busyboxes.example.com.testproject.org.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     annotations:
+        {{- if .Values.crd.keep }}
+        "helm.sh/resource-policy": keep
+        {{- end }}
         controller-gen.kubebuilder.io/version: v0.20.0
     name: busyboxes.example.com.testproject.org
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/memcacheds.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/memcacheds.example.com.testproject.org.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     annotations:
+        {{- if .Values.crd.keep }}
+        "helm.sh/resource-policy": keep
+        {{- end }}
         controller-gen.kubebuilder.io/version: v0.20.0
     name: memcacheds.example.com.testproject.org
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/wordpresses.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/wordpresses.example.com.testproject.org.yaml
@@ -3,6 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
     annotations:
+        {{- if .Values.crd.keep }}
+        "helm.sh/resource-policy": keep
+        {{- end }}
         cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project-v4-with-plugins.resourceName" (dict "suffix" "serving-cert" "context" $) }}
         controller-gen.kubebuilder.io/version: v0.20.0
     name: wordpresses.example.com.testproject.org


### PR DESCRIPTION
crd.keep value is defined but not used to inject helm.sh/resource-policy: keep annotation on CRDs

fixes #5465 
