### PR TITLE
🌱 infra: Add Pinact GitHub Actions workflow

### DIFF
--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,32 @@
+name: Pinact
+on:
+  pull_request:
+    paths: 
+     - '**/workflows/*.yml'
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: '1.26'
+
+      - name: Install pinact
+        run: |
+          go install github.com/suzuki-shunsuke/pinact/v3/cmd/pinact@v3.5.0
+
+      - name: Display changed workflows in PR
+        run: |
+          git diff --name-only origin/${{ github.base_ref }} HEAD
+          
+      - name: Run pinact on changed workflow files
+        run: |
+          git diff --name-only origin/${{ github.base_ref }} HEAD \
+          | grep -E 'workflows/.*\.ya?ml$' \
+          | xargs pinact run --diff --check --verify              


### PR DESCRIPTION
This PR adds a workflow that uses [Pinact](https://github.com/suzuki-shunsuke/pinact) to ensure all PRs that touch actions follow the recent GitHub Actions Security Policy (see kubernetes/community#8911).

Fixes #5552 