### PR TITLE
🌱 refactor(CLI): Resolve Kubernetes version via binary metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	golang.org/x/tools v0.44.0
 	helm.sh/helm/v3 v3.20.2
 	k8s.io/apimachinery v0.35.3
+	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -46,5 +48,5 @@ require (
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
@@ -57,6 +59,10 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
@@ -118,6 +124,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -131,11 +139,15 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 h1:SjGebBtkBqHFOli+05xYbK8YF1Dzkbzn+gDM4X9T4Ck=
 k8s.io/utils v0.0.0-20251002143259-bc988d571ff4/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
+sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
+sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/fXCbTiQEco=
-sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 h1:2WOzJpHUBVrrkDjU4KBT8n5LDcj824eX0I5UKcgeRUs=
+sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -22,12 +22,19 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+
+	"golang.org/x/mod/semver"
+	// Controller-runtime is being added as a dep so we can anchor the minimum version of apimachinery to CR releases.
+	// The conversion package was chosen because of its minimal dependency graph (it only imports apimachinery)
+	_ "sigs.k8s.io/controller-runtime/pkg/conversion"
+	// Controller-tools is being added for the same reason
+	// The loader package was chosen for its minimal dependency graph as well (it only imports apimachinery and x/tools)
+	_ "sigs.k8s.io/controller-tools/pkg/loader"
 )
 
 const (
-	unknown                 = "unknown"
-	develVersion            = "(devel)"
-	kubernetesVendorVersion = "1.35.0"
+	unknown      = "unknown"
+	develVersion = "(devel)"
 )
 
 type Version struct {
@@ -42,7 +49,7 @@ type Version struct {
 func New() Version {
 	v := Version{
 		KubeBuilderVersion: develVersion,
-		KubernetesVendor:   kubernetesVendorVersion,
+		KubernetesVendor:   unknown,
 		GitCommit:          unknown,
 		BuildDate:          unknown,
 		GoOs:               runtime.GOOS,
@@ -52,6 +59,7 @@ func New() Version {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		v.KubeBuilderVersion = resolveMainVersion(info.Main)
 		v.applyVCSMetadata(info.Settings)
+		v.KubernetesVendor = resolveKubernetesVersion(info.Deps, "k8s.io/apimachinery")
 	}
 
 	if testVersion := os.Getenv("KUBEBUILDER_TEST_VERSION"); testVersion != "" {
@@ -74,6 +82,36 @@ func resolveMainVersion(main debug.Module) string {
 		return main.Version
 	}
 	return develVersion
+}
+
+func resolveKubernetesVersion(deps []*debug.Module, targetPath string) string {
+	// Since we anchored the minimum apimachinery version to controller-rutime
+	// we can safely assume that it is the Kubernetes version supported by CR
+	apimachineryVersion := ""
+	for _, dep := range deps {
+		if dep.Path == targetPath {
+			if dep.Replace == nil {
+				apimachineryVersion = dep.Version
+			} else {
+				apimachineryVersion = unknown
+			}
+			break
+		}
+	}
+
+	if apimachineryVersion == "" {
+		return unknown
+	}
+
+	kubernetesVersion := unknown
+	if semver.IsValid(apimachineryVersion) {
+		apimachineryVersion = semver.MajorMinor(apimachineryVersion)
+		if kubernetesResolved, ok := strings.CutPrefix(apimachineryVersion, semver.Major(apimachineryVersion)); ok {
+			kubernetesVersion = "v1" + kubernetesResolved
+		}
+	}
+
+	return kubernetesVersion
 }
 
 // isPseudoVersion reports whether a version is a pseudo-version

--- a/internal/cli/version/version_test.go
+++ b/internal/cli/version/version_test.go
@@ -40,8 +40,8 @@ func TestNew(t *testing.T) {
 	t.Run("Fallback behavior", func(t *testing.T) {
 		v := New()
 
-		if v.KubernetesVendor != kubernetesVendorVersion {
-			t.Errorf("expected vendor %s, got %s", kubernetesVendorVersion, v.KubernetesVendor)
+		if v.KubernetesVendor != unknown {
+			t.Errorf("expected vendor %s, got %s", unknown, v.KubernetesVendor)
 		}
 		if v.GoOs == "" || v.GoArch == "" {
 			t.Error("GoOs or GoArch was not populated from runtime")
@@ -192,6 +192,62 @@ func TestApplyVCSMetadata(t *testing.T) {
 			}
 			if v.BuildDate != tt.expectDate {
 				t.Errorf("BuildDate = %v, want %v", v.BuildDate, tt.expectDate)
+			}
+		})
+	}
+}
+
+func TestResolveKubernetesVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		deps       []*debug.Module
+		targetPath string
+		expected   string
+	}{
+		{
+			name: "Valid apimachinery version",
+			deps: []*debug.Module{
+				{Path: "some/other/dep", Version: "v1.0.0"},
+				{Path: "k8s.io/apimachinery", Version: "v0.35.3"},
+			},
+			targetPath: "k8s.io/apimachinery",
+			expected:   "v1.35",
+		},
+		{
+			name: "Replaced apimachinery module degrades to unknown",
+			deps: []*debug.Module{
+				{
+					Path:    "k8s.io/apimachinery",
+					Version: "v0.35.3",
+					Replace: &debug.Module{Path: "../local-fork", Version: ""},
+				},
+			},
+			targetPath: "k8s.io/apimachinery",
+			expected:   unknown,
+		},
+		{
+			name: "Malformed version string degrades to unknown",
+			deps: []*debug.Module{
+				{Path: "k8s.io/apimachinery", Version: "commit-hash-123"},
+			},
+			targetPath: "k8s.io/apimachinery",
+			expected:   unknown,
+		},
+		{
+			name: "Missing target path returns unknown",
+			deps: []*debug.Module{
+				{Path: "some/other/dep", Version: "v1.0.0"},
+			},
+			targetPath: "k8s.io/apimachinery",
+			expected:   unknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveKubernetesVersion(tt.deps, tt.targetPath)
+			if got != tt.expected {
+				t.Errorf("resolveKubernetesVersion() = %v, want %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
### What

This PR is more like a proposal than a refactor.

We're adding `controller-runtime` (EDIT: and `controller-tools`) as dependencies in Kubebuilder's `go.mod` just so we can extract the version of `apimachinery` to print the Kubernetes version in the `version` subcommand (how many versions 🤯).

### Why

We still rely on a hardcoded version of Kubernetes for the `version` command. 

Making use of Go's [Minimum Version Selection (MVS)](https://go.dev/ref/mod#minimal-version-selection), it is now reliable to resolve the supported Kubernetes version based on `controller-runtime`  (EDIT: and `controller-tools`) dependency on `apimachinery`.

### How it works

We already import `apimachinery` because of the Helm plugin:

```
$ go mod why -m k8s.io/apimachinery
# k8s.io/apimachinery
sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
```
**BUT** we can't rely on that for our Kubernetes supported version because we need to wait until `controller-runtime` supports that given version.

By making a blank import of `controller-runtime` (EDIT: and `controller-tools`), we're making the Go dependency manager strictly add to `go.mod` only `apimachinery` versions that satisfies all the packages we depend on.

So, even when other packages in our module start supporting `apimachinery` 0.36 (for example), we'll only bump its version in `go.mod` when the `controller-runtime` (EDIT: and `controller-tools`) version we depend on (that would be 0.24 and 0.21, respectively) also supports it. Until then, it will remain at 0.35+patches.

At runtime, the CLI uses `debug.ReadBuildInfo()` to inspect its own compiled binary metadata, extracts that anchored `apimachinery` version, and translates it into the standard (EDIT: Kubernetes v1.XX) release format.

### Why `controller-runtime/pkg/conversion` (EDIT: and `controller-tools/pkg/loader`)?

We picked the `conversion` package precisely because [it only imports `apimachinery`](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/conversion?tab=imports), so our dependency graph won't be bloated with lots of transitive dependencies. (EDIT: And we picked the `loader` package `for the same reason`.)

### Won't it affect downstream consumers?

We're importing the `controller-runtime` (EDIT: and `controller-tool`) packages in an internal package, so nobody will be able to consume it (and end up with the transitive dependencies).

### Thoughts?

I understand that we should keep Kubebuilder's dependencies minimal, but honestly, adding those two dependencies to our `go.mod` is not a big deal, since we kind of depend on them anyway (not directly, you know what I mean).

Follow-up to #5303