### PR TITLE
🐛 fix: resolve panic when multiple plugins define the same flag (e.g. edit with go/v4 + helm)

### DIFF
--- a/pkg/plugins/common/kustomize/v2/api.go
+++ b/pkg/plugins/common/kustomize/v2/api.go
@@ -31,9 +31,6 @@ type createAPISubcommand struct {
 }
 
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
-	if err := p.configure(); err != nil {
-		return err
-	}
 	scaffolder := scaffolds.NewAPIScaffolder(p.config, *p.resource, p.force)
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {

--- a/pkg/plugins/common/kustomize/v2/create.go
+++ b/pkg/plugins/common/kustomize/v2/create.go
@@ -17,9 +17,6 @@ limitations under the License.
 package v2
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
@@ -30,13 +27,13 @@ type createSubcommand struct {
 	config   config.Config
 	resource *resource.Resource
 
-	flagSet *pflag.FlagSet
-
 	// force indicates whether to scaffold files even if they exist.
 	force bool
 }
 
-func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) { p.flagSet = fs }
+func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&p.force, "force", false, "overwrite existing files")
+}
 
 func (p *createSubcommand) InjectConfig(c config.Config) error {
 	p.config = c
@@ -45,14 +42,5 @@ func (p *createSubcommand) InjectConfig(c config.Config) error {
 
 func (p *createSubcommand) InjectResource(res *resource.Resource) error {
 	p.resource = res
-	return nil
-}
-
-func (p *createSubcommand) configure() (err error) {
-	if forceFlag := p.flagSet.Lookup("force"); forceFlag != nil {
-		if p.force, err = strconv.ParseBool(forceFlag.Value.String()); err != nil {
-			return fmt.Errorf("invalid value for --force %s: %w", forceFlag.Value.String(), err)
-		}
-	}
 	return nil
 }

--- a/pkg/plugins/common/kustomize/v2/create_test.go
+++ b/pkg/plugins/common/kustomize/v2/create_test.go
@@ -46,27 +46,13 @@ var _ = Describe("createSubcommand", func() {
 		}
 	})
 
-	It("should parse force flag correctly", func() {
-		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-		fs.Bool("force", false, "force flag")
-		subCmd.BindFlags(fs)
+	It("should bind force flag and receive value via merge/sync", func() {
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		subCmd.BindFlags(flags)
 
-		err := fs.Set("force", "true")
-		Expect(err).NotTo(HaveOccurred())
-
-		err = subCmd.configure()
+		err := flags.Set("force", "true")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(subCmd.force).To(BeTrue())
-	})
-
-	It("should return error for invalid force flag value", func() {
-		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-		fs.String("force", "invalid", "force flag")
-		subCmd.BindFlags(fs)
-
-		err := subCmd.configure()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("invalid value for --force"))
 	})
 
 	It("should inject config and resource successfully", func() {

--- a/pkg/plugins/common/kustomize/v2/webhook.go
+++ b/pkg/plugins/common/kustomize/v2/webhook.go
@@ -31,9 +31,6 @@ type createWebhookSubcommand struct {
 }
 
 func (p *createWebhookSubcommand) Scaffold(fs machinery.Filesystem) error {
-	if err := p.configure(); err != nil {
-		return err
-	}
 	scaffolder := scaffolds.NewWebhookScaffolder(p.config, *p.resource, p.force)
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -253,7 +253,7 @@ func bindAllFlags(fs *pflag.FlagSet, args []string) {
 	}
 }
 
-// bindSpecificFlags with bind flags that are specified by an external plugin as an allowed flag
+// bindSpecificFlags binds flags that are specified by an external plugin as allowed.
 func bindSpecificFlags(fs *pflag.FlagSet, flags []external.Flag) {
 	// Only bind flags returned by the external plugin
 	for _, flag := range flags {


### PR DESCRIPTION
- Merge duplicate flags instead of binding twice; sync parsed value to all plugins in PreRunE.
- Aggregate flag help as "For plugin (key): desc AND for plugin (key): desc".
- Return a clear error when the same flag name is used with different types (e.g. bool vs string).

Example:

```
$ kubebuilder edit --plugins=go/v4,helm/v2-alpha --help
...

Flags:
      --force               For plugin (base.go.kubebuilder.io/v4): overwrite scaffolded files to apply changes (manual edits may be lost) AND for plugin (helm.kubebuilder.io/v2-alpha): if true, regenerates all the files
``` 

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5500