### PR TITLE
✨ feat(cli): mark resource flags as required to improve completion

### DIFF
--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//nolint:dupl
 package cli
 
 import (
@@ -35,6 +34,19 @@ func (c CLI) newCreateAPICmd() *cobra.Command {
 		RunE: errCmdFunc(
 			fmt.Errorf("api subcommand requires an existing project"),
 		),
+	}
+
+	// Show hint message on how to list flags instead of showing file completion
+	cmd.ValidArgsFunction = func(
+		_ *cobra.Command,
+		args []string,
+		toComplete string,
+	) ([]cobra.Completion, cobra.ShellCompDirective) {
+		completions := []cobra.Completion{}
+		if len(args) == 0 && toComplete == "" {
+			completions = cobra.AppendActiveHelp(completions, "Type '--' and press TAB to list more flags")
+		}
+		return completions, cobra.ShellCompDirectiveNoFileComp
 	}
 
 	// In case no plugin was resolved, instead of failing the construction of the CLI, fail the execution of

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -268,6 +268,12 @@ func initializationHooks(
 	var options *resourceOptions
 	if requiresResource {
 		options = bindResourceFlags(cmd.Flags())
+		if err := cmd.MarkFlagRequired("version"); err != nil {
+			return nil, fmt.Errorf("failed to mark 'version' flag as required: %w", err)
+		}
+		if err := cmd.MarkFlagRequired("kind"); err != nil {
+			return nil, fmt.Errorf("failed to mark 'kind' flag as required: %w", err)
+		}
 	}
 
 	// Bind flags hook: each plugin binds to a temporary FlagSet, then we merge into the command so


### PR DESCRIPTION
This PR mark the `kind` and `version` as required. 

This makes tab completion suggest those flags when completing the `create api `and `create webhooks` commands, instead of showing the files in the current directory.

👎🏻 Current behavior:

```
$ kubebuilder create api<TAB><TAB>  (shows files)
.agents/            dist/               hack/               OWNERS_ALIASES      test_e2e.sh
AGENTS.md           docs/               internal/           pkg/                test.sh
bin/                .git/               kubebuilder         README.md           VERSIONING.md
build/              .github/            LICENSE             RELEASE.md          .yamllint
code-of-conduct.md  .gitignore          main.go             roadmap/            .yamllint-helm
CONTRIBUTING.md     .golangci.yml       Makefile            SECURITY_CONTACTS   
DESIGN.md           go.mod              netlify.toml        test/               
designs/            go.sum              OWNERS              testdata/    
```

👍🏻 New behavior:

```
$ kubebuilder create api<TAB><TAB> (does not show files)
$ kubebuilder create api --<TAB> (shows resource flags instead)
--kind     (Resource Kind (e.g., CronJob, Deployment))        --version  (Resource Version (e.g., v1, v1beta1))  
```

_Edit_: Only `version` and `kind` are marked as required, so completion shows them proactively.

After the two flags are passed, tab completion shows a hint at other flags (Cobra's ActiveHelp):

```
$ kubebuilder create api --kind MyKind --version v1alpha 
Type '--' and press TAB to list more flags
```

Just a nice little polish in UX. 💅🏻 

Relates to #5446 