### PR TITLE
🐛 (helm/v2-alpha): fix double-escaping of YAML-encoded quotes in template expressions

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -190,10 +190,17 @@ func (t *HelmTemplater) escapeExistingTemplateSyntax(yamlContent string) string 
 		}
 
 		// Otherwise, escape it to preserve as literal text
-		// Collapse any newline+indent that sigs.k8s.io/yaml may have introduced via line-wrapping,
-		// then escape any quotes inside the template content.
+		// Collapse any newline+indent that sigs.k8s.io/yaml may have introduced via line-wrapping.
 		collapsed := regexp.MustCompile(`\n[ \t]+`).ReplaceAllString(content, " ")
-		escapedContent := strings.ReplaceAll(collapsed, `"`, `\"`)
+
+		// Before re-escaping for Go template string literals, unescape any YAML double-quoted
+		// scalar escape sequences. yaml.Marshal emits \" for a literal " inside a double-quoted
+		// YAML scalar; without this step the subsequent "→\" replacement double-escapes them to
+		// \\" which breaks Helm's Go template parser: \\ becomes one backslash, then the next "
+		// closes the string prematurely, leaving tokens like "asset-id" outside where "-" is a
+		// bad character (U+002D).
+		unescaped := strings.ReplaceAll(collapsed, `\"`, `"`)
+		escapedContent := strings.ReplaceAll(unescaped, `"`, `\"`)
 
 		// Wrap in Helm string literal: {{ "{{...}}" }}
 		return `{{ "{{` + escapedContent + `}}" }}`

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -948,6 +948,37 @@ spec:
 			Expect(result).To(ContainSubstring(`{{ "{{ .Config.Message \"default\" }}" }}`))
 		})
 
+		It("should not double-escape quotes already escaped by yaml.Marshal in double-quoted YAML scalars", func() {
+			// Regression test: yaml.Marshal represents literal " inside a {{ }} expression as \"
+			// in a double-quoted YAML scalar, so a second pass escaping " → \" produced \\" which
+			// broke Helm's template parser by closing the string literal early (U+002D '-' error).
+			crdResource := &unstructured.Unstructured{}
+			crdResource.SetAPIVersion("apiextensions.k8s.io/v1")
+			crdResource.SetKind("CustomResourceDefinition")
+			crdResource.SetName("webrequestcommitstatuses.promoter.argoproj.io")
+
+			// Simulate the raw YAML text that yaml.Marshal produces for a double-quoted scalar
+			// containing a " character – the inner " appears as \" in the YAML text.
+			content := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  versions:
+  - schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: "example: {{ index .NamespaceMetadata.Labels \"asset-id\" }}"`
+
+			result := templater.ApplyHelmSubstitutions(content, crdResource)
+
+			// The escaped form must be valid Go template syntax: \" (single backslash+quote),
+			// NOT \\" (double backslash+quote) which would terminate the string literal early.
+			Expect(result).To(ContainSubstring(`{{ "{{ index .NamespaceMetadata.Labels \"asset-id\" }}" }}`),
+				"pre-escaped YAML quotes must not be double-escaped to \\\\ which breaks Helm template parsing")
+			Expect(result).NotTo(ContainSubstring(`\\"asset-id\\"`),
+				"double-escaped quotes (\\\\\") must not appear in the output")
+		})
+
 		It("should escape templates in ConfigMaps and other non-CRD resources", func() {
 			configMapResource := &unstructured.Unstructured{}
 			configMapResource.SetAPIVersion("v1")


### PR DESCRIPTION
## Description

When `yaml.Marshal` serialises a CRD field containing a Go template expression with quoted
arguments (e.g. `{{ index .Labels \"asset-id\" }}`), the `escapeExistingTemplateSyntax`
function double-escaped the already-encoded `\"` into `\\"`, causing Helm to close the
string literal early and fail with `bad character U+002D '-'`.

The fix unescapes `\"` → `"` before re-escaping, so quotes are escaped exactly once in
the output. A regression test covering this scenario is included.

## Motivation
Closes: #5527 

## Fix

Before re-escaping `"` → `\"` for Go template string syntax, the function now first
unescapes any YAML-encoded `\"` → `"`. This ensures quotes are escaped exactly once in
the final output.
