### PR TITLE
🌱 Add Agent Skills and standardize CLI descriptions              

### DIFF
--- a/.agents/skills/cli-descriptions/SKILL.md
+++ b/.agents/skills/cli-descriptions/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: cli-descriptions
+description: Standards for CLI command and flag descriptions in Kubebuilder. Use when writing or reviewing CLI flags, commands, or help text.
+license: Apache-2.0
+metadata:
+  author: The Kubernetes Authors
+---
+
+# CLI Description Standards for Kubebuilder
+
+Use this skill to write, review, or normalize Kubebuilder CLI command descriptions, flag help text, and examples.
+
+## Workflow
+
+1. Identify the CLI element:
+   - boolean flag
+   - value flag
+   - command short description
+   - command long description
+   - examples/help text
+2. Apply the matching standard below.
+3. Rewrite the text to match the standard.
+4. If reviewing, explain the issue briefly and propose the corrected wording.
+
+## Core principles
+
+- Prefer clarity over brevity.
+- Use consistent patterns across similar flags and commands.
+- Include examples, defaults, or fallback behavior when useful.
+- Tell users what happens when they use the flag.
+
+## Boolean flags
+
+### Default false (opt-in behavior)
+
+Use this pattern:
+
+```
+If set, <what happens>
+```
+
+Examples:
+
+- `If set, enable multigroup layout (organize APIs by group)`
+- `If set, skip Go version check`
+- `If set, attempt to create resource even if it already exists`
+
+### Default true (opt-out behavior)
+
+When a boolean flag defaults to `true`, describe the behavior and how to disable it:
+
+```
+<what happens by default>; use --flag=false to <opposite behavior>
+```
+
+Or for flags with more context:
+
+```
+<what happens> (enabled by default; use --flag=false to disable)
+```
+
+Examples:
+
+- `Run 'make generate' after generating files (enabled by default; use --make=false to disable)`
+- `Run 'make manifests' after generating files (enabled by default; use --manifests=false to disable)`
+- `Resource is namespaced by default; use --namespaced=false to create a cluster-scoped resource`
+- `Generate the resource without prompting the user (enabled by default; use --resource=false to disable)`
+- `Download dependencies after scaffolding (enabled by default; use --fetch-deps=false to disable)`
+
+### Tri-state (enable/disable/preserve)
+
+When a boolean flag preserves existing values if not provided, and supports both enabling and disabling:
+
+```
+Enable or disable <what>; use --flag=false to disable
+```
+
+Examples:
+
+- `Enable or disable multigroup layout (organize APIs by group); use --multigroup=false to disable`
+- `Enable or disable namespace-scoped deployment (default: cluster-scoped); use --namespaced=false to disable`
+
+### Prompting flags
+
+When a flag controls prompting behavior (prompts by default, but accepts explicit true/false to skip the prompt):
+
+```
+Prompt whether to <action> by default; use --flag=true or --flag=false to skip the prompt
+```
+
+Examples:
+
+- `Prompt whether to generate the controller by default; use --controller=true or --controller=false to skip the prompt`
+
+## Value flags
+
+Use these patterns:
+
+With an example:
+```
+<what> (e.g., <example>)
+```
+
+With a default:
+```
+<what> (e.g., <example>). Defaults to <default> if unset
+```
+
+With auto-detection:
+```
+<what> (e.g., <example>); auto-detected <method> if not provided
+```
+
+Examples:
+
+- `Go module name (e.g., github.com/user/repo); auto-detected from current directory if not provided`
+- `License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset`
+- `Project version (e.g., 3). Defaults to CLI version if unset`
+- `Domain for your APIs (e.g., example.org creates crew.example.org for API groups)`
+
+## Optional value flags
+
+When a flag is optional and modifies behavior, use:
+
+```
+[Optional] <what>. <additional context if useful> (e.g., <example>)
+```
+
+Examples:
+
+- `[Optional] Container command to use for image initialization (e.g., --image-container-command="memcached,--memory-limit=64,modern,-o,-v")`
+- `[Optional] Container port used by the container image (e.g., --image-container-port="11211")`
+
+## Path flags
+
+Use:
+
+```
+Path to <what>; <behavior> (e.g., <example>)
+```
+
+Example:
+
+- `Path to custom license file; content copied to hack/boilerplate.go.txt (overrides --license)`
+
+## List flags
+
+For comma-separated lists or arrays:
+
+```
+Comma-separated list of <what> (e.g., --flag value1,value2)
+```
+
+Example:
+
+- `Comma-separated list of spoke versions to be added to the conversion webhook (e.g., --spoke v1,v2)`
+
+## Deprecated flags
+
+For deprecated flags that will be removed in future versions:
+
+```
+[DEPRECATED] If set, <what it does>. This option will be removed in future versions
+```
+
+Example:
+
+- `[DEPRECATED] If set, attempts to create resource under the API directory (legacy path). This option will be removed in future versions`
+
+## Command short descriptions
+
+Rules:
+
+- Start with a capital letter.
+- Use a brief phrase or sentence.
+- Do not end with a period.
+- Prefer imperative wording.
+
+Examples:
+
+- `Initialize a new project`
+- `Scaffold a Kubernetes API`
+- `Scaffold a Kubernetes API or webhook`
+
+## Command long descriptions
+
+Long descriptions should:
+
+- explain what the command does
+- mention generated files or directories when relevant
+- separate required vs optional/configuration flags when helpful
+- use full sentences and punctuation
+- include behavioral notes when useful
+
+Use this structure when it fits:
+
+```
+Initialize a new project including the following files:
+  - a "go.mod" with project dependencies
+  - a "PROJECT" file that stores project configuration
+  - a "Makefile" with useful make targets
+
+Required flags:
+  --domain: Domain for your APIs (e.g., example.org creates crew.example.org for API groups)
+
+Configuration flags:
+  --repo: Go module name (e.g., github.com/user/repo); auto-detected from current directory if not provided
+
+Note: Layout settings can be changed later with 'kubebuilder edit'.
+```
+
+## Command examples
+
+Examples should:
+
+- be realistic and valid
+- progress from simple to complex
+- explain non-obvious cases
+- use the command name variable when writing Go examples
+
+Example:
+
+```go
+subcmdMeta.Examples = fmt.Sprintf(`  # Initialize a new project
+  %[1]s init --domain example.org
+
+  # Initialize with multigroup layout
+  %[1]s init --domain example.org --multigroup
+
+  # Initialize with all options combined
+  %[1]s init --plugins go/v4,autoupdate/v1-alpha --domain example.org --multigroup --namespaced
+`, cliMeta.CommandName)
+```
+
+## Common Kubebuilder flag wording
+
+Use these standard descriptions when applicable:
+
+- `--domain`: `Domain for your APIs (e.g., example.org creates crew.example.org for API groups)`
+- `--repo`: `Go module name (e.g., github.com/user/repo); auto-detected from current directory if not provided`
+- `--plugins`: `Comma-separated list of plugins to use (default: go/v4)`
+- `--multigroup`:
+  - In `init`: `If set, enable multigroup layout (organize APIs by group)`
+  - In `edit`: `Enable or disable multigroup layout (organize APIs by group); use --multigroup=false to disable`
+- `--skip-go-version-check`: `If set, skip Go version check`
+- `--force`: `If set, attempt to create resource even if it already exists` (or `If set, regenerate all files except Chart.yaml` for helm plugins)
+- `--license`: `License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset`
+- `--owner`: `Owner name for copyright license headers`
+- `--namespaced`:
+  - In `api`: `Resource is namespaced by default; use --namespaced=false to create a cluster-scoped resource`
+  - In `edit`: `Enable or disable namespace-scoped deployment (default: cluster-scoped); use --namespaced=false to disable`
+- `--fetch-deps`: `Download dependencies after scaffolding (enabled by default; use --fetch-deps=false to disable)`
+- `--make`: `Run 'make generate' after generating files (enabled by default; use --make=false to disable)`
+- `--manifests`: `Run 'make manifests' after generating files (enabled by default; use --manifests=false to disable)`
+- `--resource`: `Generate the resource without prompting the user (enabled by default; use --resource=false to disable)`
+- `--controller`: `Prompt whether to generate the controller by default; use --controller=true or --controller=false to skip the prompt`
+
+## Review output pattern
+
+When reviewing, use this format:
+
+- **Issue**: one short sentence describing what is wrong
+- **Suggested text**: the corrected help text
+- **Reason**: one short sentence tying it back to the standard
+
+Example:
+
+- **Issue**: Boolean flag description does not describe the behavior when the flag is present.
+- **Suggested text**: `If set, enable multigroup layout (organize APIs by group)`
+- **Reason**: Boolean flags should follow the `If set, ...` pattern.
+
+## Checklist
+
+- [ ] Boolean flags that default to `false` use `If set, ...`
+- [ ] Boolean flags that default to `true` describe the behavior and how to disable (e.g., "enabled by default; use --flag=false to disable")
+- [ ] Value flags include examples with `(e.g., ...)`
+- [ ] List flags use `Comma-separated list of ...`
+- [ ] Deprecated flags are marked with `[DEPRECATED]`
+- [ ] Defaults are explicitly stated when they exist with "if unset" (e.g., "Defaults to X if unset")
+- [ ] Auto-detection or fallback behavior is documented
+- [ ] Short descriptions are capitalized and do not end with a period
+- [ ] Long descriptions are complete and organized
+- [ ] Examples are realistic and valid
+- [ ] Terminology is consistent across commands and plugins
+
+## Notes
+
+- Apply these standards across all Kubebuilder plugins.
+- Prefer consistency across the codebase over one-off wording choices.
+- When the same flag appears in multiple plugins (e.g., `--force`, `--make`), use identical descriptions across all plugins.
+- For multi-line flag descriptions in code, use string concatenation with `+` and break at natural boundaries (70-80 characters per line).
+- When in doubt, choose the wording that is clearest in `--help` output.
+- See [references/REFERENCE.md](references/REFERENCE.md) for technical references and industry standards that inform these guidelines.

--- a/.agents/skills/cli-descriptions/references/REFERENCE.md
+++ b/.agents/skills/cli-descriptions/references/REFERENCE.md
@@ -1,0 +1,11 @@
+# Technical References
+
+Industry standards and best practices that inform the CLI description standards.
+
+## Standards
+
+- [Cobra Documentation](https://cobra.dev/) - CLI framework used by Kubebuilder and kubectl
+- [POSIX Utility Conventions](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html) - Option syntax and argument handling
+- [GNU Coding Standards - Command-Line Interfaces](https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html) - Long options and help text
+- [Command Line Interface Guidelines](https://clig.dev/) - Modern CLI design patterns
+- [Kubernetes kubectl Usage Conventions](https://kubernetes.io/docs/reference/kubectl/conventions/) - Kubernetes CLI patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,69 @@ There are certain writing style guidelines for Kubernetes documentation, checkou
 
 Check the CI job after to do the Pull Request and then, click on in the `Details` of `netlify/kubebuilder/deploy-preview`
 
+## Contributing AI Agent Configurations
+
+Kubebuilder uses vendor-neutral standards to help AI coding agents understand the project and contribute effectively.
+
+### Agent Skills
+
+Agent Skills provide structured knowledge that helps AI agents perform specific tasks consistently. Skills are stored in `.agents/skills/` and follow the [agentskills.io][agentskills] specification.
+
+Each skill lives in its own directory with a required `SKILL.md` file:
+
+```
+.agents/skills/
+└── skill-name/
+    ├── SKILL.md          # Required: metadata + instructions
+    ├── scripts/          # Optional: executable code
+    ├── references/       # Optional: documentation
+    ├── assets/           # Optional: templates, resources
+    └── ...               # Any additional files or directories
+```
+
+To add a new skill:
+
+1. Create a directory under `.agents/skills/<category>-<what-does>/`
+   - Use the naming pattern: `<category>-<what-does>` (e.g., `cli-descriptions`, `plugin-testing`)
+   - Category describes the domain (cli, plugin, docs)
+   - What-does describes the action or focus area
+2. Add a `SKILL.md` file with frontmatter:
+
+```markdown
+---
+name: category-what-does
+description: What this skill does and when to use it.
+license: Apache-2.0
+metadata:
+  author: The Kubernetes Authors
+---
+
+Instructions for the skill...
+```
+
+3. Follow the [agentskills.io specification][agentskills]:
+   - Name must match the directory name (lowercase, hyphens only)
+   - Description should be 1-1024 characters
+   - Keep the main file under 500 lines
+   - Move detailed content to `references/` subdirectory
+
+See `.agents/skills/cli-descriptions/` for an example.
+
+### AGENTS.md
+
+The `AGENTS.md` file provides context to AI coding agents in a vendor-neutral format. It follows the [agents.md][agentsmd] standard and works with all AI tools.
+
+This file should be placed in the project root and can include:
+
+- Build and test commands
+- Code conventions and style guides
+- Setup and development procedures
+- Project-specific context that helps agents contribute
+
+Keep the content focused on what agents need to know. Reference existing documentation rather than duplicating it.
+
+**IMPORTANT:** Do not create vendor-specific configuration files. Use only the vendor-neutral standards (Agent Skills and AGENTS.md).
+
 ## Community, discussion and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
@@ -255,3 +318,5 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [kind]: https://kind.sigs.k8s.io/#installation-and-usage
 [setup-envtest]: https://book.kubebuilder.io/reference/envtest
 [k8s-contrubutiong-guide]: https://www.kubernetes.dev/docs/guide/contributing/
+[agentskills]: https://agentskills.io/
+[agentsmd]: https://agents.md/

--- a/pkg/cli/resource.go
+++ b/pkg/cli/resource.go
@@ -39,9 +39,9 @@ type resourceOptions struct {
 func bindResourceFlags(fs *pflag.FlagSet) *resourceOptions {
 	options := &resourceOptions{}
 
-	fs.StringVar(&options.Group, "group", "", "resource Group")
-	fs.StringVar(&options.Version, "version", "", "resource Version")
-	fs.StringVar(&options.Kind, "kind", "", "resource Kind")
+	fs.StringVar(&options.Group, "group", "", "Resource Group (e.g., batch, apps)")
+	fs.StringVar(&options.Version, "version", "", "Resource Version (e.g., v1, v1beta1)")
+	fs.StringVar(&options.Kind, "kind", "", "Resource Kind (e.g., CronJob, Deployment)")
 
 	return options
 }

--- a/pkg/plugins/common/kustomize/v2/create.go
+++ b/pkg/plugins/common/kustomize/v2/create.go
@@ -32,7 +32,7 @@ type createSubcommand struct {
 }
 
 func (p *createSubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&p.force, "force", false, "overwrite existing files")
+	fs.BoolVar(&p.force, "force", false, "If set, overwrite existing files")
 }
 
 func (p *createSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/common/kustomize/v2/init.go
+++ b/pkg/plugins/common/kustomize/v2/init.go
@@ -57,8 +57,11 @@ NOTE: This plugin requires kustomize version v5 and kubectl >= 1.22.
 }
 
 func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&p.domain, "domain", "my.domain", "domain for groups")
-	fs.StringVar(&p.name, "project-name", "", "name of this project")
+	fs.StringVar(&p.domain, "domain", "my.domain",
+		"Domain for your APIs (e.g., example.org creates crew.example.org for API groups). "+
+			"Defaults to my.domain if unset")
+	fs.StringVar(&p.name, "project-name", "",
+		"Name of this project (e.g., my-project); auto-detected from current directory if not provided")
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -103,24 +103,29 @@ func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdM
 }
 
 func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&p.image, "image", "", "inform the Operand image. "+
-		"The controller will be scaffolded with an example code to deploy and manage this image.")
+	fs.StringVar(&p.image, "image", "", "Operand image name (e.g., memcached:1.6.15-alpine). "+
+		"The controller will be scaffolded with example code to deploy and manage this image")
 
-	fs.StringVar(&p.imageContainerCommand, "image-container-command", "", "[Optional] if informed, "+
-		"will be used to scaffold the container command that should be used to init a container to run the image in "+
-		"the controller and its spec in the API (CRD/CR). (i.e. "+
-		"--image-container-command=\"memcached,--memory-limit=64,modern,-o,-v\")")
-	fs.StringVar(&p.imageContainerPort, "image-container-port", "", "[Optional] if informed, "+
-		"will be used to scaffold the container port that should be used by container image in "+
-		"the controller and its spec in the API (CRD/CR). (i.e --image-container-port=\"11211\") ")
-	fs.StringVar(&p.runAsUser, "run-as-user", "", "User-Id for the container formed will be set to this value")
+	fs.StringVar(&p.imageContainerCommand, "image-container-command", "",
+		"[Optional] Container command to use for image initialization "+
+			"(e.g., --image-container-command=\"memcached,--memory-limit=64,modern,-o,-v\"). "+
+			"Used to scaffold the container command in the controller and its spec in the API (CRD/CR)")
+	fs.StringVar(&p.imageContainerPort, "image-container-port", "",
+		"[Optional] Container port used by the container image "+
+			"(e.g., --image-container-port=\"11211\"). "+
+			"Used to scaffold the container port in the controller and its spec in the API (CRD/CR)")
+	fs.StringVar(&p.runAsUser, "run-as-user", "",
+		"User ID for the container (e.g., 1000); sets the securityContext.runAsUser field")
 
-	fs.BoolVar(&p.runMake, "make", true, "if true, run `make generate` after generating files")
-	fs.BoolVar(&p.runManifests, "manifests", true, "if true, run `make manifests` after generating files")
+	fs.BoolVar(&p.runMake, "make", true,
+		"Run 'make generate' after generating files (enabled by default; use --make=false to disable)")
+	fs.BoolVar(&p.runManifests, "manifests", true,
+		"Run 'make manifests' after generating files (enabled by default; use --manifests=false to disable)")
 
 	p.options = &goPlugin.Options{}
 
-	fs.StringVar(&p.options.Plural, "plural", "", "resource irregular plural form")
+	fs.StringVar(&p.options.Plural, "plural", "",
+		"Resource irregular plural form (e.g., 'people' for 'Person'); auto-detected if not provided")
 }
 
 func (p *createAPISubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -92,37 +92,41 @@ make generate will be run.
 }
 
 func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&p.runMake, "make", true, "if true, run `make generate` after generating files")
+	fs.BoolVar(&p.runMake, "make", true,
+		"Run 'make generate' after generating files (enabled by default; use --make=false to disable)")
 
 	fs.BoolVar(&p.force, "force", false,
-		"attempt to create resource even if it already exists")
+		"If set, attempt to create resource even if it already exists")
 
 	p.options = &goPlugin.Options{}
 
-	fs.StringVar(&p.options.Plural, "plural", "", "resource irregular plural form")
+	fs.StringVar(&p.options.Plural, "plural", "",
+		"Resource irregular plural form (e.g., 'people' for 'Person'); auto-detected if not provided")
 
 	fs.BoolVar(&p.options.DoAPI, "resource", true,
-		"if set, generate the resource without prompting the user")
+		"Generate the resource without prompting the user (enabled by default; use --resource=false to disable)")
 	p.resourceFlag = fs.Lookup("resource")
-	fs.BoolVar(&p.options.Namespaced, "namespaced", true, "resource is namespaced")
+	fs.BoolVar(&p.options.Namespaced, "namespaced", true,
+		"Resource is namespaced by default; use --namespaced=false to create a cluster-scoped resource")
 
 	fs.BoolVar(&p.options.DoController, "controller", true,
-		"if set, generate the controller without prompting the user")
+		"Prompt whether to generate the controller by default; "+
+			"use --controller=true or --controller=false to skip the prompt")
 	p.controllerFlag = fs.Lookup("controller")
 
 	fs.StringVar(&p.options.ControllerName, "controller-name", "",
-		"name of the controller to scaffold (allows multiple controllers per resource)")
+		"Name of the controller to scaffold (e.g., frigate-controller); allows multiple controllers per resource")
 
 	fs.StringVar(&p.options.ExternalAPIPath, "external-api-path", "",
-		"Specify the Go package import path for the external API. This is used to scaffold controllers for resources "+
-			"defined outside this project (e.g., github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1).")
+		"Go package import path for the external API (e.g., github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1). "+
+			"Used to scaffold controllers for resources defined outside this project")
 
 	fs.StringVar(&p.options.ExternalAPIDomain, "external-api-domain", "",
-		"Specify the domain name for the external API. This domain is used to generate accurate RBAC "+
-			"markers and permissions for the external resources (e.g., cert-manager.io).")
+		"Domain name for the external API (e.g., cert-manager.io). "+
+			"Used to generate accurate RBAC markers and permissions for the external resources")
 
 	fs.StringVar(&p.options.ExternalAPIModule, "external-api-module", "",
-		"external API module with optional version (e.g., github.com/cert-manager/cert-manager@v1.18.2)")
+		"External API module with optional version (e.g., github.com/cert-manager/cert-manager@v1.18.2)")
 }
 
 func (p *createAPISubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/golang/v4/edit.go
+++ b/pkg/plugins/golang/v4/edit.go
@@ -102,15 +102,17 @@ Note: To add optional plugins after initialization, use 'kubebuilder edit --plug
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	p.fs = fs
-	fs.BoolVar(&p.multigroup, "multigroup", false, "enable or disable multigroup layout")
-	fs.BoolVar(&p.namespaced, "namespaced", false, "enable or disable namespace-scoped deployment")
-	fs.BoolVar(&p.force, "force", false, "overwrite scaffolded files to apply changes (manual edits may be lost)")
+	fs.BoolVar(&p.multigroup, "multigroup", false,
+		"Enable or disable multigroup layout (organize APIs by group); use --multigroup=false to disable")
+	fs.BoolVar(&p.namespaced, "namespaced", false,
+		"Enable or disable namespace-scoped deployment (default: cluster-scoped); use --namespaced=false to disable")
+	fs.BoolVar(&p.force, "force", false, "If set, overwrite scaffolded files to apply changes (manual edits may be lost)")
 	fs.StringVar(&p.licenseFile, "license-file", "",
-		"path to custom license file; content copied to hack/boilerplate.go.txt")
+		"Path to custom license file; content copied to hack/boilerplate.go.txt")
 	fs.StringVar(&p.license, "license", "",
-		"license header to use for boilerplate "+
+		"License header to use for boilerplate (e.g., apache2, none) "+
 			"(see: https://book.kubebuilder.io/reference/license-header)")
-	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
+	fs.StringVar(&p.owner, "owner", "", "Owner name for copyright license headers")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -130,26 +130,27 @@ Note: Layout settings can be changed later with 'kubebuilder edit'.
 
 func (p *initSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.skipGoVersionCheck, "skip-go-version-check",
-		false, "skip Go version check")
+		false, "If set, skip Go version check")
 
 	// dependency args
-	fs.BoolVar(&p.fetchDeps, "fetch-deps", true, "download dependencies after scaffolding")
+	fs.BoolVar(&p.fetchDeps, "fetch-deps", true,
+		"Download dependencies after scaffolding (enabled by default; use --fetch-deps=false to disable)")
 
 	// boilerplate args
 	fs.StringVar(&p.license, "license", "apache2",
-		"license header to use for boilerplate "+
+		"License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset "+
 			"(see: https://book.kubebuilder.io/reference/license-header)")
-	fs.StringVar(&p.owner, "owner", "", "owner to add to the copyright")
+	fs.StringVar(&p.owner, "owner", "", "Owner name for copyright license headers")
 	fs.StringVar(&p.licenseFile, "license-file", "",
-		"path to custom license file; content copied to hack/boilerplate.go.txt (overrides --license)")
+		"Path to custom license file; content copied to hack/boilerplate.go.txt (overrides --license)")
 
 	// project args
 	fs.StringVar(&p.repo, "repo", "", "Go module name (e.g., github.com/user/repo); "+
 		"auto-detected from current directory if not provided")
 	fs.BoolVar(&p.multigroup, "multigroup", false,
-		"enable multigroup layout (organize APIs by group)")
+		"If set, enable multigroup layout (organize APIs by group)")
 	fs.BoolVar(&p.namespaced, "namespaced", false,
-		"enable namespace-scoped deployment (default: cluster-scoped)")
+		"If set, enable namespace-scoped deployment (default: cluster-scoped)")
 }
 
 func (p *initSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -89,45 +89,47 @@ validating and/or conversion webhooks.
 func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 	p.options = &goPlugin.Options{}
 
-	fs.BoolVar(&p.runMake, "make", true, "if true, run `make generate` after generating files")
+	fs.BoolVar(&p.runMake, "make", true,
+		"Run 'make generate' after generating files (enabled by default; use --make=false to disable)")
 
-	fs.StringVar(&p.options.Plural, "plural", "", "resource irregular plural form")
+	fs.StringVar(&p.options.Plural, "plural", "",
+		"Resource irregular plural form (e.g., 'people' for 'Person'); auto-detected if not provided")
 
 	fs.BoolVar(&p.options.DoDefaulting, "defaulting", false,
-		"if set, scaffold the defaulting webhook")
+		"If set, scaffold the defaulting webhook")
 	fs.BoolVar(&p.options.DoValidation, "programmatic-validation", false,
-		"if set, scaffold the validating webhook")
+		"If set, scaffold the validating webhook")
 	fs.BoolVar(&p.options.DoConversion, "conversion", false,
-		"if set, scaffold the conversion webhook")
+		"If set, scaffold the conversion webhook")
 
 	fs.StringSliceVar(&p.options.Spoke, "spoke",
 		nil,
 		"Comma-separated list of spoke versions to be added to the conversion webhook (e.g., --spoke v1,v2)")
 
 	fs.StringVar(&p.options.DefaultingPath, "defaulting-path", "",
-		"Custom path for the defaulting/mutating webhook (only valid with --defaulting)")
+		"Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path); only valid with --defaulting")
 
 	fs.StringVar(&p.options.ValidationPath, "validation-path", "",
-		"Custom path for the validation webhook (only valid with --programmatic-validation)")
+		"Custom path for the validation webhook (e.g., /my-custom-validate-path); only valid with --programmatic-validation")
 
 	// TODO: remove for go/v5
 	fs.BoolVar(&p.isLegacyPath, "legacy", false,
-		"[DEPRECATED] Attempts to create resource under the API directory (legacy path). "+
-			"This option will be removed in future versions.")
+		"[DEPRECATED] If set, attempts to create resource under the API directory (legacy path). "+
+			"This option will be removed in future versions")
 
 	fs.StringVar(&p.options.ExternalAPIPath, "external-api-path", "",
-		"Specify the Go package import path for the external API. This is used to scaffold webhooks for resources "+
-			"defined outside this project (e.g., github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1).")
+		"Go package import path for the external API (e.g., github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1). "+
+			"Used to scaffold webhooks for resources defined outside this project")
 
 	fs.StringVar(&p.options.ExternalAPIDomain, "external-api-domain", "",
-		"Specify the domain name for the external API. This domain is used to generate accurate RBAC "+
-			"markers and permissions for the external resources (e.g., cert-manager.io).")
+		"Domain name for the external API (e.g., cert-manager.io). "+
+			"Used to generate accurate RBAC markers and permissions for the external resources")
 
 	fs.StringVar(&p.options.ExternalAPIModule, "external-api-module", "",
-		"external API module with optional version (e.g., github.com/cert-manager/cert-manager@v1.18.2)")
+		"External API module with optional version (e.g., github.com/cert-manager/cert-manager@v1.18.2)")
 
 	fs.BoolVar(&p.force, "force", false,
-		"attempt to create resource even if it already exists")
+		"If set, attempt to create resource even if it already exists")
 }
 
 func (p *createWebhookSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/autoupdate/v1alpha/edit.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/edit.go
@@ -48,7 +48,7 @@ func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.useGHModels, "use-gh-models", false,
-		"enable GitHub Models AI summary in the scaffolded workflow (requires GitHub Models permissions)")
+		"If set, enable GitHub Models AI summary in the scaffolded workflow (requires GitHub Models permissions)")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/helm/v1alpha/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/edit.go
@@ -70,7 +70,7 @@ manifests in the chart align with the latest changes.
 }
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&p.force, "force", false, "if true, regenerates all the files")
+	fs.BoolVar(&p.force, "force", false, "If set, regenerate all files except Chart.yaml")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -101,10 +101,12 @@ The generated chart structure mirrors your config/ directory:
 }
 
 func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&p.force, "force", false, "if true, regenerates all the files")
+	fs.BoolVar(&p.force, "force", false, "If set, regenerate all files except Chart.yaml")
 	fs.StringVar(&p.manifestsFile, "manifests", DefaultManifestsFile,
-		"path to the YAML file containing Kubernetes manifests from kustomize output")
-	fs.StringVar(&p.outputDir, "output-dir", common.DefaultOutputDir, "output directory for the generated Helm chart")
+		"Path to the YAML file containing Kubernetes manifests from kustomize output "+
+			"(e.g., dist/install.yaml). Defaults to dist/install.yaml if unset")
+	fs.StringVar(&p.outputDir, "output-dir", common.DefaultOutputDir,
+		"Output directory for the generated Helm chart (e.g., charts). Defaults to dist if unset")
 }
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {


### PR DESCRIPTION
This PR adds support for AI coding agents and makes CLI help text consistent across all plugins.                       
                                                                                                                         
### What changed                                                                                                       
                                                            
  **1. Added Agent Skills support**
  - New `‎.agents/skills/cli-descriptions/` directory with CLI description standards
  - Follows [agentskills.io](https://agentskills.io/) specification                                                      
  - Works with any AI tool (vendor-neutral)                                                                              
                                                                                                                         
  **2. Updated CONTRIBUTING.md**                                                                                         
  - Documents how to add Agent Skills                                                                                    
  - Explains AGENTS.md standard (from [agents.md](https://agents.md/))
  - No vendor-specific files (Claude, Copilot, etc.)                                                                     
   
  **3. Fixed all CLI flag descriptions with SKILL**                                                                                 
  - Boolean flags now use: `"If set, <action>"`             
  - Value flags include examples: `"<what> (e.g., <example>)"`                                                           
  - Defaults are clear: `"Defaults to <value> if unset"`

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5551
Partially: https://github.com/kubernetes-sigs/kubebuilder/issues/5446                                                     

Generated-by: Claude