### PR TITLE
🐛 (API): Fix file descriptor leak from defer inside loop in external plugin handler

### DIFF
--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -200,14 +200,12 @@ func handlePluginResponse(fs machinery.Filesystem, req external.PluginRequest, p
 			return fmt.Errorf("error creating file %q: %w", file, createErr)
 		}
 
-		defer func() {
-			if err = f.Close(); err != nil {
-				return
-			}
-		}()
-
 		if _, err = f.Write([]byte(data)); err != nil {
+			_ = f.Close()
 			return fmt.Errorf("error writing file %q: %w", file, err)
+		}
+		if err = f.Close(); err != nil {
+			return fmt.Errorf("error closing file %q: %w", file, err)
 		}
 	}
 


### PR DESCRIPTION
## Problem

In `pkg/plugins/external/helpers.go`, the `handlePluginResponse` function uses `defer f.Close()` inside a `for` loop (line 203). This causes **file descriptor retention**: all deferred close calls stack up and only run when the enclosing function returns, not at each loop iteration.

If `res.Universe` contains N files, all N file descriptors remain open simultaneously until `handlePluginResponse` completes. For large responses or long-running operations, this can exhaust file descriptors.

This bug was introduced in #2338 (2021-08-10) and has been present for nearly 5 years.

## Fix

Replace the `defer` block with explicit `f.Close()` calls: one on the write error path (before returning) and one on the success path (after the write). This ensures each file is closed within its own loop iteration, releasing the file descriptor immediately after use.

## Verification

- `make lint-fix`: 0 issues
- `go test ./pkg/plugins/external/...`: all pass