### PR TITLE
🌱 (cli): correct SKILL canonical entries and normalize root help

### DIFF
--- a/.agents/skills/cli-descriptions/SKILL.md
+++ b/.agents/skills/cli-descriptions/SKILL.md
@@ -238,13 +238,17 @@ Use these standard descriptions when applicable:
 
 - `--domain`: `Domain for your APIs (e.g., example.org creates crew.example.org for API groups)`
 - `--repo`: `Go module name (e.g., github.com/user/repo); auto-detected from current directory if not provided`
-- `--plugins`: `Comma-separated list of plugins to use (default: go/v4)`
+- `--plugins`: `Comma-separated list of plugin keys to use (e.g., go/v4, helm/v2-alpha). Defaults to the built-in go/v4 bundle if unset`
 - `--multigroup`:
   - In `init`: `If set, enable multigroup layout (organize APIs by group)`
   - In `edit`: `Enable or disable multigroup layout (organize APIs by group); use --multigroup=false to disable`
-- `--skip-go-version-check`: `If set, skip Go version check`
+- `--skip-go-version-check`:
+  - When default is `false`: `If set, skip Go version check`
+  - When default is `true`: `Skip the Go version check (enabled by default; use --skip-go-version-check=false to enforce)`
 - `--force`: `If set, attempt to create resource even if it already exists` (or `If set, regenerate all files except Chart.yaml` for helm plugins)
-- `--license`: `License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset`
+- `--license`:
+  - In `init`: `License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset`
+  - In `edit`: `License header to use for boilerplate (e.g., apache2, none). If unset, preserves the existing boilerplate`
 - `--owner`: `Owner name for copyright license headers`
 - `--namespaced`:
   - In `api`: `Resource is namespaced by default; use --namespaced=false to create a cluster-scoped resource`
@@ -287,7 +291,8 @@ Example:
 
 - Apply these standards across all Kubebuilder plugins.
 - Prefer consistency across the codebase over one-off wording choices.
-- When the same flag appears in multiple plugins (e.g., `--force`, `--make`), use identical descriptions across all plugins.
+- When the same flag appears with equivalent semantics across plugins, use identical descriptions. When semantics differ (e.g., `--force` in `create`/`api`/`edit`, or `--license` in `init`/`edit`), document the per-command variant explicitly.
+- Flag descriptions should not end with a period (matches the `--help` convention used by cobra and the rest of Kubebuilder).
 - For multi-line flag descriptions in code, use string concatenation with `+` and break at natural boundaries (70-80 characters per line).
 - When in doubt, choose the wording that is clearest in `--help` output.
 - See [references/REFERENCE.md](references/REFERENCE.md) for technical references and industry standards that inform these guidelines.

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -44,7 +44,8 @@ For further help about a specific plugin, set --plugins.
 
 	// Register --project-version on the dynamically created command
 	// so that it shows up in help and does not cause a parse error.
-	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), "project version")
+	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(),
+		"Project version (e.g., 3). Defaults to CLI version if unset")
 
 	// In case no plugin was resolved, instead of failing the construction of the CLI, fail the execution of
 	// this subcommand. This allows the use of subcommands that do not require resolved plugins like help.

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -102,10 +102,13 @@ func (c CLI) newRootCmd() *cobra.Command {
 	}
 
 	// Global flags for all subcommands.
-	cmd.PersistentFlags().StringSlice(pluginsFlag, nil, "plugin keys to be used for this subcommand execution")
+	cmd.PersistentFlags().StringSlice(pluginsFlag, nil,
+		"Comma-separated list of plugin keys to use (e.g., go/v4, helm/v2-alpha). "+
+			"Defaults to the built-in go/v4 bundle if unset")
 
 	// Register --project-version on the root command so that it shows up in help.
-	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), "project version")
+	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(),
+		"Project version (e.g., 3). Defaults to CLI version if unset")
 
 	// As the root command will be used to shot the help message under some error conditions,
 	// like during plugin resolving, we need to allow unknown flags to prevent parsing errors.


### PR DESCRIPTION
## Why this PR

First off — thanks for #5631, the Agent Skills framing is great and the standardization made the plugin tree much more consistent.

While reviewing #5631 I noticed a few canonical entries in `.agents/skills/cli-descriptions/SKILL.md` that don't quite match what the code actually does. Because the whole point of SKILL is to be copy-pasted into help strings by humans and AI agents, any inaccuracy in the SKILL will propagate into `--help` output. This PR fixes those entries and then applies the corrected wording to the two top-level flags that were not touched in #5631.

Each change below follows the same shape: **what SKILL says today → what the code actually does → proposed wording**.

---

### 1. `--plugins` canonical wording doesn't match the actual default

**SKILL.md today** ([line 241](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L241)):
> ``--plugins``: ``Comma-separated list of plugins to use (default: go/v4)``

**What the code does** ([internal/cli/cmd/cmd.go:83](https://github.com/kubernetes-sigs/kubebuilder/blob/master/internal/cli/cmd/cmd.go#L83)):
```go
cli.WithDefaultPlugins(cfgv3.Version, gov4Bundle),
```
The default is the `gov4Bundle` (a bundle of plugins), not a single plugin key called `go/v4`. Someone reading `--help` and expecting `go/v4` as a literal value wouldn't be wrong exactly, but they'd be missing the bundle abstraction that actually drives plugin resolution.

**Proposed**:
> ``--plugins``: ``Comma-separated list of plugin keys to use (e.g., go/v4, helm/v2-alpha). Defaults to the built-in go/v4 bundle if unset``

---

### 2. `--license` has different semantics in `init` vs `edit`

**SKILL.md today** ([line 247](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L247)):
> ``--license``: ``License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset``

**What the code does**:
- In [`pkg/plugins/golang/v4/init.go:140`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/v4/init.go#L140) — unset → default `apache2`.
- In [`pkg/plugins/golang/v4/scaffolds/edit.go:79`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/v4/scaffolds/edit.go#L79) — unset → **preserve the existing boilerplate** (an explicit guard).

If someone applies the SKILL entry verbatim to `edit`, the help text would say "Defaults to apache2 if unset" — which is incorrect; `edit` does not overwrite an existing license when the flag is omitted.

**Proposed** — fork the entry:
> ``--license``:
>   - In ``init``: ``License header to use for boilerplate (e.g., apache2, none). Defaults to apache2 if unset``
>   - In ``edit``: ``License header to use for boilerplate (e.g., apache2, none). If unset, preserves the existing boilerplate``

---

### 3. `--skip-go-version-check` canonical wording has the wrong polarity in one call site

**SKILL.md today** ([line 245](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L245)):
> ``--skip-go-version-check``: ``If set, skip Go version check``

That pattern assumes `default=false` (the "opt-in" pattern the SKILL documents at [line 34](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L34)).

**What the code does** ([internal/cli/alpha/generate.go:81](https://github.com/kubernetes-sigs/kubebuilder/blob/master/internal/cli/alpha/generate.go#L81)):
```go
scaffoldCmd.Flags().BoolVar(&opts.SkipGoVersionCheck, "skip-go-version-check", true, ...)
```
`default=true`. SKILL already documents the opt-out pattern for default-true booleans at [lines 48–68](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L48) (used by `--make`, `--manifests`, `--namespaced`, etc.), so the fix is to expose both variants in the canonical entry.

**Proposed** — show both polarities:
> ``--skip-go-version-check``:
>   - When default is `false`: ``If set, skip Go version check``
>   - When default is `true`: ``Skip the Go version check (enabled by default; use --skip-go-version-check=false to enforce)``

(The separate question of whether `alpha generate` should even default to `true` is out of scope here — that's a behavioral discussion, not a wording one.)

---

### 4. "Identical descriptions across plugins" overgeneralizes

**SKILL.md today** ([line 290](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L290)):
> When the same flag appears in multiple plugins (e.g., ``--force``, ``--make``), use identical descriptions across all plugins.

**What #5631 actually shipped** — three different `--force` wordings, because `--force` means different things in each command:
- [`pkg/plugins/golang/v4/api.go`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/v4/api.go): ``attempt to create resource even if it already exists``
- [`pkg/plugins/common/kustomize/v2/create.go`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2/create.go): ``overwrite existing files``
- [`pkg/plugins/golang/v4/edit.go`](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/v4/edit.go): ``overwrite scaffolded files to apply changes (manual edits may be lost)``

These differences are **correct and intentional**, but the SKILL rule as written would push a future agent edit to unify them and lose the per-command nuance.

**Proposed** — qualify the rule:
> When the same flag appears with equivalent semantics across plugins, use identical descriptions. When semantics differ (e.g., ``--force`` in ``create``/``api``/``edit``, or ``--license`` in ``init``/``edit``), document the per-command variant explicitly.

---

### 5. Added: explicit "no period" rule for flag descriptions

SKILL has an explicit punctuation rule for **command short descriptions** ([line 176](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L176)) but not for **flag descriptions**. All the SKILL examples already follow the no-period convention, and cobra's own examples do too — just making the rule explicit so agents don't have to infer it. One extra bullet in the `Notes` section.

---

### 6. Root CLI help — apply the (corrected) wording

PR #5631 updated flag descriptions across `pkg/plugins/**`, but the two top-level flags that show up on literally every `kubebuilder --help` invocation weren't touched:

**Before** ([pkg/cli/root.go:105](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/cli/root.go#L105) and [pkg/cli/init.go:47](https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/cli/init.go#L47)):
```go
cmd.PersistentFlags().StringSlice(pluginsFlag, nil, "plugin keys to be used for this subcommand execution")
cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), "project version")
```

Both are lowercase sentence fragments; the whole point of the SKILL-driven standardization in #5631 is that this should read as full, capitalized descriptions with examples and defaults. This PR applies the updated SKILL wording to both.

---

## What I intentionally left out of this PR

- **`internal/cli/alpha/update.go` and `generate.go`** — about 14 more flag descriptions that pre-date #5631 and don't follow SKILL. That's a larger, independent normalization; I'll open it as a separate PR so this one stays reviewable.
- **`pkg/plugins/golang/deploy-image/v1alpha1/api.go`** long-description prose debt (separate typo cleanup).
- **Any SKILL linter/analyzer** — would be premature until the SKILL itself is accurate.

## Test plan

- [x] `go build ./...` passes locally.
- [ ] After merge: run `kubebuilder --help` and `kubebuilder init --help` to confirm the new wording renders as intended.

## Related

- Introduced the SKILL: #5631
- Closes part of: #5446 (CLI consistency)

/cc @camilamacedo86