### PR TITLE
✨ refactor(alpha/update): shorten commit message flag names

### DIFF
--- a/docs/book/src/plugins/available/autoupdate-v1-alpha.md
+++ b/docs/book/src/plugins/available/autoupdate-v1-alpha.md
@@ -85,6 +85,44 @@ The plugin scaffolds a GitHub Actions workflow that checks for new Kubebuilder r
 
 <img width="600" height="188" alt="Conflicts" src="https://github.com/user-attachments/assets/2142887a-730c-499a-94df-c717f09ab600" />
 
+## Customizing the Workflow
+
+The generated workflow uses the `kubebuilder alpha update` command with default flags. You can customize the workflow by editing `.github/workflows/auto_update.yml` to add additional flags:
+
+**Default flags used:**
+- `--force` - Continue even if conflicts occur (automation-friendly)
+- `--push` - Automatically push the output branch to remote
+- `--restore-path .github/workflows` - Preserve CI workflows from base branch
+- `--open-gh-issue` - Create a GitHub Issue with PR compare link
+- `--use-gh-models` - (optional) Add AI summary to the issue
+
+**Additional available flags:**
+- `--merge-message` - Custom commit message for clean merges
+- `--conflict-message` - Custom commit message when conflicts occur
+- `--from-version` - Specify the version to upgrade from
+- `--to-version` - Specify the version to upgrade to
+- `--output-branch` - Custom output branch name
+- `--show-commits` - Keep full history instead of squashing
+- `--git-config` - Pass per-invocation Git config
+
+For complete documentation on all available flags, see the [`kubebuilder alpha update`][alpha-update-command] reference.
+
+**Example: Customize commit messages**
+
+Edit `.github/workflows/auto_update.yml`:
+
+```yaml
+- name: Run kubebuilder alpha update
+  run: |
+    kubebuilder alpha update \
+      --force \
+      --push \
+      --restore-path .github/workflows \
+      --open-gh-issue \
+      --merge-message "chore: update kubebuilder scaffold" \
+      --conflict-message "chore: update with conflicts - review needed"
+```
+
 ## Troubleshooting
 
 #### If you get the 403 Forbidden Error

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -64,8 +64,8 @@ The command creates three temporary branches:
     - `--show-commits`: keep the full history.
     - `--restore-path`: in squash mode, restore specific files (like CI configs) from your base branch.
     - `--output-branch`: pick a custom branch name.
-    - `--commit-message`: customize the commit message for clean merges.
-    - `--commit-message-conflict`: customize the commit message when conflicts occur.
+    - `--merge-message`: customize the commit message for clean merges.
+    - `--conflict-message`: customize the commit message when conflicts occur.
     - `--push`: push the result to `origin` automatically.
     - `--git-config`: sets git configurations.
     - `--open-gh-issue`: create a GitHub issue with a checklist and compare link (requires `gh`).
@@ -127,8 +127,8 @@ Customize commit messages:
 
 ```shell
 kubebuilder alpha update --force \
---commit-message "chore: upgrade kubebuilder scaffold" \
---commit-message-conflict "chore: upgrade with conflicts - manual review needed"
+--merge-message "chore: upgrade kubebuilder scaffold" \
+--conflict-message "chore: upgrade with conflicts - manual review needed"
 ```
 
 ## Handling Conflicts (`--force` vs default)
@@ -235,12 +235,12 @@ We use that value to pick the correct CLI for re-scaffolding.
 
 | Flag                         | Description                                                                                                                                                                                                                             |
 |------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--commit-message`           | Custom commit message for successful merges (no conflicts). Defaults to `chore(kubebuilder): update scaffold <from> -> <to>`.                                                                                                           |
-| `--commit-message-conflict`  | Custom commit message for merges with conflicts. Defaults to `:warning: chore(kubebuilder): update scaffold (manual conflict resolution) <from> -> <to>`.                                                                               |
+| `--conflict-message`         | Custom commit message for merges with conflicts. Defaults to `:warning: chore(kubebuilder): update scaffold (manual conflict resolution) <from> -> <to>`.                                                                               |
 | `--force`          | Continue even if merge conflicts happen. Conflicted files are committed with conflict markers (CI/cron friendly).                                                                                                                       |
 | `--from-branch`    | Git branch that holds your current project code. Defaults to `main`.                                                                                                                                                                    |
 | `--from-version`   | Kubebuilder release to update **from** (e.g., `v4.6.0`). If unset, read from the `PROJECT` file when possible.                                                                                                                          |
 | `--git-config`     | Repeatable. Pass per-invocation Git config as `-c key=value`. **Default** (if omitted): `-c merge.renameLimit=999999 -c diff.renameLimit=999999`. Your configs are applied on top. To disable defaults, include `--git-config disable`. |
+| `--merge-message`            | Custom commit message for successful merges (no conflicts). Defaults to `chore(kubebuilder): update scaffold <from> -> <to>`.                                                                                                           |
 | `--open-gh-issue`  | Create a GitHub issue with a pre-filled checklist and compare link after the update completes (requires `gh`).                                                                                                                          |
 | `--output-branch`  | Name of the output branch. Default: `kubebuilder-update-from-<from-version>-to-<to-version>`.                                                                                                                                           |
 | `--push`           | Push the output branch to the `origin` remote after the update completes.                                                                                                                                                               |

--- a/pkg/cli/alpha/internal/update/update.go
+++ b/pkg/cli/alpha/internal/update/update.go
@@ -75,11 +75,13 @@ type Update struct {
 	// Push, when true, pushes the OutputBranch to the "origin" remote after the update completes.
 	Push bool
 
-	// CommitMessage is the custom commit message to use for successful merges (no conflicts).
+	// CommitMessage is the custom merge message to use for successful merges (no conflicts).
+	// Set via --merge-message flag.
 	// If empty, defaults to: "chore(kubebuilder): update scaffold <from> -> <to>".
 	CommitMessage string
 
-	// CommitMessageConflict is the custom commit message to use when conflicts occur.
+	// CommitMessageConflict is the custom conflict message to use when conflicts occur.
+	// Set via --conflict-message flag.
 	// If empty, defaults to: "chore(kubebuilder): (:warning: manual conflict resolution required)
 	// update scaffold <from> -> <to>".
 	CommitMessageConflict string

--- a/pkg/cli/alpha/update.go
+++ b/pkg/cli/alpha/update.go
@@ -53,8 +53,8 @@ Conflicts:
 Other options:
   • --restore-path: restore paths from base when squashing (e.g., CI configs).
   • --output-branch: override the output branch name.
-  • --commit-message: custom commit message for clean merges.
-  • --commit-message-conflict: custom commit message for merges with conflicts.
+  • --merge-message: custom commit message for clean merges.
+  • --conflict-message: custom commit message for merges with conflicts.
   • --push: push the output branch to 'origin' after the update.
   • --git-config: pass per-invocation Git config as -c key=value (repeatable). When not set,
       defaults are set to improve detection during merges.
@@ -86,8 +86,8 @@ Defaults:
 
   # Use custom commit messages for both scenarios
   kubebuilder alpha update --force \
-    --commit-message "chore: upgrade kubebuilder scaffold" \
-    --commit-message-conflict "chore: upgrade with conflicts - manual review needed"
+    --merge-message "chore: upgrade kubebuilder scaffold" \
+    --conflict-message "chore: upgrade with conflicts - manual review needed"
 
   # Create an issue and add an AI overview comment
   kubebuilder alpha update --open-gh-issue --use-gh-models
@@ -163,10 +163,10 @@ Defaults:
 		"Override the default output branch name (default: kubebuilder-update-from-<from-version>-to-<to-version>).")
 	updateCmd.Flags().BoolVar(&opts.Push, "push", false,
 		"Push the output branch to the remote repository after the update.")
-	updateCmd.Flags().StringVar(&opts.CommitMessage, "commit-message", "",
+	updateCmd.Flags().StringVar(&opts.CommitMessage, "merge-message", "",
 		"Custom commit message for successful merges (no conflicts). "+
 			"Defaults to 'chore(kubebuilder): update scaffold <from> -> <to>'.")
-	updateCmd.Flags().StringVar(&opts.CommitMessageConflict, "commit-message-conflict", "",
+	updateCmd.Flags().StringVar(&opts.CommitMessageConflict, "conflict-message", "",
 		"Custom commit message for merges with conflicts. "+
 			"Defaults to 'chore(kubebuilder): (:warning: manual conflict resolution required) update scaffold <from> -> <to>'.")
 	updateCmd.Flags().BoolVar(&opts.OpenGhIssue, "open-gh-issue", false,


### PR DESCRIPTION
Rename the flags to be more appropriate names and size before we release.
More aligned with the others. 

Follow up of: #5429