### PR TITLE
🌱 infra(git): Add kubebuilder binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ docs/book/src/docs
 \#*#
 *.swp
 
+# skip kubebuilder binary when running go build in root
+kubebuilder
+
 # skip bin dirs
 **/bin
 **/testbin


### PR DESCRIPTION
When running `go build` in root, the binary built won't be tracked by git.