### PR TITLE
🌱 ci: allow overriding APIDiff with apidiff-override label

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -29,16 +29,16 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-      # When go-apidiff fails, maintainers may add label apidiff-override to accept intentional API changes (fork PRs use GitHub Actions; same-repo PRs use Prow).
-      - name: Execute go-apidiff
-        id: go-apidiff
+      # When the APIDiff check fails, maintainers may add label apidiff-override to accept intentional API changes (fork PRs use GitHub Actions; same-repo PRs use Prow).
+      - name: Verify API differences
+        id: apidiff
         continue-on-error: true
         uses: joelanford/go-apidiff@60c4206be8f84348ebda2a3e0c3ac9cb54b8f685 # v0.8.3
         with:
           compare-imports: true
           print-compatible: true
-      - name: Require clean API diff or override label
-        if: ${{ steps.go-apidiff.outcome == 'failure' }}
+      - name: Require APIDiff success or override label
+        if: ${{ steps.apidiff.outcome == 'failure' }}
         env:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
@@ -48,8 +48,8 @@ jobs:
         run: |
           set -euo pipefail
           if gh api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.labels[].name' | grep -qxF "${OVERRIDE_LABEL}"; then
-            echo "Found label '${OVERRIDE_LABEL}'; accepting failed API diff check."
+            echo "Found label '${OVERRIDE_LABEL}'; accepting failed APIDiff check."
             exit 0
           fi
-          echo "::error::API diff reported incompatible changes and PR does not have label '${OVERRIDE_LABEL}'. Maintainers may add that label if the change is intentional."
+          echo "::error::APIDiff reported incompatible changes and PR does not have label '${OVERRIDE_LABEL}'. Maintainers may add that label if the change is intentional."
           exit 1

--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -14,6 +14,7 @@ jobs:
   go-apidiff:
     permissions:
       contents: read
+      pull-requests: read
     name: Verify API differences
     runs-on: ubuntu-latest
     # Pull requests from different repository only trigger this checks
@@ -28,8 +29,27 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+      # When go-apidiff fails, maintainers may add label apidiff-override to accept intentional API changes (fork PRs use GitHub Actions; same-repo PRs use Prow).
       - name: Execute go-apidiff
+        id: go-apidiff
+        continue-on-error: true
         uses: joelanford/go-apidiff@60c4206be8f84348ebda2a3e0c3ac9cb54b8f685 # v0.8.3
         with:
           compare-imports: true
           print-compatible: true
+      - name: Require clean API diff or override label
+        if: ${{ steps.go-apidiff.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+          OVERRIDE_LABEL: apidiff-override
+        run: |
+          set -euo pipefail
+          if gh api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.labels[].name' | grep -qxF "${OVERRIDE_LABEL}"; then
+            echo "Found label '${OVERRIDE_LABEL}'; accepting failed API diff check."
+            exit 0
+          fi
+          echo "::error::API diff reported incompatible changes and PR does not have label '${OVERRIDE_LABEL}'. Maintainers may add that label if the change is intentional."
+          exit 1


### PR DESCRIPTION
### Description

The fork-only **APIDiff** workflow (`.github/workflows/apidiff.yml`) still runs `joelanford/go-apidiff` as before, but the step now uses `continue-on-error` with id `go-apidiff`. A new step **Require clean API diff or override label** runs when that step fails: it uses the GitHub CLI and `GITHUB_TOKEN` to list the PR’s labels and **passes the job only if** the label **`apidiff-override`** is present; otherwise it fails with a clear error message. The job gains **`pull-requests: read`** so token permissions are sufficient to read labels.

### Motivation

For pull requests **from forks**, API compatibility is enforced by **GitHub Actions**, while **Prow** handles checks for PRs from the main repo. That split meant there was no supported maintainer escape hatch when `go-apidiff` failed but an incompatible API change was intentional and already reviewed. Adding a **label-based override** matches the pattern used in other projects (e.g. API diff jobs that allow a dedicated override label) and keeps the default behavior strict unless a maintainer explicitly approves the exception.

### Issue

Fixes #5655