### PR TITLE
✨ (helm/v2-alpha): add extra volumes support

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -87,6 +87,9 @@ spec:
           {}
           {{- end }}
         volumeMounts:
+          {{- if .Values.manager.extraVolumeMounts }}
+          {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
+          {{- end }}
         {{- if and .Values.certManager.enable .Values.metrics.enable }}
         - mountPath: /tmp/k8s-metrics-server/metrics-certs
           name: metrics-certs
@@ -106,6 +109,9 @@ spec:
       serviceAccountName: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
       terminationGracePeriodSeconds: 10
       volumes:
+        {{- if .Values.manager.extraVolumes }}
+        {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- if and .Values.certManager.enable .Values.metrics.enable }}
       - name: metrics-certs
         secret:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -77,7 +77,12 @@ spec:
           {{- else }}
           {}
           {{- end }}
-        volumeMounts: []
+        volumeMounts:
+          {{- if .Values.manager.extraVolumeMounts }}
+          {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
+          {{- else }}
+          []
+          {{- end }}
       securityContext:
         {{- if .Values.manager.podSecurityContext }}
         {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
@@ -86,4 +91,9 @@ spec:
         {{- end }}
       serviceAccountName: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
       terminationGracePeriodSeconds: 10
-      volumes: []
+      volumes:
+        {{- if .Values.manager.extraVolumes }}
+        {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
+        {{- else }}
+        []
+        {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -87,6 +87,9 @@ spec:
           {}
           {{- end }}
         volumeMounts:
+          {{- if .Values.manager.extraVolumeMounts }}
+          {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
+          {{- end }}
         {{- if and .Values.certManager.enable .Values.metrics.enable }}
         - mountPath: /tmp/k8s-metrics-server/metrics-certs
           name: metrics-certs
@@ -106,6 +109,9 @@ spec:
       serviceAccountName: {{ include "project.resourceName" (dict "suffix" "controller-manager" "context" $) }}
       terminationGracePeriodSeconds: 10
       volumes:
+        {{- if .Values.manager.extraVolumes }}
+        {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- if and .Values.certManager.enable .Values.metrics.enable }}
       - name: metrics-certs
         secret:

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -318,6 +318,15 @@ prometheus:
   enable: false
 ```
 
+### Extra volumes
+
+The chart supports additional volumes and volume mounts for the manager (e.g. secrets, config files), alongside the built-in webhook and metrics cert volumes.
+
+- **Config volumes**: Volumes in the manager deployment (e.g. `config/manager/manager.yaml` or kustomize patches) are written into the chart template. Re-running `kubebuilder edit --plugins=helm/v2-alpha` updates the template from config; `values.yaml` is not overwritten.
+- **Values**: When the manager deployment has extra volumes (other than webhook/metrics), `values.yaml` gets `manager.extraVolumes` and `manager.extraVolumeMounts`. Use them to add more entries; the template appends them after the config volumes. Same structure as in a Pod spec; mount names must match volume names.
+
+Webhook and metrics (`webhook-certs`, `metrics-certs`) are not in `extraVolumes`. They are conditional on `certManager.enable` and `metrics.enable`, like the rest of the chart.
+
 ### Installation
 
 The first time you run the plugin, it adds convenient Helm deployment targets to your `Makefile`:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_writer.go
@@ -82,7 +82,6 @@ func (w *ChartWriter) writeGroupDirectory(
 ) error {
 	var finalContent bytes.Buffer
 
-	// Convert each resource to YAML and apply templating
 	for i, resource := range resources {
 		if i > 0 {
 			finalContent.WriteString("---\n")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -744,17 +744,78 @@ func (t *HelmTemplater) templateSecurityContexts(yamlContent string) string {
 	return yamlContent
 }
 
-// templateVolumeMounts converts volumeMounts sections to keep them as-is since they're webhook-specific
+// templateVolumeMounts appends .Values.manager.extraVolumeMounts. Webhook and metrics
+// mounts are conditional (makeWebhookVolumeMountsConditional, makeMetricsVolumeMountsConditional).
 func (t *HelmTemplater) templateVolumeMounts(yamlContent string) string {
-	// For webhook volumeMounts, we keep them as-is since they're required for webhook functionality
-	// They will be conditionally included based on webhook configuration
-	return yamlContent
+	return t.appendToListFromValues(yamlContent, "volumeMounts:", ".Values.manager.extraVolumeMounts")
 }
 
-// templateVolumes converts volumes sections to keep them as-is since they're webhook-specific
+// templateVolumes appends .Values.manager.extraVolumes. Webhook and metrics volumes
+// are conditional (makeWebhookVolumesConditional, makeMetricsVolumesConditional).
 func (t *HelmTemplater) templateVolumes(yamlContent string) string {
-	// For webhook volumes, we keep them as-is since they're required for webhook functionality
-	// They will be conditionally included based on webhook configuration
+	return t.appendToListFromValues(yamlContent, "volumes:", ".Values.manager.extraVolumes")
+}
+
+// appendToListFromValues finds "key:" or "key: []", and either appends values path to an existing list
+// or replaces "key: []" with a template that outputs the values path when set. Idempotent if already present.
+func (t *HelmTemplater) appendToListFromValues(yamlContent string, keyColon string, valuesPath string) string {
+	if !strings.Contains(yamlContent, keyColon) {
+		return yamlContent
+	}
+	if strings.Contains(yamlContent, valuesPath) {
+		return yamlContent
+	}
+
+	lines := strings.Split(yamlContent, "\n")
+	keyEmpty := keyColon + " []"
+
+	for i := range lines {
+		trimmed := strings.TrimSpace(lines[i])
+		indentStr, indentLen := leadingWhitespace(lines[i])
+		childIndent := indentStr + "  "
+		childIndentWidth := strconv.Itoa(len(childIndent))
+
+		if trimmed == keyEmpty {
+			block := []string{
+				indentStr + keyColon,
+				childIndent + "{{- if " + valuesPath + " }}",
+				childIndent + "{{- toYaml " + valuesPath + " | nindent " + childIndentWidth + " }}",
+				childIndent + "{{- else }}",
+				childIndent + "[]",
+				childIndent + "{{- end }}",
+			}
+			newLines := append([]string{}, lines[:i]...)
+			newLines = append(newLines, block...)
+			newLines = append(newLines, lines[i+1:]...)
+			return strings.Join(newLines, "\n")
+		}
+
+		if trimmed != keyColon {
+			continue
+		}
+
+		end := i + 1
+		for ; end < len(lines); end++ {
+			tLine := strings.TrimSpace(lines[end])
+			if tLine == "" {
+				break
+			}
+			lineIndent := len(lines[end]) - len(strings.TrimLeft(lines[end], " \t"))
+			if lineIndent <= indentLen {
+				break
+			}
+		}
+
+		block := []string{
+			childIndent + "{{- if " + valuesPath + " }}",
+			childIndent + "{{- toYaml " + valuesPath + " | nindent " + childIndentWidth + " }}",
+			childIndent + "{{- end }}",
+		}
+		newLines := append([]string{}, lines[:end]...)
+		newLines = append(newLines, block...)
+		newLines = append(newLines, lines[end:]...)
+		return strings.Join(newLines, "\n")
+	}
 	return yamlContent
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -2131,6 +2131,106 @@ spec:
 			Expect(result).To(ContainSubstring("name: controller-test"))
 		})
 
+		It("should append extraVolumes and extraVolumeMounts when lists are present", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      containers:
+      - name: manager
+        image: controller:latest
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			Expect(result).To(ContainSubstring(".Values.manager.extraVolumes"))
+			Expect(result).To(ContainSubstring(".Values.manager.extraVolumeMounts"))
+		})
+
+		It("should inject extraVolumes/extraVolumeMounts when Kustomize has volumeMounts: [] and volumes: []", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			// Default Kustomize output: single-line empty lists (no webhook/metrics patches)
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        volumeMounts: []
+      volumes: []`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			Expect(result).To(ContainSubstring(".Values.manager.extraVolumes"))
+			Expect(result).To(ContainSubstring(".Values.manager.extraVolumeMounts"))
+		})
+
+		It("should append only extraVolumes from values and keep webhook/metrics conditional", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      - name: metrics-certs
+        secret:
+          secretName: metrics-server-cert
+      - name: app-secret-1
+        secret:
+          secretName: app-secret-1
+      containers:
+      - name: manager
+        image: controller:latest
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        - name: metrics-certs
+          mountPath: /tmp/k8s-metrics-server/metrics-certs
+          readOnly: true
+        - name: app-secret-1
+          mountPath: /etc/secrets
+          readOnly: true
+`
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+			Expect(result).To(ContainSubstring(".Values.certManager.enable"))
+			Expect(result).To(ContainSubstring(".Values.manager.extraVolumes"))
+			Expect(result).To(ContainSubstring("app-secret-1"))
+		})
+
 		It("should fall back to 'manager' when default-container annotation is missing", func() {
 			deployment := &unstructured.Unstructured{}
 			deployment.SetAPIVersion("apps/v1")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -217,7 +217,6 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 	f.addArgsSection(buf)
 
 	if f.DeploymentConfig == nil {
-		// Add default sections with examples
 		f.addDefaultDeploymentSections(buf)
 		return
 	}
@@ -321,6 +320,26 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("  tolerations: []\n")
 		buf.WriteString("\n")
 	}
+
+	f.addExtraVolumesFromConfig(buf)
+}
+
+// addExtraVolumesFromConfig adds manager.extraVolumeMounts and manager.extraVolumes to values
+// only when the deployment config has extra volumes (not webhook/metrics). Config volumes
+// are in the chart template; use these keys to add more without re-running edit.
+func (f *HelmValuesBasic) addExtraVolumesFromConfig(buf *bytes.Buffer) {
+	if f.DeploymentConfig == nil {
+		return
+	}
+	_, hasMounts := f.DeploymentConfig["extraVolumeMounts"]
+	_, hasVols := f.DeploymentConfig["extraVolumes"]
+	if !hasMounts && !hasVols {
+		return
+	}
+	buf.WriteString("  ## Additional volume mounts\n")
+	buf.WriteString("  extraVolumeMounts: []\n")
+	buf.WriteString("  extraVolumes: []\n")
+	buf.WriteString("\n")
 }
 
 func (f *HelmValuesBasic) IndentYamlProperly(buf *bytes.Buffer, envYaml []byte) {

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -98,6 +98,9 @@ spec:
           {}
           {{- end }}
         volumeMounts:
+          {{- if .Values.manager.extraVolumeMounts }}
+          {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
+          {{- end }}
         {{- if .Values.certManager.enable }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs
@@ -112,6 +115,9 @@ spec:
       serviceAccountName: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" $) }}
       terminationGracePeriodSeconds: 10
       volumes:
+        {{- if .Values.manager.extraVolumes }}
+        {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- if .Values.certManager.enable }}
       - name: webhook-certs
         secret:


### PR DESCRIPTION
Support manager.extraVolumes and manager.extraVolumeMounts: extract from kustomize (excluding webhook-certs/metrics-certs), inject into values when present, and template in manager deployment (including when volumes: []). Document in Helm v2-alpha plugin page.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5485
