### PR TITLE
🌱 fix: update stale import paths in alpha update integration tests

### DIFF
--- a/internal/cli/alpha/internal/update/integration_test.go
+++ b/internal/cli/alpha/internal/update/integration_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update/helpers"
+	"sigs.k8s.io/kubebuilder/v4/internal/cli/alpha/internal/update/helpers"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
 	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
 )

--- a/internal/cli/alpha/internal/update/prepare_test.go
+++ b/internal/cli/alpha/internal/update/prepare_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/common"
+	"sigs.k8s.io/kubebuilder/v4/internal/cli/alpha/internal/common"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
 	v3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"

--- a/internal/cli/alpha/internal/update/update_test.go
+++ b/internal/cli/alpha/internal/update/update_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"sigs.k8s.io/kubebuilder/v4/pkg/cli/alpha/internal/update/helpers"
+	"sigs.k8s.io/kubebuilder/v4/internal/cli/alpha/internal/update/helpers"
 )
 
 // Mock response for binary executables.


### PR DESCRIPTION
Fix broken `go mod tidy` caused by three integration test files in
  `internal/cli/alpha/internal/update/` still importing from the old
  `pkg/cli/alpha/internal/` paths after #5514 moved those packages to `internal/`.
