### PR TITLE
✨ feat(cli): Show hint message when file completion not applicable to subcommand

### DIFF
--- a/internal/cli/alpha/generate.go
+++ b/internal/cli/alpha/generate.go
@@ -69,6 +69,20 @@ If no output directory is provided, the current working directory will be cleane
 		},
 	}
 
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	scaffoldCmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	scaffoldCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
 		"Path to the directory containing the PROJECT file. "+
 			"Defaults to the current working directory. WARNING: delete existing files (except .git and PROJECT).")

--- a/internal/cli/alpha/update.go
+++ b/internal/cli/alpha/update.go
@@ -144,6 +144,20 @@ Defaults:
 		},
 	}
 
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	updateCmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	updateCmd.Flags().StringVar(&opts.FromVersion, "from-version", "",
 		"binary release version to upgrade from. Should match the version used to init the project and be "+
 			"a valid release version, e.g., v4.6.0. If not set, it defaults to the version specified in the PROJECT file.")

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -37,6 +37,20 @@ func (c CLI) newCreateAPICmd() *cobra.Command {
 		),
 	}
 
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	cmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	// In case no plugin was resolved, instead of failing the construction of the CLI, fail the execution of
 	// this subcommand. This allows the use of subcommands that do not require resolved plugins like help.
 	if len(c.resolvedPlugins) == 0 {

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -37,6 +37,20 @@ func (c CLI) newEditCmd() *cobra.Command {
 		),
 	}
 
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	cmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	// In case no plugin was resolved, instead of failing the construction of the CLI, fail the execution of
 	// this subcommand. This allows the use of subcommands that do not require resolved plugins like help.
 	if len(c.resolvedPlugins) == 0 {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -42,6 +42,20 @@ For further help about a specific plugin, set --plugins.
 		Run:     func(_ *cobra.Command, _ []string) {},
 	}
 
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	cmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	// Register --project-version on the dynamically created command
 	// so that it shows up in help and does not cause a parse error.
 	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), "project version")

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -33,5 +33,20 @@ func (c CLI) newVersionCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	cmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -37,6 +37,20 @@ func (c CLI) newCreateWebhookCmd() *cobra.Command {
 		),
 	}
 
+	// Show hint message on how to list flags instead of showing file completion for
+	// commands that don't take files as arguments
+	cmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	// In case no plugin was resolved, instead of failing the construction of the CLI, fail the execution of
 	// this subcommand. This allows the use of subcommands that do not require resolved plugins like help.
 	if len(c.resolvedPlugins) == 0 {


### PR DESCRIPTION
This PR adds [ActiveHelp](https://github.com/spf13/cobra/blob/main/site/content/active_help.md) to the `init`, `edit`, `alpha generate`, `alpha update`, `create api` and `create webhook` subcommands.

Now, when hitting TAB on subcommands that don't take files as arguments, the cli will show a hint message (ActiveHelp) on how to list flags instead of showing file completions.

**👎🏻 Current behavior:**

```
$ kubebuilder create api <TAB>
AGENTS.md           designs/            go.mod              Makefile            RELEASE.md          test.sh
bin/                docs/               go.sum              netlify.toml        roadmap/            VERSIONING.md
build/              .git/               hack/               OWNERS              SECURITY_CONTACTS   .yamllint
code-of-conduct.md  .github/            internal/           OWNERS_ALIASES      test/               .yamllint-helm
CONTRIBUTING.md     .gitignore          LICENSE             pkg/                testdata/           
DESIGN.md           .golangci.yml       main.go             README.md           test_e2e.sh 
```
**👍🏻 New behavior:**

```
$ kubebuilder create api <TAB>
Type '--' and press TAB to list flags
```
> [!NOTE]
> This is just a first iteration and can be expanded upon, as we see fit.

Relates to #5446 