### PR TITLE
🐛 fix(helm/v2-alpha): Replace bitnami/kubectl:latest with busybox:1.37

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
@@ -45,16 +45,6 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.certManager.enable }}
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - certificates
-    verbs:
-      - get
-      - list
-      - watch
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -95,10 +85,16 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  volumes:
+    - name: tmp
+      emptyDir: {}
   containers:
     - name: test
-      image: bitnami/kubectl:latest
-      imagePullPolicy: IfNotPresent
+      image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
       command:
         - /bin/sh
         - -ec
@@ -110,23 +106,28 @@ spec:
           echo "Namespace: {{ .Release.Namespace }}"
           echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
           echo ""
-
-          {{- if .Values.certManager.enable }}
-          echo "Step 1/3: Validating cert-manager certificates..."
-          if ! kubectl wait --for=condition=Ready certificate --all \
-            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
-            echo "Warning: No certificates found or certificates not ready"
-            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          
+          # Check if kubectl is already available in the image
+          if command -v kubectl >/dev/null 2>&1; then
+            echo "Using kubectl from image (pre-installed)"
           else
-            echo "SUCCESS: Certificates are ready"
+            # Download kubectl from official Kubernetes release
+            KUBECTL_VERSION="{{ .Values.test.kubectlVersion }}"
+            case "$(uname -m)" in
+              x86_64) ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+              armv7l) ARCH="arm" ;;
+              *) ARCH="$(uname -m)" ;;
+            esac
+            echo "Downloading kubectl ${KUBECTL_VERSION} for ${ARCH}..."
+            wget -q -O /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+            chmod +x /tmp/kubectl
+            export PATH="/tmp:$PATH"
+            echo "kubectl ${KUBECTL_VERSION} installed successfully"
           fi
           echo ""
-          {{- else }}
-          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
-          echo ""
-          {{- end }}
 
-          echo "Step 2/3: Verifying manager deployment is available..."
+          echo "Step 1/2: Verifying manager deployment is available..."
           if ! kubectl wait --for=condition=Available deployment \
             -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} --timeout=5m; then
@@ -145,7 +146,7 @@ spec:
           echo "SUCCESS: Manager deployment is available"
           echo ""
 
-          echo "Step 3/3: Verifying manager pod is running..."
+          echo "Step 2/2: Verifying manager pod is running..."
           POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} \
             -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -108,3 +108,14 @@ webhook:
 prometheus:
   enable: false
 
+## Helm test configuration.
+## Configure the image used for chart tests (helm test).
+##
+test:
+  image:
+    repository: busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  # Kubectl version to download from dl.k8s.io if not available in image
+  kubectlVersion: v1.35.0
+

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
@@ -45,16 +45,6 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.certManager.enable }}
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - certificates
-    verbs:
-      - get
-      - list
-      - watch
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -95,10 +85,16 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  volumes:
+    - name: tmp
+      emptyDir: {}
   containers:
     - name: test
-      image: bitnami/kubectl:latest
-      imagePullPolicy: IfNotPresent
+      image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
       command:
         - /bin/sh
         - -ec
@@ -110,23 +106,28 @@ spec:
           echo "Namespace: {{ .Release.Namespace }}"
           echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
           echo ""
-
-          {{- if .Values.certManager.enable }}
-          echo "Step 1/3: Validating cert-manager certificates..."
-          if ! kubectl wait --for=condition=Ready certificate --all \
-            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
-            echo "Warning: No certificates found or certificates not ready"
-            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          
+          # Check if kubectl is already available in the image
+          if command -v kubectl >/dev/null 2>&1; then
+            echo "Using kubectl from image (pre-installed)"
           else
-            echo "SUCCESS: Certificates are ready"
+            # Download kubectl from official Kubernetes release
+            KUBECTL_VERSION="{{ .Values.test.kubectlVersion }}"
+            case "$(uname -m)" in
+              x86_64) ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+              armv7l) ARCH="arm" ;;
+              *) ARCH="$(uname -m)" ;;
+            esac
+            echo "Downloading kubectl ${KUBECTL_VERSION} for ${ARCH}..."
+            wget -q -O /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+            chmod +x /tmp/kubectl
+            export PATH="/tmp:$PATH"
+            echo "kubectl ${KUBECTL_VERSION} installed successfully"
           fi
           echo ""
-          {{- else }}
-          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
-          echo ""
-          {{- end }}
 
-          echo "Step 2/3: Verifying manager deployment is available..."
+          echo "Step 1/2: Verifying manager deployment is available..."
           if ! kubectl wait --for=condition=Available deployment \
             -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} --timeout=5m; then
@@ -145,7 +146,7 @@ spec:
           echo "SUCCESS: Manager deployment is available"
           echo ""
 
-          echo "Step 3/3: Verifying manager pod is running..."
+          echo "Step 2/2: Verifying manager pod is running..."
           POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} \
             -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -101,3 +101,14 @@ certManager:
 prometheus:
   enable: false
 
+## Helm test configuration.
+## Configure the image used for chart tests (helm test).
+##
+test:
+  image:
+    repository: busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  # Kubectl version to download from dl.k8s.io if not available in image
+  kubectlVersion: v1.35.0
+

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/tests/test-manager-ready.yaml
@@ -45,16 +45,6 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.certManager.enable }}
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - certificates
-    verbs:
-      - get
-      - list
-      - watch
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -95,10 +85,16 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "project.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  volumes:
+    - name: tmp
+      emptyDir: {}
   containers:
     - name: test
-      image: bitnami/kubectl:latest
-      imagePullPolicy: IfNotPresent
+      image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
       command:
         - /bin/sh
         - -ec
@@ -110,23 +106,28 @@ spec:
           echo "Namespace: {{ .Release.Namespace }}"
           echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
           echo ""
-
-          {{- if .Values.certManager.enable }}
-          echo "Step 1/3: Validating cert-manager certificates..."
-          if ! kubectl wait --for=condition=Ready certificate --all \
-            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
-            echo "Warning: No certificates found or certificates not ready"
-            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          
+          # Check if kubectl is already available in the image
+          if command -v kubectl >/dev/null 2>&1; then
+            echo "Using kubectl from image (pre-installed)"
           else
-            echo "SUCCESS: Certificates are ready"
+            # Download kubectl from official Kubernetes release
+            KUBECTL_VERSION="{{ .Values.test.kubectlVersion }}"
+            case "$(uname -m)" in
+              x86_64) ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+              armv7l) ARCH="arm" ;;
+              *) ARCH="$(uname -m)" ;;
+            esac
+            echo "Downloading kubectl ${KUBECTL_VERSION} for ${ARCH}..."
+            wget -q -O /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+            chmod +x /tmp/kubectl
+            export PATH="/tmp:$PATH"
+            echo "kubectl ${KUBECTL_VERSION} installed successfully"
           fi
           echo ""
-          {{- else }}
-          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
-          echo ""
-          {{- end }}
 
-          echo "Step 2/3: Verifying manager deployment is available..."
+          echo "Step 1/2: Verifying manager deployment is available..."
           if ! kubectl wait --for=condition=Available deployment \
             -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} --timeout=5m; then
@@ -145,7 +146,7 @@ spec:
           echo "SUCCESS: Manager deployment is available"
           echo ""
 
-          echo "Step 3/3: Verifying manager pod is running..."
+          echo "Step 2/2: Verifying manager pod is running..."
           POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} \
             -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -108,3 +108,14 @@ webhook:
 prometheus:
   enable: false
 
+## Helm test configuration.
+## Configure the image used for chart tests (helm test).
+##
+test:
+  image:
+    repository: busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  # Kubectl version to download from dl.k8s.io if not available in image
+  kubectlVersion: v1.35.0
+

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -319,6 +319,17 @@ webhook:
 ##
 prometheus:
   enable: false
+
+## Helm test configuration.
+## Configure the image used for chart tests (helm test).
+##
+test:
+  image:
+    repository: busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  # Kubectl version to download from dl.k8s.io during tests
+  kubectlVersion: v1.35.0
 ```
 
 ### Installation
@@ -345,17 +356,37 @@ The Makefile targets use sensible defaults extracted from your project configura
 
 ### Testing
 
-The generated chart includes Helm tests to verify deployment health:
+The generated chart includes Helm tests to verify deployment health. Tests are **optional** and run only when explicitly invoked:
 
 ```shell
 # Run tests after installation
 helm test my-release --namespace my-project-system
 ```
 
-Tests verify:
-- Manager deployment is available
-- Manager pod is running
-- Cert-manager certificates are ready (if cert-manager is enabled)
+**What the tests do:**
+- Download kubectl from `dl.k8s.io` (official Kubernetes release CDN) if not already in image
+- Verify manager deployment is available
+- Verify manager pod is running
+
+**Test configuration:**
+
+The test image can be customized via `values.yaml`:
+
+```yaml
+test:
+  image:
+    repository: busybox  # Base image for test pod
+    tag: "1.37"          # Use version-pinned tag
+    pullPolicy: IfNotPresent
+  kubectlVersion: v1.35.0  # kubectl version to download
+```
+
+This allows users to:
+- Use their own registry (e.g., `test.image.repository: my-registry.com/busybox`)
+- Match kubectl version to their cluster
+- Control image pull behavior for air-gapped environments
+
+**Note:** Tests only run when you execute `helm test`. They do NOT run automatically during `helm install` or `helm upgrade`.
 
 ## Flags
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/test_manager_ready.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/test_manager_ready.go
@@ -27,10 +27,9 @@ var _ machinery.Template = &TestManagerReady{}
 
 // TestManagerReady scaffolds a Helm test that verifies the manager deployment is healthy.
 //
-// The test validates deployment readiness in three steps:
-//  1. Cert-manager certificates are Ready (if cert-manager is enabled)
-//  2. Manager deployment is Available (waits up to 5 minutes)
-//  3. Manager pod is Running (validates pod actually started)
+// The test validates deployment readiness in two steps:
+//  1. Manager deployment is Available (waits up to 5 minutes)
+//  2. Manager pod is Running (validates pod actually started)
 //
 // The test pod uses a dedicated ServiceAccount, Role, and RoleBinding
 // and follows security best practices with a restrictive security context.
@@ -122,16 +121,6 @@ rules:
       - get
       - list
       - watch
-  {{ "{{- if .Values.certManager.enable }}" }}
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - certificates
-    verbs:
-      - get
-      - list
-      - watch
-  {{ "{{- end }}" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -172,10 +161,16 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"test-manager-ready\" \"context\" $) }}" }}
+  volumes:
+    - name: tmp
+      emptyDir: {}
   containers:
     - name: test
-      image: bitnami/kubectl:latest
-      imagePullPolicy: IfNotPresent
+      image: {{ "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}" }}
+      imagePullPolicy: {{ "{{ .Values.test.image.pullPolicy }}" }}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
       command:
         - /bin/sh
         - -ec
@@ -187,23 +182,28 @@ spec:
           echo "Namespace: {{ "{{ .Release.Namespace }}" }}"
           echo "Chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version }}" }}"
           echo ""
-
-          {{ "{{- if .Values.certManager.enable }}" }}
-          echo "Step 1/3: Validating cert-manager certificates..."
-          if ! kubectl wait --for=condition=Ready certificate --all \
-            -n {{ "{{ .Release.Namespace }}" }} --timeout=3m 2>/dev/null; then
-            echo "Warning: No certificates found or certificates not ready"
-            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          
+          # Check if kubectl is already available in the image
+          if command -v kubectl >/dev/null 2>&1; then
+            echo "Using kubectl from image (pre-installed)"
           else
-            echo "SUCCESS: Certificates are ready"
+            # Download kubectl from official Kubernetes release
+            KUBECTL_VERSION="{{ "{{ .Values.test.kubectlVersion }}" }}"
+            case "$(uname -m)" in
+              x86_64) ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+              armv7l) ARCH="arm" ;;
+              *) ARCH="$(uname -m)" ;;
+            esac
+            echo "Downloading kubectl ${KUBECTL_VERSION} for ${ARCH}..."
+            wget -q -O /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+            chmod +x /tmp/kubectl
+            export PATH="/tmp:$PATH"
+            echo "kubectl ${KUBECTL_VERSION} installed successfully"
           fi
           echo ""
-          {{ "{{- else }}" }}
-          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
-          echo ""
-          {{ "{{- end }}" }}
 
-          echo "Step 2/3: Verifying manager deployment is available..."
+          echo "Step 1/2: Verifying manager deployment is available..."
           if ! kubectl wait --for=condition=Available deployment \
             -l control-plane=controller-manager \
             -n {{ "{{ .Release.Namespace }}" }} --timeout=5m; then
@@ -222,7 +222,7 @@ spec:
           echo "SUCCESS: Manager deployment is available"
           echo ""
 
-          echo "Step 3/3: Verifying manager pod is running..."
+          echo "Step 2/2: Verifying manager pod is running..."
           POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
             -n {{ "{{ .Release.Namespace }}" }} \
             -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -206,6 +206,20 @@ webhook:
 ##
 prometheus:
   enable: false
+
+`)
+
+	// Test configuration
+	buf.WriteString(`## Helm test configuration.
+## Configure the image used for chart tests (helm test).
+##
+test:
+  image:
+    repository: busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  # Kubectl version to download from dl.k8s.io if not available in image
+  kubectlVersion: v1.35.0
 `)
 
 	buf.WriteString("\n")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/k8s_version.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/k8s_version.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+// KubernetesVersion is the Kubernetes version used for kubectl in generated Helm chart tests.
+// This should match the k8s.io/api version used in testdata projects' go.mod files.
+//
+// Update this when updating the Kubernetes version in Kubebuilder (see VERSIONING.md).
+// The version should correspond to the k8s.io/api version (e.g., k8s.io/api v0.35.0 → v1.35.0)
+//
+// This constant is used to download kubectl in Helm test pods from the official Kubernetes release:
+//   - https://dl.k8s.io/release/${KubernetesVersion}/bin/linux/${ARCH}/kubectl
+//
+// The Helm test uses busybox:1.37 as the base image and downloads kubectl at runtime to ensure:
+//   - Official kubectl binaries from dl.k8s.io
+//   - Multi-architecture support (amd64, arm64, arm, ppc64le, s390x)
+//   - Minimal and secure base image
+//   - Modern TLS support for downloading from dl.k8s.io
+//
+// GitHub workflows in scaffolded projects extract the version dynamically from go.mod
+// and do not use this constant.
+const KubernetesVersion = "v1.35.0"

--- a/testdata/project-v4-with-plugins/dist/chart/templates/tests/test-manager-ready.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/tests/test-manager-ready.yaml
@@ -45,16 +45,6 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.certManager.enable }}
-  - apiGroups:
-      - cert-manager.io
-    resources:
-      - certificates
-    verbs:
-      - get
-      - list
-      - watch
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -95,10 +85,16 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "test-manager-ready" "context" $) }}
+  volumes:
+    - name: tmp
+      emptyDir: {}
   containers:
     - name: test
-      image: bitnami/kubectl:latest
-      imagePullPolicy: IfNotPresent
+      image: {{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
       command:
         - /bin/sh
         - -ec
@@ -110,23 +106,28 @@ spec:
           echo "Namespace: {{ .Release.Namespace }}"
           echo "Chart: {{ .Chart.Name }}-{{ .Chart.Version }}"
           echo ""
-
-          {{- if .Values.certManager.enable }}
-          echo "Step 1/3: Validating cert-manager certificates..."
-          if ! kubectl wait --for=condition=Ready certificate --all \
-            -n {{ .Release.Namespace }} --timeout=3m 2>/dev/null; then
-            echo "Warning: No certificates found or certificates not ready"
-            echo "This may be expected if webhooks are not enabled or certificates are still being provisioned"
+          
+          # Check if kubectl is already available in the image
+          if command -v kubectl >/dev/null 2>&1; then
+            echo "Using kubectl from image (pre-installed)"
           else
-            echo "SUCCESS: Certificates are ready"
+            # Download kubectl from official Kubernetes release
+            KUBECTL_VERSION="{{ .Values.test.kubectlVersion }}"
+            case "$(uname -m)" in
+              x86_64) ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+              armv7l) ARCH="arm" ;;
+              *) ARCH="$(uname -m)" ;;
+            esac
+            echo "Downloading kubectl ${KUBECTL_VERSION} for ${ARCH}..."
+            wget -q -O /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+            chmod +x /tmp/kubectl
+            export PATH="/tmp:$PATH"
+            echo "kubectl ${KUBECTL_VERSION} installed successfully"
           fi
           echo ""
-          {{- else }}
-          echo "Step 1/3: Skipping certificate validation (cert-manager not enabled)"
-          echo ""
-          {{- end }}
 
-          echo "Step 2/3: Verifying manager deployment is available..."
+          echo "Step 1/2: Verifying manager deployment is available..."
           if ! kubectl wait --for=condition=Available deployment \
             -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} --timeout=5m; then
@@ -145,7 +146,7 @@ spec:
           echo "SUCCESS: Manager deployment is available"
           echo ""
 
-          echo "Step 3/3: Verifying manager pod is running..."
+          echo "Step 2/2: Verifying manager pod is running..."
           POD_STATUS=$(kubectl get pods -l control-plane=controller-manager \
             -n {{ .Release.Namespace }} \
             -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -116,3 +116,14 @@ webhook:
 prometheus:
   enable: false
 
+## Helm test configuration.
+## Configure the image used for chart tests (helm test).
+##
+test:
+  image:
+    repository: busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  # Kubectl version to download from dl.k8s.io if not available in image
+  kubectlVersion: v1.35.0
+


### PR DESCRIPTION
## Summary

Replace `bitnami/kubectl:latest` with `busybox:1.37` + runtime kubectl download from official Kubernetes releases (`dl.k8s.io`).

## Problem

The current Helm chart tests use `bitnami/kubectl:latest`, which has several issues:
- Third-party dependency (Bitnami) that could be deprecated or removed
- Unpredictable `:latest` tag breaks reproducibility
- Large image size (~130MB)
- Not aligned with Kubebuilder being an official Kubernetes project

## Investigation: Why Not Use registry.k8s.io Images?

We thoroughly investigated using **only** official Kubernetes registry images:

### Option 1: `registry.k8s.io/kubectl:v1.35.0`
❌ **No shell** - Image contains only the kubectl binary, cannot run test scripts that require `/bin/sh`

### Option 2: `registry.k8s.io/busybox:1.27.2`
❌ **Outdated TLS** - From 2017, uses old SSL/TLS libraries that fail to download from modern HTTPS endpoints