### PR TITLE
🐛 (CLI): Fix redundant guard and swallowed checkout error in alpha update push

### DIFF
--- a/internal/cli/alpha/internal/update/update.go
+++ b/internal/cli/alpha/internal/update/update.go
@@ -206,12 +206,12 @@ func (opts *Update) Update() error {
 
 	// Push the output branch if requested
 	if opts.Push {
-		if opts.Push {
-			out := opts.getOutputBranchName()
-			_ = helpers.GitCmd(opts.GitConfig, "checkout", out).Run()
-			if err := helpers.GitCmd(opts.GitConfig, "push", "-u", "origin", out).Run(); err != nil {
-				return fmt.Errorf("failed to push %s: %w", out, err)
-			}
+		out := opts.getOutputBranchName()
+		if err := helpers.GitCmd(opts.GitConfig, "checkout", out).Run(); err != nil {
+			return fmt.Errorf("failed to checkout %s: %w", out, err)
+		}
+		if err := helpers.GitCmd(opts.GitConfig, "push", "-u", "origin", out).Run(); err != nil {
+			return fmt.Errorf("failed to push %s: %w", out, err)
 		}
 	}
 

--- a/internal/cli/alpha/internal/update/update_test.go
+++ b/internal/cli/alpha/internal/update/update_test.go
@@ -167,6 +167,37 @@ exit 1`
 				fmt.Sprintf("checkout %s", opts.FromBranch),
 			))
 		})
+
+		It("pushes the output branch when Push is enabled", func() {
+			opts.Push = true
+			err = opts.Update()
+			Expect(err).ToNot(HaveOccurred())
+
+			logs, readErr := os.ReadFile(logFile)
+			Expect(readErr).ToNot(HaveOccurred())
+			s := string(logs)
+
+			out := opts.getOutputBranchName()
+			Expect(s).To(ContainSubstring(
+				fmt.Sprintf("push -u origin %s", out),
+			))
+		})
+
+		It("returns error when checkout fails before push", func() {
+			opts.Push = true
+			out := opts.getOutputBranchName()
+			failOnPushCheckout := fmt.Sprintf(`#!/bin/bash
+echo "$@" >> "%s"
+if [[ "$1" == "checkout" && "$2" == "%s" ]]; then exit 1; fi
+exit 0`, logFile, out)
+			Expect(mockBinResponse(failOnPushCheckout, mockGit)).To(Succeed())
+
+			err = opts.Update()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(
+				fmt.Sprintf("failed to checkout %s", out),
+			))
+		})
 	})
 
 	Context("RegenerateProjectWithVersion", func() {


### PR DESCRIPTION
### What
Remove a redundant nested `if opts.Push` guard and check the git checkout error that was previously discarded with `_` in the `alpha update` push path.

### Why
Two issues in the push block of `alpha update`:

1. The inner `if opts.Push` on line 209 is always true because the outer guard on line 208 already checks the same field. This is a copy-paste artifact.

2. The git checkout error on line 211 is silently discarded with `_`. While the checkout is typically a no-op (the squash path already leaves the user on the output branch), silently discarding the error means any systemic git failure (corrupted state, locked index) is hidden from the user, who sees "Update completed successfully" despite the error.

The error check pattern matches the identical checkout handling at lines 197-198 for the `ShowCommits` path.

### How
- Removed the redundant inner `if opts.Push` block
- Changed `_ = helpers.GitCmd(...)` to `if err := helpers.GitCmd(...); err != nil { return ... }`
- Added integration tests for the push path (success and checkout failure error propagation)

Introduced in #5013 (2025-08-18).