### PR TITLE
📖 docs(helm/v1alpha): Add deprecation notice

### DIFF
--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -33,7 +33,7 @@ import (
 	deployimagev1alpha1 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/deploy-image/v1alpha1"
 	autoupdatev1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
 	grafanav1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
-	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
+	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha" //nolint:staticcheck // Deprecated
 	helmv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
 )
 

--- a/internal/cli/cmd/cmd.go
+++ b/internal/cli/cmd/cmd.go
@@ -34,7 +34,7 @@ import (
 	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
 	autoupdatev1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/autoupdate/v1alpha"
 	grafanav1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/grafana/v1alpha"
-	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha"
+	helmv1alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha" //nolint:staticcheck // Deprecated
 	helmv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
 )
 

--- a/pkg/plugins/optional/helm/v1alpha/commons.go
+++ b/pkg/plugins/optional/helm/v1alpha/commons.go
@@ -14,6 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha implements the Helm chart scaffolding plugin for Kubebuilder.
+//
+// Deprecated: The helm/v1alpha package is deprecated. Use [helm/v2alpha] instead.
+// The new helm/v2-alpha plugin replaces the deprecated helm/v1-alpha and brings major improvements in
+// flexibility and maintainability, championing changes driven by community feedback. Chart values are
+// now better exposed, enabling easier customization and addressing long-standing issues.
+// See [Helm Plugin (helm/v2-alpha)].
+//
+// This package is kept for compatibility and will eventually be removed.
+//
+// [helm/v2alpha]: https://pkg.go.dev/sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha
+// [Helm Plugin (helm/v2-alpha)]: https://book.kubebuilder.io/plugins/available/helm-v2-alpha
 package v1alpha
 
 import (

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
-	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v1alpha/scaffolds" //nolint:staticcheck // Deprecated
 )
 
 var _ plugin.EditSubcommand = &editSubcommand{}

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -14,6 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package scaffolds implements the scaffolding engine for the Helm v1-alpha plugin.
+//
+// Deprecated: The helm/v1alpha/scaffolds package is deprecated. Use [helm/v2alpha/scaffolds] instead.
+// The new helm/v2-alpha plugin replaces the deprecated helm/v1-alpha and brings major improvements in
+// flexibility and maintainability, championing changes driven by community feedback. Chart values are
+// now better exposed, enabling easier customization and addressing long-standing issues.
+// See [Helm Plugin (helm/v2-alpha)].
+//
+// This package is kept for compatibility and will eventually be removed.
+//
+// [helm/v2alpha/scaffolds]: https://pkg.go.dev/sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/scaffolds
+// [Helm Plugin (helm/v2-alpha)]: https://book.kubebuilder.io/plugins/available/helm-v2-alpha
 package scaffolds
 
 import (


### PR DESCRIPTION
This PR adds deprecation notices to the `helm/v1alpha` and `helm/v1alpha/scaffolds` packages to warn users about importing them.

Users are directed to use `helm/v2-alpha` packages instead.

This is necessary to get warns from IDEs and linters, and [pkg.go.dev](https://pkg.go.dev/) will hide their docs by default.

Relates to: https://github.com/kubernetes-sigs/kubebuilder/discussions/5277#discussioncomment-15400518