### PR TITLE
🐛 (CLI): Fix panic from unchecked type assertion in printDeprecationWarnings

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -583,8 +583,11 @@ func (c *CLI) addExtraCommands() error {
 // printDeprecationWarnings prints the deprecation warnings of the resolved plugins.
 func (c CLI) printDeprecationWarnings() {
 	for _, p := range c.resolvedPlugins {
-		if p != nil && p.(plugin.Deprecated) != nil && len(p.(plugin.Deprecated).DeprecationWarning()) > 0 {
-			_, _ = fmt.Fprintf(os.Stderr, noticeColor, fmt.Sprintf(deprecationFmt, p.(plugin.Deprecated).DeprecationWarning()))
+		if p == nil {
+			continue
+		}
+		if deprecated, ok := p.(plugin.Deprecated); ok && len(deprecated.DeprecationWarning()) > 0 {
+			_, _ = fmt.Fprintf(os.Stderr, noticeColor, fmt.Sprintf(deprecationFmt, deprecated.DeprecationWarning()))
 		}
 	}
 }


### PR DESCRIPTION
## Problem

In `pkg/cli/cli.go` line 586, `printDeprecationWarnings` uses bare type assertions:

```go
if p != nil && p.(plugin.Deprecated) != nil && len(p.(plugin.Deprecated).DeprecationWarning()) > 0 {
    _, _ = fmt.Fprintf(os.Stderr, noticeColor, fmt.Sprintf(deprecationFmt, p.(plugin.Deprecated).DeprecationWarning()))
}
```

`p.(plugin.Deprecated)` without the comma-ok pattern panics at runtime if any resolved plugin does not implement the `plugin.Deprecated` interface. This can be triggered by external plugins (user-installed binaries) that do not implement `Deprecated`.

The safe comma-ok pattern is already used elsewhere in the same codebase:
- `pkg/cli/root.go:180`: `if deprecated, ok := p.(plugin.Deprecated); ok {`
- `pkg/cli/init.go:102`: `if _, isDeprecated := p.(plugin.Deprecated); !isDeprecated {`

The unsafe assertion on line 586 was introduced on 2023-03-20.

## Fix

Use the comma-ok pattern (`deprecated, ok := p.(plugin.Deprecated)`), matching the style in `root.go:180`. This also eliminates three redundant type assertions per iteration by reusing the `deprecated` variable.

## Verification

- `make lint-fix`: 0 issues
- `go test ./pkg/cli/...`: all pass