### PR TITLE
✨ (go/v4): add support YEAR placeholder in boilerplate for copyright 

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -51,7 +53,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/docs/book/src/cronjob-tutorial/testdata/project/hack/boilerplate.go.txt
+++ b/docs/book/src/cronjob-tutorial/testdata/project/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes authors.
+Copyright YEAR The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -47,7 +49,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/docs/book/src/getting-started/testdata/project/hack/boilerplate.go.txt
+++ b/docs/book/src/getting-started/testdata/project/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes authors.
+Copyright YEAR The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -51,7 +53,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/docs/book/src/multiversion-tutorial/testdata/project/hack/boilerplate.go.txt
+++ b/docs/book/src/multiversion-tutorial/testdata/project/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes authors.
+Copyright YEAR The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -25,8 +25,10 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/spf13/afero"
 	"golang.org/x/tools/imports"
@@ -108,10 +110,11 @@ func WithConfig(cfg config.Config) ScaffoldOption {
 	}
 }
 
-// WithBoilerplate provides the boilerplate to the Scaffold
+// WithBoilerplate provides the boilerplate to the Scaffold.
+// Any YEAR placeholder in the boilerplate is substituted with the current year.
 func WithBoilerplate(boilerplate string) ScaffoldOption {
 	return func(s *Scaffold) {
-		s.injector.boilerplate = boilerplate
+		s.injector.boilerplate = SubstituteYear(boilerplate)
 	}
 }
 
@@ -545,4 +548,10 @@ func (s Scaffold) writeFile(f *File) error {
 	}
 
 	return nil
+}
+
+// SubstituteYear replaces every occurrence of "YEAR" in the boilerplate string
+// with the current UTC year.
+func SubstituteYear(boilerplate string) string {
+	return strings.ReplaceAll(boilerplate, "YEAR", strconv.Itoa(time.Now().UTC().Year()))
 }

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -17,6 +17,8 @@ package machinery
 import (
 	"errors"
 	"os"
+	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -103,6 +105,19 @@ var _ = Describe("Scaffold", func() {
 			Expect(s.injector.boilerplate).To(Equal(""))
 			Expect(s.injector.resource).NotTo(BeNil())
 			Expect(s.injector.resource.GVK.IsEqualTo(res.GVK)).To(BeTrue())
+		})
+	})
+
+	Describe("SubstituteYear", func() {
+		It("should replace YEAR with the current UTC year", func() {
+			currentYear := strconv.Itoa(time.Now().UTC().Year())
+			Expect(SubstituteYear("Copyright YEAR The Authors.")).
+				To(Equal("Copyright " + currentYear + " The Authors."))
+		})
+
+		It("should leave strings without YEAR unchanged", func() {
+			Expect(SubstituteYear("Copyright 2024 The Authors.")).
+				To(Equal("Copyright 2024 The Authors."))
 		})
 	})
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate.go
@@ -19,7 +19,6 @@ package hack
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
@@ -42,9 +41,6 @@ type Boilerplate struct {
 
 	// Owner is the copyright owner - e.g. "The Kubernetes Authors"
 	Owner string
-
-	// Year is the copyright year
-	Year string
 }
 
 // Validate implements file.RequiresValidation
@@ -79,10 +75,6 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 		}
 	}
 
-	if f.Year == "" {
-		f.Year = fmt.Sprintf("%v", time.Now().Year())
-	}
-
 	// Boilerplate given
 	if len(f.Boilerplate) > 0 {
 		f.TemplateBody = f.Boilerplate
@@ -96,9 +88,9 @@ func (f *Boilerplate) SetTemplateDefaults() error {
 
 const boilerplateTemplate = `/*
 {{ if .Owner -}}
-Copyright {{ .Year }} {{ .Owner }}.
+Copyright YEAR {{ .Owner }}.
 {{- else -}}
-Copyright {{ .Year }}.
+Copyright YEAR.
 {{- end }}
 {{ index .Licenses .License }}*/`
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hack_test
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
+)
+
+func TestBoilerplateTemplateContainsYEAR(t *testing.T) {
+	bp := &hack.Boilerplate{
+		Owner:   "The Kubernetes Authors",
+		License: "apache2",
+	}
+	if err := bp.SetTemplateDefaults(); err != nil {
+		t.Fatalf("SetTemplateDefaults() error: %v", err)
+	}
+	body := bp.GetBody()
+	if !strings.Contains(body, "YEAR") {
+		t.Errorf("boilerplate template body must contain literal YEAR token; got:\n%s", body)
+	}
+}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -75,6 +75,8 @@ func (f *Makefile) SetTemplateDefaults() error {
 //nolint:lll
 const makefileTemplate = `# Image URL to use all building/pushing image targets
 IMG ?= {{ .Image }}
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -123,7 +125,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	{{ if .BoilerplatePath -}}
-	"$(CONTROLLER_GEN)" object:headerFile={{printf "%q" .BoilerplatePath}} paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile={{printf "%q" .BoilerplatePath}},year=$(YEAR) paths="./..."
 	{{- else -}}
 	"$(CONTROLLER_GEN)" object paths="./..."
 	{{- end }}

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -47,7 +49,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/testdata/project-v4-multigroup/hack/boilerplate.go.txt
+++ b/testdata/project-v4-multigroup/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes authors.
+Copyright YEAR The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -47,7 +49,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/testdata/project-v4-with-plugins/hack/boilerplate.go.txt
+++ b/testdata/project-v4-with-plugins/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes authors.
+Copyright YEAR The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
+YEAR ?= $(shell date +%Y)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -47,7 +49,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	"$(CONTROLLER_GEN)" object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/testdata/project-v4/hack/boilerplate.go.txt
+++ b/testdata/project-v4/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes authors.
+Copyright YEAR The Kubernetes authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Use the literal YEAR token in the scaffolded hack/boilerplate.go.txt file instead of resolving the current year at scaffold time and substitute YEAR when scaffolding/generating files. This aligns with the convention established in gengo[^1] and controller-gen[^2].

Closes kubernetes-sigs/kubebuilder#5553

[^1]: https://github.com/kubernetes/gengo/blob/5ee0d033ba5bcb073f0e69c32057520b82d75ccb/v2/execute.go#L59
[^2]: https://github.com/kubernetes-sigs/controller-tools/pull/544