### PR TITLE
:sparkles: [WiP] helm/valpha2: Add extra pod spec

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -558,6 +558,13 @@ func (t *HelmTemplater) substituteCertManagerAnnotations(yamlContent string) str
 func (t *HelmTemplater) templateDeploymentFields(yamlContent string) string {
 	// Template replicas from values.yaml (manager.replicas)
 	yamlContent = t.templateReplicas(yamlContent)
+	// Template strategy at Deployment spec level
+	yamlContent = t.templateBasicWithStatement(
+		yamlContent,
+		"strategy",
+		"spec",
+		".Values.manager.strategy",
+	)
 	// Template configuration fields
 	yamlContent = t.templateImageReference(yamlContent)
 	yamlContent = t.templateEnvironmentVariables(yamlContent)
@@ -587,6 +594,30 @@ func (t *HelmTemplater) templateDeploymentFields(yamlContent string) string {
 		"spec.template.spec",
 		".Values.manager.tolerations",
 	)
+
+	// Template additional pod spec fields
+	podSpecFields := []string{
+		"priorityClassName",
+		"initContainers",
+		"ephemeralContainers",
+		"hostname",
+		"dnsConfig",
+		"dnsPolicy",
+		"hostIPC",
+		"hostNetwork",
+		"restartPolicy",
+		"nodeName",
+		"topologySpreadConstraints",
+		"schedulerName",
+	}
+	for _, field := range podSpecFields {
+		yamlContent = t.templateBasicWithStatement(
+			yamlContent,
+			field,
+			"spec.template.spec",
+			".Values.manager."+field,
+		)
+	}
 
 	return yamlContent
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic.go
@@ -102,6 +102,10 @@ func (f *HelmValuesBasic) generateBasicValues() string {
 manager:
   replicas: 1
 
+  ## Deployment strategy
+  ##
+  # strategy: {}
+
   image:
     repository: %s
     tag: %s
@@ -318,6 +322,33 @@ func (f *HelmValuesBasic) addDeploymentConfig(buf *bytes.Buffer) {
 		buf.WriteString("\n")
 	} else {
 		buf.WriteString("  tolerations: []\n")
+		buf.WriteString("\n")
+	}
+
+	// Additional pod spec fields
+	podSpecFields := []struct {
+		comment string
+		field   string
+		value   string
+	}{
+		{"Manager pod's priority class", "priorityClassName", `""`},
+		{"Init containers to run before the manager container", "initContainers", "[]"},
+		{"Ephemeral containers for debugging", "ephemeralContainers", "[]"},
+		{"Hostname for the pod", "hostname", `""`},
+		{"DNS configuration for the pod", "dnsConfig", "{}"},
+		{"DNS policy for the pod", "dnsPolicy", `""`},
+		{"Share the host IPC namespace", "hostIPC", "false"},
+		{"Share the host network namespace", "hostNetwork", "false"},
+		{"Restart policy for the pod", "restartPolicy", `""`},
+		{"Node name to schedule the pod on", "nodeName", `""`},
+		{"Topology spread constraints", "topologySpreadConstraints", "[]"},
+		{"Scheduler name", "schedulerName", `""`},
+	}
+
+	for _, field := range podSpecFields {
+		buf.WriteString("  ## " + field.comment + "\n")
+		buf.WriteString("  ##\n")
+		buf.WriteString("  # " + field.field + ": " + field.value + "\n")
 		buf.WriteString("\n")
 	}
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_basic_test.go
@@ -172,6 +172,9 @@ var _ = Describe("HelmValuesBasic", func() {
 			Expect(content).To(ContainSubstring("affinity: {}"))
 			Expect(content).To(ContainSubstring("nodeSelector: {}"))
 			Expect(content).To(ContainSubstring("tolerations: []"))
+			Expect(content).To(ContainSubstring("# priorityClassName:"))
+			Expect(content).To(ContainSubstring("# initContainers:"))
+			Expect(content).To(ContainSubstring("# ephemeralContainers:"))
 		})
 	})
 


### PR DESCRIPTION
The PR adds support for extra pod spec in helm plugin. 
Issue: https://github.com/kubernetes-sigs/kubebuilder/issues/5544

**TODO:**
1. Add placements for extra pod spec with "kubebuilder edit --plugins-helm/v2-alpha" - Done
2. Additionally should we also add support for extra pod spec when converting chart from kustomize output if the fields are present already?
3. Check for additional requirements
4. Generate testdata/ samples
5. Add documentation

(Implementation is based on my reference to https://github.com/kubernetes-sigs/kubebuilder/pull/5496/changes and AI code assistants)
