### PR TITLE
✨ (helm/v2-alpha): Add manager.envOverrides for CLI env overrides

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -25,6 +25,11 @@ manager:
   ##
   env: []
 
+  ## Env overrides (--set manager.envOverrides.VAR=value)
+  ## Same name in env above: this value takes precedence.
+  ##
+  envOverrides: {}
+
   ## Image pull secrets
   ##
   imagePullSecrets: []

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -25,6 +25,11 @@ manager:
   ##
   env: []
 
+  ## Env overrides (--set manager.envOverrides.VAR=value)
+  ## Same name in env above: this value takes precedence.
+  ##
+  envOverrides: {}
+
   ## Image pull secrets
   ##
   imagePullSecrets: []

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -25,6 +25,11 @@ manager:
   ##
   env: []
 
+  ## Env overrides (--set manager.envOverrides.VAR=value)
+  ## Same name in env above: this value takes precedence.
+  ##
+  envOverrides: {}
+
   ## Image pull secrets
   ##
   imagePullSecrets: []

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -2047,9 +2047,10 @@ spec:
 			Expect(result).To(ContainSubstring("{{- if .Values.manager.resources }}"))
 			Expect(result).To(ContainSubstring("{{- toYaml .Values.manager.resources | nindent"))
 
-			// Should template environment variables
-			Expect(result).To(ContainSubstring("{{- if .Values.manager.env }}"))
-			Expect(result).To(ContainSubstring("{{- toYaml .Values.manager.env | nindent"))
+			// Env list + envOverrides (--set). Secret refs go in env list.
+			Expect(result).To(ContainSubstring(".Values.manager.env"))
+			Expect(result).To(ContainSubstring("toYaml .Values.manager.env"))
+			Expect(result).To(ContainSubstring("envOverrides"))
 
 			// Should template args
 			Expect(result).To(ContainSubstring("{{- range .Values.manager.args }}"))

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
@@ -52,10 +52,18 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("manager:"))
 			Expect(content).To(ContainSubstring("args: []"))
 			Expect(content).To(ContainSubstring("env: []"))
+			Expect(content).To(ContainSubstring("envOverrides: {}"))
 			Expect(content).To(ContainSubstring("metrics:"))
 			Expect(content).To(ContainSubstring("prometheus:"))
 			Expect(content).To(ContainSubstring("rbacHelpers:"))
 			Expect(content).To(ContainSubstring("imagePullSecrets: []"))
+		})
+
+		It("should include env list and envOverrides for CLI", func() {
+			content := valuesTemplate.GetBody()
+			Expect(content).To(ContainSubstring("env: []"))
+			Expect(content).To(ContainSubstring("envOverrides: {}"))
+			Expect(content).To(ContainSubstring("--set manager.envOverrides.VAR=value"))
 		})
 	})
 
@@ -153,8 +161,8 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("args:"))
 			Expect(content).To(ContainSubstring("- --leader-elect"))
 			Expect(content).To(ContainSubstring("env:"))
-			Expect(content).To(ContainSubstring("name: TEST_ENV"))
-			Expect(content).To(ContainSubstring("value: test-value"))
+			Expect(content).To(ContainSubstring("TEST_ENV"))
+			Expect(content).To(ContainSubstring("test-value"))
 			Expect(content).To(ContainSubstring("repository: example.com/custom-controller"))
 			Expect(content).To(ContainSubstring("tag: v1.2.3"))
 			Expect(content).To(ContainSubstring("pullPolicy: Always"))
@@ -288,7 +296,7 @@ var _ = Describe("HelmValuesBasic", func() {
 		It("should render nested env configuration", func() {
 			content := valuesTemplate.GetBody()
 			Expect(content).To(ContainSubstring("env:"))
-			Expect(content).To(ContainSubstring("name: POD_NAMESPACE"))
+			Expect(content).To(ContainSubstring("POD_NAMESPACE"))
 			Expect(content).To(ContainSubstring("valueFrom:"))
 			Expect(content).To(ContainSubstring("fieldRef:"))
 			Expect(content).To(ContainSubstring("fieldPath: metadata.namespace"))

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -53,8 +53,16 @@ spec:
                   command:
                     - /manager
                   env:
+{{- if or .Values.manager.env (and (kindIs "map" .Values.manager.envOverrides) (not (empty .Values.manager.envOverrides))) }}
                     {{- if .Values.manager.env }}
                     {{- toYaml .Values.manager.env | nindent 20 }}
+                    {{- end }}
+                    {{- if kindIs "map" .Values.manager.envOverrides }}
+                    {{- range $k, $v := .Values.manager.envOverrides }}
+                    - name: {{ $k }}
+                      value: {{ $v | quote }}
+                    {{ end }}
+                    {{- end }}
                     {{- else }}
                     []
                     {{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -33,6 +33,11 @@ manager:
         fieldRef:
             fieldPath: metadata.namespace
 
+  ## Env overrides (--set manager.envOverrides.VAR=value)
+  ## Same name in env above: this value takes precedence.
+  ##
+  envOverrides: {}
+
   ## Image pull secrets
   ##
   imagePullSecrets: []


### PR DESCRIPTION
Charts define `manager.env` as a list to support Kubernetes env entries with `valueFrom` (e.g. `fieldRef`, `secretKeyRef`, etc.). The list format is required for operator defaults like `RELATED_IMAGE_*`, `MEMORY_LIMIT_BYTES`, `WATCH_NAMESPACE`, but it makes Helm CLI overrides painful because `--set` doesn’t target list items.

This PR adds `manager.envOverrides` (map) for install-time overrides/additions. The chart renders `manager.env` + `manager.envOverrides`, and when the same env var name exists in both, the override value wins.

Example:
```bash
helm install my-op ./dist/chart/ \
  --set manager.envOverrides.LOG_LEVEL=debug \
  --set manager.envOverrides.DEBUG=true
```

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5489