### PR TITLE
🐛 fix(CLI): Change level for plugin discovery log to debug

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -320,7 +320,7 @@ func DiscoverExternalPlugins(filesystem afero.Fs) (ps []plugin.Plugin, err error
 						return nil, fmt.Errorf("error parsing external plugin version %q: %w", version.Name(), err)
 					}
 
-					slog.Info("Adding external plugin", "plugin name", ep.Name())
+					slog.Debug("Adding external plugin", "plugin name", ep.Name())
 
 					ps = append(ps, ep)
 				}


### PR DESCRIPTION
This PR changes the log for when a plugin is discovered by Kubebuilder to DEBUG level.

Fixes #5597 