### PR TITLE
🐛 (go/v4): CI lint by using make lint instead of golangci-lint-action so the custom binary (with logcheck plugin) is built and used.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.8.0
+        run: make lint

--- a/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.8.0
+        run: make lint

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.8.0
+        run: make lint

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/github/lint.go
@@ -65,8 +65,8 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: {{ .GolangciLintVersion }}
+        run: make lint
 `

--- a/testdata/project-v4-multigroup/.github/workflows/lint.yml
+++ b/testdata/project-v4-multigroup/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.8.0
+        run: make lint

--- a/testdata/project-v4-with-plugins/.github/workflows/lint.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.8.0
+        run: make lint

--- a/testdata/project-v4/.github/workflows/lint.yml
+++ b/testdata/project-v4/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check linter configuration
+        run: make lint-config
       - name: Run linter
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.8.0
+        run: make lint


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5492