### PR TITLE
✨ (helm/v2-alpha): Helm charts now include optional NetworkPolicy resources by default when none are defined in the informed Kustomize file.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enable }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+  name: {{ include "project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+  name: {{ include "project.resourceName" (dict "suffix" "allow-webhook-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: {{ .Values.webhook.port }}
+          protocol: TCP
+{{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -177,3 +177,9 @@ webhook:
 prometheus:
   enable: false
 
+## Network policies for controlling traffic flow.
+## Enable to restrict ingress to the controller manager.
+##
+networkPolicy:
+  enable: false
+

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enable }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+  name: {{ include "project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -170,3 +170,9 @@ certManager:
 prometheus:
   enable: false
 
+## Network policies for controlling traffic flow.
+## Enable to restrict ingress to the controller manager.
+##
+networkPolicy:
+  enable: false
+

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enable }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+  name: {{ include "project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project.name" . }}
+  name: {{ include "project.resourceName" (dict "suffix" "allow-webhook-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: {{ .Values.webhook.port }}
+          protocol: TCP
+{{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -177,3 +177,9 @@ webhook:
 prometheus:
   enable: false
 
+## Network policies for controlling traffic flow.
+## Enable to restrict ingress to the controller manager.
+##
+networkPolicy:
+  enable: false
+

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -26,7 +26,8 @@ Many users prefer Helm for packaging and upgrades. This plugin converts `dist/in
 - Preserves environment variables, labels, annotations, and patches
 - Organizes templates to match your `config/` directory layout
 - Includes only configurable parameters in `values.yaml`
-- Never overwrites `Chart.yaml`; preserves `values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, and `test-chart.yml` unless you use `--force`
+- Never overwrites `Chart.yaml`; preserves `values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`, and `templates/network-policy/*.yaml` unless you use `--force`
+- Adds default `ServiceMonitor` and `NetworkPolicy` templates when kustomize output does not provide them
 - Places custom resources in `templates/extras/` with Helm templating
 
 ## Usage
@@ -112,6 +113,9 @@ The plugin generates a chart layout that mirrors your `config/` directory:
     │   └── webhook-service.yaml
     ├── monitoring/
     │   └── servicemonitor.yaml
+    ├── network-policy/
+    │   ├── allow-metrics-traffic.yaml
+    │   └── allow-webhook-traffic.yaml  # If webhooks are configured
     └── extras/                  # Custom resources (if any)
         ├── my-service.yaml
         └── my-config.yaml
@@ -194,6 +198,12 @@ Install without webhooks:
 helm install my-release ./dist/chart --set webhook.enable=false --set certManager.enable=false
 ```
 
+Install with NetworkPolicy resources:
+
+```bash
+helm install my-release ./dist/chart --set networkPolicy.enable=true
+```
+
 ### Extra volumes
 
 Add volumes and volume mounts to the manager deployment beyond webhook and metrics certificates.
@@ -224,6 +234,12 @@ When `false`:
 The `metrics-auth-role` and `metrics-reader` are always ClusterRoles, even when `rbac.namespaced=true`. Metrics authentication uses cluster-scoped APIs for authenticating scrapers like Prometheus.
 
 </aside>
+
+### NetworkPolicy configuration
+
+Set `networkPolicy.enable: true` to install NetworkPolicy resources for the manager pod.
+
+When the kustomize output includes `NetworkPolicy` resources, the plugin converts them into chart templates and sets `networkPolicy.enable: true`. When no `NetworkPolicy` resources are present in the kustomize output, the plugin generates default templates for metrics traffic, and also for webhook traffic when webhooks are detected in the provided kustomize input files.
 
 ### Custom labels and annotations
 
@@ -335,7 +351,7 @@ Optional fields in `values.yaml` use Helm conditionals. Comment them out to excl
 |---------------------|-----------------------------------------------------------------------------|
 | **--manifests**     | Path to YAML file containing Kubernetes manifests (default: `dist/install.yaml`) |
 | **--output-dir** string | Output directory for chart (default: `dist`)                                |
-| **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`) |
+| **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`, `templates/network-policy/*.yaml`) |
 
 <aside class="note" role="note">
 <p class="note-title"> Examples </p>

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -58,7 +58,8 @@ func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 	subcmdMeta.Description = `Generate a Helm chart from your project's kustomize output.
 
 Parses 'make build-installer' output (dist/install.yaml) and generates chart to allow easy
-distribution of your project. When enabled, adds Helm helpers targets to Makefile`
+distribution of your project. It also scaffolds default ServiceMonitor and NetworkPolicy templates
+when the kustomize output does not provide them. When enabled, adds Helm helpers targets to Makefile`
 
 	subcmdMeta.Examples = fmt.Sprintf(`# Generate Helm chart from default manifests (dist/install.yaml) to default output (dist/)
   %[1]s edit --plugins=%[2]s
@@ -81,7 +82,7 @@ distribution of your project. When enabled, adds Helm helpers targets to Makefil
 
 **NOTE**: Chart.yaml is never overwritten (contains user-managed version info).
 Without --force, the plugin also preserves values.yaml, NOTES.txt, _helpers.tpl, .helmignore,
-and .github/workflows/test-chart.yml.
+.github/workflows/test-chart.yml, and templates/network-policy/*.yaml.
 All other template files in templates/ are always regenerated to match your current
 kustomize output. Use --force to regenerate all files except Chart.yaml.
 
@@ -96,6 +97,7 @@ The generated chart structure mirrors your config/ directory:
     ├── rbac/
     ├── manager/
     ├── webhook/
+    ├── network-policy/
     └── ...
 `, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }

--- a/pkg/plugins/optional/helm/v2alpha/internal/common/consts.go
+++ b/pkg/plugins/optional/helm/v2alpha/internal/common/consts.go
@@ -36,12 +36,14 @@ const (
 	KindMutatingWebhook    = "MutatingWebhookConfiguration"
 	KindDeployment         = "Deployment"
 	KindCRD                = "CustomResourceDefinition"
+	KindNetworkPolicy      = "NetworkPolicy"
 )
 
 // API versions
 const (
 	APIVersionCertManager = "cert-manager.io/v1"
 	APIVersionMonitoring  = "monitoring.coreos.com/v1"
+	APIVersionNetworking  = "networking.k8s.io/v1"
 )
 
 // YAML keys

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
@@ -93,6 +93,7 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 		Certificates:              resources.Certificates,
 		Issuer:                    resources.Issuer,
 		ServiceMonitors:           resources.ServiceMonitors,
+		NetworkPolicies:           resources.NetworkPolicies,
 		Other:                     resources.Other,
 	}, s.config.ProjectName)
 
@@ -144,6 +145,21 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 			ServiceName: metricsServiceName,
 			Force:       s.config.Force,
 		})
+	}
+
+	// Add fallback policies only when kustomize output does not define any NetworkPolicy.
+	if !extraction.Features.HasNetworkPolicy {
+		builders = append(builders, &charttemplates.NetworkPolicy{
+			OutputDir: s.config.OutputDir,
+			Force:     s.config.Force,
+		})
+		if extraction.Features.HasWebhooks {
+			builders = append(builders, &charttemplates.NetworkPolicy{
+				Webhook:   true,
+				OutputDir: s.config.OutputDir,
+				Force:     s.config.Force,
+			})
+		}
 	}
 
 	// Append kustomize-derived chart templates

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
@@ -1,0 +1,367 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("ChartScaffolder", func() {
+	Describe("PrepareTemplates", func() {
+		It("should add the generic metrics NetworkPolicy when it is missing", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(manifestsPath, []byte(manifestsWithoutNetworkPolicy), 0o600)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+
+			rendered := string(content)
+			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(rendered).To(ContainSubstring("kind: NetworkPolicy"))
+			Expect(rendered).To(ContainSubstring(
+				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))
+			Expect(rendered).To(ContainSubstring("metrics: enabled"))
+			Expect(rendered).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			_, err = afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-webhook-traffic.yaml")
+			Expect(err).To(HaveOccurred())
+
+			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: false"))
+		})
+
+		It("should add generic metrics and webhook NetworkPolicies when no policy exists", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithWebhooksWithoutNetworkPolicy),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			metricsPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-metrics-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(metricsPolicy)).To(ContainSubstring("metrics: enabled"))
+			Expect(string(metricsPolicy)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			webhookPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-webhook-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(webhookPolicy)).To(ContainSubstring("webhook: enabled"))
+			Expect(string(webhookPolicy)).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+		})
+
+		It("should not add fallback policies when kustomize output provides NetworkPolicies", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithMetricsNetworkPolicyAndWebhooks),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rendered := string(content)
+			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(rendered).To(ContainSubstring("metrics: enabled"))
+			Expect(rendered).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			_, err = afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-webhook-traffic.yaml")
+			Expect(err).To(HaveOccurred())
+
+			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: true"))
+		})
+
+		It("should place all NetworkPolicies from kustomize output in the network-policy directory", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithMultipleNetworkPolicies),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			metricsPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-metrics-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(metricsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(string(metricsPolicy)).To(ContainSubstring("metrics: enabled"))
+			Expect(string(metricsPolicy)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			dnsPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-dns-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(dnsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(string(dnsPolicy)).To(ContainSubstring("dns: enabled"))
+			Expect(string(dnsPolicy)).To(ContainSubstring("port: 5353"))
+
+			webhookPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-webhook-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(webhookPolicy)).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+			Expect(string(webhookPolicy)).To(ContainSubstring("webhook: enabled"))
+			Expect(string(webhookPolicy)).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+
+			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: true"))
+		})
+
+		It("should add new kustomize NetworkPolicies after fallback policies were scaffolded", func() {
+			tmpDir := GinkgoT().TempDir()
+			firstManifestsPath := filepath.Join(tmpDir, "install-without-network-policy.yaml")
+			Expect(os.WriteFile(firstManifestsPath, []byte(manifestsWithoutNetworkPolicy), 0o600)).To(Succeed())
+
+			fs := executeChartScaffolder(firstManifestsPath)
+			_, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+
+			secondManifestsPath := filepath.Join(tmpDir, "install-with-custom-network-policies.yaml")
+			Expect(os.WriteFile(
+				secondManifestsPath,
+				[]byte(manifestsWithMultipleNetworkPolicies),
+				0o600,
+			)).To(Succeed())
+
+			executeChartScaffolderWithFS(secondManifestsPath, fs)
+
+			metricsPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-metrics-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(metricsPolicy)).To(ContainSubstring("metrics: enabled"))
+			Expect(string(metricsPolicy)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			dnsPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-dns-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(dnsPolicy)).To(ContainSubstring("dns: enabled"))
+			Expect(string(dnsPolicy)).To(ContainSubstring("port: 5353"))
+
+			webhookPolicy, err := afero.ReadFile(
+				fs,
+				"dist/chart/templates/network-policy/allow-webhook-traffic.yaml",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(webhookPolicy)).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+			Expect(string(webhookPolicy)).To(ContainSubstring("webhook: enabled"))
+			Expect(string(webhookPolicy)).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+
+			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: false"))
+		})
+	})
+})
+
+func executeChartScaffolder(manifestsPath string) afero.Fs {
+	return executeChartScaffolderWithFS(manifestsPath, afero.NewMemMapFs())
+}
+
+func executeChartScaffolderWithFS(manifestsPath string, fs afero.Fs) afero.Fs {
+	scaffolder := NewChartScaffolder(ChartScaffolderConfig{
+		ProjectName:   "test-project",
+		ManifestsFile: manifestsPath,
+		OutputDir:     "dist",
+	})
+	builders, err := scaffolder.PrepareTemplates(machinery.Filesystem{})
+	Expect(err).NotTo(HaveOccurred())
+
+	cfg := cfgv3.New()
+	Expect(cfg.SetProjectName("test-project")).To(Succeed())
+
+	scaffold := machinery.NewScaffold(machinery.Filesystem{FS: fs}, machinery.WithConfig(cfg))
+	Expect(scaffold.Execute(builders...)).To(Succeed())
+
+	return fs
+}
+
+const manifestsWithoutNetworkPolicy = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-project-controller-manager-metrics-service
+  namespace: test-system
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: test-project
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+        app.kubernetes.io/name: test-project
+    spec:
+      containers:
+        - name: manager
+          image: controller:latest
+`
+
+const manifestsWithWebhooksWithoutNetworkPolicy = manifestsWithoutNetworkPolicy + `---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: test-project-validating-webhook-configuration
+webhooks: []
+`
+
+const manifestsWithMetricsNetworkPolicyAndWebhooks = manifestsWithoutNetworkPolicy + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-metrics-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: test-project-validating-webhook-configuration
+webhooks: []
+`
+
+const manifestsWithMultipleNetworkPolicies = manifestsWithoutNetworkPolicy + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-metrics-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-dns-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            dns: enabled
+      ports:
+        - port: 5353
+          protocol: UDP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-webhook-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: 443
+          protocol: TCP
+`

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/extractor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/extractor.go
@@ -70,6 +70,7 @@ type ResourceSet struct {
 	Certificates              []*unstructured.Unstructured
 	Issuer                    *unstructured.Unstructured
 	ServiceMonitors           []*unstructured.Unstructured
+	NetworkPolicies           []*unstructured.Unstructured
 	Other                     []*unstructured.Unstructured
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -26,18 +26,22 @@ import (
 type FeaturesExtractor struct{}
 
 // FeatureSet represents detected features in the resources.
-// It includes flags for CRDs, webhooks, metrics, Prometheus, cert-manager, and cluster-scoped RBAC.
+// It includes flags for CRDs, webhooks, metrics, Prometheus, cert-manager,
+// NetworkPolicies, NetworkPolicy traffic paths, and cluster-scoped RBAC.
 // It also includes port configurations and multi-namespace RBAC mappings.
 type FeatureSet struct {
-	HasCRDs              bool
-	HasWebhooks          bool
-	HasMetrics           bool
-	HasPrometheus        bool
-	HasCertManager       bool
-	HasClusterScopedRBAC bool
-	WebhookPort          int
-	MetricsPort          int
-	RoleNamespaces       map[string]string
+	HasCRDs                 bool
+	HasWebhooks             bool
+	HasMetrics              bool
+	HasPrometheus           bool
+	HasCertManager          bool
+	HasNetworkPolicy        bool
+	HasMetricsNetworkPolicy bool
+	HasWebhookNetworkPolicy bool
+	HasClusterScopedRBAC    bool
+	WebhookPort             int
+	MetricsPort             int
+	RoleNamespaces          map[string]string
 }
 
 // DetectFeatures detects features from parsed resources.
@@ -61,6 +65,16 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 	}
 
 	features.HasPrometheus = len(resources.ServiceMonitors) > 0
+	features.HasNetworkPolicy = len(resources.NetworkPolicies) > 0
+	for _, policy := range resources.NetworkPolicies {
+		name := policy.GetName()
+		if strings.HasSuffix(name, "allow-metrics-traffic") {
+			features.HasMetricsNetworkPolicy = true
+		}
+		if strings.HasSuffix(name, "allow-webhook-traffic") {
+			features.HasWebhookNetworkPolicy = true
+		}
+	}
 
 	for _, svc := range resources.Services {
 		name := svc.GetName()

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/categorizer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/categorizer.go
@@ -26,7 +26,7 @@ import (
 
 // ResourceCategorizer groups Kubernetes resources by their logical function, matching the config/
 // directory structure used by kubebuilder. The groups are: crd, rbac, manager, metrics, webhook,
-// cert-manager, prometheus, and extras.
+// cert-manager, prometheus, network-policy, and extras.
 //
 // This categorization determines how resources are organized in the final Helm chart templates.
 type ResourceCategorizer struct {
@@ -75,6 +75,11 @@ func (c *ResourceCategorizer) CategorizeByFunction() map[string][]*unstructured.
 	prometheusResources := c.collectPrometheusResources()
 	if len(prometheusResources) > 0 {
 		groups["prometheus"] = prometheusResources
+	}
+
+	networkPolicyResources := c.collectNetworkPolicyResources()
+	if len(networkPolicyResources) > 0 {
+		groups["network-policy"] = networkPolicyResources
 	}
 
 	extrasResources := c.collectExtrasResources()
@@ -144,6 +149,11 @@ func (c *ResourceCategorizer) collectPrometheusResources() []*unstructured.Unstr
 	prometheusResources := make([]*unstructured.Unstructured, 0, len(c.resources.ServiceMonitors))
 	prometheusResources = append(prometheusResources, c.resources.ServiceMonitors...)
 	return prometheusResources
+}
+
+// collectNetworkPolicyResources gathers network policy related resources.
+func (c *ResourceCategorizer) collectNetworkPolicyResources() []*unstructured.Unstructured {
+	return c.resources.NetworkPolicies
 }
 
 // isWebhookService determines if a service is webhook-related.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/generator.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/generator.go
@@ -133,8 +133,8 @@ func (g *TemplatesGenerator) templateResource(
 
 func (g *TemplatesGenerator) shouldSplitFiles(groupName string) bool {
 	return groupName == "crd" || groupName == "cert-manager" || groupName == "webhook" ||
-		groupName == "prometheus" || groupName == "rbac" || groupName == "metrics" ||
-		groupName == "extras"
+		groupName == "prometheus" || groupName == "network-policy" || groupName == "rbac" ||
+		groupName == "metrics" || groupName == "extras"
 }
 
 // generateFileName creates a unique filename for a resource based on its metadata.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser.go
@@ -53,6 +53,9 @@ type ParsedResources struct {
 	// Monitoring resources
 	ServiceMonitors []*unstructured.Unstructured
 
+	// Network policy resources
+	NetworkPolicies []*unstructured.Unstructured
+
 	// Other resources not fitting above categories
 	Other []*unstructured.Unstructured
 }
@@ -95,6 +98,7 @@ func (p *Parser) ParseFromReader(reader io.Reader) (*ParsedResources, error) {
 		Certificates:              make([]*unstructured.Unstructured, 0),
 		WebhookConfigurations:     make([]*unstructured.Unstructured, 0),
 		ServiceMonitors:           make([]*unstructured.Unstructured, 0),
+		NetworkPolicies:           make([]*unstructured.Unstructured, 0),
 		CustomResources:           make([]*unstructured.Unstructured, 0),
 		Other:                     make([]*unstructured.Unstructured, 0),
 	}
@@ -156,6 +160,8 @@ func (p *Parser) categorizeResource(obj *unstructured.Unstructured, resources *P
 		resources.WebhookConfigurations = append(resources.WebhookConfigurations, obj)
 	case kind == "ServiceMonitor" && apiVersion == "monitoring.coreos.com/v1":
 		resources.ServiceMonitors = append(resources.ServiceMonitors, obj)
+	case kind == "NetworkPolicy" && apiVersion == "networking.k8s.io/v1":
+		resources.NetworkPolicies = append(resources.NetworkPolicies, obj)
 	default:
 		resources.Other = append(resources.Other, obj)
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_test.go
@@ -214,6 +214,47 @@ spec:
 		})
 	})
 
+	Context("with NetworkPolicy", func() {
+		BeforeEach(func() {
+			yamlContent := `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+`
+			err := os.WriteFile(tempFile, []byte(yamlContent), 0o600)
+			Expect(err).NotTo(HaveOccurred())
+
+			parser = NewParser(tempFile)
+		})
+
+		It("should parse NetworkPolicy", func() {
+			resources, err := parser.Parse()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resources.NetworkPolicies).To(HaveLen(1))
+
+			np := resources.NetworkPolicies[0]
+			Expect(np.GetKind()).To(Equal("NetworkPolicy"))
+			Expect(np.GetName()).To(Equal("allow-metrics-traffic"))
+		})
+	})
+
 	Context("with empty or invalid YAML", func() {
 		It("should handle empty file gracefully", func() {
 			err := os.WriteFile(tempFile, []byte(""), 0o600)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -47,6 +47,11 @@ func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructu
 	case kind == common.KindServiceMonitor && apiVersion == common.APIVersionMonitoring:
 		// CRITICAL: newline before {{- end }} prevents whitespace chomping from eating content
 		return fmt.Sprintf("{{- if .Values.prometheus.enable }}\n%s\n{{- end }}", yamlContent)
+	case kind == common.KindNetworkPolicy && apiVersion == common.APIVersionNetworking:
+		if strings.HasSuffix(name, "allow-webhook-traffic") {
+			return fmt.Sprintf("{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}\n%s\n{{- end }}", yamlContent)
+		}
+		return fmt.Sprintf("{{- if .Values.networkPolicy.enable }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceAccount, kind == common.KindRole, kind == common.KindClusterRole,
 		kind == common.KindRoleBinding, kind == common.KindClusterRoleBinding:
 		return HandleRBACConditionalWrappers(yamlContent, kind, name)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -25,19 +25,20 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
-// TemplatePorts templates port numbers for Services and Deployments using values.yaml.
+// TemplatePorts templates port numbers for Services, Deployments, and NetworkPolicies using values.yaml.
 func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) string {
 	resourceName := resource.GetName()
 	resourceKind := resource.GetKind()
 
 	// Use suffix matching to avoid false positives when project name contains "webhook"
-	isWebhook := resourceKind == common.KindService &&
-		strings.HasSuffix(resourceName, "-webhook-service")
+	isWebhook := (resourceKind == common.KindService && strings.HasSuffix(resourceName, "-webhook-service")) ||
+		(resourceKind == common.KindNetworkPolicy && strings.HasSuffix(resourceName, "allow-webhook-traffic"))
 
 	// Use suffix matching to avoid false positives when project name contains "metrics"
-	isMetrics := resourceKind == common.KindService &&
+	isMetrics := (resourceKind == common.KindService &&
 		(strings.HasSuffix(resourceName, "-controller-manager-metrics-service") ||
-			strings.HasSuffix(resourceName, "-metrics-service"))
+			strings.HasSuffix(resourceName, "-metrics-service"))) ||
+		(resourceKind == common.KindNetworkPolicy && strings.HasSuffix(resourceName, "allow-metrics-traffic"))
 
 	// For Deployments, detect webhook ports from content
 	if resourceKind == common.KindDeployment {
@@ -48,6 +49,12 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 
 	// Template webhook ports
 	if isWebhook {
+		if resourceKind == common.KindNetworkPolicy {
+			yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
+				ReplaceAllString(yamlContent, "${1}port: {{ .Values.webhook.port }}")
+			return yamlContent
+		}
+
 		// Replace containerPort for webhook-server with template (matches any numeric port)
 		if strings.Contains(yamlContent, "webhook-server") {
 			yamlContent = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*webhook-server)`).
@@ -64,6 +71,10 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 		// Replace port with metrics.port template (matches any numeric port)
 		yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
 			ReplaceAllString(yamlContent, "${1}port: {{ .Values.metrics.port }}")
+
+		if resourceKind == common.KindNetworkPolicy {
+			return yamlContent
+		}
 
 		// Replace targetPort with metrics.port template (matches any numeric port)
 		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*\d+`).

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
@@ -85,7 +85,9 @@ func (t *Templater) ApplyHelmSubstitutions(yamlContent string, resource *unstruc
 		yamlContent = appliers.MakeMetricsVolumeMountsConditional(yamlContent)
 		yamlContent = appliers.MakeMetricsVolumesConditional(yamlContent)
 	}
-	if resource.GetKind() == common.KindService || resource.GetKind() == common.KindDeployment {
+	if resource.GetKind() == common.KindService ||
+		resource.GetKind() == common.KindDeployment ||
+		resource.GetKind() == common.KindNetworkPolicy {
 		yamlContent = appliers.TemplatePorts(yamlContent, resource)
 	}
 	if resource.GetKind() == common.KindServiceMonitor {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -526,6 +526,66 @@ metadata:
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
+		It("should add networkPolicy conditional for NetworkPolicy resources", func() {
+			networkPolicyResource := &unstructured.Unstructured{}
+			networkPolicyResource.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicyResource.SetKind("NetworkPolicy")
+			networkPolicyResource.SetName("allow-metrics-traffic")
+
+			content := `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager`
+
+			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
+
+			Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(result).To(ContainSubstring("{{- end }}"))
+		})
+
+		It("should add webhook conditional for webhook NetworkPolicy resources", func() {
+			networkPolicyResource := &unstructured.Unstructured{}
+			networkPolicyResource.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicyResource.SetKind("NetworkPolicy")
+			networkPolicyResource.SetName("allow-webhook-traffic")
+
+			content := `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager`
+
+			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
+
+			Expect(result).To(ContainSubstring("{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+			Expect(result).To(ContainSubstring("{{- end }}"))
+		})
+
+		It("should not wrap NetworkPolicy with wrong apiVersion", func() {
+			networkPolicyResource := &unstructured.Unstructured{}
+			networkPolicyResource.SetAPIVersion("acme.io/v1")
+			networkPolicyResource.SetKind("NetworkPolicy")
+			networkPolicyResource.SetName("custom-policy")
+
+			content := `apiVersion: acme.io/v1
+kind: NetworkPolicy
+metadata:
+  name: custom-policy`
+
+			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
+
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+		})
+
 		It("should template ServiceMonitor port and scheme based on metrics.secure", func() {
 			serviceMonitorResource := &unstructured.Unstructured{}
 			serviceMonitorResource.SetAPIVersion("monitoring.coreos.com/v1")
@@ -2429,6 +2489,72 @@ spec:
 			// Should not template regular service ports
 			Expect(result).To(ContainSubstring("port: 8080"))
 			Expect(result).To(ContainSubstring("targetPort: 8080"))
+			Expect(result).NotTo(ContainSubstring("{{ .Values"))
+		})
+
+		It("should template metrics NetworkPolicy ports", func() {
+			networkPolicy := &unstructured.Unstructured{}
+			networkPolicy.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicy.SetKind("NetworkPolicy")
+			networkPolicy.SetName("test-project-allow-metrics-traffic")
+
+			content := `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-metrics-traffic
+spec:
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP`
+
+			result := templater.templatePorts(content, networkPolicy)
+
+			Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+			Expect(result).NotTo(ContainSubstring("port: 8443"))
+		})
+
+		It("should template webhook NetworkPolicy ports", func() {
+			networkPolicy := &unstructured.Unstructured{}
+			networkPolicy.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicy.SetKind("NetworkPolicy")
+			networkPolicy.SetName("test-project-allow-webhook-traffic")
+
+			content := `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-webhook-traffic
+spec:
+  ingress:
+  - ports:
+    - port: 443
+      protocol: TCP`
+
+			result := templater.templatePorts(content, networkPolicy)
+
+			Expect(result).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+			Expect(result).NotTo(ContainSubstring("port: 443"))
+		})
+
+		It("should not template custom NetworkPolicy ports", func() {
+			networkPolicy := &unstructured.Unstructured{}
+			networkPolicy.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicy.SetKind("NetworkPolicy")
+			networkPolicy.SetName("test-project-custom-policy")
+
+			content := `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-custom-policy
+spec:
+  ingress:
+  - ports:
+    - port: 8080
+      protocol: TCP`
+
+			result := templater.templatePorts(content, networkPolicy)
+
+			Expect(result).To(ContainSubstring("port: 8080"))
 			Expect(result).NotTo(ContainSubstring("{{ .Values"))
 		})
 	})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/suite_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
+)
+
+var _ machinery.Template = &NetworkPolicy{}
+
+// NetworkPolicy scaffolds default NetworkPolicy manifests for the Helm chart.
+type NetworkPolicy struct {
+	machinery.TemplateMixin
+	machinery.ProjectNameMixin
+
+	// Webhook generates the webhook ingress policy instead of the metrics ingress policy.
+	Webhook bool
+	// OutputDir specifies the output directory for the chart.
+	OutputDir string
+	// Force if true allows overwriting the scaffolded file.
+	Force bool
+}
+
+// SetTemplateDefaults implements machinery.Template.
+func (f *NetworkPolicy) SetTemplateDefaults() error {
+	if f.Path == "" {
+		outputDir := f.OutputDir
+		if outputDir == "" {
+			outputDir = common.DefaultOutputDir
+		}
+		filename := "allow-metrics-traffic.yaml"
+		if f.Webhook {
+			filename = "allow-webhook-traffic.yaml"
+		}
+		f.Path = filepath.Join(outputDir, "chart", "templates", "network-policy", filename)
+	}
+
+	chartName := f.ProjectName
+	if f.Webhook {
+		f.TemplateBody = fmt.Sprintf(webhookNetworkPolicyTemplate, chartName, chartName, chartName)
+	} else {
+		f.TemplateBody = fmt.Sprintf(networkPolicyTemplate, chartName, chartName, chartName)
+	}
+
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
+
+	return nil
+}
+
+const networkPolicyTemplate = `{{` + "`" + `{{- if .Values.networkPolicy.enable }}` + "`" + `}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ "{{ .Release.Service }}" }}
+    app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"allow-metrics-traffic\" \"context\" $) }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: {{ "{{ .Values.metrics.port }}" }}
+          protocol: TCP
+{{` + "`" + `{{- end }}` + "`" + `}}
+`
+
+const webhookNetworkPolicyTemplate = `{{` + "`" +
+	`{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}` + "`" + `}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ "{{ .Release.Service }}" }}
+    app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+  name: {{ "{{ include \"%s.resourceName\" (dict \"suffix\" \"allow-webhook-traffic\" \"context\" $) }}" }}
+  namespace: {{ "{{ .Release.Namespace }}" }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ "{{ include \"%s.name\" . }}" }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: {{ "{{ .Values.webhook.port }}" }}
+          protocol: TCP
+{{` + "`" + `{{- end }}` + "`" + `}}
+`

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("NetworkPolicy", func() {
+	Context("SetTemplateDefaults", func() {
+		var networkPolicy *NetworkPolicy
+
+		BeforeEach(func() {
+			networkPolicy = &NetworkPolicy{
+				OutputDir: "dist",
+				Force:     true,
+			}
+			networkPolicy.InjectProjectName("test-project")
+		})
+
+		It("should set the correct path", func() {
+			err := networkPolicy.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(networkPolicy.Path).To(Equal("dist/chart/templates/network-policy/allow-metrics-traffic.yaml"))
+		})
+
+		It("should use default output dir when not specified", func() {
+			networkPolicy.OutputDir = ""
+			err := networkPolicy.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(networkPolicy.Path).To(Equal("dist/chart/templates/network-policy/allow-metrics-traffic.yaml"))
+		})
+
+		It("should set OverwriteFile action when Force is true", func() {
+			err := networkPolicy.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(networkPolicy.IfExistsAction).To(Equal(machinery.OverwriteFile))
+		})
+
+		It("should set SkipFile action when Force is false", func() {
+			networkPolicy.Force = false
+			err := networkPolicy.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(networkPolicy.IfExistsAction).To(Equal(machinery.SkipFile))
+		})
+
+		It("should generate a metrics NetworkPolicy guarded by networkPolicy.enable", func() {
+			err := networkPolicy.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring("{{`{{- if .Values.networkPolicy.enable }}`}}"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring("kind: NetworkPolicy"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
+				`name: {{ "{{ include \"test-project.resourceName\" ` +
+					`(dict \"suffix\" \"allow-metrics-traffic\" \"context\" $) }}" }}`))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring("metrics: enabled"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(`port: {{ "{{ .Values.metrics.port }}" }}`))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(`{{ "{{ include \"test-project.name\" . }}" }}`))
+			Expect(networkPolicy.TemplateBody).NotTo(ContainSubstring("allow-webhook-traffic"))
+		})
+
+		It("should add a webhook NetworkPolicy when webhooks are included", func() {
+			networkPolicy.Webhook = true
+			err := networkPolicy.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(networkPolicy.Path).To(Equal("dist/chart/templates/network-policy/allow-webhook-traffic.yaml"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
+				"{{`{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}`}}"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
+				`name: {{ "{{ include \"test-project.resourceName\" ` +
+					`(dict \"suffix\" \"allow-webhook-traffic\" \"context\" $) }}" }}`))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring("webhook: enabled"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(`port: {{ "{{ .Values.webhook.port }}" }}`))
+			Expect(networkPolicy.TemplateBody).NotTo(ContainSubstring("allow-metrics-traffic"))
+		})
+
+		It("should render Helm template syntax through machinery", func() {
+			cfg := cfgv3.New()
+			Expect(cfg.SetProjectName("test-project")).To(Succeed())
+
+			fs := afero.NewMemMapFs()
+			scaffold := machinery.NewScaffold(machinery.Filesystem{FS: fs}, machinery.WithConfig(cfg))
+			err := scaffold.Execute(&NetworkPolicy{
+				OutputDir: "dist",
+			}, &NetworkPolicy{
+				Webhook:   true,
+				OutputDir: "dist",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			metricsPolicy := string(content)
+
+			content, err = afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-webhook-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			webhookPolicy := string(content)
+
+			Expect(metricsPolicy).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(metricsPolicy).To(ContainSubstring(`{{ include "test-project.name" . }}`))
+			Expect(metricsPolicy).To(ContainSubstring(
+				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))
+			Expect(metricsPolicy).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			Expect(webhookPolicy).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+			Expect(webhookPolicy).To(ContainSubstring(`{{ include "test-project.name" . }}`))
+			Expect(webhookPolicy).To(ContainSubstring(
+				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-webhook-traffic" "context" $) }}`))
+			Expect(webhookPolicy).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+		})
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -160,6 +160,16 @@ prometheus:
 
 `)
 
+	// NetworkPolicy configuration (always present, enabled when NetworkPolicy resources exist)
+	networkPolicyEnabled := f.Extraction != nil && f.Extraction.Features.HasNetworkPolicy
+
+	buf.WriteString(`## Network policies for controlling traffic flow.
+## Enable to restrict ingress to the controller manager.
+##
+networkPolicy:
+`)
+	fmt.Fprintf(&buf, "  enable: %t\n\n", networkPolicyEnabled)
+
 	return buf.String()
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
@@ -28,6 +28,49 @@ import (
 const testProjectName = "test-project"
 
 var _ = Describe("HelmValues", func() {
+	Describe("NetworkPolicy section", func() {
+		It("should default networkPolicy.enable to false when no NetworkPolicy resources exist", func() {
+			values := &HelmValues{
+				Extraction: nil,
+			}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("networkPolicy:\n  enable: false"))
+		})
+
+		It("should set networkPolicy.enable to true when NetworkPolicy resources are detected", func() {
+			values := &HelmValues{
+				Extraction: &extractor.Extraction{
+					Features: extractor.FeatureSet{
+						HasNetworkPolicy: true,
+					},
+				},
+			}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("networkPolicy:\n  enable: true"))
+		})
+
+		It("should set networkPolicy.enable to false when HasNetworkPolicy is false", func() {
+			values := &HelmValues{
+				Extraction: &extractor.Extraction{
+					Features: extractor.FeatureSet{
+						HasNetworkPolicy: false,
+					},
+				},
+			}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("networkPolicy:\n  enable: false"))
+		})
+	})
+
 	Describe("RoleNamespaces rendering", func() {
 		Context("when no roleNamespaces are detected", func() {
 			It("should not include roleNamespaces section when Extraction is nil", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/force_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/force_integration_test.go
@@ -136,7 +136,7 @@ spec:
 	})
 
 	Context("when --force flag is NOT used", func() {
-		It("should NOT overwrite existing Chart.yaml, values.yaml, .helmignore, _helpers.tpl, NOTES.txt, and test-chart.yml", func() {
+		It("should NOT overwrite existing Chart.yaml, values.yaml, .helmignore, _helpers.tpl, NOTES.txt, test-chart.yml, and NetworkPolicy templates", func() {
 			// First generation with force=false
 			scaffolder := scaffolds.NewChartScaffolder(projectConfig, false, manifestsFile, outputDir)
 			scaffolder.InjectFS(fs)
@@ -149,6 +149,9 @@ spec:
 			helmignorePath := filepath.Join(tmpDir, outputDir, "chart", ".helmignore")
 			helpersPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "_helpers.tpl")
 			notesPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "NOTES.txt")
+			networkPolicyPath := filepath.Join(
+				tmpDir, outputDir, "chart", "templates", "network-policy", "allow-metrics-traffic.yaml",
+			)
 			testChartPath := filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml")
 
 			// Verify files exist
@@ -162,6 +165,8 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			_, err = os.ReadFile(notesPath)
 			Expect(err).NotTo(HaveOccurred())
+			_, err = os.ReadFile(networkPolicyPath)
+			Expect(err).NotTo(HaveOccurred())
 			_, err = os.ReadFile(testChartPath)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -171,6 +176,7 @@ spec:
 			customHelmignoreContent := "# CUSTOM HELMIGNORE\n*.custom\n"
 			customHelpersContent := "# CUSTOM HELPERS TPL\n{{/* custom helper */}}\n"
 			customNotesContent := "# CUSTOM NOTES\nMy custom install notes\n"
+			customNetworkPolicyContent := "# CUSTOM NETWORK POLICY\n"
 			customTestChartContent := "# CUSTOM TEST CHART\nname: Custom Workflow\n"
 
 			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
@@ -182,6 +188,8 @@ spec:
 			err = os.WriteFile(helpersPath, []byte(customHelpersContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(notesPath, []byte(customNotesContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(networkPolicyPath, []byte(customNetworkPolicyContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(testChartPath, []byte(customTestChartContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
@@ -213,6 +221,13 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(notesContent)).To(Equal(customNotesContent), "NOTES.txt should not be overwritten without --force")
 
+			networkPolicyContent, err := os.ReadFile(networkPolicyPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(networkPolicyContent)).To(
+				Equal(customNetworkPolicyContent),
+				"NetworkPolicy templates should not be overwritten without --force",
+			)
+
 			testChartContent, err := os.ReadFile(testChartPath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(testChartContent)).To(Equal(customTestChartContent), "test-chart.yml should not be overwritten without --force")
@@ -233,6 +248,9 @@ spec:
 			helmignorePath := filepath.Join(tmpDir, outputDir, "chart", ".helmignore")
 			helpersPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "_helpers.tpl")
 			notesPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "NOTES.txt")
+			networkPolicyPath := filepath.Join(
+				tmpDir, outputDir, "chart", "templates", "network-policy", "allow-metrics-traffic.yaml",
+			)
 			testChartPath := filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml")
 
 			// Modify all protected files with custom content
@@ -241,6 +259,7 @@ spec:
 			customHelmignoreContent := "# CUSTOM HELMIGNORE\n*.custom\n"
 			customHelpersContent := "# CUSTOM HELPERS TPL\n{{/* custom helper */}}\n"
 			customNotesContent := "# CUSTOM NOTES\nMy custom install notes\n"
+			customNetworkPolicyContent := "# CUSTOM NETWORK POLICY\n"
 			customTestChartContent := "# CUSTOM TEST CHART\nname: Custom Workflow\n"
 
 			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
@@ -252,6 +271,8 @@ spec:
 			err = os.WriteFile(helpersPath, []byte(customHelpersContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(notesPath, []byte(customNotesContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(networkPolicyPath, []byte(customNetworkPolicyContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(testChartPath, []byte(customTestChartContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
@@ -286,6 +307,17 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(notesContent)).NotTo(Equal(customNotesContent), "NOTES.txt should be overwritten with --force")
 			Expect(string(notesContent)).To(ContainSubstring("installed"), "NOTES.txt should contain installation message")
+
+			networkPolicyContent, err := os.ReadFile(networkPolicyPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(networkPolicyContent)).NotTo(
+				Equal(customNetworkPolicyContent),
+				"NetworkPolicy templates should be overwritten with --force",
+			)
+			Expect(string(networkPolicyContent)).To(
+				ContainSubstring("kind: NetworkPolicy"),
+				"NetworkPolicy template should contain the generated policy",
+			)
 
 			testChartContent, err := os.ReadFile(testChartPath)
 			Expect(err).NotTo(HaveOccurred())

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enable }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+  name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "allow-webhook-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: {{ .Values.webhook.port }}
+          protocol: TCP
+{{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -194,3 +194,9 @@ webhook:
 prometheus:
   enable: false
 
+## Network policies for controlling traffic flow.
+## Enable to restrict ingress to the controller manager.
+##
+networkPolicy:
+  enable: false
+


### PR DESCRIPTION
## Summary

Fixes #5471

The helm/v2-alpha plugin has inconsistent handling between `prometheus` and `network-policy` options. Prometheus always emits `prometheus.enable: false` in values.yaml with conditional template guards, but NetworkPolicy resources get no values.yaml entry and no conditional wrapper — making it impossible to toggle NetworkPolicy via Helm values alone.

This PR adds NetworkPolicy support following the same pattern as prometheus and certManager:

- **Parser**: Recognizes `kind: NetworkPolicy` with `apiVersion: networking.k8s.io/v1`
- **Feature detection**: `HasNetworkPolicy` flag set when NetworkPolicy resources exist
- **Categorizer**: Groups NetworkPolicy resources into `"network-policy"` template directory
- **Conditional wrapper**: Wraps templates with `{{- if .Values.networkPolicy.enable }}`
- **values.yaml**: Emits `networkPolicy.enable` — defaults to `true` when NetworkPolicy resources are present in kustomize input, `false` otherwise (matching the certManager pattern)
- **Generator**: Splits network-policy group into individual files

## Changes

| File | Change |
|---|---|
| `consts.go` | Add `KindNetworkPolicy` + `APIVersionNetworking` constants |
| `parser.go` | Add `NetworkPolicies` field + switch case |
| `extractor.go` | Add `NetworkPolicies` to `ResourceSet` |
| `features.go` | Add `HasNetworkPolicy` flag + detection |
| `chart_scaffolder.go` | Map `NetworkPolicies` to extractor |
| `categorizer.go` | Add `"network-policy"` group |
| `conditionals.go` | Add conditional wrapper with apiVersion check |
| `values.go` | Add dynamic `networkPolicy.enable` section |
| `generator.go` | Add `"network-policy"` to `shouldSplitFiles` |

## Test plan

- [x] Unit tests: parser recognizes NetworkPolicy resources
- [x] Unit tests: values.yaml emits `networkPolicy:\n  enable: true` when detected
- [x] Unit tests: values.yaml emits `networkPolicy:\n  enable: false` when absent
- [x] Unit tests: conditional wrapper applied for correct apiVersion
- [x] Unit tests: conditional wrapper NOT applied for wrong apiVersion
- [x] All existing tests continue to pass
- [ ] Integration test with `kubebuilder init --plugins=helm/v2-alpha` + `kubebuilder edit` (requires integration tag)