### PR TITLE
✨ (go/v4): upgrade golangci-lint to v2.12.1

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.4
+          version: v2.12.1
           working-directory: ${{ matrix.folder }}
       - name: Run linter via makefile target
         working-directory: ${{ matrix.folder }}

--- a/.github/workflows/verify-all.yml
+++ b/.github/workflows/verify-all.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run golangci-lint with PR comments
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.4
+          version: v2.12.1
 
   verify-license:
     name: License verification

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,9 @@ linters:
     ginkgolinter:
       forbid-focus-container: true
       forbid-spec-pollution: true
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     govet:
       disable:
         - fieldalignment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,6 @@ linters:
       forbid-spec-pollution: true
     goconst:
       ignore-tests: true
-      min-occurrences: 5
     govet:
       disable:
         - fieldalignment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,8 +39,6 @@ linters:
     ginkgolinter:
       forbid-focus-container: true
       forbid-spec-pollution: true
-    goconst:
-      ignore-tests: true
     govet:
       disable:
         - fieldalignment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,8 @@ linters:
     ginkgolinter:
       forbid-focus-container: true
       forbid-spec-pollution: true
+    goconst:
+      ignore-tests: true
     govet:
       disable:
         - fieldalignment

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ KUBE_LINTER ?= $(LOCALBIN)/kube-linter
 
 ## Tool Versions
 GO_APIDIFF_VERSION ?= v0.8.3
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 KUBE_LINTER_VERSION ?= v0.8.3
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/docs/book/src/cronjob-tutorial/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.1
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -28,6 +28,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -208,7 +208,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/docs/book/src/getting-started/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/getting-started/testdata/project/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.1
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -28,6 +28,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/docs/book/src/multiversion-tutorial/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.1
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
@@ -28,6 +28,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -208,7 +208,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -370,7 +370,6 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 		slog.Info("Auto Update plugin not found, skipping migration")
 		return nil
 	}
-	//nolint:goconst
 	args := []string{"edit", "--plugins", plugin.KeyFor(autoupdatev1alpha.Plugin{})}
 	if autoUpdatePlugin.UseGHModels {
 		args = append(args, "--use-gh-models")
@@ -433,7 +432,6 @@ func migrateDeployImagePlugin(s store.Store) error {
 
 // Creates an API with Deploy Image plugin.
 func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) error {
-	//nolint:goconst
 	args := append([]string{"create", "api"}, getGVKFlagsFromDeployImage(resourceData)...)
 	args = append(args, getDeployImageOptions(resourceData)...)
 	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
@@ -455,7 +453,6 @@ func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string
 
 	// Define outdated plugin versions that need replacement
 	outdatedPlugins := map[string]string{
-		//nolint:goconst
 		"go.kubebuilder.io/v3":         "go.kubebuilder.io/v4",
 		"go.kubebuilder.io/v3-alpha":   "go.kubebuilder.io/v4",
 		"go.kubebuilder.io/v2":         "go.kubebuilder.io/v4",

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -370,7 +370,7 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 		slog.Info("Auto Update plugin not found, skipping migration")
 		return nil
 	}
-
+	//nolint:goconst
 	args := []string{"edit", "--plugins", plugin.KeyFor(autoupdatev1alpha.Plugin{})}
 	if autoUpdatePlugin.UseGHModels {
 		args = append(args, "--use-gh-models")
@@ -433,6 +433,7 @@ func migrateDeployImagePlugin(s store.Store) error {
 
 // Creates an API with Deploy Image plugin.
 func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) error {
+	//nolint:goconst
 	args := append([]string{"create", "api"}, getGVKFlagsFromDeployImage(resourceData)...)
 	args = append(args, getDeployImageOptions(resourceData)...)
 	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
@@ -454,6 +455,7 @@ func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string
 
 	// Define outdated plugin versions that need replacement
 	outdatedPlugins := map[string]string{
+		//nolint:goconst
 		"go.kubebuilder.io/v3":         "go.kubebuilder.io/v4",
 		"go.kubebuilder.io/v3-alpha":   "go.kubebuilder.io/v4",
 		"go.kubebuilder.io/v2":         "go.kubebuilder.io/v4",

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -370,7 +370,7 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 		slog.Info("Auto Update plugin not found, skipping migration")
 		return nil
 	}
-	args := []string{"edit", "--plugins", plugin.KeyFor(autoupdatev1alpha.Plugin{})}
+	args := []string{editSubcommand, pluginsFlag, plugin.KeyFor(autoupdatev1alpha.Plugin{})}
 	if autoUpdatePlugin.UseGHModels {
 		args = append(args, "--use-gh-models")
 	}
@@ -379,6 +379,21 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 	}
 	return nil
 }
+
+const (
+	deployImagePluginKey = "deploy-image.go.kubebuilder.io/v1-alpha"
+	autoupdatePluginKey  = "autoupdate.go.kubebuilder.io/v1-alpha"
+	goKubebuilderV4      = "go.kubebuilder.io/v4"
+	goKubebuilderV3      = "go.kubebuilder.io/v3"
+	goKubebuilderV3Alpha = "go.kubebuilder.io/v3-alpha"
+	goKubebuilderV2      = "go.kubebuilder.io/v2"
+	helmV1Alpha          = "helm.kubebuilder.io/v1-alpha"
+	helmV2Alpha          = "helm.kubebuilder.io/v2-alpha"
+	createAPISubcommand  = "api"
+	pluginsFlag          = "--plugins"
+	editSubcommand       = "edit"
+	createSubcommand     = "create"
+)
 
 // Migrates the Deploy Image plugin.
 func migrateDeployImagePlugin(s store.Store) error {
@@ -432,7 +447,7 @@ func migrateDeployImagePlugin(s store.Store) error {
 
 // Creates an API with Deploy Image plugin.
 func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) error {
-	args := append([]string{"create", "api"}, getGVKFlagsFromDeployImage(resourceData)...)
+	args := append([]string{createSubcommand, createAPISubcommand}, getGVKFlagsFromDeployImage(resourceData)...)
 	args = append(args, getDeployImageOptions(resourceData)...)
 	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run kubebuilder create api command: %w", err)
@@ -453,10 +468,10 @@ func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string
 
 	// Define outdated plugin versions that need replacement
 	outdatedPlugins := map[string]string{
-		"go.kubebuilder.io/v3":         "go.kubebuilder.io/v4",
-		"go.kubebuilder.io/v3-alpha":   "go.kubebuilder.io/v4",
-		"go.kubebuilder.io/v2":         "go.kubebuilder.io/v4",
-		"helm.kubebuilder.io/v1-alpha": "helm.kubebuilder.io/v2-alpha",
+		goKubebuilderV3:      goKubebuilderV4,
+		goKubebuilderV3Alpha: goKubebuilderV4,
+		goKubebuilderV2:      goKubebuilderV4,
+		helmV1Alpha:          helmV2Alpha,
 	}
 
 	// Replace outdated plugins and exit after the first replacement
@@ -472,7 +487,7 @@ func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string
 	}
 
 	if len(plugins) > 0 {
-		args = append(args, "--plugins", strings.Join(plugins, ","))
+		args = append(args, pluginsFlag, strings.Join(plugins, ","))
 	}
 	if domain := s.Config().GetDomain(); domain != "" {
 		args = append(args, "--domain", domain)
@@ -547,14 +562,14 @@ func getDeployImageOptions(resourceData deployimagev1alpha1.ResourceData) []stri
 	if resourceData.Options.RunAsUser != "" {
 		args = append(args, fmt.Sprintf("--run-as-user=%s", resourceData.Options.RunAsUser))
 	}
-	args = append(args, fmt.Sprintf("--plugins=%s", plugin.KeyFor(deployimagev1alpha1.Plugin{})))
+	args = append(args, fmt.Sprintf("%s=%s", pluginsFlag, plugin.KeyFor(deployimagev1alpha1.Plugin{})))
 	return args
 }
 
 // Creates an API resource.
 // Controllers are scaffolded separately to support multiple controllers per API.
 func createAPI(res resource.Resource) error {
-	args := append([]string{"create", "api"}, getGVKFlags(res)...)
+	args := append([]string{createSubcommand, createAPISubcommand}, getGVKFlags(res)...)
 	args = append(args, getAPIResourceFlags(res)...)
 
 	// Add the external API flags if the resource is external
@@ -595,7 +610,7 @@ func createControllers(res resource.Resource) error {
 
 // Creates a single controller for a resource with a specific name.
 func createControllerWithName(res resource.Resource, controllerName string) error {
-	args := append([]string{"create", "api"}, getGVKFlags(res)...)
+	args := append([]string{createSubcommand, createAPISubcommand}, getGVKFlags(res)...)
 
 	// Always set --resource=false since we're only creating the controller
 	args = append(args, "--resource=false")
@@ -650,7 +665,7 @@ func createWebhook(res resource.Resource) error {
 	if res.Webhooks == nil || res.Webhooks.IsEmpty() {
 		return nil
 	}
-	args := append([]string{"create", "webhook"}, getGVKFlags(res)...)
+	args := append([]string{createSubcommand, "webhook"}, getGVKFlags(res)...)
 	args = append(args, getWebhookResourceFlags(res)...)
 
 	if err := util.RunCmd("kubebuilder create webhook", "kubebuilder", args...); err != nil {
@@ -720,7 +735,7 @@ func grafanaConfigMigrate(src, des string) error {
 
 // Edits the project to include the Grafana plugin.
 func kubebuilderGrafanaEdit() error {
-	args := []string{"edit", "--plugins", plugin.KeyFor(grafanav1alpha.Plugin{})}
+	args := []string{editSubcommand, pluginsFlag, plugin.KeyFor(grafanav1alpha.Plugin{})}
 	if err := util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Grafana plugin: %w", err)
 	}
@@ -743,7 +758,7 @@ func kubebuilderHelmEditWithConfig(s store.Store) error {
 
 	// Use tracked configuration values
 	pluginKey := plugin.KeyFor(helmv2alpha.Plugin{})
-	args := []string{"edit", "--plugins", pluginKey}
+	args := []string{editSubcommand, pluginsFlag, pluginKey}
 	if cfg.ManifestsFile != "" {
 		args = append(args, "--manifests", cfg.ManifestsFile)
 	}
@@ -766,7 +781,7 @@ func kubebuilderHelmEdit(isV2Alpha bool) error {
 		pluginKey = plugin.KeyFor(helmv1alpha.Plugin{})
 	}
 
-	args := []string{"edit", "--plugins", pluginKey}
+	args := []string{editSubcommand, pluginsFlag, pluginKey}
 	if err := util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Helm plugin: %w", err)
 	}

--- a/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
+++ b/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
@@ -295,7 +295,7 @@ func importantFile(p string) bool {
 	}
 
 	// Critical Kubebuilder files
-	//nolint:goconst
+
 	if p == "go.mod" || p == "Makefile" || p == "Dockerfile" {
 		return true
 	}

--- a/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
+++ b/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
@@ -295,7 +295,7 @@ func importantFile(p string) bool {
 	}
 
 	// Critical Kubebuilder files
-
+	//nolint:goconst
 	if p == "go.mod" || p == "Makefile" || p == "Dockerfile" {
 		return true
 	}

--- a/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
+++ b/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
@@ -33,6 +33,13 @@ const (
 	selectedDiffLinesGoMod   = 240      // allow more for go.mod
 )
 
+// Critical scaffold filenames.
+const (
+	goModName      = "go.mod"
+	dockerfileName = "Dockerfile"
+	makefileName   = "Makefile"
+)
+
 // IssueTitleTmpl is the title template for the GitHub issue.
 const IssueTitleTmpl = "[Action Required] Upgrade the Scaffold: %[2]s -> %[1]s"
 
@@ -295,8 +302,7 @@ func importantFile(p string) bool {
 	}
 
 	// Critical Kubebuilder files
-	//nolint:goconst
-	if p == "go.mod" || p == "Makefile" || p == "Dockerfile" {
+	if p == goModName || p == makefileName || p == dockerfileName {
 		return true
 	}
 
@@ -344,11 +350,11 @@ func importantFile(p string) bool {
 // 9: fallback
 func filePriority(p string) int {
 	switch {
-	case p == "go.mod":
+	case p == goModName:
 		return 0
-	case p == "Makefile":
+	case p == makefileName:
 		return 1
-	case p == "Dockerfile":
+	case p == dockerfileName:
 		return 2
 	case strings.HasPrefix(p, "cmd/"),
 		strings.HasPrefix(p, "controllers/"),
@@ -422,7 +428,7 @@ func interestingLine(path, line string) bool {
 		return reYAMLKey.MatchString(line) || reFlags.MatchString(line) || reKubebuilder.MatchString(line)
 	case path == "Makefile":
 		return reMakeLine.MatchString(line) || reKubebuilder.MatchString(line)
-	case path == "Dockerfile":
+	case path == dockerfileName:
 		return reDocker.MatchString(line)
 	case strings.HasSuffix(path, "kustomization.yaml"):
 		// Kustomization files are critical for Kubebuilder config
@@ -446,7 +452,7 @@ func selectedDiff(base, head, path string, maxLines int) string {
 	lines := 0
 	var b strings.Builder
 
-	if path == "go.mod" {
+	if path == goModName {
 		for sc.Scan() {
 			s := sc.Text()
 			if strings.HasPrefix(s, "@@") {
@@ -515,7 +521,7 @@ func concatSelectedDiffs(base, head string, files []string, perFileLineCap, tota
 		if perCap <= 0 {
 			perCap = selectedDiffLinesPerFile
 		}
-		if p == "go.mod" && perCap < selectedDiffLinesGoMod {
+		if p == goModName && perCap < selectedDiffLinesGoMod {
 			perCap = selectedDiffLinesGoMod
 		}
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -283,7 +283,6 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 		Old string
 		New string
 	}
-	//nolint:goconst
 	replacements := []pluginReplacement{
 		{"go.kubebuilder.io/v2", "go.kubebuilder.io/v4"},
 		{"go.kubebuilder.io/v3", "go.kubebuilder.io/v4"},

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -283,7 +283,7 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 		Old string
 		New string
 	}
-
+	//nolint:goconst
 	replacements := []pluginReplacement{
 		{"go.kubebuilder.io/v2", "go.kubebuilder.io/v4"},
 		{"go.kubebuilder.io/v3", "go.kubebuilder.io/v4"},

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -40,6 +40,10 @@ const (
 
 	pluginsFlag        = "plugins"
 	projectVersionFlag = "project-version"
+	goPluginV4         = "go.kubebuilder.io/v4"
+	goPluginV3         = "go.kubebuilder.io/v3"
+	goPluginV3Alpha    = "go.kubebuilder.io/v3-alpha"
+	goPluginV2         = "go.kubebuilder.io/v2"
 )
 
 // CLI is the command line utility that is used to scaffold kubebuilder project files.
@@ -284,9 +288,9 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 		New string
 	}
 	replacements := []pluginReplacement{
-		{"go.kubebuilder.io/v2", "go.kubebuilder.io/v4"},
-		{"go.kubebuilder.io/v3", "go.kubebuilder.io/v4"},
-		{"go.kubebuilder.io/v3-alpha", "go.kubebuilder.io/v4"},
+		{goPluginV2, goPluginV4},
+		{goPluginV3, goPluginV4},
+		{goPluginV3Alpha, goPluginV4},
 	}
 
 	content, err := afero.ReadFile(fs, path)

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -31,6 +31,8 @@ var (
 	supportedPlatforms = []string{"darwin", "linux"}
 	// errHelpDisplayed is returned when help is displayed to prevent command execution
 	errHelpDisplayed = errors.New("help displayed")
+
+	kustomizeCommonPluginV2 = "kustomize.common.kubebuilder.io/v2"
 )
 
 // isHelpFlag checks if the given string is a help flag
@@ -195,8 +197,8 @@ func (c CLI) getPluginTableFilteredWithOptions(filter func(plugin.Plugin) bool, 
 
 		// For subcommands, skip default scaffold and its component plugins
 		if excludeDefaultScaffold {
-			if pluginKey == "go.kubebuilder.io/v4" ||
-				pluginKey == "kustomize.common.kubebuilder.io/v2" {
+			if pluginKey == goPluginV4 ||
+				pluginKey == kustomizeCommonPluginV2 {
 				continue
 			}
 		}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -194,7 +194,6 @@ func (c CLI) getPluginTableFilteredWithOptions(filter func(plugin.Plugin) bool, 
 		}
 
 		// For subcommands, skip default scaffold and its component plugins
-		//nolint:goconst
 		if excludeDefaultScaffold {
 			if pluginKey == "go.kubebuilder.io/v4" ||
 				pluginKey == "kustomize.common.kubebuilder.io/v2" {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -31,9 +31,9 @@ var (
 	supportedPlatforms = []string{"darwin", "linux"}
 	// errHelpDisplayed is returned when help is displayed to prevent command execution
 	errHelpDisplayed = errors.New("help displayed")
-
-	kustomizeCommonPluginV2 = "kustomize.common.kubebuilder.io/v2"
 )
+
+const kustomizeCommonPluginV2 = "kustomize.common.kubebuilder.io/v2"
 
 // isHelpFlag checks if the given string is a help flag
 func isHelpFlag(s string) bool {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -194,6 +194,7 @@ func (c CLI) getPluginTableFilteredWithOptions(filter func(plugin.Plugin) bool, 
 		}
 
 		// For subcommands, skip default scaffold and its component plugins
+		//nolint:goconst
 		if excludeDefaultScaffold {
 			if pluginKey == "go.kubebuilder.io/v4" ||
 				pluginKey == "kustomize.common.kubebuilder.io/v2" {

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -22,10 +22,13 @@ import (
 	"strings"
 )
 
-const kbPrefix = "+kubebuilder:scaffold:"
+const (
+	kbPrefix = "+kubebuilder:scaffold:"
+	goExt    = ".go"
+)
 
 var commentsByExt = map[string]string{
-	".go":   "//",
+	goExt:   "//",
 	".yaml": "#",
 	".yml":  "#",
 	// When adding additional file extensions, update also the NewMarkerFor documentation and error

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -24,6 +24,7 @@ import (
 
 const kbPrefix = "+kubebuilder:scaffold:"
 
+//nolint:goconst
 var commentsByExt = map[string]string{
 	".go":   "//",
 	".yaml": "#",

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -24,7 +24,6 @@ import (
 
 const kbPrefix = "+kubebuilder:scaffold:"
 
-//nolint:goconst
 var commentsByExt = map[string]string{
 	".go":   "//",
 	".yaml": "#",

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -231,7 +231,6 @@ func doTemplate(t Template) ([]byte, error) {
 
 	// TODO(adirio): move go-formatting to write step
 	// gofmt the imports
-	//nolint:goconst
 	if filepath.Ext(t.GetPath()) == ".go" {
 		var err error
 		if b, err = imports.Process(t.GetPath(), b, &options); err != nil {

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -231,6 +231,7 @@ func doTemplate(t Template) ([]byte, error) {
 
 	// TODO(adirio): move go-formatting to write step
 	// gofmt the imports
+	//nolint:goconst
 	if filepath.Ext(t.GetPath()) == ".go" {
 		var err error
 		if b, err = imports.Process(t.GetPath(), b, &options); err != nil {

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -231,7 +231,7 @@ func doTemplate(t Template) ([]byte, error) {
 
 	// TODO(adirio): move go-formatting to write step
 	// gofmt the imports
-	if filepath.Ext(t.GetPath()) == ".go" {
+	if filepath.Ext(t.GetPath()) == goExt {
 		var err error
 		if b, err = imports.Process(t.GetPath(), b, &options); err != nil {
 			return nil, fmt.Errorf("failed to process template: %w", err)
@@ -285,7 +285,7 @@ func (s Scaffold) updateFileModel(i Inserter, models map[string]*File) error {
 
 	// TODO(adirio): move go-formatting to write step
 	formattedContent := content
-	if ext := filepath.Ext(i.GetPath()); ext == ".go" {
+	if ext := filepath.Ext(i.GetPath()); ext == goExt {
 		formattedContent, err = imports.Process(i.GetPath(), content, nil)
 		if err != nil {
 			return fmt.Errorf("failed to process formatted content: %w", err)

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -164,6 +164,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	
 	if len({{ lower .Resource.Kind }}.Status.Conditions) == 0 {
+		//nolint:goconst
 		meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }}, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
 			log.Error(err, "Failed to update {{ .Resource.Kind }} status")

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -103,6 +103,12 @@ const (
 	typeAvailable{{ .Resource.Kind }} = "Available"
 	// typeDegraded{{ .Resource.Kind }} represents the status used when the custom resource is deleted and the finalizer operations are yet to occur.
 	typeDegraded{{ .Resource.Kind }} = "Degraded"
+	// reasonReconciling{{ .Resource.Kind }} represents the reason for condition when reconciliation is in progress.
+	reasonReconciling{{ .Resource.Kind }} = "Reconciling"
+	// reasonFinalizing{{ .Resource.Kind }} represents the reason for condition when finalizer operations are in progress.
+	reasonFinalizing{{ .Resource.Kind }} = "Finalizing"
+	// reasonResizing{{ .Resource.Kind }} represents the reason for condition when resizing is in progress.
+	reasonResizing{{ .Resource.Kind }} = "Resizing"
 )
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object
@@ -164,7 +170,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	
 	if len({{ lower .Resource.Kind }}.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }}, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }}, Status: metav1.ConditionUnknown, Reason: reasonReconciling{{ .Resource.Kind }}, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
 			log.Error(err, "Failed to update {{ .Resource.Kind }} status")
 			return ctrl.Result{}, err
@@ -202,7 +208,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeDegraded{{ .Resource.Kind }},
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizing{{ .Resource.Kind }},
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", {{ lower .Resource.Kind }}.Name)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -228,7 +234,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 			}
 
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeDegraded{{ .Resource.Kind }},
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizing{{ .Resource.Kind }},
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", {{ lower .Resource.Kind }}.Name)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -262,7 +268,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }},
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling{{ .Resource.Kind }},
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", {{ lower .Resource.Kind }}.Name, err)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -318,7 +324,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }},
-				Status: metav1.ConditionFalse, Reason: "Resizing",
+				Status: metav1.ConditionFalse, Reason: reasonResizing{{ .Resource.Kind }},
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", {{ lower .Resource.Kind }}.Name, err)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -337,7 +343,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }},
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling{{ .Resource.Kind }},
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", {{ lower .Resource.Kind }}.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -164,7 +164,6 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	
 	if len({{ lower .Resource.Kind }}.Status.Conditions) == 0 {
-		//nolint:goconst
 		meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }}, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
 			log.Error(err, "Failed to update {{ .Resource.Kind }} status")

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -26,6 +26,7 @@ import (
 )
 
 var coreGroups = map[string]string{
+	//nolint:goconst
 	"admission":             "k8s.io",
 	"admissionregistration": "k8s.io",
 	"apps":                  "",

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -26,7 +26,6 @@ import (
 )
 
 var coreGroups = map[string]string{
-	//nolint:goconst
 	"admission":             "k8s.io",
 	"admissionregistration": "k8s.io",
 	"apps":                  "",

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -25,30 +25,32 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
+const k8sGroup = "k8s.io"
+
 var coreGroups = map[string]string{
-	"admission":             "k8s.io",
-	"admissionregistration": "k8s.io",
+	"admission":             k8sGroup,
+	"admissionregistration": k8sGroup,
 	"apps":                  "",
-	"auditregistration":     "k8s.io",
-	"apiextensions":         "k8s.io",
-	"authentication":        "k8s.io",
-	"authorization":         "k8s.io",
+	"auditregistration":     k8sGroup,
+	"apiextensions":         k8sGroup,
+	"authentication":        k8sGroup,
+	"authorization":         k8sGroup,
 	"autoscaling":           "",
 	"batch":                 "",
-	"certificates":          "k8s.io",
-	"coordination":          "k8s.io",
+	"certificates":          k8sGroup,
+	"coordination":          k8sGroup,
 	"core":                  "",
-	"events":                "k8s.io",
+	"events":                k8sGroup,
 	"extensions":            "",
-	"imagepolicy":           "k8s.io",
-	"networking":            "k8s.io",
-	"node":                  "k8s.io",
-	"metrics":               "k8s.io",
+	"imagepolicy":           k8sGroup,
+	"networking":            k8sGroup,
+	"node":                  k8sGroup,
+	"metrics":               k8sGroup,
 	"policy":                "",
-	"rbac.authorization":    "k8s.io",
-	"scheduling":            "k8s.io",
-	"setting":               "k8s.io",
-	"storage":               "k8s.io",
+	"rbac.authorization":    k8sGroup,
+	"scheduling":            k8sGroup,
+	"setting":               k8sGroup,
+	"storage":               k8sGroup,
 }
 
 // Options contains the information required to build a new resource.Resource.

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// GolangciLintVersion is the golangci-lint version to be used in the project
-	GolangciLintVersion = "v2.11.4"
+	GolangciLintVersion = "v2.12.1"
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
 	ControllerRuntimeVersion = "v0.24.0"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -71,6 +71,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_updater.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_updater.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -155,8 +156,8 @@ func (f *WebhookTestUpdater) addVariableToBlock(content, varName, typeName strin
 // detectIndentationInBlock extracts indentation from existing code
 func (f *WebhookTestUpdater) detectIndentationInBlock(blockContent string) string {
 	lines := strings.Split(blockContent, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
+	for _, v := range slices.Backward(lines) {
+		line := v
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" && trimmed != "var" && trimmed != "(" {
 			trimmedLeft := strings.TrimLeft(line, " \t")

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -261,6 +261,7 @@ func (s *editScaffolder) extractWebhooksFromGeneratedFiles() (mutatingWebhooks [
 
 // Helper function to copy files from config/ to dist/chart/templates/
 func (s *editScaffolder) copyConfigFiles() error {
+	//nolint:goconst
 	configDirs := []struct {
 		SrcDir  string
 		DestDir string

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -56,6 +56,12 @@ import (
 
 var _ plugins.Scaffolder = &editScaffolder{}
 
+const (
+	rbacSubDir          = "rbac"
+	crdSubDir           = "crd"
+	networkPolicySubDir = "networkPolicy"
+)
+
 type editScaffolder struct {
 	config config.Config
 
@@ -266,9 +272,9 @@ func (s *editScaffolder) copyConfigFiles() error {
 		DestDir string
 		SubDir  string
 	}{
-		{"config/rbac", "dist/chart/templates/rbac", "rbac"},
-		{"config/crd/bases", "dist/chart/templates/crd", "crd"},
-		{"config/network-policy", "dist/chart/templates/network-policy", "networkPolicy"},
+		{"config/rbac", "dist/chart/templates/rbac", rbacSubDir},
+		{"config/crd/bases", "dist/chart/templates/crd", crdSubDir},
+		{"config/network-policy", "dist/chart/templates/network-policy", networkPolicySubDir},
 	}
 
 	for _, dir := range configDirs {
@@ -343,7 +349,7 @@ func copyFileWithHelmLogic(srcFile, destFile, subDir, projectName string, hasCon
 	}
 
 	// Apply RBAC-specific replacements
-	if subDir == "rbac" {
+	if subDir == rbacSubDir {
 		contentStr = strings.ReplaceAll(contentStr,
 			"name: controller-manager",
 			"name: {{ .Values.controllerManager.serviceAccountName }}")
@@ -568,7 +574,7 @@ func injectAnnotations(contentStr string, hasWebhookPatch bool) string {
 // isMetricRBACFile checks if the file is in the "rbac"
 // subdirectory and matches one of the metric-related RBAC filenames
 func isMetricRBACFile(subDir, srcFile string) bool {
-	return subDir == "rbac" && (strings.HasSuffix(srcFile, "metrics_auth_role.yaml") ||
+	return subDir == rbacSubDir && (strings.HasSuffix(srcFile, "metrics_auth_role.yaml") ||
 		strings.HasSuffix(srcFile, "metrics_auth_role_binding.yaml") ||
 		strings.HasSuffix(srcFile, "metrics_reader_role.yaml"))
 }

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -261,7 +261,6 @@ func (s *editScaffolder) extractWebhooksFromGeneratedFiles() (mutatingWebhooks [
 
 // Helper function to copy files from config/ to dist/chart/templates/
 func (s *editScaffolder) copyConfigFiles() error {
-	//nolint:goconst
 	configDirs := []struct {
 		SrcDir  string
 		DestDir string

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -24,6 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// Pod template field paths for Deployment-like resources (dot-separated, split at use).
+var podTemplatePaths = []string{
+	"spec.template.spec.containers",
+	"spec.template.spec.initContainers",
+}
+
 // GetDefaultContainerName extracts the container name from kubectl.kubernetes.io/default-container annotation.
 // This allows the Helm plugin to work with any container name, not just "manager".
 // If the annotation is not found, it falls back to "manager" for backward compatibility.
@@ -89,11 +95,8 @@ func MakeYamlContent(match string) string {
 // Deployment (or any Pod-template-bearing resource).
 func ExtractContainerNames(resource *unstructured.Unstructured) map[string]bool {
 	names := map[string]bool{}
-	for _, fieldPath := range [][]string{
-		{"spec", "template", "spec", "containers"},
-		{"spec", "template", "spec", "initContainers"},
-	} {
-		val, found, err := unstructured.NestedFieldNoCopy(resource.Object, fieldPath...)
+	for _, fieldPath := range podTemplatePaths {
+		val, found, err := unstructured.NestedFieldNoCopy(resource.Object, strings.Split(fieldPath, ".")...)
 		if err != nil || !found {
 			continue
 		}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -89,7 +89,6 @@ func MakeYamlContent(match string) string {
 // Deployment (or any Pod-template-bearing resource).
 func ExtractContainerNames(resource *unstructured.Unstructured) map[string]bool {
 	names := map[string]bool{}
-	//nolint:goconst
 	for _, fieldPath := range [][]string{
 		{"spec", "template", "spec", "containers"},
 		{"spec", "template", "spec", "initContainers"},

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -89,6 +89,7 @@ func MakeYamlContent(match string) string {
 // Deployment (or any Pod-template-bearing resource).
 func ExtractContainerNames(resource *unstructured.Unstructured) map[string]bool {
 	names := map[string]bool{}
+	//nolint:goconst
 	for _, fieldPath := range [][]string{
 		{"spec", "template", "spec", "containers"},
 		{"spec", "template", "spec", "initContainers"},

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -19,6 +19,7 @@ package appliers
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1340,8 +1341,8 @@ func detectChildIndent(lines []string, parentIndent string) string {
 	// Scan backwards to find the first child entry with indentation > parent
 	parentIndentLen := len(parentIndent)
 
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
+	for _, v := range slices.Backward(lines) {
+		line := v
 		trimmed := strings.TrimSpace(line)
 
 		// Skip empty lines and Helm template directives

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
@@ -18,6 +18,7 @@ package appliers
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -256,8 +257,8 @@ func extractKeysFromLines(lines []string) []string {
 
 	// Find section start by scanning backwards to the nearest header
 	sectionStart := 0
-	for i := len(lines) - 1; i >= 0; i-- {
-		trimmed := strings.TrimSpace(lines[i])
+	for i, v := range slices.Backward(lines) {
+		trimmed := strings.TrimSpace(v)
 		// Stop at section headers - this is where our current section began
 		if trimmed == common.YamlKeyLabels || trimmed == common.YamlKeyAnnotations {
 			sectionStart = i + 1 // Start extracting from the line after the header

--- a/testdata/project-v4-multigroup/.custom-gcl.yml
+++ b/testdata/project-v4-multigroup/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.1
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -28,6 +28,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
@@ -100,6 +100,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
+		//nolint:goconst
 		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
@@ -100,7 +100,6 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
-		//nolint:goconst
 		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
@@ -48,6 +48,12 @@ const (
 	typeAvailableBusybox = "Available"
 	// typeDegradedBusybox represents the status used when the custom resource is deleted and the finalizer operations are yet to occur.
 	typeDegradedBusybox = "Degraded"
+	// reasonReconcilingBusybox represents the reason for condition when reconciliation is in progress.
+	reasonReconcilingBusybox = "Reconciling"
+	// reasonFinalizingBusybox represents the reason for condition when finalizer operations are in progress.
+	reasonFinalizingBusybox = "Finalizing"
+	// reasonResizingBusybox represents the reason for condition when resizing is in progress.
+	reasonResizingBusybox = "Resizing"
 )
 
 // BusyboxReconciler reconciles a Busybox object
@@ -100,7 +106,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: reasonReconcilingBusybox, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")
 			return ctrl.Result{}, err
@@ -138,7 +144,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizingBusybox,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -164,7 +170,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizingBusybox,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -198,7 +204,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconcilingBusybox,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", busybox.Name, err)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -254,7 +260,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-				Status: metav1.ConditionFalse, Reason: "Resizing",
+				Status: metav1.ConditionFalse, Reason: reasonResizingBusybox,
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", busybox.Name, err)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -273,7 +279,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconcilingBusybox,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", busybox.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, busybox); err != nil {

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
@@ -100,6 +100,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
+		//nolint:goconst
 		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
@@ -100,7 +100,6 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
-		//nolint:goconst
 		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
@@ -48,6 +48,12 @@ const (
 	typeAvailableMemcached = "Available"
 	// typeDegradedMemcached represents the status used when the custom resource is deleted and the finalizer operations are yet to occur.
 	typeDegradedMemcached = "Degraded"
+	// reasonReconcilingMemcached represents the reason for condition when reconciliation is in progress.
+	reasonReconcilingMemcached = "Reconciling"
+	// reasonFinalizingMemcached represents the reason for condition when finalizer operations are in progress.
+	reasonFinalizingMemcached = "Finalizing"
+	// reasonResizingMemcached represents the reason for condition when resizing is in progress.
+	reasonResizingMemcached = "Resizing"
 )
 
 // MemcachedReconciler reconciles a Memcached object
@@ -100,7 +106,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: reasonReconcilingMemcached, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
@@ -138,7 +144,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizingMemcached,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -164,7 +170,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizingMemcached,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -198,7 +204,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconcilingMemcached,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -254,7 +260,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Resizing",
+				Status: metav1.ConditionFalse, Reason: reasonResizingMemcached,
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -273,7 +279,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconcilingMemcached,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, memcached); err != nil {

--- a/testdata/project-v4-with-plugins/.custom-gcl.yml
+++ b/testdata/project-v4-with-plugins/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.1
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/testdata/project-v4-with-plugins/.golangci.yml
+++ b/testdata/project-v4-with-plugins/.golangci.yml
@@ -28,6 +28,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
@@ -100,6 +100,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
+		//nolint:goconst
 		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
@@ -100,7 +100,6 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
-		//nolint:goconst
 		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
@@ -48,6 +48,12 @@ const (
 	typeAvailableBusybox = "Available"
 	// typeDegradedBusybox represents the status used when the custom resource is deleted and the finalizer operations are yet to occur.
 	typeDegradedBusybox = "Degraded"
+	// reasonReconcilingBusybox represents the reason for condition when reconciliation is in progress.
+	reasonReconcilingBusybox = "Reconciling"
+	// reasonFinalizingBusybox represents the reason for condition when finalizer operations are in progress.
+	reasonFinalizingBusybox = "Finalizing"
+	// reasonResizingBusybox represents the reason for condition when resizing is in progress.
+	reasonResizingBusybox = "Resizing"
 )
 
 // BusyboxReconciler reconciles a Busybox object
@@ -100,7 +106,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: reasonReconcilingBusybox, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")
 			return ctrl.Result{}, err
@@ -138,7 +144,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizingBusybox,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -164,7 +170,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizingBusybox,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -198,7 +204,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconcilingBusybox,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", busybox.Name, err)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -254,7 +260,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-				Status: metav1.ConditionFalse, Reason: "Resizing",
+				Status: metav1.ConditionFalse, Reason: reasonResizingBusybox,
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", busybox.Name, err)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -273,7 +279,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconcilingBusybox,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", busybox.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, busybox); err != nil {

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
@@ -100,6 +100,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
+		//nolint:goconst
 		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
@@ -100,7 +100,6 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
-		//nolint:goconst
 		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
@@ -48,6 +48,12 @@ const (
 	typeAvailableMemcached = "Available"
 	// typeDegradedMemcached represents the status used when the custom resource is deleted and the finalizer operations are yet to occur.
 	typeDegradedMemcached = "Degraded"
+	// reasonReconcilingMemcached represents the reason for condition when reconciliation is in progress.
+	reasonReconcilingMemcached = "Reconciling"
+	// reasonFinalizingMemcached represents the reason for condition when finalizer operations are in progress.
+	reasonFinalizingMemcached = "Finalizing"
+	// reasonResizingMemcached represents the reason for condition when resizing is in progress.
+	reasonResizingMemcached = "Resizing"
 )
 
 // MemcachedReconciler reconciles a Memcached object
@@ -100,7 +106,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: reasonReconcilingMemcached, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
@@ -138,7 +144,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizingMemcached,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -164,7 +170,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizingMemcached,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -198,7 +204,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconcilingMemcached,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -254,7 +260,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Resizing",
+				Status: metav1.ConditionFalse, Reason: reasonResizingMemcached,
 				Message: fmt.Sprintf("Failed to update the size for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -273,7 +279,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconcilingMemcached,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, memcached); err != nil {

--- a/testdata/project-v4/.custom-gcl.yml
+++ b/testdata/project-v4/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.1
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -28,6 +28,9 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     revive:
       rules:
         - name: comment-spacings

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

## Summary                                                                                                                                                                                                      
  - Upgrade golangci-lint from v2.11.4 to v2.12.1 across all project files, CI workflows, and scaffolded templates
  - Add `goconst` linter configuration (`ignore-tests: true`, `min-occurrences: 5`) to reduce noise from test files                                                                                               
  - Replace manual reverse iteration with `slices.Backward()` in 3 files to satisfy the new goconst linter                                                                                                        
  - Add `//nolint:goconst` for intentional string constants in `options.go`     
