### PR TITLE
📖  (CLI) Improve CLI help text and examples

### DIFF
--- a/internal/cli/alpha/generate.go
+++ b/internal/cli/alpha/generate.go
@@ -43,19 +43,18 @@ func NewScaffoldCommand() *cobra.Command {
 	scaffoldCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Re-scaffold a Kubebuilder project from its PROJECT file",
-		Long: `The 'generate' command re-creates a Kubebuilder project scaffold based on the configuration 
+		Long: `The 'generate' command re-creates a Kubebuilder project scaffold based on the configuration
 defined in the PROJECT file, using the latest installed Kubebuilder version and plugins.
 
-This is helpful for migrating projects to a newer Kubebuilder layout or plugin version (e.g., v3 to v4)
-as update your project from any previous version to the current one.
+This is useful for migrating a project to a newer Kubebuilder layout or plugin version, such as from v3 to v4.
 
 If no output directory is provided, the current working directory will be cleaned (except .git and PROJECT).`,
 		Example: `
-  # **WARNING**(will delete all files to allow the re-scaffold except .git and PROJECT)
-  # Re-scaffold the project in-place 
+  # **WARNING**: will delete all files except .git and PROJECT
+  # Re-scaffold the current project in-place
   kubebuilder alpha generate
 
-  # Re-scaffold the project from ./test into ./my-output
+  # Re-scaffold the project from ./path/to/project into ./my-output
   kubebuilder alpha generate --input-dir="./path/to/project" --output-dir="./my-output"
 `,
 		PreRunE: func(_ *cobra.Command, _ []string) error {

--- a/pkg/cli/api.go
+++ b/pkg/cli/api.go
@@ -30,7 +30,9 @@ func (c CLI) newCreateAPICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Scaffold a Kubernetes API",
-		Long:  `Scaffold a Kubernetes API.`,
+		Long: `Scaffold a Kubernetes API by adding a resource definition and, when requested, a controller.
+
+Run this command from an initialized project.`,
 		RunE: errCmdFunc(
 			fmt.Errorf("api subcommand requires an existing project"),
 		),

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -46,6 +46,11 @@ const (
 	kubebuilderSubcommandInit = "init"
 	pluginGoKubebuilderV4     = "go.kubebuilder.io/v4"
 	pluginGoKubebuilderV2     = "go.kubebuilder.io/v2"
+
+	pluginsFlagDescription = "Comma-separated list of plugin keys to use. " +
+		"If unset, Kubebuilder uses the plugin chain from PROJECT or the CLI default"
+	projectVersionFlagDescription = "Project config version used to select compatible plugins and write PROJECT " +
+		"(e.g., 3). If unset, Kubebuilder uses the version from PROJECT or the CLI default"
 )
 
 // CLI is the command line utility that is used to scaffold kubebuilder project files.

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -31,6 +31,9 @@ func (c CLI) newCreateCmd() *cobra.Command {
 		Short:      "Scaffold a Kubernetes API or webhook",
 		Long: fmt.Sprintf(`Scaffold a Kubernetes API or webhook.
 
+Use "create api" to add resources and controllers to an initialized project.
+Use "create webhook" to add defaulting, validating, or conversion webhooks.
+
 Available plugins that support 'create' subcommands:
 
 %s

--- a/pkg/cli/edit.go
+++ b/pkg/cli/edit.go
@@ -31,7 +31,10 @@ func (c CLI) newEditCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "Update the project configuration",
-		Long:  `Edit the project configuration.`,
+		Long: `Update an initialized project's configuration and scaffold files needed for the selected settings.
+
+Use this command to enable layout options such as multigroup or namespace-scoped deployment, or to run optional
+plugins that modify an existing project.`,
 		RunE: errCmdFunc(
 			fmt.Errorf("project must be initialized"),
 		),

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -19,8 +19,6 @@ package cli
 import (
 	"fmt"
 	"slices"
-	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -44,8 +42,7 @@ For further help about a specific plugin, set --plugins.
 
 	// Register --project-version on the dynamically created command
 	// so that it shows up in help and does not cause a parse error.
-	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(),
-		"Project version (e.g., 3). Defaults to CLI version if unset")
+	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), projectVersionFlagDescription)
 
 	// In case no plugin was resolved, instead of failing the construction of the CLI, fail the execution of
 	// this subcommand. This allows the use of subcommands that do not require resolved plugins like help.
@@ -83,19 +80,31 @@ For further help about a specific plugin, set --plugins.
 }
 
 func (c CLI) getInitHelpExamples() string {
-	var sb strings.Builder
-	for _, version := range c.getAvailableProjectVersions() {
-		rendered := fmt.Sprintf(`  # Help for initializing a project with version %[2]s
-  %[1]s init --project-version=%[2]s -h
+	projectVersionExample := c.defaultProjectVersion.String()
+	if c.defaultProjectVersion.Validate() != nil {
+		versions := c.getAvailableProjectVersions()
+		if len(versions) == 0 {
+			return fmt.Sprintf(`  # Initialize a new project
+  %[1]s init --domain example.org
 
-`,
-			c.commandName, version)
-		sb.WriteString(rendered)
+  # Initialize with optional plugins
+  %[1]s init --domain example.org --plugins <PLUGIN_KEYS>`, c.commandName)
+		}
+		projectVersionExample = versions[len(versions)-1].String()
 	}
-	return strings.TrimSuffix(sb.String(), "\n\n")
+
+	return fmt.Sprintf(`  # Initialize a new project
+  %[1]s init --domain example.org
+
+  # Initialize with optional plugins
+  %[1]s init --domain example.org --plugins <PLUGIN_KEYS>
+
+  # Initialize with a specific project config version
+  %[1]s init --domain example.org --plugins <PLUGIN_KEYS> --project-version %[2]s`,
+		c.commandName, projectVersionExample)
 }
 
-func (c CLI) getAvailableProjectVersions() (projectVersions []string) {
+func (c CLI) getAvailableProjectVersions() (projectVersions []config.Version) {
 	versionSet := make(map[config.Version]struct{})
 	for _, p := range c.plugins {
 		// Only return versions of non-deprecated plugins.
@@ -106,8 +115,10 @@ func (c CLI) getAvailableProjectVersions() (projectVersions []string) {
 		}
 	}
 	for version := range versionSet {
-		projectVersions = append(projectVersions, strconv.Quote(version.String()))
+		projectVersions = append(projectVersions, version)
 	}
-	slices.Sort(projectVersions)
+	slices.SortFunc(projectVersions, func(a, b config.Version) int {
+		return a.Compare(b)
+	})
 	return projectVersions
 }

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/model/stage"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
@@ -41,13 +42,13 @@ var _ = Describe("init", func() {
 			examples := cli.getInitHelpExamples()
 
 			Expect(examples).To(ContainSubstring("kubebuilder init"))
-			Expect(examples).To(ContainSubstring("project-version"))
-			Expect(examples).To(ContainSubstring("-h"))
+			Expect(examples).To(ContainSubstring("--plugins"))
+			Expect(examples).To(ContainSubstring("--project-version 4"))
 		})
 
 		It("should handle multiple versions", func() {
-			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 2})
-			plugin2 := newMockPlugin("plugin2", "3", config.Version{Number: 3})
+			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 10})
+			plugin2 := newMockPlugin("plugin2", "3", config.Version{Number: 3, Stage: stage.Alpha})
 
 			cli := CLI{
 				commandName: "kb",
@@ -60,17 +61,35 @@ var _ = Describe("init", func() {
 			examples := cli.getInitHelpExamples()
 
 			Expect(examples).To(ContainSubstring("kb init"))
+			Expect(examples).To(ContainSubstring("--project-version 10"))
 			Expect(examples).NotTo(HaveSuffix("\n\n"))
 		})
 
-		It("should return empty string when no plugins", func() {
+		It("should omit project version example when no version is available", func() {
 			cli := CLI{
 				commandName: kubebuilderCommandName,
 				plugins:     map[string]plugin.Plugin{},
 			}
 
 			examples := cli.getInitHelpExamples()
-			Expect(examples).To(BeEmpty())
+			Expect(examples).To(ContainSubstring("kubebuilder init --domain example.org"))
+			Expect(examples).NotTo(ContainSubstring("--project-version 0"))
+		})
+	})
+
+	Context("flag descriptions", func() {
+		It("should use the same project version description for root and init", func() {
+			cli := CLI{
+				commandName:           "kubebuilder",
+				defaultProjectVersion: config.Version{Number: 3},
+				plugins:               map[string]plugin.Plugin{},
+			}
+
+			rootCmd := cli.newRootCmd()
+			initCmd := cli.newInitCmd()
+
+			Expect(rootCmd.Flags().Lookup(projectVersionFlag).Usage).To(Equal(projectVersionFlagDescription))
+			Expect(initCmd.Flags().Lookup(projectVersionFlag).Usage).To(Equal(projectVersionFlagDescription))
 		})
 	})
 
@@ -90,8 +109,8 @@ var _ = Describe("init", func() {
 
 			versions := cli.getAvailableProjectVersions()
 
-			Expect(versions).To(ContainElement("\"3\""))
-			Expect(versions).To(ContainElement("\"4\""))
+			Expect(versions).To(ContainElement(config.Version{Number: 3}))
+			Expect(versions).To(ContainElement(config.Version{Number: 4}))
 			Expect(versions).To(HaveLen(2))
 		})
 
@@ -108,26 +127,33 @@ var _ = Describe("init", func() {
 
 			versions := cli.getAvailableProjectVersions()
 
-			Expect(versions).NotTo(ContainElement("\"2\""))
-			Expect(versions).To(ContainElement("\"3\""))
+			Expect(versions).NotTo(ContainElement(config.Version{Number: 2}))
+			Expect(versions).To(ContainElement(config.Version{Number: 3}))
 		})
 
-		It("should return sorted versions", func() {
-			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 4})
+		It("should return versions sorted by project version order", func() {
+			plugin1 := newMockPlugin("plugin1", "3", config.Version{Number: 10})
 			plugin2 := newMockPlugin("plugin2", "3", config.Version{Number: 2})
 			plugin3 := newMockPlugin("plugin3", "3", config.Version{Number: 3})
+			plugin4 := newMockPlugin("plugin4", "3", config.Version{Number: 3, Stage: stage.Alpha})
 
 			cli := CLI{
 				plugins: map[string]plugin.Plugin{
 					plugin.KeyFor(plugin1): plugin1,
 					plugin.KeyFor(plugin2): plugin2,
 					plugin.KeyFor(plugin3): plugin3,
+					plugin.KeyFor(plugin4): plugin4,
 				},
 			}
 
 			versions := cli.getAvailableProjectVersions()
 
-			Expect(versions).To(Equal([]string{"\"2\"", "\"3\"", "\"4\""}))
+			Expect(versions).To(Equal([]config.Version{
+				{Number: 2},
+				{Number: 3, Stage: stage.Alpha},
+				{Number: 3},
+				{Number: 10},
+			}))
 		})
 
 		It("should return empty slice when no plugins", func() {
@@ -154,9 +180,9 @@ var _ = Describe("init", func() {
 			versions := cli.getAvailableProjectVersions()
 
 			Expect(versions).To(HaveLen(3))
-			Expect(versions).To(ContainElement("\"2\""))
-			Expect(versions).To(ContainElement("\"3\""))
-			Expect(versions).To(ContainElement("\"4\""))
+			Expect(versions).To(ContainElement(config.Version{Number: 2}))
+			Expect(versions).To(ContainElement(config.Version{Number: 3}))
+			Expect(versions).To(ContainElement(config.Version{Number: 4}))
 		})
 	})
 })

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -102,13 +102,10 @@ func (c CLI) newRootCmd() *cobra.Command {
 	}
 
 	// Global flags for all subcommands.
-	cmd.PersistentFlags().StringSlice(pluginsFlag, nil,
-		"Comma-separated list of plugin keys to use (e.g., go/v4, helm/v2-alpha). "+
-			"Defaults to the built-in go/v4 bundle if unset")
+	cmd.PersistentFlags().StringSlice(pluginsFlag, nil, pluginsFlagDescription)
 
 	// Register --project-version on the root command so that it shows up in help.
-	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(),
-		"Project version (e.g., 3). Defaults to CLI version if unset")
+	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), projectVersionFlagDescription)
 
 	// As the root command will be used to shot the help message under some error conditions,
 	// like during plugin resolving, we need to allow unknown flags to prevent parsing errors.
@@ -121,19 +118,20 @@ func (c CLI) newRootCmd() *cobra.Command {
 func (c CLI) rootExamples() string {
 	str := fmt.Sprintf(`Get started by initializing a new project:
 
-    %[1]s init --domain <YOUR_DOMAIN>
+    %[1]s init --domain example.org
 
-The default plugin scaffold includes everything you need. To use optional plugins:
+Use optional plugins when you want extra scaffolding during init:
 
-    %[1]s init --plugins=<PLUGIN_KEYS>
+    %[1]s init --domain example.org --plugins <PLUGIN_KEYS>
 
 Available plugins:
 
 %[2]s
 
-To see which plugins support a specific command:
+To see help for a command with a specific plugin:
 
     %[1]s <init|edit|create> --help
+    %[1]s init --help --plugins <PLUGIN_KEYS> [--project-version <PROJECT_VERSION>]
 `,
 		c.commandName, c.getPluginTable())
 

--- a/pkg/cli/webhook.go
+++ b/pkg/cli/webhook.go
@@ -31,7 +31,9 @@ func (c CLI) newCreateWebhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "webhook",
 		Short: "Scaffold a webhook for an API resource",
-		Long:  `Scaffold a webhook for an API resource.`,
+		Long: `Scaffold defaulting, validating, or conversion webhooks for an API resource.
+
+Run this command from an initialized project after creating the API resource.`,
 		RunE: errCmdFunc(
 			fmt.Errorf("webhook subcommand requires an existing project"),
 		),

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -61,33 +61,21 @@ type createAPISubcommand struct {
 func (p *createAPISubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
 	subcmdMeta.Description = `Scaffold a Kubernetes API by writing a Resource definition and/or a Controller.
 
-If information about whether the resource and controller should be scaffolded
-was not explicitly provided, it will prompt the user if they should be.
+If --resource or --controller is not explicitly set, Kubebuilder prompts for what to scaffold.
 
-After the scaffold is written, the dependencies will be updated and
-make generate will be run.
+After writing the scaffold, Kubebuilder updates dependencies. When an API resource is scaffolded,
+Kubebuilder runs make generate unless --make=false is set.
 `
-	subcmdMeta.Examples = fmt.Sprintf(`  # Create a frigates API with Group: ship, Version: v1beta1 and Kind: Frigate
-  %[1]s create api --group ship --version v1beta1 --kind Frigate
+	subcmdMeta.Examples = fmt.Sprintf(`  # Create a namespaced API resource and controller
+  %[1]s create api --group crew --version v1 --kind Captain
 
-  # Edit the API Scheme
+  # Create a cluster-scoped API resource without a controller
+  %[1]s create api --group crew --version v1 --kind Admiral --namespaced=false --controller=false
 
-  nano api/v1beta1/frigate_types.go
-
-  # Edit the Controller
-  nano internal/controller/frigate/frigate_controller.go
-
-  # Edit the Controller Test
-  nano internal/controller/frigate/frigate_controller_test.go
-
-  # Generate the manifests
-  make manifests
-
-  # Install CRDs into the Kubernetes cluster using kubectl apply
-  make install
-
-  # Regenerate code and run against the Kubernetes cluster configured by ~/.kube/config
-  make run
+  # Create a controller for an external API type
+  %[1]s create api --group cert-manager --version v1 --kind Certificate \
+    --resource=false --controller=true \
+    --external-api-path github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1
 `, cliMeta.CommandName)
 }
 

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -24,16 +24,18 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	goPlugin "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
 )
 
 const (
-	crewGroup   = "crew"
-	testIO      = "test.io"
-	captainKind = "Captain"
-	captains    = "captains"
-	shipGroup   = "ship"
-	frigateKind = "Frigate"
+	crewGroup       = "crew"
+	testIO          = "test.io"
+	testCommandName = "kubebuilder"
+	captainKind     = "Captain"
+	captains        = "captains"
+	shipGroup       = "ship"
+	frigateKind     = "Frigate"
 )
 
 var _ = Describe("createAPISubcommand", func() {
@@ -65,6 +67,19 @@ var _ = Describe("createAPISubcommand", func() {
 		}
 
 		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+	})
+
+	Context("UpdateMetadata", func() {
+		It("should provide concise API examples", func() {
+			meta := &plugin.SubcommandMetadata{}
+
+			subCmd.UpdateMetadata(plugin.CLIMetadata{CommandName: testCommandName}, meta)
+
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder create api --group crew --version v1 --kind Captain"))
+			Expect(meta.Examples).To(ContainSubstring("--namespaced=false --controller=false"))
+			Expect(meta.Examples).To(ContainSubstring("--external-api-path"))
+			Expect(meta.Examples).NotTo(ContainSubstring("nano "))
+		})
 	})
 
 	It("should reject external API options when creating API in project", func() {

--- a/pkg/plugins/golang/v4/edit.go
+++ b/pkg/plugins/golang/v4/edit.go
@@ -80,19 +80,19 @@ Note: To add optional plugins after initialization, use 'kubebuilder edit --plug
 	subcmdMeta.Examples = fmt.Sprintf(`  # Enable multigroup layout
   %[1]s edit --multigroup
 
+  # Disable multigroup layout
+  %[1]s edit --multigroup=false
+
   # Enable namespace-scoped permissions
   %[1]s edit --namespaced
 
-  # Enable with automatic file regeneration
+  # Enable namespace-scoped permissions and regenerate scaffolded files
   %[1]s edit --namespaced --force
-
-  # Disable multigroup layout
-  %[1]s edit --multigroup=false
 
   # Enable/disable multiple settings
   %[1]s edit --multigroup --namespaced --force
 
-  # Update license header from custom file
+  # Update license headers from a custom file
   %[1]s edit --license-file ./my-header.txt
 
   # Update license header to built-in apache2

--- a/pkg/plugins/golang/v4/edit_test.go
+++ b/pkg/plugins/golang/v4/edit_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds"
 )
 
@@ -45,6 +46,22 @@ var _ = Describe("editSubcommand", func() {
 	It("should inject config successfully", func() {
 		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
 		Expect(subCmd.config).To(Equal(cfg))
+	})
+
+	Context("UpdateMetadata", func() {
+		It("should provide concise edit examples", func() {
+			meta := &plugin.SubcommandMetadata{}
+
+			subCmd.UpdateMetadata(plugin.CLIMetadata{CommandName: testCommandName}, meta)
+
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder edit --multigroup"))
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder edit --multigroup=false"))
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder edit --namespaced\n"))
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder edit --namespaced --force"))
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder edit --multigroup --namespaced --force"))
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder edit --license-file ./my-header.txt"))
+			Expect(meta.Examples).To(ContainSubstring(`kubebuilder edit --license apache2 --owner "Your Company"`))
+		})
 	})
 
 	Context("PreScaffold", func() {

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -81,10 +81,11 @@ Configuration flags:
   --license: License to use (apache2 or none, default: apache2)
 
 Plugin flags:
-  --plugins: Comma-separated list of plugins to use (default: go/v4)
-             Plugins scaffold files during init and are saved to the PROJECT layout
-             Future operations (i.e. create api, create webhook) call all plugins in the chain
-             Run 'kubebuilder init --plugins --help' to see available plugins
+  --plugins: Comma-separated list of plugins to use (e.g., go/v4,<PLUGIN_KEY>).
+             If unset, Kubebuilder uses the default go/v4 scaffold.
+             Plugins used during init are saved to the PROJECT layout.
+             Future operations, such as create api and create webhook, use that plugin chain.
+             Run 'kubebuilder init --plugins --help' to see available plugins.
 
 Layout flags:
   --multigroup: Enable multigroup layout to organize APIs by group
@@ -109,7 +110,7 @@ Note: Layout settings can be changed later with 'kubebuilder edit'.
 
   # Initialize with optional plugins
   %[1]s init --plugins go/v4,autoupdate/v1-alpha --domain example.org
-  %[1]s init --plugins go/v4,helm/v2-alpha --domain example.org
+  %[1]s init --plugins go/v4,<PLUGIN_KEY> --domain example.org
 
   # Initialize with custom settings
   %[1]s init --domain example.org --owner "Your Name" --license apache2

--- a/pkg/plugins/golang/v4/init_test.go
+++ b/pkg/plugins/golang/v4/init_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds"
 )
 
@@ -41,6 +42,23 @@ var _ = Describe("initSubcommand", func() {
 	BeforeEach(func() {
 		subCmd = &initSubcommand{}
 		cfg = cfgv3.New()
+	})
+
+	Context("UpdateMetadata", func() {
+		It("should provide init examples", func() {
+			meta := &plugin.SubcommandMetadata{}
+
+			subCmd.UpdateMetadata(plugin.CLIMetadata{CommandName: testCommandName}, meta)
+
+			Expect(meta.Examples).To(ContainSubstring("kubebuilder init --domain example.org"))
+			Expect(meta.Examples).To(ContainSubstring("--domain example.org --multigroup"))
+			Expect(meta.Examples).To(ContainSubstring("--domain example.org --namespaced"))
+			Expect(meta.Examples).To(ContainSubstring("--plugins go/v4,<PLUGIN_KEY>"))
+			Expect(meta.Examples).To(ContainSubstring(`--owner "Your Name" --license apache2`))
+			Expect(meta.Examples).To(ContainSubstring("--license-file ./my-header.txt"))
+			Expect(meta.Examples).To(ContainSubstring("--project-version 3"))
+			Expect(meta.Examples).NotTo(ContainSubstring("--project-version 0"))
+		})
 	})
 
 	Context("InjectConfig", func() {

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -73,12 +73,12 @@ validating and/or conversion webhooks.
   # and Kind: Frigate
   %[1]s create webhook --group ship --version v1beta1 --kind Frigate --defaulting \
     --defaulting-path=/my-custom-mutate-path
-  
+
   # Create validation webhook with custom path for Group: ship, Version: v1beta1
   # and Kind: Frigate
   %[1]s create webhook --group ship --version v1beta1 --kind Frigate \
     --programmatic-validation --validation-path=/my-custom-validate-path
-  
+
   # Create both defaulting and validation webhooks with different custom paths
   %[1]s create webhook --group ship --version v1beta1 --kind Frigate \
     --defaulting --programmatic-validation \

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	goPlugin "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
 )
 
@@ -49,6 +50,19 @@ var _ = Describe("createWebhookSubcommand", func() {
 			Plural:   captains,
 			Webhooks: &resource.Webhooks{},
 		}
+	})
+
+	Context("UpdateMetadata", func() {
+		It("should provide webhook examples", func() {
+			meta := &plugin.SubcommandMetadata{}
+
+			subCmd.UpdateMetadata(plugin.CLIMetadata{CommandName: testCommandName}, meta)
+
+			Expect(meta.Examples).To(ContainSubstring("--defaulting --programmatic-validation"))
+			Expect(meta.Examples).To(ContainSubstring("--conversion --spoke v1"))
+			Expect(meta.Examples).To(ContainSubstring("--defaulting-path=/my-custom-mutate-path"))
+			Expect(meta.Examples).To(ContainSubstring("--validation-path=/my-custom-validate-path"))
+		})
 	})
 
 	It("should reject defaulting-path without --defaulting", func() {


### PR DESCRIPTION
## Summary

- Standardize shared `--plugins` and `--project-version` help text.
- Replace noisy init/create/edit/webhook examples with focused, high-value examples.
- Clarify `alpha generate` help text and examples.
- Add tests to keep the updated help metadata from regressing.

Closes #5446

