### PR TITLE
🌱 (cli/alpha): normalize update/generate flag descriptions per SKILL

### DIFF
--- a/internal/cli/alpha/generate.go
+++ b/internal/cli/alpha/generate.go
@@ -70,16 +70,17 @@ If no output directory is provided, the current working directory will be cleane
 	}
 
 	scaffoldCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
-		"Path to the directory containing the PROJECT file. "+
-			"Defaults to the current working directory. WARNING: delete existing files (except .git and PROJECT).")
+		"Path to the directory containing the PROJECT file (e.g., ./my-project). "+
+			"Defaults to the current working directory if unset. "+
+			"WARNING: deletes existing files except .git and PROJECT")
 
 	scaffoldCmd.Flags().StringVar(&opts.OutputDir, "output-dir", "",
 		"Directory where the new project scaffold will be written. "+
-			"If unset, re-scaffolding occurs in-place "+
-			"and will delete existing files (except .git and PROJECT).")
+			"If unset, re-scaffolding occurs in-place and deletes existing files except .git and PROJECT")
 
 	scaffoldCmd.Flags().BoolVar(&opts.SkipGoVersionCheck, "skip-go-version-check", true,
-		"skip the Go version check during project generation")
+		"Skip the Go version check during project generation "+
+			"(enabled by default; use --skip-go-version-check=false to enforce)")
 
 	return scaffoldCmd
 }

--- a/internal/cli/alpha/update.go
+++ b/internal/cli/alpha/update.go
@@ -145,44 +145,47 @@ Defaults:
 	}
 
 	updateCmd.Flags().StringVar(&opts.FromVersion, "from-version", "",
-		"binary release version to upgrade from. Should match the version used to init the project and be "+
-			"a valid release version, e.g., v4.6.0. If not set, it defaults to the version specified in the PROJECT file.")
+		"Kubebuilder release version to upgrade from (e.g., v4.6.0); should match the version used "+
+			"to init the project. Defaults to the version in the PROJECT file if unset")
 	updateCmd.Flags().StringVar(&opts.ToVersion, "to-version", "",
-		"binary release version to upgrade to. Should be a valid release version, e.g., v4.7.0. "+
-			"If not set, it defaults to the latest release version available in the project repository.")
+		"Kubebuilder release version to upgrade to (e.g., v4.7.0). "+
+			"Defaults to the latest release available if unset")
 	updateCmd.Flags().StringVar(&opts.FromBranch, "from-branch", "",
-		"Git branch to use as current state of the project for the update.")
+		"Git branch to use as the current state of the project for the update")
 	updateCmd.Flags().BoolVar(&opts.Force, "force", false,
-		"Force the update even if conflicts occur. Conflicted files will include conflict markers, and a "+
-			"commit will be created automatically. Ideal for automation (e.g., cronjobs, CI).")
+		"If set, force the update even if conflicts occur; conflicted files include conflict markers "+
+			"and a commit is created automatically (ideal for automation, e.g., cronjobs, CI)")
 	updateCmd.Flags().BoolVar(&opts.ShowCommits, "show-commits", false,
-		"If set, the update will keep the full history instead of squashing into a single commit.")
+		"If set, keep the full history instead of squashing into a single commit")
 	updateCmd.Flags().StringArrayVar(&opts.RestorePath, "restore-path", nil,
-		"Paths to preserve from the base branch (repeatable). Not supported with --show-commits.")
+		"Paths to preserve from the base branch (repeatable; not supported with --show-commits)")
 	updateCmd.Flags().StringVar(&opts.OutputBranch, "output-branch", "",
-		"Override the default output branch name (default: kubebuilder-update-from-<from-version>-to-<to-version>).")
+		"Override the default output branch name. "+
+			"Defaults to kubebuilder-update-from-<from-version>-to-<to-version> if unset")
 	updateCmd.Flags().BoolVar(&opts.Push, "push", false,
-		"Push the output branch to the remote repository after the update.")
+		"If set, push the output branch to the remote repository after the update")
 	updateCmd.Flags().StringVar(&opts.CommitMessage, "merge-message", "",
 		"Custom commit message for successful merges (no conflicts). "+
-			"Defaults to 'chore(kubebuilder): update scaffold <from> -> <to>'.")
+			"Defaults to 'chore(kubebuilder): update scaffold <from> -> <to>' if unset")
 	updateCmd.Flags().StringVar(&opts.CommitMessageConflict, "conflict-message", "",
-		"Custom commit message for merges with conflicts. "+
-			"Defaults to 'chore(kubebuilder): (:warning: manual conflict resolution required) update scaffold <from> -> <to>'.")
+		"Custom commit message for merges with conflicts. Defaults to "+
+			"'chore(kubebuilder): (:warning: manual conflict resolution required) update scaffold <from> -> <to>' "+
+			"if unset")
 	updateCmd.Flags().BoolVar(&opts.OpenGhIssue, "open-gh-issue", false,
-		"Create a GitHub issue with a pre-filled checklist and compare link after the update completes (requires `gh`).")
+		"If set, create a GitHub issue with a pre-filled checklist and compare link after the update "+
+			"completes (requires `gh`)")
 	updateCmd.Flags().BoolVar(
 		&opts.UseGhModels,
 		"use-gh-models",
 		false,
-		"Generate and post an AI summary comment to the GitHub Issue using `gh models run`. "+
-			"Requires --open-gh-issue and GitHub CLI (`gh`) with the `gh-models` extension.")
+		"If set, generate and post an AI summary comment to the GitHub Issue using `gh models run` "+
+			"(requires --open-gh-issue and GitHub CLI with the `gh-models` extension)")
 	updateCmd.Flags().StringArrayVar(
 		&gitCfg,
 		"git-config",
 		nil,
-		"Per-invocation Git config (repeatable). "+
-			"Defaults: -c merge.renameLimit=999999 -c diff.renameLimit=999999 -c merge.conflictStyle=merge. "+
-			"Your configs are applied on top. To disable defaults, include `--git-config disable`")
+		"Per-invocation Git config (repeatable). Defaults to "+
+			"'-c merge.renameLimit=999999 -c diff.renameLimit=999999 -c merge.conflictStyle=merge' if unset; "+
+			"your configs are applied on top. To disable defaults, include '--git-config disable'")
 	return updateCmd
 }


### PR DESCRIPTION
## Why this PR

Follow-up to #5631. The cli-descriptions SKILL introduced there standardizes help text across the `pkg/plugins/**` tree, but `kubebuilder alpha update` and `kubebuilder alpha generate` were not part of that pass. Those two commands together expose ~16 user-visible flags that still use pre-SKILL wording (lowercase fragments, trailing periods, `If not set, ...` instead of SKILL's `Defaults to X if unset`, etc.).

This PR normalizes them. **No behavior changes** — help text only.

Why it matters: the SKILL is most useful when the whole CLI surface reflects it. A user running `kubebuilder init --help` gets SKILL-compliant flag help today; a user running `kubebuilder alpha update --help` does not. Closing that gap makes the SKILL a credible description of what the CLI actually does, which in turn makes it safer for future AI-agent edits to lint off of.

Depends conceptually on #5648 (SKILL fixes), because the `--skip-go-version-check` canonical entry needed to cover `default=true` call sites. This PR doesn't strictly require #5648 to merge first — the new opt-out wording matches SKILL's existing default-true pattern at lines 48–68 — but reviewers reading both PRs should look at #5648 first.

---

## Flag-by-flag rationale

### `internal/cli/alpha/update.go`

Each row: **current wording → proposed wording → SKILL rule**.

| Flag | Default | Change | SKILL rule applied |
|------|---------|--------|---------------------|
| `--from-version` | `""` | `binary release version to upgrade from. ... If not set, it defaults to ...` → `Kubebuilder release version to upgrade from (e.g., v4.6.0); should match the version used to init the project. Defaults to the version in the PROJECT file if unset` | Value flag with example + "Defaults to X if unset" ([SKILL line 104](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L104)) |
| `--to-version` | `""` | Same shape as above | Same |
| `--from-branch` | `""` | Drop trailing period; add missing article | Flag descriptions no period |
| `--force` | `false` | `Force the update even if conflicts occur. ...` → `If set, force the update ...` | Boolean default-false → `If set, ...` ([SKILL line 38](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L38)) |
| `--show-commits` | `false` | Trim `the update will` and trailing period | Clarity + no period |
| `--restore-path` | `nil` | Fold "Not supported with --show-commits." into the parenthetical | No period |
| `--output-branch` | `""` | `(default: kubebuilder-update-...).` → `Defaults to kubebuilder-update-... if unset` | Value flag with default phrasing |
| `--push` | `false` | `Push the ... update.` → `If set, push ...` | Boolean default-false → `If set, ...` |
| `--merge-message` | `""` | Trailing period → `if unset` | Defaults phrasing |
| `--conflict-message` | `""` | Same | Same |
| `--open-gh-issue` | `false` | `Create a GitHub issue ...` → `If set, create ...` | Boolean default-false → `If set, ...` |
| `--use-gh-models` | `false` | `Generate and post ...` → `If set, generate and post ...` | Boolean default-false → `If set, ...` |
| `--git-config` | `nil` | `Defaults: -c merge.renameLimit=...` → `Defaults to '-c merge.renameLimit=...' if unset` | Defaults phrasing |

### `internal/cli/alpha/generate.go`

| Flag | Default | Change | SKILL rule applied |
|------|---------|--------|---------------------|
| `--input-dir` | `""` | Add `(e.g., ./my-project)`, change `Defaults to the current working directory.` → `Defaults to ... if unset`, drop parenthetical periods | Value flag with example + default |
| `--output-dir` | `""` | Drop trailing periods, tighten | No period, clarity |
| `--skip-go-version-check` | **`true`** | `skip the Go version check during project generation` → `Skip the Go version check during project generation (enabled by default; use --skip-go-version-check=false to enforce)` | **This flag has `default=true`** ([generate.go:81](https://github.com/kubernetes-sigs/kubebuilder/blob/master/internal/cli/alpha/generate.go#L81)), which means the SKILL's opt-in `If set, skip ...` pattern is the wrong polarity. Switched to the default-true pattern ([SKILL line 48](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.agents/skills/cli-descriptions/SKILL.md#L48)). Not flipping the default itself — that is a separate conversation. |

---

## Test plan

- [x] `go build ./...` passes locally.
- [ ] After merge: run `kubebuilder alpha update --help` and `kubebuilder alpha generate --help` to visually confirm the new wording.

## Related

- Depends conceptually on: #5648
- Introduced the SKILL: #5631
- Closes part of: #5446

/cc @camilamacedo86
