### PR TITLE
🐛 Clean up temp directory in regenerateProjectWithVersion

### DIFF
--- a/internal/cli/alpha/internal/update/update.go
+++ b/internal/cli/alpha/internal/update/update.go
@@ -434,8 +434,13 @@ func regenerateProjectWithVersion(version string) error {
 	if err != nil {
 		return fmt.Errorf("failed to download release %s binary: %w", version, err)
 	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			log.Warn("failed to remove temporary directory", "dir", tempDir, "error", err)
+		}
+	}()
 	if err := runAlphaGenerate(tempDir, version); err != nil {
-		return fmt.Errorf("failed to run alpha generate on ancestor branch: %w", err)
+		return fmt.Errorf("failed to run alpha generate for version %s: %w", version, err)
 	}
 	return nil
 }
@@ -518,9 +523,9 @@ func runMakeTargets(skipConflicts bool) {
 	}
 }
 
-// runAlphaGenerate executes the old Kubebuilder version's 'alpha generate' command
-// to create clean scaffolding in the ancestor branch. This uses the downloaded
-// binary with the original PROJECT file to recreate the project's initial state.
+// runAlphaGenerate executes the specified Kubebuilder version's 'alpha generate' command
+// to create clean scaffolding. This uses the downloaded binary with the original
+// PROJECT file to recreate the project state for the given version.
 func runAlphaGenerate(tempDir, version string) error {
 	log.Info("Generating project", "version", version)
 

--- a/internal/cli/alpha/internal/update/update_test.go
+++ b/internal/cli/alpha/internal/update/update_test.go
@@ -206,6 +206,38 @@ exit 0`, logFile, out)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("cleans up temp directory after success", func() {
+			tmpBase := GinkgoT().TempDir()
+			GinkgoT().Setenv("TMPDIR", tmpBase)
+
+			err = regenerateProjectWithVersion(opts.FromVersion)
+			Expect(err).ToNot(HaveOccurred())
+
+			entries, err := filepath.Glob(filepath.Join(tmpBase, "kubebuilder*"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entries).To(BeEmpty(), "temp directory should be removed after success")
+		})
+
+		It("cleans up temp directory after failure", func() {
+			fail := `#!/bin/bash
+echo "$@" >> "` + logFile + `"
+exit 1`
+			gock.Off()
+			gock.New("https://github.com").
+				Get("/kubernetes-sigs/kubebuilder/releases/download").
+				Times(2).Reply(200).Body(strings.NewReader(fail))
+
+			tmpBase := GinkgoT().TempDir()
+			GinkgoT().Setenv("TMPDIR", tmpBase)
+
+			err = regenerateProjectWithVersion(opts.FromVersion)
+			Expect(err).To(HaveOccurred())
+
+			entries, err := filepath.Glob(filepath.Join(tmpBase, "kubebuilder*"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entries).To(BeEmpty(), "temp directory should be removed after failure")
+		})
+
 		It("fails downloading binary", func() {
 			gock.Off()
 			gock.New("https://github.com").
@@ -231,7 +263,7 @@ exit 1`
 			err = regenerateProjectWithVersion(opts.FromVersion)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(
-				"failed to run alpha generate on ancestor branch",
+				fmt.Sprintf("failed to run alpha generate for version %s", opts.FromVersion),
 			))
 		})
 	})


### PR DESCRIPTION
## Summary

`regenerateProjectWithVersion` in `internal/cli/alpha/internal/update/update.go` creates a temp directory via `DownloadReleaseVersionWith()` but never removes it. Since this function is called twice per `alpha update` run (once for the ancestor branch, once for the upgrade branch), each invocation leaks a temp directory containing the kubebuilder binary (~60MB), totaling ~120MB per run.

## Fix

Add `defer os.RemoveAll(tempDir)` after the download, with a logged warning on failure. The temp directory contents (the kubebuilder binary) are only needed during `runAlphaGenerate`, which completes within the function scope. Neither caller captures or uses `tempDir` after the function returns.

## Bug origin

The function was introduced by vitorfloriano in PR #4871 (2025-06-12) and later refactored by Camila Macedo in PR #5013 (2025-08-18). Neither version included cleanup. The older code path in `internal/cli/alpha/internal/update.go` explicitly notes "Downloaded binary kept for debugging purposes"; the newer code path has no such comment, suggesting the omission was an oversight during the refactor.

## Test plan

- `go test ./internal/cli/alpha/internal/update/... -count=1`: 25/25 pass
- `gofmt`, `go vet`, `go build` all clean
- `make lint-fix`: 0 issues