### PR TITLE
✨ feat(CLI): Add completion for the plugins flag

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -231,6 +231,34 @@ var _ = Describe("CLI", func() {
 		})
 	})
 
+	Describe("completionPluginsFlag", func() {
+		It("should suggest available plugins and filter out entered/deprecated ones", func() {
+			p1 := newMockPlugin("p1.io", "v1", projectVersion)
+			p2 := newMockPlugin("p2.io", "v1", projectVersion)
+			p3 := newMockDeprecatedPlugin("p3.io", "v1-alpha", "deprecated", projectVersion)
+
+			c.plugins = makeMapFor(p1, p2, p3)
+
+			k1 := plugin.KeyFor(p1)
+			k2 := plugin.KeyFor(p2)
+
+			c.cmd = c.newRootCmd()
+			c.cmd.Flags().StringSlice(pluginsFlag, []string{}, "test usage")
+
+			err := c.cmd.Flags().Set(pluginsFlag, k1)
+			Expect(err).NotTo(HaveOccurred())
+
+			got, directive := c.completionPluginsFlag(c.cmd, []string{}, "")
+
+			Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace))
+
+			expected := fmt.Sprintf("%s\tExternal or custom plugin", k2)
+
+			Expect(got).To(HaveLen(1))
+			Expect(got).To(ContainElement(expected))
+		})
+	})
+
 	Context("buildCmd", func() {
 		var projectFile string
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -103,6 +103,7 @@ func (c CLI) newRootCmd() *cobra.Command {
 
 	// Global flags for all subcommands.
 	cmd.PersistentFlags().StringSlice(pluginsFlag, nil, "plugin keys to be used for this subcommand execution")
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc(pluginsFlag, c.completionPluginsFlag))
 
 	// Register --project-version on the root command so that it shows up in help.
 	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), "project version")
@@ -251,4 +252,49 @@ func (c CLI) getPluginTableFilteredWithOptions(filter func(plugin.Plugin) bool, 
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// completionPluginsFlag implements cobra.CompletionFunc and is registered
+// as the flag completion function for --plugins
+// We should note that flag completion does not work for comma-chained values
+// but works fine when repeating the flag
+func (c CLI) completionPluginsFlag(
+	cmd *cobra.Command,
+	_ []string,
+	_ string,
+) ([]string, cobra.ShellCompDirective) {
+	// We filter strings that the user already passed to --plugins,
+	// in case the user chains the --plugins flag multiple times,
+	alreadyEntered, err := cmd.Flags().GetStringSlice(pluginsFlag)
+	if err != nil {
+		cobra.CheckErr(err)
+	}
+
+	comps := make([]string, 0, len(c.plugins))
+
+	for pluginKey, p := range c.plugins {
+		if slices.Contains(alreadyEntered, pluginKey) {
+			continue
+		}
+
+		// We also omit deprecated plugins from completion
+		if deprecated, ok := p.(plugin.Deprecated); ok {
+			if deprecated.DeprecationWarning() != "" {
+				continue
+			}
+		}
+
+		// If the plugin provides a description, we show that
+		// otherwise, we show the default description
+		desc := ""
+		if describable, ok := p.(plugin.Describable); ok {
+			desc = describable.Description()
+		} else {
+			desc = getPluginDescription(pluginKey)
+		}
+
+		comps = append(comps, cobra.CompletionWithDesc(pluginKey, desc))
+	}
+
+	return comps, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 }


### PR DESCRIPTION
This PR adds dynamic flag completion for the `--plugins` flag. 

The `--plugins` flag now shows completion for all the available plugins **(external ones too, including out-of-tree! 🎉)**, while hiding deprecated ones.

```
$ kubebuilder init --plugins 
autoupdate.kubebuilder.io/v1-alpha       (Proposes Kubebuilder scaffold updates via GitHub Actions)
base.go.kubebuilder.io/v4                (Default scaffold (go/v4 + kustomize/v2))
deploy-image.go.kubebuilder.io/v1-alpha  (Scaffolds a CRD+controller to deploy an image-based Operand)
foo.acme.io/v2                           (External or custom plugin)
go.kubebuilder.io/v4                     (Default scaffold (go/v4 + kustomize/v2))
grafana.kubebuilder.io/v1-alpha          (Generates Grafana Dashboards for metrics)
helm.kubebuilder.io/v2-alpha             (Generates a Helm chart for project distribution)
kustomize.common.kubebuilder.io/v2       (Scaffolds base Kustomize configuration)
```
This will improve plugin discoverability and usage, especially for the **autoupdate** plugin.

Relates to #5446 and #5291

> [!NOTE]
> Completion does not work for comma-chained values, so users will either use another instance of `--plugins` to get completion or type everything (or copy-paste) the keys after a comma:
>
> Works (multiple instances of the flag):
>  ```
> $ kubebuilder init --plugins=foo.acme.io/v2 --plugins autoupdate.kubebuilder.io/v1-alpha --plugins base.go.kubebuilder.io/v4 --plugins helm.kubebuilder.io/v2-alpha --plugins 
> deploy-image.go.kubebuilder.io/v1-alpha  (Scaffolds a CRD+controller to deploy an image-based Operand)
> go.kubebuilder.io/v4                     (Default scaffold (go/v4 + kustomize/v2))
> grafana.kubebuilder.io/v1-alpha          (Generates Grafana Dashboards for metrics)
> kustomize.common.kubebuilder.io/v2       (Scaffolds base Kustomize configuration)
> ```
> Does not work (trailing comma):
> ```
> $ kubebuilder init --plugins foo.acme.io/v2,<TAB><TAB><TAB furiously>
> (nothing happens)
> $ kubebuilder init --plugins=foo.acme.io/v2,<TAB><TAB><TAB furiously>
> (nothing happens)
> ```
> This is a known limitation in Cobra. There are workarounds but they look a bit of a kludge.