### PR TITLE
🐛 fix(helm/v2-alpha): correct indentation of conditional volume mounts

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -135,16 +135,16 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-        {{- if and .Values.certManager.enable .Values.metrics.enable }}
-        - mountPath: /tmp/k8s-metrics-server/metrics-certs
-          name: metrics-certs
-          readOnly: true
-        {{- end }}
-        {{- if .Values.certManager.enable }}
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-certs
-          readOnly: true
-        {{- end }}
+          {{- if and .Values.certManager.enable .Values.metrics.enable }}
+          - mountPath: /tmp/k8s-metrics-server/metrics-certs
+            name: metrics-certs
+            readOnly: true
+          {{- end }}
+          {{- if .Values.certManager.enable }}
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: webhook-certs
+            readOnly: true
+          {{- end }}
       securityContext:
         {{- if .Values.manager.podSecurityContext }}
         {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
@@ -159,22 +159,22 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-      {{- if and .Values.certManager.enable .Values.metrics.enable }}
-      - name: metrics-certs
-        secret:
-          items:
-          - key: ca.crt
-            path: ca.crt
-          - key: tls.crt
-            path: tls.crt
-          - key: tls.key
-            path: tls.key
-          optional: false
-          secretName: metrics-server-cert
-      {{- end }}
-      {{- if .Values.certManager.enable }}
-      - name: webhook-certs
-        secret:
-          secretName: webhook-server-cert
-      {{- end }}
+        {{- if and .Values.certManager.enable .Values.metrics.enable }}
+        - name: metrics-certs
+          secret:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+            optional: false
+            secretName: metrics-server-cert
+        {{- end }}
+        {{- if .Values.certManager.enable }}
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
+        {{- end }}
 {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -135,16 +135,16 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-        {{- if and .Values.certManager.enable .Values.metrics.enable }}
-        - mountPath: /tmp/k8s-metrics-server/metrics-certs
-          name: metrics-certs
-          readOnly: true
-        {{- end }}
-        {{- if .Values.certManager.enable }}
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-certs
-          readOnly: true
-        {{- end }}
+          {{- if and .Values.certManager.enable .Values.metrics.enable }}
+          - mountPath: /tmp/k8s-metrics-server/metrics-certs
+            name: metrics-certs
+            readOnly: true
+          {{- end }}
+          {{- if .Values.certManager.enable }}
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: webhook-certs
+            readOnly: true
+          {{- end }}
       securityContext:
         {{- if .Values.manager.podSecurityContext }}
         {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
@@ -159,22 +159,22 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-      {{- if and .Values.certManager.enable .Values.metrics.enable }}
-      - name: metrics-certs
-        secret:
-          items:
-          - key: ca.crt
-            path: ca.crt
-          - key: tls.crt
-            path: tls.crt
-          - key: tls.key
-            path: tls.key
-          optional: false
-          secretName: metrics-server-cert
-      {{- end }}
-      {{- if .Values.certManager.enable }}
-      - name: webhook-certs
-        secret:
-          secretName: webhook-server-cert
-      {{- end }}
+        {{- if and .Values.certManager.enable .Values.metrics.enable }}
+        - name: metrics-certs
+          secret:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+            optional: false
+            secretName: metrics-server-cert
+        {{- end }}
+        {{- if .Values.certManager.enable }}
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
+        {{- end }}
 {{- end }}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -58,6 +58,8 @@ func IsManagerDeployment(resource *unstructured.Unstructured) bool {
 
 // MakeYamlContent wraps YAML content with conditional cert-manager wrappers.
 // This function is used as a callback for regexp.ReplaceAllStringFunc.
+// It shifts the block by 2 additional spaces so that items align with the
+// child indent used by appendToListFromValues for extraVolumes/extraVolumeMounts.
 func MakeYamlContent(match string) string {
 	lines := strings.Split(match, "\n")
 	if len(lines) > 0 {
@@ -73,13 +75,15 @@ func MakeYamlContent(match string) string {
 			}
 		}
 
-		// Reconstruct the block with conditional wrapper
+		childIndent := indent.String() + "  "
+
+		// Reconstruct the block with conditional wrapper at child indent
 		var result strings.Builder
-		fmt.Fprintf(&result, "%s{{- if .Values.certManager.enable }}\n", indent.String())
+		fmt.Fprintf(&result, "%s{{- if .Values.certManager.enable }}\n", childIndent)
 		for _, line := range lines {
-			result.WriteString(line + "\n")
+			result.WriteString("  " + line + "\n")
 		}
-		fmt.Fprintf(&result, "%s{{- end }}", indent.String())
+		fmt.Fprintf(&result, "%s{{- end }}", childIndent)
 		return result.String()
 	}
 	return match

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -1452,13 +1452,15 @@ func MakeMetricsVolumesConditional(yamlContent string) string {
 					}
 				}
 
-				// Reconstruct the block with conditional wrapper
+				childIndent := indent.String() + "  "
+
+				// Reconstruct the block with conditional wrapper at child indent
 				var result strings.Builder
-				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n", indent.String())
+				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n", childIndent)
 				for _, line := range lines {
-					result.WriteString(line + "\n")
+					result.WriteString("  " + line + "\n")
 				}
-				fmt.Fprintf(&result, "%s{{- end }}", indent.String())
+				fmt.Fprintf(&result, "%s{{- end }}", childIndent)
 				return result.String()
 			}
 			return match
@@ -1491,13 +1493,15 @@ func MakeMetricsVolumeMountsConditional(yamlContent string) string {
 					}
 				}
 
-				// Reconstruct the block with conditional wrapper
+				childIndent := indent.String() + "  "
+
+				// Reconstruct the block with conditional wrapper at child indent
 				var result strings.Builder
-				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n", indent.String())
+				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n", childIndent)
 				for _, line := range lines {
-					result.WriteString(line + "\n")
+					result.WriteString("  " + line + "\n")
 				}
-				fmt.Fprintf(&result, "%s{{- end }}", indent.String())
+				fmt.Fprintf(&result, "%s{{- end }}", childIndent)
 				return result.String()
 			}
 			return match

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -146,11 +146,11 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-        {{- if .Values.certManager.enable }}
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-certs
-          readOnly: true
-        {{- end }}
+          {{- if .Values.certManager.enable }}
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: webhook-certs
+            readOnly: true
+          {{- end }}
       securityContext:
         {{- if .Values.manager.podSecurityContext }}
         {{- toYaml .Values.manager.podSecurityContext | nindent 8 }}
@@ -165,9 +165,9 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-      {{- if .Values.certManager.enable }}
-      - name: webhook-certs
-        secret:
-          secretName: webhook-server-cert
-      {{- end }}
+        {{- if .Values.certManager.enable }}
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert
+        {{- end }}
 {{- end }}


### PR DESCRIPTION
The conditional wrappers for webhook-certs and metrics-certs volumes/volumeMounts were placed at the same indent level as the parent key. This caused a YAML parse error when extraVolumeMounts or extraVolumes were populated, since those template directives were at child indent (key + 2 spaces), resulting in mixed indent levels within the same YAML list.

Shift the conditional blocks by 2 additional spaces so that items align with the child indent used by appendToListFromValues.

See https://github.com/kubernetes-sigs/kubebuilder/issues/5677.