### PR TITLE
🐛 fix(go/v4): disable kubectl kuberc in the e2e tests by default

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -69,6 +69,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= project-test-e2e

--- a/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -43,6 +43,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -65,6 +67,7 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 	By("checking if Prometheus is already installed")
 	if !utils.IsPrometheusCRDsInstalled() {
@@ -86,6 +89,21 @@ var _ = AfterSuite(func() {
 
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -65,6 +65,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= project-test-e2e

--- a/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/test/e2e/e2e_suite_test.go
@@ -41,6 +41,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -60,12 +62,28 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 })
 
 var _ = AfterSuite(func() {
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -69,6 +69,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= project-test-e2e

--- a/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/test/e2e/e2e_suite_test.go
@@ -43,6 +43,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -65,6 +67,7 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 	By("checking if Prometheus is already installed")
 	if !utils.IsPrometheusCRDsInstalled() {
@@ -86,6 +89,21 @@ var _ = AfterSuite(func() {
 
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -144,6 +144,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= {{ .ProjectName }}-test-e2e

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/test/e2e/suite.go
@@ -69,6 +69,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -88,12 +90,28 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 })
 
 var _ = AfterSuite(func() {
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -65,6 +65,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= project-v4-multigroup-test-e2e

--- a/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-multigroup/test/e2e/e2e_suite_test.go
@@ -41,6 +41,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -60,12 +62,28 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 })
 
 var _ = AfterSuite(func() {
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -65,6 +65,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= project-v4-with-plugins-test-e2e

--- a/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4-with-plugins/test/e2e/e2e_suite_test.go
@@ -41,6 +41,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -60,12 +62,28 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 })
 
 var _ = AfterSuite(func() {
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -65,6 +65,8 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 
 # TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
+# kubectl kuberc is disabled by default for test isolation; enable with:
+# - KUBECTL_KUBERC=true
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= project-v4-test-e2e

--- a/testdata/project-v4/test/e2e/e2e_suite_test.go
+++ b/testdata/project-v4/test/e2e/e2e_suite_test.go
@@ -41,6 +41,8 @@ var (
 // TestE2E runs the e2e test suite to validate the solution in an isolated environment.
 // The default setup requires Kind and CertManager.
 //
+// To enable kubectl kuberc (use custom kubectl configurations), set: KUBECTL_KUBERC=true
+// By default, kuberc is disabled to ensure consistent test behavior across different environments.
 // To skip CertManager installation, set: CERT_MANAGER_INSTALL_SKIP=true
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -60,12 +62,28 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(managerImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager image into Kind")
 
+	configureKubectlKubeRC()
 	setupCertManager()
 })
 
 var _ = AfterSuite(func() {
 	teardownCertManager()
 })
+
+// Disable kubectl kuberc by default for test isolation.
+// This prevents local kubectl configurations from affecting test behavior.
+// To enable kuberc, set: KUBECTL_KUBERC=true
+func configureKubectlKubeRC() {
+	if os.Getenv("KUBECTL_KUBERC") != "true" {
+		By("disabling kubectl kuberc for test isolation")
+		err := os.Setenv("KUBECTL_KUBERC", "false")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to disable kubectl kuberc")
+		_, _ = fmt.Fprintf(GinkgoWriter,
+			"kubectl kuberc disabled for consistent test behavior (override with KUBECTL_KUBERC=true)\n")
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "kubectl kuberc enabled (KUBECTL_KUBERC=true)\n")
+	}
+}
 
 // setupCertManager installs CertManager if needed for webhook tests.
 // Skips installation if CERT_MANAGER_INSTALL_SKIP=true or if already present.


### PR DESCRIPTION
To make kubectl executions consistent when running e2e across differences workstations, we should disable kuberc by default by setting `KUBECTL_KUBERC=false`

### Context:
With the introduction of kuberc https://kubernetes.io/docs/reference/kubectl/kuberc/, kubectl commands can now behave non-universally. 
