### PR TITLE
WIP ✨ (helm/v2-alpha):  Add --input-dir flag to helm/v2-alpha plugin to allow operating on projects in different directories

### DIFF
--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -690,7 +690,8 @@ The Makefile targets use sensible defaults extracted from your project configura
 | Flag                | Description                                                                 |
 |---------------------|-----------------------------------------------------------------------------|
 | **--manifests**     | Path to YAML file containing Kubernetes manifests (default: `dist/install.yaml`) |
-| **--output-dir** string | Output directory for chart (default: `dist`)                                |
+| **--output-dir**    | Output directory for chart (default: `dist`)                                |
+| **--input-dir**     | Path to directory containing PROJECT file. All operations will use files from this directory (default: current working directory) |
 | **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`) |
 
 <aside class="note" role="note">

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	log "log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -96,6 +97,12 @@ func New(options ...Option) (*CLI, error) {
 	// Create the CLI.
 	c, err := newCLI(options...)
 	if err != nil {
+		return nil, err
+	}
+
+	// Handle --input-dir flag before building the command tree.
+	// This must happen before getInfoFromConfigFile() tries to load the PROJECT file.
+	if err := handleInputDirBeforeConfigLoad(); err != nil {
 		return nil, err
 	}
 
@@ -316,6 +323,129 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 		}
 	}
 
+	return nil
+}
+
+// parseInputDirFromArgs extracts --input-dir from raw CLI args without depending on
+// Cobra flag registration. It supports both:
+//
+//	--input-dir=/path/to/project
+//	--input-dir /path/to/project
+func parseInputDirFromArgs(args []string) (string, bool) {
+	for i := range args {
+		arg := args[i]
+
+		if arg == "--input-dir" {
+			if i+1 >= len(args) {
+				// Flag needs an argument but none provided
+				return "", false
+			}
+			if strings.HasPrefix(args[i+1], "-") {
+				// Next token is another flag, so treat this as missing a value
+				return "", false
+			}
+			return args[i+1], true
+		}
+
+		if after, ok := strings.CutPrefix(arg, "--input-dir="); ok {
+			return after, true
+		}
+	}
+
+	return "", false
+}
+
+// consumesNextArgForCommandDetection reports whether a pre-command flag takes its
+// value as the next CLI token, so that token should not be treated as a subcommand.
+func consumesNextArgForCommandDetection(arg string) bool {
+	switch arg {
+	case "--" + pluginsFlag, "--" + projectVersionFlag:
+		return true
+	default:
+		return false
+	}
+}
+
+// isEditCommand checks if the command invocation is `kubebuilder edit`
+// by scanning os.Args for the first positional argument, skipping flags and
+// flag values for known pre-command flags.
+func isEditCommand(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--" {
+			if i+1 < len(args) {
+				return args[i+1] == "edit"
+			}
+			return false
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			// Flags using --flag=value consume only the current token.
+			if strings.Contains(arg, "=") {
+				continue
+			}
+
+			// Skip the next token for known flags that take a separate value.
+			if consumesNextArgForCommandDetection(arg) && i+1 < len(args) {
+				i++
+			}
+			continue
+		}
+
+		// First positional argument is the subcommand.
+		return arg == "edit"
+	}
+	return false
+}
+
+// handleInputDirBeforeConfigLoad checks if --input-dir flag is set for edit command
+// and changes directory if needed. This must run BEFORE the framework loads PROJECT file.
+func handleInputDirBeforeConfigLoad() error {
+	// Only process --input-dir for edit command
+	if !isEditCommand(os.Args[1:]) {
+		return nil
+	}
+
+	inputDir, found := parseInputDirFromArgs(os.Args[1:])
+	if !found || inputDir == "" {
+		return nil
+	}
+
+	// Resolve to absolute path
+	if !filepath.IsAbs(inputDir) {
+		absPath, err := filepath.Abs(inputDir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve input-dir %q: %w", inputDir, err)
+		}
+		inputDir = absPath
+	}
+
+	// Validate directory exists
+	if info, err := os.Stat(inputDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("input-dir does not exist: %q", inputDir)
+		}
+		return fmt.Errorf("failed to access input-dir %q: %w", inputDir, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("input-dir is not a directory: %q", inputDir)
+	}
+
+	// Validate PROJECT file exists in input-dir
+	projectFilePath := filepath.Join(inputDir, yamlstore.DefaultPath)
+	if _, err := os.Stat(projectFilePath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("input-dir does not contain %q: %q", yamlstore.DefaultPath, inputDir)
+		}
+		return fmt.Errorf("failed to access project file %q: %w", projectFilePath, err)
+	}
+
+	// Change working directory
+	if err := os.Chdir(inputDir); err != nil {
+		return fmt.Errorf("failed to change to input-dir %q: %w", inputDir, err)
+	}
+
+	log.Info("Operating in input directory", "path", inputDir)
 	return nil
 }
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -805,6 +806,243 @@ plugins:
 				Expect(c.Command()).NotTo(BeNil())
 				Expect(c.Command()).To(Equal(c.cmd))
 			})
+		})
+	})
+
+	Context("parseInputDirFromArgs", func() {
+		It("should return empty when flag is not present", func() {
+			args := []string{"edit", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			dir, found := parseInputDirFromArgs(args)
+			Expect(found).To(BeFalse())
+			Expect(dir).To(BeEmpty())
+		})
+
+		It("should parse --input-dir with = syntax", func() {
+			args := []string{"edit", "--input-dir=/path/to/project", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			dir, found := parseInputDirFromArgs(args)
+			Expect(found).To(BeTrue())
+			Expect(dir).To(Equal("/path/to/project"))
+		})
+
+		It("should parse --input-dir with space syntax", func() {
+			args := []string{"edit", "--input-dir", "/path/to/project", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			dir, found := parseInputDirFromArgs(args)
+			Expect(found).To(BeTrue())
+			Expect(dir).To(Equal("/path/to/project"))
+		})
+
+		It("should return false when --input-dir has no value", func() {
+			args := []string{"edit", "--input-dir"}
+			dir, found := parseInputDirFromArgs(args)
+			Expect(found).To(BeFalse())
+			Expect(dir).To(BeEmpty())
+		})
+
+		It("should return false when --input-dir is followed by another flag", func() {
+			args := []string{"edit", "--input-dir", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			dir, found := parseInputDirFromArgs(args)
+			Expect(found).To(BeFalse())
+			Expect(dir).To(BeEmpty())
+		})
+	})
+
+	Context("isEditCommand", func() {
+		It("should return true for edit command", func() {
+			args := []string{"edit", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			Expect(isEditCommand(args)).To(BeTrue())
+		})
+
+		It("should return true for edit command with flags before", func() {
+			args := []string{"--verbose", "edit", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			Expect(isEditCommand(args)).To(BeTrue())
+		})
+
+		It("should return true for edit command with persistent flags that consume values", func() {
+			args := []string{"--plugins", "helm.kubebuilder.io/v2-alpha", "edit"}
+			Expect(isEditCommand(args)).To(BeTrue())
+		})
+
+		It("should return true for edit command with project-version flag", func() {
+			args := []string{"--project-version", "3", "edit"}
+			Expect(isEditCommand(args)).To(BeTrue())
+		})
+
+		It("should return false for init command", func() {
+			args := []string{"init", "--plugins=go.kubebuilder.io/v4"}
+			Expect(isEditCommand(args)).To(BeFalse())
+		})
+
+		It("should return false for create command", func() {
+			args := []string{"create", "api"}
+			Expect(isEditCommand(args)).To(BeFalse())
+		})
+
+		It("should return false for alpha generate command", func() {
+			args := []string{"alpha", "generate"}
+			Expect(isEditCommand(args)).To(BeFalse())
+		})
+
+		It("should return false for alpha generate with input-dir flag", func() {
+			args := []string{"alpha", "generate", "--input-dir=./project"}
+			Expect(isEditCommand(args)).To(BeFalse())
+		})
+	})
+
+	Context("handleInputDirBeforeConfigLoad integration", func() {
+		var (
+			originalArgs []string
+			originalDir  string
+			tmpDir       string
+		)
+
+		BeforeEach(func() {
+			// Save original os.Args and working directory
+			originalArgs = os.Args
+			var err error
+			originalDir, err = os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create temp directory for testing
+			tmpDir, err = os.MkdirTemp("", "input-dir-integration-*")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// Restore original state
+			os.Args = originalArgs
+			if originalDir != "" {
+				_ = os.Chdir(originalDir)
+			}
+			if tmpDir != "" {
+				_ = os.RemoveAll(tmpDir)
+			}
+		})
+
+		It("should do nothing when not an edit command", func() {
+			os.Args = []string{"kubebuilder", "init", "--plugins=go.kubebuilder.io/v4"}
+			err := handleInputDirBeforeConfigLoad()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying working directory has not changed")
+			currentDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(currentDir).To(Equal(originalDir))
+		})
+
+		It("should do nothing when input-dir is not specified", func() {
+			os.Args = []string{"kubebuilder", "edit", "--plugins=helm.kubebuilder.io/v2-alpha"}
+			err := handleInputDirBeforeConfigLoad()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying working directory has not changed")
+			currentDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(currentDir).To(Equal(originalDir))
+		})
+
+		It("should return error when input-dir does not exist", func() {
+			os.Args = []string{"kubebuilder", "edit", "--input-dir=/nonexistent/path"}
+			err := handleInputDirBeforeConfigLoad()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+
+		It("should return error when input-dir is not a directory", func() {
+			By("creating a file instead of directory")
+			filePath := filepath.Join(tmpDir, "testfile")
+			err := os.WriteFile(filePath, []byte("test"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			os.Args = []string{"kubebuilder", "edit", "--input-dir=" + filePath}
+			err = handleInputDirBeforeConfigLoad()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a directory"))
+		})
+
+		It("should return error when input-dir does not contain PROJECT file", func() {
+			By("creating empty directory")
+			emptyDir := filepath.Join(tmpDir, "empty")
+			err := os.MkdirAll(emptyDir, 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			os.Args = []string{"kubebuilder", "edit", "--input-dir=" + emptyDir}
+			err = handleInputDirBeforeConfigLoad()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("does not contain"))
+			Expect(err.Error()).To(ContainSubstring("PROJECT"))
+		})
+
+		It("should change directory when valid input-dir is provided", func() {
+			By("creating project directory with PROJECT file")
+			projectDir := filepath.Join(tmpDir, "project")
+			err := os.MkdirAll(projectDir, 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			projectFile := filepath.Join(projectDir, "PROJECT")
+			projectContent := `domain: example.com
+layout:
+- go.kubebuilder.io/v4
+- helm.kubebuilder.io/v2-alpha
+projectName: test-project
+repo: example.com/test-project
+version: "3"
+`
+			err = os.WriteFile(projectFile, []byte(projectContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			os.Args = []string{"kubebuilder", "edit", "--input-dir=" + projectDir}
+			err = handleInputDirBeforeConfigLoad()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying directory changed")
+			currentDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("resolving symlinks for comparison")
+			expectedDir, err := filepath.EvalSymlinks(projectDir)
+			Expect(err).NotTo(HaveOccurred())
+			actualDir, err := filepath.EvalSymlinks(currentDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(actualDir).To(Equal(expectedDir))
+		})
+
+		It("should handle relative paths correctly", func() {
+			By("creating project directory with PROJECT file")
+			projectDir := filepath.Join(tmpDir, "project")
+			err := os.MkdirAll(projectDir, 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			projectFile := filepath.Join(projectDir, "PROJECT")
+			projectContent := `domain: example.com
+layout:
+- go.kubebuilder.io/v4
+projectName: test-project
+repo: example.com/test-project
+version: "3"
+`
+			err = os.WriteFile(projectFile, []byte(projectContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("changing to tmpDir and using relative path")
+			err = os.Chdir(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			os.Args = []string{"kubebuilder", "edit", "--input-dir=./project"}
+			err = handleInputDirBeforeConfigLoad()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying directory changed")
+			currentDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("resolving symlinks for comparison")
+			expectedDir, err := filepath.EvalSymlinks(projectDir)
+			Expect(err).NotTo(HaveOccurred())
+			actualDir, err := filepath.EvalSymlinks(currentDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(actualDir).To(Equal(expectedDir))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -52,6 +52,7 @@ type editSubcommand struct {
 	force         bool
 	manifestsFile string
 	outputDir     string
+	inputDir      string
 }
 
 //nolint:lll
@@ -75,6 +76,9 @@ distribution of your project. When enabled, adds Helm helpers targets to Makefil
 
 # Generate from custom manifests to custom output directory
   %[1]s edit --plugins=%[2]s --manifests=manifests/install.yaml --output-dir=helm-charts
+
+# Work with a project in a different directory (useful for monorepos)
+  %[1]s edit --plugins=%[2]s --input-dir=./path/to/project
 
 # Typical workflow:
   make build-installer  # Generate dist/install.yaml with latest changes
@@ -105,10 +109,16 @@ func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.force, "force", false, "if true, regenerates all the files")
 	fs.StringVar(&p.manifestsFile, "manifests", DefaultManifestsFile,
 		"path to the YAML file containing Kubernetes manifests from kustomize output")
-	fs.StringVar(&p.outputDir, "output-dir", DefaultOutputDir, "output directory for the generated Helm chart")
+	fs.StringVar(&p.outputDir, "output-dir", DefaultOutputDir,
+		"output directory for the generated Helm chart")
+	fs.StringVar(&p.inputDir, "input-dir", "",
+		"path to directory containing PROJECT file; "+
+			"all operations will use files from this directory (defaults to current working directory)")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {
+	// The --input-dir flag is handled by handleInputDirBeforeConfigLoad in pkg/cli/cli.go
+	// before this method is called, so the working directory is already set.
 	p.config = c
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/edit_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit_test.go
@@ -31,6 +31,14 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
+const testProjectContent = `domain: example.com
+layout:
+- go.kubebuilder.io/v4
+projectName: test-project
+repo: example.com/test-project
+version: "3"
+`
+
 var _ = Describe("editSubcommand", func() {
 	var (
 		editCmd *editSubcommand
@@ -45,14 +53,7 @@ var _ = Describe("editSubcommand", func() {
 		store := yaml.New(fs)
 
 		// Create a basic PROJECT file
-		projectContent := `domain: example.com
-layout:
-- go.kubebuilder.io/v4
-projectName: test-project
-repo: example.com/test-project
-version: "3"
-`
-		err := afero.WriteFile(memFs, "PROJECT", []byte(projectContent), 0o644)
+		err := afero.WriteFile(memFs, "PROJECT", []byte(testProjectContent), 0o644)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = store.LoadFrom("PROJECT")
@@ -94,6 +95,19 @@ version: "3"
 
 			forceFlag := flagSet.Lookup("force")
 			Expect(forceFlag).NotTo(BeNil())
+
+			inputDirFlag := flagSet.Lookup("input-dir")
+			Expect(inputDirFlag).NotTo(BeNil())
+			Expect(inputDirFlag.DefValue).To(BeEmpty())
+		})
+
+		It("should include input-dir in examples", func() {
+			cliMeta := plugin.CLIMetadata{CommandName: "kubebuilder"}
+			meta := plugin.SubcommandMetadata{}
+			editCmd.UpdateMetadata(cliMeta, &meta)
+
+			Expect(meta.Examples).To(ContainSubstring("--input-dir"))
+			Expect(meta.Examples).To(ContainSubstring("path/to/project"))
 		})
 	})
 
@@ -143,14 +157,7 @@ version: "3"
 			freshFs := machinery.Filesystem{FS: memFs}
 			store := yaml.New(freshFs)
 
-			projectContent := `domain: example.com
-layout:
-- go.kubebuilder.io/v4
-projectName: test-project
-repo: example.com/test-project
-version: "3"
-`
-			err := afero.WriteFile(memFs, "PROJECT", []byte(projectContent), 0o644)
+			err := afero.WriteFile(memFs, "PROJECT", []byte(testProjectContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = store.LoadFrom("PROJECT")


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/5549

**Motivations**
- Allow generate the Helm Chart for monorepos.
- Ensure consistency with other commands such as alpha generate
- Scenario raised in https://github.com/kubernetes-sigs/kubebuilder/pull/5549


Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5548