### PR TITLE
🐛 (alpha/generate): Skip go version check by default

### DIFF
--- a/internal/cli/alpha/generate.go
+++ b/internal/cli/alpha/generate.go
@@ -78,5 +78,8 @@ If no output directory is provided, the current working directory will be cleane
 			"If unset, re-scaffolding occurs in-place "+
 			"and will delete existing files (except .git and PROJECT).")
 
+	scaffoldCmd.Flags().BoolVar(&opts.SkipGoVersionCheck, "skip-go-version-check", true,
+		"skip the Go version check during project generation")
+
 	return scaffoldCmd
 }

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -39,8 +39,9 @@ import (
 
 // Generate store the required info for the command
 type Generate struct {
-	InputDir  string
-	OutputDir string
+	InputDir           string
+	OutputDir          string
+	SkipGoVersionCheck bool
 }
 
 // Define a variable to allow overriding the behavior of getExecutablePath for testing.
@@ -95,7 +96,7 @@ func (opts *Generate) Generate() error {
 		return fmt.Errorf("error changing working directory %q: %w", opts.OutputDir, err)
 	}
 
-	if err = kubebuilderInit(projectConfig); err != nil {
+	if err = kubebuilderInit(projectConfig, opts); err != nil {
 		return fmt.Errorf("error initializing project config: %w", err)
 	}
 
@@ -186,8 +187,8 @@ func changeWorkingDirectory(outputDir string) error {
 }
 
 // Initializes the project with Kubebuilder.
-func kubebuilderInit(s store.Store) error {
-	args := append([]string{"init"}, getInitArgs(s)...)
+func kubebuilderInit(s store.Store, opts *Generate) error {
+	args := append([]string{"init"}, getInitArgs(s, opts)...)
 	execPath, err := getExecutablePathFunc()
 	if err != nil {
 		return err
@@ -387,8 +388,13 @@ func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) err
 }
 
 // Helper function to get Init arguments for Kubebuilder.
-func getInitArgs(s store.Store) []string {
+func getInitArgs(s store.Store, opts *Generate) []string {
 	var args []string
+
+	if opts.SkipGoVersionCheck {
+		args = append(args, "--skip-go-version-check")
+	}
+
 	plugins := s.Config().GetPluginChain()
 
 	// Define outdated plugin versions that need replacement

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -340,8 +340,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 				It("should return correct args for plugins, domain, repo", func() {
 					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3"}, domain: "foo.com", repo: "bar"}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
 				})
 			})
@@ -350,8 +350,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 				It("should return correct args for plugins, domain, repo", func() {
 					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3-alpha"}, domain: "foo.com", repo: "bar"}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
 				})
 			})
@@ -364,8 +364,10 @@ var _ = Describe("generate: get-args-helpers", func() {
 						repo:        "bar",
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("helm.kubebuilder.io/v2-alpha"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements(
+						"--skip-go-version-check",
+						"--plugins", ContainSubstring("helm.kubebuilder.io/v2-alpha"),
 						"--domain", "foo.com", "--repo", "bar"))
 					Expect(args).NotTo(ContainElement(ContainSubstring("helm.kubebuilder.io/v1-alpha")))
 				})
@@ -377,8 +379,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 				It("returns correct args for plugins, domain, repo", func() {
 					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v4"}, domain: "foo.com", repo: "bar"}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar"))
 				})
 			})
@@ -392,8 +394,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 						projectName: "my-project",
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--project-name", "my-project"))
 				})
 			})
@@ -407,8 +409,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 						multigroup:  true,
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--multigroup"))
 				})
 			})
@@ -422,8 +424,8 @@ var _ = Describe("generate: get-args-helpers", func() {
 						namespaced:  true,
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--namespaced"))
 				})
 			})
@@ -438,10 +440,21 @@ var _ = Describe("generate: get-args-helpers", func() {
 						namespaced:  true,
 					}
 					store := &fakeStore{cfg: cfg}
-					args := getInitArgs(store)
-					Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true})
+					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
 						"--domain", "foo.com", "--repo", "bar", "--multigroup", "--namespaced"))
 				})
+			})
+		})
+
+		Context("when skipGoVersionCheck is false", func() {
+			It("does not include --skip-go-version-check", func() {
+				cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v4"}, domain: "foo.com", repo: "bar"}
+				store := &fakeStore{cfg: cfg}
+				args := getInitArgs(store, &Generate{SkipGoVersionCheck: false})
+				Expect(args).NotTo(ContainElement("--skip-go-version-check"))
+				Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
+					"--domain", "foo.com", "--repo", "bar"))
 			})
 		})
 	})
@@ -766,7 +779,7 @@ var _ = Describe("generate: kubebuilder", func() {
 				repo:        "github.com/example/repo",
 			}
 			store := &fakeStore{cfg: cfg}
-			Expect(kubebuilderInit(store)).To(Succeed())
+			Expect(kubebuilderInit(store, &Generate{SkipGoVersionCheck: true})).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
`kubebuilder alpha generate` validates the Go version via `kubebuilder init`, which can fail when the version string contains non-standard suffixes (e.g., `go1.26-X:nodwarf5`), even when the version is within the supported range.

This change passes `--skip-go-version-check` to the underlying `kubebuilder init` call by default, avoiding false validation failures during project re-scaffolding. A `--skip-go-version-check` flag is added to `alpha generate` (defaulting to `true`) so users can enforce the version check by explicitly setting it to `false`.

Fixes #5543
