### PR TITLE
✨ (go/v4): Add support for multiple controllers per GVK

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -98,6 +98,7 @@
 
   - [Sub-Module Layouts](./reference/submodule-layouts.md)
   - [Using an external Resource / API](./reference/using_an_external_resource.md)
+  - [Multiple Controllers Per Resource](./reference/multiple-controllers.md)
 
   - [Configuring EnvTest](./reference/envtest.md)
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -204,7 +204,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "CronJob")
+		setupLog.Error(err, "Failed to create controller", "controller", "cronjob")
 		os.Exit(1)
 	}
 

--- a/docs/book/src/getting-started/testdata/project/cmd/main.go
+++ b/docs/book/src/getting-started/testdata/project/cmd/main.go
@@ -182,7 +182,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Memcached")
+		setupLog.Error(err, "Failed to create controller", "controller", "memcached")
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder

--- a/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
@@ -203,7 +203,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "CronJob")
+		setupLog.Error(err, "Failed to create controller", "controller", "cronjob")
 		os.Exit(1)
 	}
 

--- a/docs/book/src/reference/multiple-controllers.md
+++ b/docs/book/src/reference/multiple-controllers.md
@@ -1,0 +1,140 @@
+# Multiple Controllers Per Resource
+
+Kubebuilder supports multiple named controllers for the same API resource. This allows different reconciliation logic for the same resource type.
+
+## Usage
+
+### Creating the First Controller
+
+```bash
+kubebuilder create api --group crew --version v1 --kind Captain \
+  --resource=true \
+  --controller=true \
+  --controller-name=captain
+```
+
+Creates:
+- API types in `api/v1/captain_types.go`
+- Controller in `internal/controller/captain_controller.go` with struct `CaptainReconciler`
+- Registration in `cmd/main.go`
+
+### Adding Additional Controllers
+
+```bash
+kubebuilder create api --group crew --version v1 --kind Captain \
+  --resource=false \
+  --controller=true \
+  --controller-name=captain-backup
+```
+
+Creates:
+- Controller in `internal/controller/captain_backup_controller.go` with struct `CaptainBackupReconciler`
+- Additional registration in `cmd/main.go`
+
+The API is only created once. Additional controllers reference the existing API.
+
+## PROJECT File Format
+
+### Legacy Format (Still Supported)
+
+```yaml
+resources:
+- api:
+    crdVersion: v1
+  controller: true
+  group: crew
+  kind: Captain
+  version: v1
+```
+
+### Multiple Controllers Format
+
+```yaml
+resources:
+- api:
+    crdVersion: v1
+  controllers:
+  - name: captain
+  - name: captain-backup
+  group: crew
+  kind: Captain
+  version: v1
+```
+
+When both formats exist on the same resource (due to manual editing), the `controllers:` array takes precedence and `controller: true` is automatically cleared.
+
+## Controller Naming
+
+### Storage
+Controller names are stored in the PROJECT file exactly as provided by the user.
+
+### Code Generation
+Names are normalized for Go code:
+
+- **File name**: Replace hyphens with underscores: `captain-backup` → `captain_backup_controller.go`
+- **Struct name**: Convert to PascalCase and append Reconciler: `captain-backup` → `CaptainBackupReconciler`
+- **Runtime name**: Use exact name from PROJECT: `Named("captain-backup")`
+- **Multigroup**: Prefix with group name: `Named("crew-captain-backup")`
+
+### Validation Rules
+
+1. Names must be unique within a resource
+2. Names must be valid DNS labels: lowercase, alphanumeric, and hyphens only, max 63 characters
+3. Different names that normalize to the same identifier are rejected (e.g., `captain-backup` and `captainbackup`)
+
+## Controller Coordination
+
+Multiple controllers for the same resource require coordination to avoid conflicts:
+
+- **Field ownership**: Each controller should manage different fields
+- **Finalizers**: Use unique names: `{controller-name}.example.com/finalizer`
+- **Status updates**: Assign different status subfields to each controller
+- **Conditional logic**: Use labels or annotations to route resources to specific controllers
+
+Kubebuilder scaffolds the controllers but does not manage coordination between them.
+
+## Migration from Legacy Format
+
+Existing projects with `controller: true` continue to work unchanged. When adding named controllers to a resource with `controller: true`, Kubebuilder automatically migrates the format:
+
+**Before migration:**
+```yaml
+resources:
+- api:
+    crdVersion: v1
+  controller: true
+  group: crew
+  kind: Captain
+  version: v1
+```
+
+**After adding a named controller:**
+```bash
+kubebuilder create api --group crew --version v1 --kind Captain \
+  --resource=false \
+  --controller=true \
+  --controller-name=captain-backup
+```
+
+**Result:**
+```yaml
+resources:
+- api:
+    crdVersion: v1
+  controllers:
+  - name: captain
+  - name: captain-backup
+  group: crew
+  kind: Captain
+  version: v1
+```
+
+The original unnamed controller is assigned the name `captain` (lowercase kind) and the `controller: true` flag is automatically cleared. This maintains backward compatibility while enabling multiple controllers.
+
+## Common Errors
+
+**"duplicate controller name"**: Two controllers have the same name. Use unique names.
+
+**"conflicts with ... both normalize to"**: Different names generate the same struct name. Choose distinct names.
+
+**"controller with name ... already exists"**: Controller already exists for this resource. Use a different name.

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -368,7 +368,7 @@ CronJob controller's`+" `"+`SetupWithManager`+"`"+` method.
 
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "cmd/main.go"),
-		`setupLog.Error(err, "Failed to create controller", "controller", "CronJob")
+		`setupLog.Error(err, "Failed to create controller", "controller", "cronjob")
 		os.Exit(1)
 	}`, mainEnableWebhook)
 	hackutils.CheckError("fixing main.go", err)

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -207,15 +207,23 @@ func kubebuilderCreate(s store.Store) error {
 		return fmt.Errorf("failed to get resources: %w", err)
 	}
 
-	// First, scaffold all APIs
+	// Scaffold APIs first, as controllers and webhooks depend on them
 	for _, r := range resources {
 		if err = createAPI(r); err != nil {
 			return fmt.Errorf("failed to create API for %s/%s/%s: %w", r.Group, r.Version, r.Kind, err)
 		}
 	}
 
-	// Then, scaffold all webhooks
-	// We cannot create a webhook for an API that does not exist
+	// Scaffold controllers on top of APIs
+	// Multiple controllers can be scaffolded for the same API
+	for _, r := range resources {
+		if err = createControllers(r); err != nil {
+			return fmt.Errorf("failed to create controllers for %s/%s/%s: %w", r.Group, r.Version, r.Kind, err)
+		}
+	}
+
+	// Scaffold webhooks on top of APIs
+	// Webhooks require the API to exist
 	for _, r := range resources {
 		if err = createWebhook(r); err != nil {
 			return fmt.Errorf("failed to create webhook for %s/%s/%s: %w", r.Group, r.Version, r.Kind, err)
@@ -491,9 +499,59 @@ func getDeployImageOptions(resourceData deployimagev1alpha1.ResourceData) []stri
 }
 
 // Creates an API resource.
+// Controllers are scaffolded separately to support multiple controllers per API.
 func createAPI(res resource.Resource) error {
 	args := append([]string{"create", "api"}, getGVKFlags(res)...)
 	args = append(args, getAPIResourceFlags(res)...)
+
+	// Add the external API flags if the resource is external
+	if res.IsExternal() {
+		args = append(args, "--external-api-path", res.Path)
+		args = append(args, "--external-api-domain", res.Domain)
+		// Add module if specified
+		if res.Module != "" {
+			args = append(args, "--external-api-module", res.Module)
+		}
+	}
+
+	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
+		return fmt.Errorf("failed to run kubebuilder create api command: %w", err)
+	}
+
+	return nil
+}
+
+// Creates controllers for a resource.
+// This function supports multiple controllers per resource (GVK).
+func createControllers(res resource.Resource) error {
+	if res.Controllers == nil || res.Controllers.IsEmpty() {
+		if !res.Controller {
+			return nil
+		}
+		return createControllerWithName(res, "")
+	}
+
+	for _, controller := range *res.Controllers {
+		if err := createControllerWithName(res, controller.Name); err != nil {
+			return fmt.Errorf("failed to create controller %q: %w", controller.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// Creates a single controller for a resource with a specific name.
+func createControllerWithName(res resource.Resource, controllerName string) error {
+	args := append([]string{"create", "api"}, getGVKFlags(res)...)
+
+	// Always set --resource=false since we're only creating the controller
+	args = append(args, "--resource=false")
+	args = append(args, "--controller=true")
+
+	// Add controller name if specified
+	if controllerName != "" {
+		args = append(args, "--controller-name", controllerName)
+	}
 
 	// Add the external API flags if the resource is external
 	if res.IsExternal() {
@@ -526,11 +584,11 @@ func getAPIResourceFlags(res resource.Resource) []string {
 			args = append(args, "--namespaced=false")
 		}
 	}
-	if res.Controller {
-		args = append(args, "--controller")
-	} else {
-		args = append(args, "--controller=false")
-	}
+
+	// Always disable controller creation in the API scaffolding step
+	// Controllers will be created separately in createControllers()
+	args = append(args, "--controller=false")
+
 	return args
 }
 

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -507,7 +507,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 		Context("returns correct flags", func() {
 			It("for nil API with Controller set", func() {
 				res.Controller = true
-				Expect(getAPIResourceFlags(res)).To(ContainElements("--resource=false", "--controller"))
+				// Controllers are now created separately, so always --controller=false in API step
+				Expect(getAPIResourceFlags(res)).To(ContainElements("--resource=false", "--controller=false"))
 			})
 			It("for non nil API (namespaced not set) with Controller not set", func() {
 				res.API.CRDVersion = "v1"
@@ -521,6 +522,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 			})
 		})
 	})
+
 	// getWebhookResourceFlags
 	Context("getWebhookResourceFlags", func() {
 		It("returns correct flags for specified resources", func() {

--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -395,5 +395,10 @@ func (c *Cfg) UnmarshalYAML(b []byte) error {
 		return config.UnmarshalError{Err: err}
 	}
 
+	// Normalize resources to auto-migrate legacy controller: true format
+	for i := range c.Resources {
+		c.Resources[i].Normalize()
+	}
+
 	return nil
 }

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -474,9 +474,9 @@ var _ = Describe("Cfg", func() {
 							Version: "v1",
 							Kind:    "Kind2",
 						},
-						API:        &resource.API{CRDVersion: "v1"},
-						Controller: true,
-						Webhooks:   &resource.Webhooks{WebhookVersion: "v1"},
+						API:         &resource.API{CRDVersion: "v1"},
+						Controllers: &resource.Controllers{{Name: "kind2"}},
+						Webhooks:    &resource.Webhooks{WebhookVersion: "v1"},
 					},
 					{
 						GVK: resource.GVK{
@@ -498,7 +498,7 @@ var _ = Describe("Cfg", func() {
 							CRDVersion: "v1",
 							Namespaced: true,
 						},
-						Controller: true,
+						Controllers: &resource.Controllers{{Name: "kind"}},
 						Webhooks: &resource.Webhooks{
 							WebhookVersion: "v1",
 							Defaulting:     true,
@@ -553,7 +553,8 @@ resources:
   version: v1
 - api:
     crdVersion: v1
-  controller: true
+  controllers:
+  - name: kind2
   group: group
   kind: Kind2
   version: v1
@@ -566,7 +567,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: kind
   group: group2
   kind: Kind
   version: v1

--- a/pkg/model/resource/controller.go
+++ b/pkg/model/resource/controller.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// Controller represents a named controller for a resource.
+// Each controller has a unique name that identifies it within a resource (GVK).
+type Controller struct {
+	// Name is the controller identifier, unique within a resource.
+	// Must be a valid DNS label (lowercase, alphanumeric, hyphens, max 63 chars).
+	Name string `json:"name,omitempty"`
+}
+
+// Validate checks that the Controller is valid.
+func (c Controller) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("controller name cannot be empty")
+	}
+
+	// Controller names must be valid DNS labels
+	if errors := validation.IsDNS1035Label(c.Name); len(errors) != 0 {
+		return fmt.Errorf("invalid controller name %q: %s", c.Name, strings.Join(errors, ", "))
+	}
+
+	return nil
+}
+
+// Controllers holds a list of controllers for a resource.
+type Controllers []Controller
+
+// IsEmpty returns true if there are no controllers.
+func (c *Controllers) IsEmpty() bool {
+	return c == nil || len(*c) == 0
+}
+
+// Validate checks that all controllers are valid and have unique names.
+// It also detects name collisions that would occur after normalization,
+// such as "captain-backup" and "captainbackup" both becoming "CaptainBackupReconciler".
+func (c *Controllers) Validate() error {
+	if c.IsEmpty() {
+		return nil
+	}
+
+	names := make(map[string]bool)
+	normalizedNames := make(map[string]string) // Maps normalized name to original name
+
+	for _, controller := range *c {
+		if err := controller.Validate(); err != nil {
+			return err
+		}
+
+		// Check for exact duplicate names
+		if names[controller.Name] {
+			return fmt.Errorf("duplicate controller name %q", controller.Name)
+		}
+		names[controller.Name] = true
+
+		// Check for normalization collisions where different names would generate the same struct
+		normalized := normalizeControllerName(controller.Name)
+		if existingName, exists := normalizedNames[normalized]; exists {
+			return fmt.Errorf("controller name %q conflicts with %q: both normalize to %q",
+				controller.Name, existingName, normalized+"Reconciler")
+		}
+		normalizedNames[normalized] = controller.Name
+	}
+
+	return nil
+}
+
+// normalizeControllerName removes non-alphanumeric characters and converts to lowercase
+// for collision detection. This helps identify names that would generate the same struct.
+func normalizeControllerName(name string) string {
+	var result strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			result.WriteRune(r)
+		}
+	}
+	return strings.ToLower(result.String())
+}
+
+// NormalizeFileName converts a controller name to a valid Go filename.
+// Hyphens are replaced with underscores to follow Go file naming conventions.
+// Example: "captain-backup" becomes "captain_backup".
+func NormalizeFileName(controllerName string) string {
+	return strings.ReplaceAll(controllerName, "-", "_")
+}
+
+// NormalizeReconcilerName converts a controller name to a PascalCase reconciler struct name.
+// For backward compatibility, returns "{Kind}Reconciler" when the controller name
+// is empty or matches the lowercase kind.
+// Example: "captain-backup" becomes "CaptainBackupReconciler".
+func NormalizeReconcilerName(controllerName, kind string) string {
+	// Backward compatible: no controller name or name matches kind
+	if controllerName == "" || controllerName == strings.ToLower(kind) {
+		return kind + "Reconciler"
+	}
+
+	// Convert hyphenated name to PascalCase (e.g., "captain-backup" -> "CaptainBackup")
+	parts := strings.Split(controllerName, "-")
+	var result strings.Builder
+	for _, part := range parts {
+		if len(part) > 0 {
+			result.WriteString(strings.ToUpper(part[:1]) + part[1:])
+		}
+	}
+	return result.String() + "Reconciler"
+}
+
+// GetControllerName returns the runtime name used in Named() and error logs.
+// In multigroup projects, the group name is prefixed to avoid naming conflicts.
+// Examples: "captain" in single-group, "crew-captain" in multigroup.
+func GetControllerName(controllerName, kind, group string, multiGroup bool) string {
+	var name string
+	if controllerName != "" {
+		name = controllerName
+	} else {
+		name = strings.ToLower(kind)
+	}
+
+	// In multigroup mode, prefix with the group name
+	if multiGroup && group != "" {
+		return strings.ToLower(group) + "-" + name
+	}
+
+	return name
+}
+
+// HasController returns true if a controller with the given name exists.
+func (c *Controllers) HasController(name string) bool {
+	if c.IsEmpty() {
+		return false
+	}
+
+	for _, controller := range *c {
+		if controller.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// AddController adds a new controller with the given name.
+// Returns an error if a controller with that name already exists.
+func (c *Controllers) AddController(name string) error {
+	if c == nil {
+		return fmt.Errorf("cannot add controller to nil Controllers")
+	}
+
+	controller := Controller{Name: name}
+	if err := controller.Validate(); err != nil {
+		return err
+	}
+
+	if c.HasController(name) {
+		return fmt.Errorf("controller with name %q already exists", name)
+	}
+
+	*c = append(*c, controller)
+	return nil
+}
+
+// GetControllerNames returns a slice of all controller names.
+func (c *Controllers) GetControllerNames() []string {
+	if c.IsEmpty() {
+		return nil
+	}
+
+	names := make([]string, 0, len(*c))
+	for _, controller := range *c {
+		names = append(names, controller.Name)
+	}
+	return names
+}
+
+// Copy returns a deep copy of the Controllers.
+func (c *Controllers) Copy() Controllers {
+	if c == nil {
+		return Controllers{}
+	}
+
+	controllers := make(Controllers, len(*c))
+	copy(controllers, *c)
+	return controllers
+}
+
+// Update combines fields of two Controllers.
+// It adds controllers from other that don't exist in c.
+func (c *Controllers) Update(other *Controllers) error {
+	if c == nil {
+		return fmt.Errorf("cannot update a nil Controllers")
+	}
+
+	if other == nil || other.IsEmpty() {
+		return nil
+	}
+
+	for _, controller := range *other {
+		if !c.HasController(controller.Name) {
+			*c = append(*c, controller)
+		}
+	}
+
+	return nil
+}

--- a/pkg/model/resource/controller_test.go
+++ b/pkg/model/resource/controller_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+)
+
+func TestController_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctrl    Controller
+		wantErr bool
+	}{
+		{
+			name:    "valid controller name",
+			ctrl:    Controller{Name: "my-controller"},
+			wantErr: false,
+		},
+		{
+			name:    "empty controller name",
+			ctrl:    Controller{Name: ""},
+			wantErr: true,
+		},
+		{
+			name:    "invalid controller name with uppercase",
+			ctrl:    Controller{Name: "MyController"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid controller name with underscore",
+			ctrl:    Controller{Name: "my_controller"},
+			wantErr: true,
+		},
+		{
+			name:    "valid controller name with numbers",
+			ctrl:    Controller{Name: "controller-1"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ctrl.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Controller.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestControllers_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctrls   *Controllers
+		wantErr bool
+	}{
+		{
+			name:    "nil controllers",
+			ctrls:   nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty controllers",
+			ctrls:   &Controllers{},
+			wantErr: false,
+		},
+		{
+			name: "valid controllers",
+			ctrls: &Controllers{
+				{Name: "controller-1"},
+				{Name: "controller-2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "duplicate controller names",
+			ctrls: &Controllers{
+				{Name: "controller-1"},
+				{Name: "controller-1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid controller name",
+			ctrls: &Controllers{
+				{Name: "Controller-1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "normalization collision: removes hyphens",
+			ctrls: &Controllers{
+				{Name: "captainbackup"},
+				{Name: "captain-backup"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "normalization collision: case insensitive",
+			ctrls: &Controllers{
+				{Name: "captainbackup"},
+				{Name: "captainbackup"}, // Will be caught as exact duplicate first
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ctrls.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Controllers.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestControllers_HasController(t *testing.T) {
+	ctrls := &Controllers{
+		{Name: "controller-1"},
+		{Name: "controller-2"},
+	}
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{
+			name: "controller-1",
+			want: true,
+		},
+		{
+			name: "controller-2",
+			want: true,
+		},
+		{
+			name: "controller-3",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ctrls.HasController(tt.name); got != tt.want {
+				t.Errorf("Controllers.HasController() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControllers_AddController(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial *Controllers
+		addName string
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name:    "add to nil controllers",
+			initial: nil,
+			addName: "controller-1",
+			wantErr: true,
+		},
+		{
+			name:    "add valid controller",
+			initial: &Controllers{},
+			addName: "controller-1",
+			wantErr: false,
+			wantLen: 1,
+		},
+		{
+			name: "add duplicate controller",
+			initial: &Controllers{
+				{Name: "controller-1"},
+			},
+			addName: "controller-1",
+			wantErr: true,
+			wantLen: 1,
+		},
+		{
+			name:    "add invalid controller name",
+			initial: &Controllers{},
+			addName: "Controller_1",
+			wantErr: true,
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.initial.AddController(tt.addName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Controllers.AddController() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.initial != nil && len(*tt.initial) != tt.wantLen {
+				t.Errorf("Controllers.AddController() len = %v, want %v", len(*tt.initial), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestResource_Update_WithControllers(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    Resource
+		other   Resource
+		wantErr bool
+		wantLen int
+	}{
+		{
+			name: "update resource without controllers with one that has controllers",
+			base: Resource{
+				GVK: GVK{
+					Group:   "crew",
+					Version: "v1",
+					Kind:    "Captain",
+				},
+				Plural: "captains",
+			},
+			other: Resource{
+				GVK: GVK{
+					Group:   "crew",
+					Version: "v1",
+					Kind:    "Captain",
+				},
+				Plural: "captains",
+				Controllers: &Controllers{
+					{Name: "captain-backup"},
+				},
+			},
+			wantErr: false,
+			wantLen: 1,
+		},
+		{
+			name: "update resource with controllers with another controller",
+			base: Resource{
+				GVK: GVK{
+					Group:   "crew",
+					Version: "v1",
+					Kind:    "Captain",
+				},
+				Plural: "captains",
+				Controllers: &Controllers{
+					{Name: "captain"},
+				},
+			},
+			other: Resource{
+				GVK: GVK{
+					Group:   "crew",
+					Version: "v1",
+					Kind:    "Captain",
+				},
+				Plural: "captains",
+				Controllers: &Controllers{
+					{Name: "captain-backup"},
+				},
+			},
+			wantErr: false,
+			wantLen: 2,
+		},
+		{
+			name: "update with nil other controllers",
+			base: Resource{
+				GVK: GVK{
+					Group:   "crew",
+					Version: "v1",
+					Kind:    "Captain",
+				},
+				Plural: "captains",
+				Controllers: &Controllers{
+					{Name: "captain"},
+				},
+			},
+			other: Resource{
+				GVK: GVK{
+					Group:   "crew",
+					Version: "v1",
+					Kind:    "Captain",
+				},
+				Plural: "captains",
+			},
+			wantErr: false,
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.base.Update(tt.other)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resource.Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if tt.base.Controllers != nil {
+					if len(*tt.base.Controllers) != tt.wantLen {
+						t.Errorf("Resource.Update() controllers len = %v, want %v", len(*tt.base.Controllers), tt.wantLen)
+					}
+				} else if tt.wantLen > 0 {
+					t.Errorf("Resource.Update() controllers is nil, want %v controllers", tt.wantLen)
+				}
+			}
+		})
+	}
+}
+
+func TestResource_GetControllerNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource Resource
+		want     []string
+	}{
+		{
+			name: "resource with new Controllers field",
+			resource: Resource{
+				GVK: GVK{Kind: "MyKind"},
+				Controllers: &Controllers{
+					{Name: "controller-1"},
+					{Name: "controller-2"},
+				},
+			},
+			want: []string{"controller-1", "controller-2"},
+		},
+		{
+			name: "resource with legacy Controller bool",
+			resource: Resource{
+				GVK:        GVK{Kind: "MyKind"},
+				Controller: true,
+			},
+			want: []string{"mykind"},
+		},
+		{
+			name: "resource with no controllers",
+			resource: Resource{
+				GVK: GVK{Kind: "MyKind"},
+			},
+			want: nil,
+		},
+		{
+			name: "resource with both fields (new takes precedence)",
+			resource: Resource{
+				GVK:        GVK{Kind: "MyKind"},
+				Controller: true,
+				Controllers: &Controllers{
+					{Name: "custom-controller"},
+				},
+			},
+			want: []string{"custom-controller"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.resource.GetControllerNames()
+			if len(got) != len(tt.want) {
+				t.Errorf("Resource.GetControllerNames() = %v, want %v", got, tt.want)
+				return
+			}
+			for i, name := range got {
+				if name != tt.want[i] {
+					t.Errorf("Resource.GetControllerNames()[%d] = %v, want %v", i, name, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -37,8 +37,12 @@ type Resource struct {
 	// API holds the information related to the resource API.
 	API *API `json:"api,omitempty"`
 
-	// Controller specifies if a controller has been scaffolded.
+	// Controller specifies if a controller has been scaffolded (legacy, deprecated).
+	// Deprecated: Use Controllers for multiple controller support.
 	Controller bool `json:"controller,omitempty"`
+
+	// Controllers holds named controllers for this resource.
+	Controllers *Controllers `json:"controllers,omitempty"`
 
 	// Webhooks holds the information related to the associated webhooks.
 	Webhooks *Webhooks `json:"webhooks,omitempty"`
@@ -84,10 +88,32 @@ func (r Resource) Validate() error {
 		}
 	}
 
+	// Validate the Controllers
+	if r.Controllers != nil && !r.Controllers.IsEmpty() {
+		if err := r.Controllers.Validate(); err != nil {
+			return fmt.Errorf("invalid Controllers: %w", err)
+		}
+	}
+
 	return nil
 }
 
-// PackageName returns a name valid to be used por go packages.
+// Normalize handles the edge case where both controller: true and controllers: are set.
+// This can only occur if someone manually edits the PROJECT file.
+// The new controllers array format takes precedence, and the legacy flag is cleared.
+func (r *Resource) Normalize() {
+	if r == nil {
+		return
+	}
+
+	// If both controller: true and controllers: are set (manual edit),
+	// keep the explicit controllers array and clear the legacy flag
+	if r.Controller && r.Controllers != nil && !r.Controllers.IsEmpty() {
+		r.Controller = false
+	}
+}
+
+// PackageName returns a name valid to be used for Go packages.
 func (r Resource) PackageName() string {
 	if r.Group == "" {
 		return safeImport(r.Domain)
@@ -110,9 +136,18 @@ func (r Resource) HasAPI() bool {
 	return r.API != nil && r.API.CRDVersion != ""
 }
 
-// HasController returns true if the resource has an associated controller.
+// HasController returns true if the resource has at least one associated controller.
+// It checks both the legacy Controller bool field and the new Controllers field.
 func (r Resource) HasController() bool {
-	return r.Controller
+	// Check legacy field first for backward compatibility
+	if r.Controller {
+		return true
+	}
+	// Check new Controllers field
+	if r.Controllers != nil && !r.Controllers.IsEmpty() {
+		return true
+	}
+	return false
 }
 
 // HasDefaultingWebhook returns true if the resource has an associated defaulting webhook.
@@ -140,6 +175,24 @@ func (r Resource) IsRegularPlural() bool {
 	return r.Plural == RegularPlural(r.Kind)
 }
 
+// GetControllerNames returns the names of all controllers for this resource.
+// For resources using the new Controllers field, it returns the actual controller names.
+// For resources using the legacy Controller bool field, it returns a default name (lowercase kind).
+// Returns nil if the resource has no controllers.
+func (r Resource) GetControllerNames() []string {
+	// New format: return explicit controller names
+	if r.Controllers != nil && !r.Controllers.IsEmpty() {
+		return r.Controllers.GetControllerNames()
+	}
+
+	// Legacy format: generate default name from kind
+	if r.Controller {
+		return []string{strings.ToLower(r.Kind)}
+	}
+
+	return nil
+}
+
 // Copy returns a deep copy of the Resource that can be safely modified without affecting the original.
 func (r Resource) Copy() Resource {
 	// As this function doesn't use a pointer receiver, r is already a shallow copy.
@@ -147,6 +200,10 @@ func (r Resource) Copy() Resource {
 	if r.API != nil {
 		api := r.API.Copy()
 		r.API = &api
+	}
+	if r.Controllers != nil {
+		controllers := r.Controllers.Copy()
+		r.Controllers = &controllers
 	}
 	if r.Webhooks != nil {
 		webhooks := r.Webhooks.Copy()
@@ -188,8 +245,36 @@ func (r *Resource) Update(other Resource) error {
 		return err
 	}
 
-	// Update controller.
-	r.Controller = r.Controller || other.Controller
+	// Update controllers
+	if other.Controllers != nil && !other.Controllers.IsEmpty() {
+		// Migrate legacy controller: true to the new controllers array format
+		if r.Controller {
+			if r.Controllers == nil {
+				r.Controllers = &Controllers{}
+			}
+			// Add a default controller with a kind-based name
+			defaultName := strings.ToLower(r.Kind)
+			if !r.Controllers.HasController(defaultName) {
+				_ = r.Controllers.AddController(defaultName)
+			}
+		}
+
+		// Initialize controllers array if not yet created
+		if r.Controllers == nil {
+			r.Controllers = &Controllers{}
+		}
+
+		// Merge controllers from the other resource
+		if err := r.Controllers.Update(other.Controllers); err != nil {
+			return err
+		}
+
+		// Clear the legacy flag now that we're using the new format
+		r.Controller = false
+	} else {
+		// Only update the legacy field if not using the new format
+		r.Controller = r.Controller || other.Controller
+	}
 
 	// Update Webhooks.
 	if r.Webhooks == nil && other.Webhooks != nil {

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -17,7 +17,9 @@ limitations under the License.
 package golang
 
 import (
+	log "log/slog"
 	"path"
+	"strings"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
@@ -75,6 +77,11 @@ type Options struct {
 	DoValidation bool
 	DoConversion bool
 
+	// ControllerName is the name of the controller to scaffold.
+	// This is used when creating multiple controllers for the same resource (GVK).
+	// If not provided, a default name based on the resource kind will be used.
+	ControllerName string
+
 	// Spoke versions for conversion webhook
 	Spoke []string
 
@@ -101,7 +108,7 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 
 	if opts.DoController {
-		res.Controller = true
+		opts.updateControllers(res)
 	}
 
 	if opts.DoDefaulting || opts.DoValidation || opts.DoConversion {
@@ -161,4 +168,38 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 			}
 		}
 	}
+}
+
+// updateControllers applies controller-related options to the resource.
+// It handles both legacy (--controller) and new (--controller-name) controller creation.
+func (opts Options) updateControllers(res *resource.Resource) {
+	if opts.ControllerName == "" {
+		// No controller name specified: use legacy mode
+		if res.Controllers == nil || res.Controllers.IsEmpty() {
+			res.Controller = true
+		} else {
+			// Warn when trying to use legacy mode on a resource with named controllers
+			log.Warn("resource already has named controllers; use --controller-name to add another controller")
+		}
+		return
+	}
+
+	// Controller name specified: migrate from legacy format if needed
+	if res.Controller {
+		if res.Controllers == nil {
+			res.Controllers = &resource.Controllers{}
+		}
+		// Convert the legacy controller: true to a named controller
+		defaultName := strings.ToLower(res.Kind)
+		_ = res.Controllers.AddController(defaultName)
+		res.Controller = false
+	}
+
+	// Initialize controllers array if not yet created
+	if res.Controllers == nil {
+		res.Controllers = &resource.Controllers{}
+	}
+
+	// Add the new named controller (AddController validates and checks for duplicates)
+	_ = res.Controllers.AddController(opts.ControllerName)
 }

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	log "log/slog"
 	"os"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -109,6 +110,9 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 		"if set, generate the controller without prompting the user")
 	p.controllerFlag = fs.Lookup("controller")
 
+	fs.StringVar(&p.options.ControllerName, "controller-name", "",
+		"name of the controller to scaffold (allows multiple controllers per resource)")
+
 	fs.StringVar(&p.options.ExternalAPIPath, "external-api-path", "",
 		"Specify the Go package import path for the external API. This is used to scaffold controllers for resources "+
 			"defined outside this project (e.g., github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1).")
@@ -139,14 +143,29 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 		p.options.DoController = util.YesNo(reader)
 	}
 
-	// Ensure that external API options cannot be used when creating an API in the project.
-	if p.options.DoAPI {
-		if len(p.options.ExternalAPIPath) != 0 || len(p.options.ExternalAPIDomain) != 0 ||
-			len(p.options.ExternalAPIModule) != 0 {
-			return errors.New("cannot use '--external-api-path', '--external-api-domain', or '--external-api-module' " +
-				"when creating an API in the project with '--resource=true'. " +
-				"Use '--resource=false' when referencing an external API")
+	// When scaffolding a controller without an API (--resource=false), copy essential
+	// fields from the existing resource in the PROJECT file, such as Path and Plural.
+	// Note: API, Controllers, and Webhooks are managed separately by UpdateResource.
+	if !p.options.DoAPI {
+		if existingRes, err := p.config.GetResource(res.GVK); err == nil {
+			p.resource.Path = existingRes.Path
+			p.resource.Plural = existingRes.Plural
+			p.resource.External = existingRes.External
+			p.resource.Core = existingRes.Core
+			p.resource.Module = existingRes.Module
 		}
+	}
+
+	// Ensure that external API options cannot be used when creating an API in the project.
+	if p.options.DoAPI &&
+		(len(p.options.ExternalAPIPath) != 0 ||
+			len(p.options.ExternalAPIDomain) != 0 ||
+			len(p.options.ExternalAPIModule) != 0) {
+		return errors.New(
+			"cannot use '--external-api-path', '--external-api-domain', or '--external-api-module' " +
+				"when creating an API in the project with '--resource=true'. " +
+				"Use '--resource=false' when referencing an external API",
+		)
 	}
 
 	// Validate that --external-api-module requires --external-api-path
@@ -160,21 +179,111 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 		return fmt.Errorf("error validating resource: %w", err)
 	}
 
-	// In case we want to scaffold a resource API we need to do some checks
-	if p.options.DoAPI {
-		// Check that resource doesn't have the API scaffolded or flag force was set
-		if r, err := p.config.GetResource(p.resource.GVK); err == nil && r.HasAPI() && !p.force {
-			return errors.New("API resource already exists")
-		}
+	if err := p.validateAPI(); err != nil {
+		return err
+	}
 
-		// Check that the provided group can be added to the project
-		if !p.config.IsMultiGroup() && p.config.ResourcesLength() != 0 && !p.config.HasGroup(p.resource.Group) {
-			return fmt.Errorf("multiple groups are not allowed by default, " +
-				"to enable multi-group visit https://kubebuilder.io/migration/multi-group.html")
-		}
+	return p.validateController()
+}
+
+func (p *createAPISubcommand) validateAPI() error {
+	if !p.options.DoAPI {
+		return nil
+	}
+
+	// Check that resource doesn't have the API scaffolded or flag force was set
+	if r, err := p.config.GetResource(p.resource.GVK); err == nil && r.HasAPI() && !p.force {
+		return errors.New("API resource already exists")
+	}
+
+	// Check that the provided group can be added to the project
+	if !p.config.IsMultiGroup() && p.config.ResourcesLength() != 0 && !p.config.HasGroup(p.resource.Group) {
+		return fmt.Errorf(
+			"multiple groups are not allowed by default, " +
+				"to enable multi-group visit https://kubebuilder.io/migration/multi-group.html",
+		)
 	}
 
 	return nil
+}
+
+func (p *createAPISubcommand) validateController() error {
+	if !p.options.DoController {
+		return nil
+	}
+
+	existingRes, err := p.config.GetResource(p.resource.GVK)
+	if err != nil {
+		// Resource does not exist yet, no validation needed
+		return nil
+	}
+
+	// Require --controller-name when adding a controller to a resource that already has controllers.
+	// Exception: if --resource=true (creating/recreating API), allow --controller=true without
+	// a name for backward compatibility.
+	if p.options.ControllerName == "" && !p.options.DoAPI &&
+		existingRes.Controllers != nil && !existingRes.Controllers.IsEmpty() {
+		return errors.New(
+			"resource already has controllers defined; please specify '--controller-name' " +
+				"to add another controller, or use '--controller=false' to skip controller scaffolding",
+		)
+	}
+
+	// No controller name specified: using legacy mode, no further validation needed
+	if p.options.ControllerName == "" {
+		return nil
+	}
+
+	// Check that the controller name does not already exist
+	if existingRes.Controllers != nil && existingRes.Controllers.HasController(p.options.ControllerName) {
+		return fmt.Errorf(
+			"controller with name %q already exists for resource %s/%s/%s",
+			p.options.ControllerName,
+			p.resource.Group,
+			p.resource.Version,
+			p.resource.Kind,
+		)
+	}
+
+	// Check for name collisions after normalization (e.g., "foo-bar" vs "foobar")
+	if existingRes.Controllers != nil {
+		newNormalized := normalizeForCollisionCheck(p.options.ControllerName)
+		for _, existing := range *existingRes.Controllers {
+			if newNormalized == normalizeForCollisionCheck(existing.Name) {
+				return fmt.Errorf(
+					"controller name %q conflicts with existing controller %q: "+
+						"both would generate the same reconciler struct name",
+					p.options.ControllerName,
+					existing.Name,
+				)
+			}
+		}
+	}
+
+	// Also check legacy controller: true case
+	if existingRes.Controller && p.options.ControllerName == strings.ToLower(p.resource.Kind) {
+		return fmt.Errorf(
+			"controller with name %q already exists for resource %s/%s/%s",
+			p.options.ControllerName,
+			p.resource.Group,
+			p.resource.Version,
+			p.resource.Kind,
+		)
+	}
+
+	return nil
+}
+
+// normalizeForCollisionCheck normalizes a controller name to detect potential collisions.
+// Different names that normalize to the same value would generate conflicting code.
+func normalizeForCollisionCheck(name string) string {
+	var result strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			result.WriteRune(r)
+		}
+	}
+	return strings.ToLower(result.String())
 }
 
 func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -106,9 +106,25 @@ func (s *apiScaffolder) Scaffold() error {
 	}
 
 	if doController {
+		// Get the controller name to scaffold
+		// If using the new Controllers field, get the last added controller name
+		// Otherwise, use empty string to generate default name
+		controllerName := ""
+		if s.resource.Controllers != nil && !s.resource.Controllers.IsEmpty() {
+			names := s.resource.Controllers.GetControllerNames()
+			if len(names) > 0 {
+				// Use the last controller name (the one just added)
+				controllerName = names[len(names)-1]
+			}
+		}
+
 		if err := scaffold.Execute(
 			&controllers.SuiteTest{Force: s.force},
-			&controllers.Controller{ControllerRuntimeVersion: ControllerRuntimeVersion, Force: s.force},
+			&controllers.Controller{
+				ControllerRuntimeVersion: ControllerRuntimeVersion,
+				Force:                    s.force,
+				ControllerName:           controllerName,
+			},
 			&controllers.ControllerTest{Force: s.force, DoAPI: doAPI},
 		); err != nil {
 			return fmt.Errorf("error scaffolding controller: %w", err)
@@ -116,7 +132,19 @@ func (s *apiScaffolder) Scaffold() error {
 	}
 
 	if err := scaffold.Execute(
-		&cmd.MainUpdater{WireResource: doAPI, WireController: doController},
+		&cmd.MainUpdater{
+			WireResource:   doAPI,
+			WireController: doController,
+			ControllerName: func() string {
+				if s.resource.Controllers != nil && !s.resource.Controllers.IsEmpty() {
+					names := s.resource.Controllers.GetControllerNames()
+					if len(names) > 0 {
+						return names[len(names)-1]
+					}
+				}
+				return ""
+			}(),
+		},
 	); err != nil {
 		return fmt.Errorf("error updating cmd/main.go: %w", err)
 	}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
 const defaultMainPath = "cmd/main.go"
@@ -64,11 +65,20 @@ type MainUpdater struct {
 	// Flags to indicate which parts need to be included when updating the file
 	WireResource, WireController, WireWebhook bool
 
+	// ControllerName is the specific name for the controller being wired.
+	// If empty, the default name based on the resource kind will be used.
+	ControllerName string
+
 	// Deprecated - The flag should be removed from go/v5
 	// IsLegacyPath indicates if webhooks should be scaffolded under the API.
 	// Webhooks are now decoupled from APIs based on controller-runtime updates and community feedback.
 	// This flag ensures backward compatibility by allowing scaffolding in the legacy/deprecated path.
 	IsLegacyPath bool
+}
+
+// ReconcilerName returns the name for the reconciler struct.
+func (f *MainUpdater) ReconcilerName() string {
+	return resource.NormalizeReconcilerName(f.ControllerName, f.Resource.Kind)
 }
 
 // GetPath implements file.Builder
@@ -109,7 +119,7 @@ const (
 `
 	addschemeCodeFragment = `utilruntime.Must(%s.AddToScheme(scheme))
 `
-	reconcilerSetupCodeFragment = `if err := (&controller.%sReconciler{
+	reconcilerSetupCodeFragment = `if err := (&controller.%s{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
@@ -117,7 +127,7 @@ const (
 		os.Exit(1)
 	}
 `
-	multiGroupReconcilerSetupCodeFragment = `if err := (&%scontroller.%sReconciler{
+	multiGroupReconcilerSetupCodeFragment = `if err := (&%scontroller.%s{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
@@ -187,12 +197,15 @@ func (f *MainUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
 	// Generate setup code fragments
 	setup := make([]string, 0)
 	if f.WireController {
+		reconcilerName := f.ReconcilerName()
+		controllerName := resource.GetControllerName(f.ControllerName, f.Resource.Kind, f.Resource.Group, f.MultiGroup)
+
 		if !f.MultiGroup || f.Resource.Group == "" {
 			setup = append(setup, fmt.Sprintf(reconcilerSetupCodeFragment,
-				f.Resource.Kind, f.Resource.Kind))
+				reconcilerName, controllerName))
 		} else {
 			setup = append(setup, fmt.Sprintf(multiGroupReconcilerSetupCodeFragment,
-				f.Resource.PackageName(), f.Resource.Kind, f.Resource.Kind))
+				f.Resource.PackageName(), reconcilerName, controllerName))
 		}
 	}
 	if f.WireWebhook {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
 var _ machinery.Template = &Controller{}
@@ -39,15 +40,26 @@ type Controller struct {
 	ControllerRuntimeVersion string
 
 	Force bool
+
+	// ControllerName is the specific name for this controller.
+	// If empty, a default name based on the resource kind will be used.
+	ControllerName string
 }
 
 // SetTemplateDefaults implements machinery.Template
 func (f *Controller) SetTemplateDefaults() error {
 	if f.Path == "" {
+		fileName := "%[kind]_controller.go"
+		if f.ControllerName != "" {
+			// Normalize controller name for file naming (hyphens to underscores)
+			normalizedName := resource.NormalizeFileName(f.ControllerName)
+			fileName = normalizedName + "_controller.go"
+		}
+
 		if f.MultiGroup && f.Resource.Group != "" {
-			f.Path = filepath.Join("internal", "controller", "%[group]", "%[kind]_controller.go")
+			f.Path = filepath.Join("internal", "controller", "%[group]", fileName)
 		} else {
-			f.Path = filepath.Join("internal", "controller", "%[kind]_controller.go")
+			f.Path = filepath.Join("internal", "controller", fileName)
 		}
 	}
 
@@ -63,6 +75,16 @@ func (f *Controller) SetTemplateDefaults() error {
 	}
 
 	return nil
+}
+
+// ReconcilerName returns the name for the reconciler struct.
+func (f *Controller) ReconcilerName() string {
+	return resource.NormalizeReconcilerName(f.ControllerName, f.Resource.Kind)
+}
+
+// ControllerRuntimeName returns the controller runtime name used in Named().
+func (f *Controller) ControllerRuntimeName() string {
+	return resource.GetControllerName(f.ControllerName, f.Resource.Kind, f.Resource.Group, f.MultiGroup)
 }
 
 //nolint:lll
@@ -81,8 +103,8 @@ import (
 	{{- end }}
 )
 
-// {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
-type {{ .Resource.Kind }}Reconciler struct {
+// {{ .ReconcilerName }} reconciles a {{ .Resource.Kind }} object
+type {{ .ReconcilerName }} struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
@@ -106,7 +128,7 @@ type {{ .Resource.Kind }}Reconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@{{ .ControllerRuntimeVersion }}/pkg/reconcile
-func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *{{ .ReconcilerName }}) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = logf.FromContext(ctx)
 
 	// TODO(user): your logic here
@@ -115,7 +137,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *{{ .ReconcilerName }}) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		{{ if not (isEmptyStr .Resource.Path) -}}
 		For(&{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}).
@@ -123,11 +145,7 @@ func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) erro
 		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
 		// For().
 		{{- end }}
-		{{- if and (.MultiGroup) (not (isEmptyStr .Resource.Group)) }}
-		Named("{{ lower .Resource.Group }}-{{ lower .Resource.Kind }}").
-		{{- else }}
-		Named("{{ lower .Resource.Kind }}").
-		{{- end }}
+		Named("{{ .ControllerRuntimeName }}").
 		Complete(r)
 }
 `

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -38,8 +38,10 @@ function scaffold_test_project {
 
   if [ $project == "project-v4" ] ; then
     header_text 'Creating APIs ...'
-    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false
+    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false --controller-name=captain
     $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false --force
+    # Create a second controller for the Captain resource to test multiple controllers per API
+    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=false --make=false --controller-name=captain-backup
     $kb create webhook --group crew --version v1 --kind Captain --defaulting --make=false
     $kb create webhook --group crew --version v1 --kind Captain --programmatic-validation --make=false
 
@@ -70,7 +72,9 @@ function scaffold_test_project {
 
   if [[ $project =~ multigroup ]]; then
     header_text 'Creating APIs ...'
-    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false
+    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false --controller-name=captain
+    # Create a second controller for the Captain resource to test multiple controllers per API
+    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=false --make=false --controller-name=captain-backup
     # Test incremental webhook additions
     $kb create webhook --group crew --version v1 --kind Captain --defaulting --make=false
     $kb create webhook --group crew --version v1 --kind Captain --programmatic-validation --make=false

--- a/testdata/project-v4-multigroup/PROJECT
+++ b/testdata/project-v4-multigroup/PROJECT
@@ -32,7 +32,9 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: captain
+  - name: captain-backup
   domain: testproject.org
   group: crew
   kind: Captain

--- a/testdata/project-v4-multigroup/cmd/main.go
+++ b/testdata/project-v4-multigroup/cmd/main.go
@@ -223,7 +223,14 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Captain")
+		setupLog.Error(err, "Failed to create controller", "controller", "crew-captain")
+		os.Exit(1)
+	}
+	if err := (&crewcontroller.CaptainBackupReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to create controller", "controller", "crew-captain-backup")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -237,14 +244,14 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Frigate")
+		setupLog.Error(err, "Failed to create controller", "controller", "ship-frigate")
 		os.Exit(1)
 	}
 	if err := (&shipcontroller.DestroyerReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Destroyer")
+		setupLog.Error(err, "Failed to create controller", "controller", "ship-destroyer")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -258,7 +265,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Cruiser")
+		setupLog.Error(err, "Failed to create controller", "controller", "ship-cruiser")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -272,49 +279,49 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Kraken")
+		setupLog.Error(err, "Failed to create controller", "controller", "sea-creatures-kraken")
 		os.Exit(1)
 	}
 	if err := (&seacreaturescontroller.LeviathanReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Leviathan")
+		setupLog.Error(err, "Failed to create controller", "controller", "sea-creatures-leviathan")
 		os.Exit(1)
 	}
 	if err := (&foopolicycontroller.HealthCheckPolicyReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "HealthCheckPolicy")
+		setupLog.Error(err, "Failed to create controller", "controller", "foo.policy-healthcheckpolicy")
 		os.Exit(1)
 	}
 	if err := (&appscontroller.DeploymentReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Deployment")
+		setupLog.Error(err, "Failed to create controller", "controller", "apps-deployment")
 		os.Exit(1)
 	}
 	if err := (&foocontroller.BarReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Bar")
+		setupLog.Error(err, "Failed to create controller", "controller", "foo-bar")
 		os.Exit(1)
 	}
 	if err := (&fizcontroller.BarReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Bar")
+		setupLog.Error(err, "Failed to create controller", "controller", "fiz-bar")
 		os.Exit(1)
 	}
 	if err := (&certmanagercontroller.CertificateReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Certificate")
+		setupLog.Error(err, "Failed to create controller", "controller", "cert-manager-certificate")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -343,7 +350,7 @@ func main() {
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorder("memcached-controller"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Memcached")
+		setupLog.Error(err, "Failed to create controller", "controller", "example.com-memcached")
 		os.Exit(1)
 	}
 	if err := (&examplecomcontroller.BusyboxReconciler{
@@ -351,7 +358,7 @@ func main() {
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorder("busybox-controller"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Busybox")
+		setupLog.Error(err, "Failed to create controller", "controller", "example.com-busybox")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -365,7 +372,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Wordpress")
+		setupLog.Error(err, "Failed to create controller", "controller", "example.com-wordpress")
 		os.Exit(1)
 	}
 	// nolint:goconst

--- a/testdata/project-v4-multigroup/internal/controller/crew/captain_backup_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/captain_backup_controller.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crew
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/crew/v1"
+)
+
+// CaptainBackupReconciler reconciles a Captain object
+type CaptainBackupReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Captain object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/reconcile
+func (r *CaptainBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = logf.FromContext(ctx)
+
+	// TODO(user): your logic here
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *CaptainBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&crewv1.Captain{}).
+		Named("crew-captain-backup").
+		Complete(r)
+}

--- a/testdata/project-v4-with-plugins/cmd/main.go
+++ b/testdata/project-v4-with-plugins/cmd/main.go
@@ -234,7 +234,7 @@ func main() {
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorder("memcached-controller"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Memcached")
+		setupLog.Error(err, "Failed to create controller", "controller", "memcached")
 		os.Exit(1)
 	}
 	if err := (&controller.BusyboxReconciler{
@@ -242,7 +242,7 @@ func main() {
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorder("busybox-controller"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Busybox")
+		setupLog.Error(err, "Failed to create controller", "controller", "busybox")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -256,7 +256,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Wordpress")
+		setupLog.Error(err, "Failed to create controller", "controller", "wordpress")
 		os.Exit(1)
 	}
 	// nolint:goconst

--- a/testdata/project-v4/PROJECT
+++ b/testdata/project-v4/PROJECT
@@ -12,7 +12,9 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: captain
+  - name: captain-backup
   domain: testproject.org
   group: crew
   kind: Captain

--- a/testdata/project-v4/cmd/main.go
+++ b/testdata/project-v4/cmd/main.go
@@ -188,7 +188,14 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Captain")
+		setupLog.Error(err, "Failed to create controller", "controller", "captain")
+		os.Exit(1)
+	}
+	if err := (&controller.CaptainBackupReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to create controller", "controller", "captain-backup")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -202,7 +209,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "FirstMate")
+		setupLog.Error(err, "Failed to create controller", "controller", "firstmate")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -216,7 +223,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Sailor")
+		setupLog.Error(err, "Failed to create controller", "controller", "sailor")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -230,7 +237,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Admiral")
+		setupLog.Error(err, "Failed to create controller", "controller", "admiral")
 		os.Exit(1)
 	}
 	// nolint:goconst
@@ -244,7 +251,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to create controller", "controller", "Certificate")
+		setupLog.Error(err, "Failed to create controller", "controller", "certificate")
 		os.Exit(1)
 	}
 	// nolint:goconst

--- a/testdata/project-v4/internal/controller/captain_backup_controller.go
+++ b/testdata/project-v4/internal/controller/captain_backup_controller.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	crewv1 "sigs.k8s.io/kubebuilder/testdata/project-v4/api/v1"
+)
+
+// CaptainBackupReconciler reconciles a Captain object
+type CaptainBackupReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crew.testproject.org,resources=captains/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Captain object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/reconcile
+func (r *CaptainBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = logf.FromContext(ctx)
+
+	// TODO(user): your logic here
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *CaptainBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&crewv1.Captain{}).
+		Named("captain-backup").
+		Complete(r)
+}


### PR DESCRIPTION
Change API to allow it via a `controllers[]` list in the PROJECT file, with a new `--controller-name` flag for scaffolding additional controllers while maintaining full backward compatibility with existing `controller: true` behavior.


Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5473
Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/5474
