### PR TITLE
🌱 chore: Pin setup-envtest to commit hash

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -125,16 +125,7 @@ function fetch_tools {
   if ! is_installed setup-envtest; then
     header_text "Installing setup-envtest to $(go env GOPATH)/bin"
 
-    # TODO: Current workaround for setup-envtest compatibility
-    # Due to past instances where controller-runtime maintainers released
-    # versions without corresponding branches, directly relying on branches
-    # poses a risk of breaking the Kubebuilder chain. Such practices may
-    # change over time, potentially leading to compatibility issues. This
-    # approach, although not ideal, remains the best solution for ensuring
-    # compatibility with controller-runtime releases as of now. For more
-    # details on the quest for a more robust solution, refer to the issue
-    # raised in the controller-runtime repository: https://github.com/kubernetes-sigs/controller-runtime/issues/2744
-    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@d3eaef3ab45410342c30528d1eaab982137c4d5a # v0.24.0
   fi
 
   if [ -z "$SKIP_FETCH_TOOLS" ]; then


### PR DESCRIPTION
As of [v0.24.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.24.0), `controller-runtime` creates a dedicated tag for `tools/setup-envtest`, which makes it possible to use the commit hash to install the `setup-envtest` binary via `go install`.

This change hardens security and remediates a Code scanning alert about downloading an unpinned version.

It also provides a more elegant fix for that issue regarding `setup-envtest` version. 💃🏻 

xref kubernetes-sigs/controller-runtime#3476
xref kubernetes-sigs/controller-runtime#2744 
xref #3824
