### PR TITLE
🐛fix(helm/v2alpha): fix duplicate tolerations block in generated manager template

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/chart_generation_integration_test.go
@@ -415,6 +415,80 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			Expect(valuesStr).To(ContainSubstring("securityContext:"))
 		})
 	})
+
+	// A project that already has hand-authored tolerations, nodeSelector, and affinity in
+	// its manager Deployment (typical of a project created before the Helm plugin was added)
+	// must produce a chart where each scheduling field appears exactly once in
+	// templates/manager/manager.yaml as a Helm-templated stanza only, without any leftover
+	// raw YAML list items that would cause duplicate blocks and Helm parse errors.
+	Context("Scheduling fields upgrade-path", func() {
+		It("should produce exactly one Helm-templated stanza per scheduling field with no raw remnants", func() {
+			kustomizeYAML := createKustomizeWithTolerationsAndSchedulingFields("test-project")
+			err := setupKustomizeFile(manifestsFile, kustomizeYAML)
+			Expect(err).NotTo(HaveOccurred())
+
+			scaffolderBase = &editKustomizeScaffolder{
+				config:        projectConfig,
+				fs:            fs,
+				manifestsFile: manifestsFile,
+				outputDir:     outputDir,
+			}
+
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			chartPath := filepath.Join(tmpDir, outputDir, "chart")
+			managerTemplatePath := filepath.Join(chartPath, "templates", "manager", "manager.yaml")
+
+			By("reading the generated manager template")
+			managerBytes, err := os.ReadFile(managerTemplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			managerStr := string(managerBytes)
+
+			By("verifying tolerations appears exactly once and is Helm-templated")
+			Expect(strings.Count(managerStr, "tolerations:")).To(Equal(1),
+				"tolerations: must appear exactly once in the manager template")
+			Expect(managerStr).To(ContainSubstring("{{- with .Values.manager.tolerations }}"),
+				"manager template must contain Helm with-block for tolerations")
+			Expect(managerStr).To(ContainSubstring("tolerations: {{ toYaml . | nindent"),
+				"manager template must use toYaml for tolerations")
+
+			By("verifying no raw toleration list items remain")
+			Expect(managerStr).NotTo(ContainSubstring("effect: NoSchedule"),
+				"raw toleration effect must not remain in manager template")
+			Expect(managerStr).NotTo(ContainSubstring("key: node-role.kubernetes.io/control-plane"),
+				"raw toleration key must not remain in manager template")
+			Expect(managerStr).NotTo(ContainSubstring("key: dedicated"),
+				"raw toleration key must not remain in manager template")
+
+			By("verifying nodeSelector appears exactly once and is Helm-templated")
+			Expect(strings.Count(managerStr, "nodeSelector:")).To(Equal(1),
+				"nodeSelector: must appear exactly once in the manager template")
+			Expect(managerStr).To(ContainSubstring("{{- with .Values.manager.nodeSelector }}"))
+			Expect(managerStr).NotTo(ContainSubstring("kubernetes.io/os: linux"),
+				"raw nodeSelector entry must not remain in the manager template")
+
+			By("verifying affinity appears exactly once and is Helm-templated")
+			Expect(strings.Count(managerStr, "affinity:")).To(Equal(1),
+				"affinity: must appear exactly once in the manager template")
+			Expect(managerStr).To(ContainSubstring("{{- with .Values.manager.affinity }}"))
+			Expect(managerStr).NotTo(ContainSubstring("nodeAffinity:"),
+				"raw affinity sub-field must not remain in the manager template")
+
+			By("verifying tolerations are extracted to values.yaml")
+			valuesPath := filepath.Join(chartPath, "values.yaml")
+			valuesBytes, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			valuesStr := string(valuesBytes)
+			Expect(valuesStr).To(ContainSubstring("tolerations:"),
+				"tolerations must be extracted to values.yaml")
+
+			By("verifying the chart loads cleanly (no YAML parse errors)")
+			chart, err := helmChartLoader.LoadDir(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chart.Validate()).To(Succeed())
+		})
+	})
 })
 
 // Helper functions to create kustomize YAML outputs for different scenarios
@@ -673,4 +747,75 @@ func setupKustomizeFile(filePath, content string) error {
 		return err
 	}
 	return os.WriteFile(filePath, []byte(content), 0o644)
+}
+
+// createKustomizeWithTolerationsAndSchedulingFields simulates a manager.yaml that already
+// contains custom tolerations, nodeSelector, and affinity – the real-world case that
+// triggered https://github.com/kubernetes-sigs/kubebuilder/issues/5569 where Helm chart
+// generation produces a duplicate tolerations block causing Helm render failures.
+func createKustomizeWithTolerationsAndSchedulingFields(projectName string) string {
+	return `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: dedicated
+        operator: Equal
+        value: controller
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: ` + projectName + `-controller-manager
+`
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -1120,6 +1120,10 @@ func (t *HelmTemplater) templateBasicWithStatement(
 	parentKey string,
 	valuePath string,
 ) string {
+	if strings.Contains(yamlContent, valuePath) {
+		return yamlContent
+	}
+
 	lines := strings.Split(yamlContent, "\n")
 	yamlKey := fmt.Sprintf("%s:", key)
 
@@ -1151,9 +1155,9 @@ func (t *HelmTemplater) templateBasicWithStatement(
 		}
 		_, indentLen = leadingWhitespace(lines[start])
 	} else {
-		// Find the existing block
+		// Find the existing block - stop at the first match.
 		for i := range len(lines) {
-			if !strings.HasPrefix(strings.TrimSpace(lines[i]), key) {
+			if !strings.HasPrefix(strings.TrimSpace(lines[i]), yamlKey) {
 				continue
 			}
 			start = i
@@ -1161,14 +1165,21 @@ func (t *HelmTemplater) templateBasicWithStatement(
 			trimmed := strings.TrimSpace(lines[i])
 			if len(trimmed) == len(yamlKey) {
 				_, indentLenSearch := leadingWhitespace(lines[i])
-				for j := end; j < len(lines); j++ {
+				end = len(lines)
+				for j := i + 1; j < len(lines); j++ {
+					trimmedJ := strings.TrimSpace(lines[j])
 					_, indentLenLine := leadingWhitespace(lines[j])
-					if indentLenLine <= indentLenSearch {
+					if indentLenLine < indentLenSearch {
+						end = j
+						break
+					}
+					if indentLenLine == indentLenSearch && !strings.HasPrefix(trimmedJ, "- ") {
 						end = j
 						break
 					}
 				}
 			}
+			break // use the first match only
 		}
 		_, indentLen = leadingWhitespace(lines[start])
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -949,7 +949,7 @@ spec:
 		})
 
 		It("should not double-escape quotes already escaped by yaml.Marshal in double-quoted YAML scalars", func() {
-			// Regression test: yaml.Marshal represents literal " inside a {{ }} expression as \"
+			// yaml.Marshal represents literal " inside a {{ }} expression as \"
 			// in a double-quoted YAML scalar, so a second pass escaping " → \" produced \\" which
 			// broke Helm's template parser by closing the string literal early (U+002D '-' error).
 			crdResource := &unstructured.Unstructured{}
@@ -2190,6 +2190,207 @@ spec:
 			// Should NOT template sidecar container (doesn't match annotation)
 			Expect(result).To(ContainSubstring("image: sidecar:latest"))
 			Expect(result).NotTo(ContainSubstring("{{ .Values.manager.image.repository }}"))
+		})
+	})
+
+	// templateBasicWithStatement must correctly consume entire YAML sequence blocks
+	// (like tolerations) because their list items start at the same indentation as
+	// the parent key, distinguished only by the leading "- " marker.
+	Context("scheduling fields templating (nodeSelector / affinity / tolerations)", func() {
+		It("should replace an existing multi-item tolerations block with a single Helm stanza", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: another-key
+        value: somevalue
+      securityContext:
+        runAsNonRoot: true`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			// Exactly one Helm-templated tolerations stanza must be present.
+			Expect(strings.Count(result, "tolerations:")).To(Equal(1),
+				"Expected exactly one tolerations: line in output")
+			Expect(result).To(ContainSubstring("{{- with .Values.manager.tolerations }}"))
+			Expect(result).To(ContainSubstring("tolerations: {{ toYaml . | nindent"))
+			Expect(result).To(ContainSubstring("{{- end }}"))
+
+			// The raw list items must be gone.
+			Expect(result).NotTo(ContainSubstring("- effect: NoSchedule"))
+			Expect(result).NotTo(ContainSubstring("- effect: NoExecute"))
+			Expect(result).NotTo(ContainSubstring("key: node-role.kubernetes.io/control-plane"))
+			Expect(result).NotTo(ContainSubstring("key: another-key"))
+
+			// Fields after tolerations must still be present.
+			Expect(result).To(ContainSubstring("securityContext:"))
+			Expect(result).To(ContainSubstring("runAsNonRoot: true"))
+		})
+
+		It("should insert a tolerations Helm stanza when the field is absent", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+      securityContext:
+        runAsNonRoot: true`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			Expect(result).To(ContainSubstring("{{- with .Values.manager.tolerations }}"))
+			Expect(result).To(ContainSubstring("tolerations: {{ toYaml . | nindent"))
+			Expect(result).To(ContainSubstring("{{- end }}"))
+		})
+
+		It("should be idempotent: running templating twice does not duplicate stanzas", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists`
+
+			first := templater.ApplyHelmSubstitutions(content, deployment)
+			second := templater.ApplyHelmSubstitutions(first, deployment)
+
+			Expect(strings.Count(second, "{{- with .Values.manager.tolerations }}")).To(Equal(1),
+				"Expected exactly one {{- with .Values.manager.tolerations }} after two passes")
+			Expect(strings.Count(second, "tolerations:")).To(Equal(1),
+				"Expected exactly one tolerations: line after two passes")
+		})
+
+		It("should correctly template nodeSelector (map type) without regression", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+      nodeSelector:
+        kubernetes.io/os: linux
+        custom-label: my-node`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			Expect(strings.Count(result, "nodeSelector:")).To(Equal(1))
+			Expect(result).To(ContainSubstring("{{- with .Values.manager.nodeSelector }}"))
+			Expect(result).To(ContainSubstring("nodeSelector: {{ toYaml . | nindent"))
+			// Raw entries must be removed.
+			Expect(result).NotTo(ContainSubstring("kubernetes.io/os: linux"))
+			Expect(result).NotTo(ContainSubstring("custom-label: my-node"))
+		})
+
+		It("should correctly template affinity (map type) without regression", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			Expect(strings.Count(result, "affinity:")).To(Equal(1))
+			Expect(result).To(ContainSubstring("{{- with .Values.manager.affinity }}"))
+			Expect(result).To(ContainSubstring("affinity: {{ toYaml . | nindent"))
+			// Raw sub-fields must be removed.
+			Expect(result).NotTo(ContainSubstring("nodeAffinity:"))
+			Expect(result).NotTo(ContainSubstring("requiredDuringSchedulingIgnoredDuringExecution:"))
+		})
+
+		It("should not match a key that only shares a prefix with the target field name", func() {
+			// Regression guard: key matching must require the trailing colon so that
+			// e.g. "nodeSelector" does not accidentally match "nodeSelectorTerms:".
+			// This YAML tests that nodeSelectorTerms inside an affinity block is not
+			// treated as the nodeSelector field itself.
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			// The nodeSelector Helm stanza must be inserted (field was absent).
+			Expect(result).To(ContainSubstring("{{- with .Values.manager.nodeSelector }}"))
+			// The affinity block must only appear once and be Helm-templated.
+			Expect(strings.Count(result, "affinity:")).To(Equal(1))
+			Expect(result).To(ContainSubstring("{{- with .Values.manager.affinity }}"))
+			// nodeSelectorTerms is part of the affinity value; it must be gone since
+			// the whole affinity block is replaced by the Helm stanza.
+			Expect(result).NotTo(ContainSubstring("nodeSelectorTerms:"))
 		})
 	})
 })


### PR DESCRIPTION
**Description:**
When a project with hand-authored `tolerations` in `config/manager/manager.yaml` runs `kubebuilder edit --plugins=helm/v2alpha`, the generated `dist/chart/templates/manager/manager.yaml` ends up with a duplicate `tolerations` block: the raw list items from the source manifest are left behind alongside the new Helm `{{- with .Values.manager.tolerations }}` template block. This causes `helm install` / `helm upgrade` to fail with a YAML parse error.

**Root cause:**
`templateBasicWithStatement` determined the end of a YAML block with `indentLenLine <= indentLenSearch`. `tolerations` is sequence-valued — its list items (`- effect: NoSchedule`) sit at the same indentation as the parent's tolerations:` key, so the check fired on the first list item and left every `- effect: ...` line behind. `nodeSelector` and `affinity` are map-valued (children always at greater indentation) and were not affected.

**Changes:**
Fixed by updating the inner block-end scan to continue past lines at equal indentation when they start with `- ` (YAML sequence items), only stopping when it reaches a sibling key at equal indentation or a line at lesser indentation. Also adds a break after the first key match in the outer loop, tightens the match condition to require a trailing colon, and adds an idempotency guard.

Fixes #5569 
