### PR TITLE
📖 docs(designs): typo `commited` -> `committed` in update_action design

### DIFF
--- a/designs/update_action.md
+++ b/designs/update_action.md
@@ -422,7 +422,7 @@ git checkout -b merge
 git merge upgrade
 git add .
 git commit -m "Merge with upgrade with conflict markers"
-## Now that we have performed the three way merge and commited the conflict markers, we can open a PR against main.
+## Now that we have performed the three way merge and committed the conflict markers, we can open a PR against main.
 ```
 
 As the script:


### PR DESCRIPTION
One-character typo fix inside `designs/update_action.md:425` (prose, not a code snippet). No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>