### PR TITLE
🌱 infra(CI): Add zero-trust top-level permissions in workflows

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions: {}
+
 jobs:
   go-apidiff:
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '30 20 * * 1'  # Runs every Monday at 8:30 PM
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze Go

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths-ignore: ['**/*.md']
 
+permissions: {}
+
 jobs:
   coverage:
     permissions:

--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions: {}
+
 jobs:
   test:
     permissions:

--- a/.github/workflows/docs-accessibility.yml
+++ b/.github/workflows/docs-accessibility.yml
@@ -8,8 +8,12 @@ on:
     paths:
       - '**/*.md'
 
+permissions: {}
+
 jobs:
   lint:
+    permissions:
+      contents: read
     name: "Check Docs Accessibility"
     runs-on: ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
@@ -17,5 +21,7 @@ jobs:
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run check
         run: make test-docs-accessibility

--- a/.github/workflows/external-plugin.yml
+++ b/.github/workflows/external-plugin.yml
@@ -12,6 +12,8 @@ on:
       - 'docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin'
       - '.github/workflows/external-plugin.yml'
 
+permissions: {}
+  
 jobs:
   external:
     name: Verify external plugin

--- a/.github/workflows/legacy-webhook-path.yml
+++ b/.github/workflows/legacy-webhook-path.yml
@@ -14,6 +14,8 @@ on:
       - 'testdata/**'
       - '.github/workflows/legacy-webhook-path.yml'
 
+permissions: {}
+
 jobs:
   webhook-legacy-path:
     permissions:

--- a/.github/workflows/lint-gha-workflows.yml
+++ b/.github/workflows/lint-gha-workflows.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths: 
      - '**/workflows/*.yml'
+
+permissions: {}
+
 jobs:
   zizmor:
     permissions:

--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -12,6 +12,8 @@ on:
       - 'docs/book/src/**/testdata/**'
       - '.github/workflows/lint-sample.yml'
 
+permissions: {}
+
 jobs:
   lint-samples:
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - '**/*.md'
 
+permissions: {}
+
 jobs:
   lint:
     name: golangci-lint

--- a/.github/workflows/release-version-ci.yml
+++ b/.github/workflows/release-version-ci.yml
@@ -10,6 +10,8 @@ on:
       - 'build/.goreleaser.yml'
       - '.github/workflows/release-version-ci.yml'
 
+permissions: {}
+
 jobs:
   go-releaser-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   goreleaser:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,8 +10,7 @@ on:
   push:
     branches: ["master"]
 
-# Declare default permissions as read only.
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/spaces.yml
+++ b/.github/workflows/spaces.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - '**/*.md'
 
+permissions: {}
+
 jobs:
   lint:
     permissions:

--- a/.github/workflows/test-alpha-generate.yml
+++ b/.github/workflows/test-alpha-generate.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - 'pkg/cli/alpha/**'
       - '.github/workflows/test-alpha-generate.yml'
+
+permissions: {}
       
 jobs:
   unsupported:

--- a/.github/workflows/test-book.yml
+++ b/.github/workflows/test-book.yml
@@ -14,6 +14,8 @@ on:
       - 'docs/book/src/multiversion-tutorial/testdata/project/**'
       - '.github/workflows/test-e2e-book.yml'
 
+permissions: {}
+      
 jobs:
   e2e:
     permissions:

--- a/.github/workflows/test-devcontainer.yml
+++ b/.github/workflows/test-devcontainer.yml
@@ -12,6 +12,8 @@ on:
       - '.github/workflows/test-devcontainer.yml'
       - 'pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go'
 
+permissions: {}
+      
 jobs:
   test-devcontainer:
     permissions:

--- a/.github/workflows/test-e2e-samples.yml
+++ b/.github/workflows/test-e2e-samples.yml
@@ -10,6 +10,8 @@ on:
       - 'testdata/**'
       - '.github/workflows/test-e2e-samples.yml'
 
+permissions: {}
+
 jobs:
   e2e-tests-project-v4:
     permissions:

--- a/.github/workflows/test-helm-book.yml
+++ b/.github/workflows/test-helm-book.yml
@@ -14,6 +14,8 @@ on:
       - "docs/book/src/multiversion-tutorial/testdata/project/**"
       - ".github/workflows/test-helm-book.yml"
 
+permissions: {}
+
 jobs:
   helm-test:
     permissions:

--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -10,6 +10,8 @@ on:
       - "testdata/project-v4-with-plugins/**"
       - ".github/workflows/test-helm-samples.yml"
 
+permissions: {}
+
 jobs:
   helm-test-project-v4-with-plugins:
     permissions:

--- a/.github/workflows/testdata.yml
+++ b/.github/workflows/testdata.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
 
   testdata:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   verify:
     permissions:


### PR DESCRIPTION
This PR sets the top-level permission in all Kubebuilder CI workflows to the most restrictive, zero-trust, `permissions: {}`. This remediates all the token permission vulnerabilities found by the scorecard workflow.

Now, by default, no jobs are allowed to do anything, unless explicitly permitted in job-level permissions. 

This appears to be the _crème de la crème_ in security practices.

> [!NOTE]
> We could have set them to `permissions: contents: read`, but that would be less secure than `permissions: {}`, considering that it would still grant some privileges that could be explored in attacks. 

Adresses: #5562
