### PR TITLE
🐛 fix(helm/v2-alpha): secretRef fix

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater.go
@@ -401,28 +401,23 @@ func (t *HelmTemplater) substituteResourceNamesWithPrefix(
 
 	isServiceAccount := resource.GetKind() == kindServiceAccount
 
+	// Extract actual container names from the structured object so
+	// they can be skipped without backward text-scanning.
+	containerNameSet := extractContainerNames(resource)
+
 	for i, line := range lines {
 		if !namePattern.MatchString(line) {
 			result = append(result, line)
 			continue
 		}
 
-		// Check if this is a container name by looking at surrounding context
-		// Container names appear after "containers:" and before other container fields (image, args, etc.)
 		isContainerName := false
-		if strings.Contains(line, "name:") {
-			// Look backward for "containers:" within ~20 lines
-			for j := i - 1; j >= 0 && j >= i-20; j-- {
-				trimmed := strings.TrimSpace(lines[j])
-				if trimmed == "containers:" {
+		if len(containerNameSet) > 0 && strings.Contains(line, "name:") {
+			parts := namePattern.FindStringSubmatch(line)
+			if len(parts) >= 4 {
+				candidateName := t.detectedPrefix + parts[3]
+				if containerNameSet[candidateName] {
 					isContainerName = true
-					break
-				}
-				// Stop if we hit a new top-level section
-				//nolint:goconst // YAML keywords used in different contexts
-				if strings.HasPrefix(lines[j], "  ") && strings.HasSuffix(trimmed, ":") &&
-					(trimmed == "spec:" || trimmed == "template:" || trimmed == "volumes:") {
-					break
 				}
 			}
 		}
@@ -1051,11 +1046,11 @@ func (t *HelmTemplater) templateImagePullSecrets(yamlContent string) string {
 	foundTemplate := false
 	for i := range lines {
 		trimmed := strings.TrimSpace(lines[i])
-		if trimmed == "template:" {
+		if trimmed == "template:" { //nolint:goconst
 			foundTemplate = true
 			continue
 		}
-		if foundTemplate && trimmed == "spec:" {
+		if foundTemplate && trimmed == "spec:" { //nolint:goconst
 			// Found pod spec, inject at next line
 			insertAt = i + 1
 			break
@@ -1214,6 +1209,35 @@ func leadingWhitespace(line string) (string, int) {
 	trimmed := strings.TrimLeft(line, " \t")
 	indentLen := len(line) - len(trimmed)
 	return line[:indentLen], indentLen
+}
+
+// extractContainerNames returns the set of container and initContainer names declared in a
+// Deployment (or any Pod-template-bearing resource).
+func extractContainerNames(resource *unstructured.Unstructured) map[string]bool {
+	names := map[string]bool{}
+	for _, fieldPath := range [][]string{
+		{"spec", "template", "spec", "containers"},
+		{"spec", "template", "spec", "initContainers"},
+	} {
+		val, found, err := unstructured.NestedFieldNoCopy(resource.Object, fieldPath...)
+		if err != nil || !found {
+			continue
+		}
+		containers, ok := val.([]any)
+		if !ok {
+			continue
+		}
+		for _, c := range containers {
+			container, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if n, ok := container["name"].(string); ok && n != "" {
+				names[n] = true
+			}
+		}
+	}
+	return names
 }
 
 // isManagerDeployment checks if a Deployment is the controller manager.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/helm_templater_test.go
@@ -920,6 +920,64 @@ metadata:
 			Expect(result).To(ContainSubstring(expected))
 			Expect(result).NotTo(ContainSubstring("name: test-project-controller-manager-metrics-monitor"))
 		})
+
+		It("should template secretRef name inside envFrom", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        envFrom:
+        - secretRef:
+            name: test-project-manager-secrets`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			// secretRef.name inside envFrom must be templated, not left as a hardcoded string
+			expectedSecretRef := `name: {{ include "test-project.resourceName" ` +
+				`(dict "suffix" "manager-secrets" "context" $) }}`
+			Expect(result).To(ContainSubstring(expectedSecretRef))
+			Expect(result).NotTo(ContainSubstring("name: test-project-manager-secrets"))
+		})
+
+		It("should template configMapRef name inside envFrom", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        envFrom:
+        - configMapRef:
+            name: test-project-manager-config`
+
+			result := templater.ApplyHelmSubstitutions(content, deployment)
+
+			// configMapRef.name inside envFrom must be templated
+			expectedConfigMapRef := `name: {{ include "test-project.resourceName" ` +
+				`(dict "suffix" "manager-config" "context" $) }}`
+			Expect(result).To(ContainSubstring(expectedConfigMapRef))
+			Expect(result).NotTo(ContainSubstring("name: test-project-manager-config"))
+		})
 	})
 
 	Context("app.kubernetes.io/name label templating", func() {


### PR DESCRIPTION
fix(helm/v2-alpha): template secretRef/configMapRef names inside envFrom

`substituteResourceNamesWithPrefix` used a backward line-scan to differentiate container names from resource reference name fields.  The scan looked for `containers:` and stopped at a hard-coded set of section headers. When a `secretRef` or `configMapRef` entry appeared between `containers:` and the target `name:` field, the scan falsely concluded the field was a container name and skipped templating it, leaving a hardcoded string in the generated Helm chart (regression introduced after v4.11.1).

Replace the scan with `extractContainerNames`, which reads actual container and initContainer names directly from the structured `*unstructured.Unstructured` object. A line is skipped only when its value is literally one of those names.

Also switch from `unstructured.NestedSlice` to `unstructured.NestedFieldNoCopy` to avoid a `panic: cannot deep copy int`.

Fixes #5622