### PR TITLE
🐛 (CLI): Fix CloseFileError wrapping nil instead of actual close error

### DIFF
--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -539,7 +539,7 @@ func (s Scaffold) writeFile(f *File) error {
 	}
 	defer func() {
 		if closeErr := writer.Close(); err == nil && closeErr != nil {
-			err = CloseFileError{err}
+			err = CloseFileError{closeErr}
 		}
 	}()
 


### PR DESCRIPTION
## Problem

In `pkg/machinery/scaffold.go`, the deferred close handler in `writeFile` wraps the wrong variable:

```go
defer func() {
    if closeErr := writer.Close(); err == nil && closeErr != nil {
        err = CloseFileError{err}   // BUG: err is nil here
    }
}()
```

When `err == nil && closeErr != nil`, the code creates `CloseFileError{err}` which wraps a **nil** error, not the actual `closeErr`. This means any file close failure produces an empty, misleading error message with no useful information about what went wrong.

## Fix

One-line change: `CloseFileError{err}` to `CloseFileError{closeErr}`.

## Verification

- `make lint-fix`: 0 issues
- `go test ./pkg/machinery/...`: all pass