### PR TITLE
📖 docs: make ToC highlight current page

### DIFF
--- a/docs/book/theme/css/custom.css
+++ b/docs/book/theme/css/custom.css
@@ -49,6 +49,5 @@ html {
     --sidebar-bg: #eef5ff;
     --sidebar-fg: #334155;
     --sidebar-non-existant: #7b8da8;
-    --sidebar-active: #466bb3;
     --sidebar-spacer: #c9d3e0;
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,10 @@
     publish = "docs/book/book"
     functions = "docs/book/functions"
 
+# Disables Pretty URLs feature so it doesn't break mdBook's ToC logic
+[build.processing.html]
+    pretty_urls = false
+
 # TODO(directxman12): I don't know why, but this (functions) stanza is in the
 # docs and local `netlify dev`, but the above one (under build) is used by the
 # online version :-/


### PR DESCRIPTION
This PR disables Netlify's Pretty URL feature so it doesn't break mdBook's Table of Contents logic. 

It also removes the active page custom color to enhance readability.

The book ToC now highlights and centers on the current page, making it easier for readers to identify what page they are currently reading in the book.

> [!TIP]
> To test this change, visit the [deploy preview](https://deploy-preview-5523--kubebuilder.netlify.app/) and navigate through the pages using the arrows. Notice how the ToC now highlights and follows the pages. 

Closes #5522 