### PR TITLE
🐛 fix(helm/v2-alpha): remove issues to pre-load image

### DIFF
--- a/.github/workflows/test-helm-book.yml
+++ b/.github/workflows/test-helm-book.yml
@@ -61,11 +61,6 @@ jobs:
       - name: Install Helm
         run: make install-helm
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Lint Helm chart
         run: |
           helm lint ${{ matrix.folder }}/dist/chart

--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -70,11 +70,6 @@ jobs:
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Install Prometheus Operator CRDs
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
@@ -167,11 +162,6 @@ jobs:
         run: |
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
-
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
 
       - name: Lint Helm chart
         working-directory: test-helm-no-webhooks

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -35,11 +35,6 @@ jobs:
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Install Helm
         run: make install-helm
 

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/test-chart.yml
@@ -35,11 +35,6 @@ jobs:
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Install Helm
         run: make install-helm
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -35,11 +35,6 @@ jobs:
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Install Helm
         run: make install-helm
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
@@ -87,11 +87,6 @@ jobs:
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Install Helm
         run: make install-helm
 

--- a/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
@@ -35,11 +35,6 @@ jobs:
           make docker-build IMG=controller:latest
           kind load docker-image controller:latest
 
-      - name: Pre-load kubectl image for Helm tests
-        run: |
-          docker pull bitnami/kubectl:latest
-          kind load docker-image bitnami/kubectl:latest
-
       - name: Install Helm
         run: make install-helm
 


### PR DESCRIPTION
Fix issue start to be faced

```
Run docker pull bitnami/kubectl:latest
latest: Pulling from bitnami/kubectl
95152fca54f6: Pulling fs layer
95152fca54f6: Download complete
95152fca54f6: Pull complete
Digest: sha256:4c5f63828f5170142d714cdf1f96bad9e223f7ad79bd67d6d6b21e59a188c514
Status: Downloaded newer image for bitnami/kubectl:latest
docker.io/bitnami/kubectl:latest
Image: "bitnami/kubectl:latest" with ID "sha256:4c5f63828f5170142d714cdf1f96bad9e223f7ad79bd67d6d6b21e59a188c514" not yet present on node "kind-control-plane", loading...
ERROR: failed to load image: command "docker exec --privileged -i kind-control-plane ctr --namespace=k8s.io images import --all-platforms --digests --snapshotter=overlayfs -" failed with error: exit status 1

Command Output: ctr: content digest sha256:54e53ebdbe23823060197816a4754fff9dfb650779283448930856f82a370487: not found
```