### PR TITLE
🐛 (CLI): Add context timeout to HTTP calls in alpha update

### DIFF
--- a/internal/cli/alpha/internal/update.go
+++ b/internal/cli/alpha/internal/update.go
@@ -17,6 +17,7 @@ limitations under the License.
 package internal
 
 import (
+	"context"
 	"fmt"
 	"io"
 	log "log/slog"
@@ -25,6 +26,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/afero"
 	"golang.org/x/mod/semver"
@@ -130,7 +132,15 @@ func (opts *Update) downloadKubebuilderBinary() (string, error) {
 	}()
 
 	// Download the binary from GitHub releases
-	response, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build download request: %w", err)
+	}
+
+	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to download the binary: %w", err)
 	}
@@ -475,7 +485,15 @@ func (opts *Update) validateBinaryAvailability() error {
 	opts.BinaryURL = fmt.Sprintf("https://github.com/kubernetes-sigs/kubebuilder/releases/download/%s/kubebuilder_%s_%s",
 		opts.CliVersion, runtime.GOOS, runtime.GOARCH)
 
-	resp, err := http.Head(opts.BinaryURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, opts.BinaryURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build binary availability request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to check binary availability: %w", err)
 	}

--- a/internal/cli/alpha/internal/update/prepare.go
+++ b/internal/cli/alpha/internal/update/prepare.go
@@ -17,11 +17,13 @@ limitations under the License.
 package update
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	log "log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"sigs.k8s.io/kubebuilder/v4/internal/cli/alpha/internal/common"
 	"sigs.k8s.io/kubebuilder/v4/pkg/config/store"
@@ -92,7 +94,16 @@ func (opts *Update) defineToVersion() string {
 }
 
 func fetchLatestRelease() (string, error) {
-	resp, err := http.Get("https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases/latest")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"https://api.github.com/repos/kubernetes-sigs/kubebuilder/releases/latest", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build release request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch latest release: %w", err)
 	}


### PR DESCRIPTION
### What
Replace `http.Get` (no timeout) with `http.NewRequestWithContext` in two call sites in the `alpha update` command.

### Why
Both call sites use `http.DefaultClient` with no timeout. If GitHub is unreachable, the CLI blocks indefinitely with no way to cancel. The newer `helpers/download.go` in the same package already uses `context.WithTimeout` correctly for the same kind of download operation.

**Call sites fixed:**
- `downloadKubebuilderBinary` (`update.go:133`): downloads a release binary from GitHub. Now uses a 2-minute timeout, matching `helpers/download.go:71`.
- `fetchLatestRelease` (`prepare.go:95`): fetches the latest release tag from the GitHub API. Now uses a 30-second timeout (generous for a single JSON response).

### How
- Replaced `http.Get(url)` with `http.NewRequestWithContext(ctx, http.MethodGet, url, nil)` + `http.DefaultClient.Do(req)`
- Added `context.WithTimeout` with appropriate durations for each call site
- Follows the existing pattern in `helpers/download.go:71-81`

Both call sites were introduced in #4871 (2025-06-12).