### PR TITLE
✨(go/v4) Upgrade golang-ci from v2.11.4 to v2.12.2

### DIFF
--- a/.github/workflows/lint-sample.yml
+++ b/.github/workflows/lint-sample.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.11.4
+          version: v2.12.2
           working-directory: ${{ matrix.folder }}
       - name: Run linter via makefile target
         working-directory: ${{ matrix.folder }}

--- a/.github/workflows/verify-all.yml
+++ b/.github/workflows/verify-all.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run golangci-lint with PR comments
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.11.4
+          version: v2.12.2
 
   verify-license:
     name: License verification

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ KUBE_LINTER ?= $(LOCALBIN)/kube-linter
 
 ## Tool Versions
 GO_APIDIFF_VERSION ?= v0.8.3
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 KUBE_LINTER_VERSION ?= v0.8.3
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/docs/book/src/cronjob-tutorial/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/docs/book/src/cronjob-tutorial/testdata/project/Makefile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Makefile
@@ -208,7 +208,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/docs/book/src/getting-started/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/getting-started/testdata/project/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/docs/book/src/getting-started/testdata/project/Makefile
+++ b/docs/book/src/getting-started/testdata/project/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/docs/book/src/getting-started/testdata/project/internal/controller/conditions.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/conditions.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+const (
+	reasonReconciling = "Reconciling"
+)

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller.go
@@ -43,6 +43,8 @@ const (
 	typeAvailableMemcached = "Available"
 )
 
+const memcachedContainerName = "memcached"
+
 // MemcachedReconciler reconciles a Memcached object
 type MemcachedReconciler struct {
 	client.Client
@@ -91,7 +93,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Let's just set the status as Unknown when no status is available
 	if len(memcached.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
@@ -119,7 +121,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -194,7 +196,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, memcached); err != nil {
@@ -242,7 +244,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 					},
 					Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "memcached",
+						Name:            memcachedContainerName,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
@@ -258,7 +260,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 11211,
-							Name:          "memcached",
+							Name:          memcachedContainerName,
 						}},
 						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller_test.go
@@ -35,13 +35,16 @@ import (
 
 var _ = Describe("Memcached Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default" // TODO(user): Modify as needed
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		memcached := &cachev1alpha1.Memcached{}
 
@@ -52,7 +55,7 @@ var _ = Describe("Memcached Controller", func() {
 				resource := &cachev1alpha1.Memcached{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					Spec: cachev1alpha1.MemcachedSpec{
 						Size: ptr.To(int32(1)),

--- a/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/memcached_controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Memcached Controller", func() {
 	Context("When reconciling a resource", func() {
 		const (
 			resourceName      = "test-resource"
-			resourceNamespace = "default" // TODO(user): Modify as needed
+			resourceNamespace = "default"
 		)
 
 		ctx := context.Background()
@@ -104,7 +104,7 @@ var _ = Describe("Memcached Controller", func() {
 				HaveField("Type", Equal(typeAvailableMemcached)), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailableMemcached)
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailableMemcached)
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailableMemcached)
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailableMemcached)
 		})
 	})
 })

--- a/docs/book/src/multiversion-tutorial/testdata/project/.custom-gcl.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/docs/book/src/multiversion-tutorial/testdata/project/Makefile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Makefile
@@ -208,7 +208,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -36,7 +36,12 @@ import (
 var _ = Describe("CronJob controller", func() {
 	Context("CronJob controller test", func() {
 
-		const NamespaceName = "test-cronjob"
+		const (
+			NamespaceName      = "test-cronjob"
+			testSchedule       = "1 * * * *"
+			testContainerName  = "test-container"
+			testContainerImage = "test-image"
+		)
 
 		ctx := context.Background()
 
@@ -77,15 +82,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -121,15 +126,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -183,15 +188,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -215,8 +220,8 @@ var _ = Describe("CronJob controller", func() {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Name:  "test-container",
-									Image: "test-image",
+									Name:  testContainerName,
+									Image: testContainerImage,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,
@@ -279,15 +284,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -311,8 +316,8 @@ var _ = Describe("CronJob controller", func() {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Name:  "test-container",
-									Image: "test-image",
+									Name:  testContainerName,
+									Image: testContainerImage,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,
@@ -384,15 +389,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,

--- a/hack/docs/internal/getting-started/generate_getting_started.go
+++ b/hack/docs/internal/getting-started/generate_getting_started.go
@@ -18,6 +18,7 @@ package gettingstarted
 
 import (
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -42,6 +43,7 @@ func NewSample(binaryPath, samplePath string) Sample {
 func (sp *Sample) UpdateTutorial() {
 	sp.updateAPI()
 	sp.updateSample()
+	sp.updateConditions()
 	sp.updateController()
 	sp.updateControllerTest()
 }
@@ -90,7 +92,7 @@ func (sp *Sample) updateControllerTest() {
 				HaveField("Type", Equal(typeAvailableMemcached)), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailableMemcached)
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailableMemcached)
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailableMemcached)`,
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailableMemcached)`,
 	)
 	hackutils.CheckError("add spec apis", err)
 }
@@ -125,6 +127,12 @@ func (sp *Sample) updateSample() {
 	file := filepath.Join(sp.ctx.Dir, "config/samples/cache_v1alpha1_memcached.yaml")
 	err := pluginutil.ReplaceInFile(file, "# TODO(user): Add fields here", sampleSizeFragment)
 	hackutils.CheckError("update sample to add size", err)
+}
+
+func (sp *Sample) updateConditions() {
+	path := filepath.Join(sp.ctx.Dir, "internal/controller/conditions.go")
+	err := os.WriteFile(path, []byte(controllerConditionsFile), 0o644)
+	hackutils.CheckError("write conditions.go", err)
 }
 
 func (sp *Sample) updateController() {
@@ -279,7 +287,33 @@ const controllerStatusTypes = `
 const (
 	// typeAvailableMemcached represents the status of the Deployment reconciliation
 	typeAvailableMemcached = "Available"
-)`
+)
+
+const memcachedContainerName = "memcached"
+`
+
+const controllerConditionsFile = `/*
+Copyright 2026 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+const (
+	reasonReconciling = "Reconciling"
+)
+`
 
 const controllerInfoReconcileOld = `// TODO(user): Modify the Reconcile function to compare the state specified by
 // the Memcached object against the actual cluster state, and then
@@ -314,7 +348,7 @@ const controllerReconcileImplementation = `// Fetch the Memcached instance
 
 	// Let's just set the status as Unknown when no status is available
 	if len(memcached.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
@@ -342,7 +376,7 @@ const controllerReconcileImplementation = `// Fetch the Memcached instance
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -417,7 +451,7 @@ const controllerReconcileImplementation = `// Fetch the Memcached instance
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, memcached); err != nil {
@@ -453,7 +487,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 					},
 					Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "memcached",
+						Name:            memcachedContainerName,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
@@ -469,7 +503,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 11211,
-							Name:          "memcached",
+							Name:          memcachedContainerName,
 						}},
 						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},

--- a/hack/docs/internal/multiversion-tutorial/controller_tests_code.go
+++ b/hack/docs/internal/multiversion-tutorial/controller_tests_code.go
@@ -54,7 +54,12 @@ import (
 var _ = Describe("CronJob controller", func() {
 	Context("CronJob controller test", func() {
 
-		const NamespaceName = "test-cronjob"
+		const (
+			NamespaceName      = "test-cronjob"
+			testSchedule       = "1 * * * *"
+			testContainerName  = "test-container"
+			testContainerImage = "test-image"
+		)
 
 		ctx := context.Background()
 
@@ -95,15 +100,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -139,15 +144,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -201,15 +206,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -233,8 +238,8 @@ var _ = Describe("CronJob controller", func() {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Name:  "test-container",
-									Image: "test-image",
+									Name:  testContainerName,
+									Image: testContainerImage,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,
@@ -297,15 +302,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,
@@ -329,8 +334,8 @@ var _ = Describe("CronJob controller", func() {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Name:  "test-container",
-									Image: "test-image",
+									Name:  testContainerName,
+									Image: testContainerImage,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,
@@ -402,15 +407,15 @@ var _ = Describe("CronJob controller", func() {
 					Namespace: NamespaceName,
 				},
 				Spec: cronjobv1.CronJobSpec{
-					Schedule: "1 * * * *",
+					Schedule: testSchedule,
 					JobTemplate: batchv1.JobTemplateSpec{
 						Spec: batchv1.JobSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
-											Name:  "test-container",
-											Image: "test-image",
+											Name:  testContainerName,
+											Image: testContainerImage,
 										},
 									},
 									RestartPolicy: v1.RestartPolicyOnFailure,

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -37,6 +37,16 @@ import (
 	helmv2alpha "sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha"
 )
 
+const (
+	flagPlugins                  = "--plugins"
+	kubebuilderSubcommandCreate  = "create"
+	kubebuilderSubcommandEdit    = "edit"
+	kubebuilderSubcommandAPI     = "api"
+	pluginGoKubebuilderV4        = "go.kubebuilder.io/v4"
+	pluginHelmKubebuilderV1Alpha = "helm.kubebuilder.io/v1-alpha"
+	pluginHelmKubebuilderV2Alpha = "helm.kubebuilder.io/v2-alpha"
+)
+
 // Generate store the required info for the command
 type Generate struct {
 	InputDir           string
@@ -371,7 +381,7 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 		return nil
 	}
 
-	args := []string{"edit", "--plugins", plugin.KeyFor(autoupdatev1alpha.Plugin{})}
+	args := []string{kubebuilderSubcommandEdit, flagPlugins, plugin.KeyFor(autoupdatev1alpha.Plugin{})}
 	if autoUpdatePlugin.UseGHModels {
 		args = append(args, "--use-gh-models")
 	}
@@ -433,7 +443,10 @@ func migrateDeployImagePlugin(s store.Store) error {
 
 // Creates an API with Deploy Image plugin.
 func createAPIWithDeployImage(resourceData deployimagev1alpha1.ResourceData) error {
-	args := append([]string{"create", "api"}, getGVKFlagsFromDeployImage(resourceData)...)
+	args := append(
+		[]string{kubebuilderSubcommandCreate, kubebuilderSubcommandAPI},
+		getGVKFlagsFromDeployImage(resourceData)...,
+	)
 	args = append(args, getDeployImageOptions(resourceData)...)
 	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run kubebuilder create api command: %w", err)
@@ -454,10 +467,10 @@ func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string
 
 	// Define outdated plugin versions that need replacement
 	outdatedPlugins := map[string]string{
-		"go.kubebuilder.io/v3":         "go.kubebuilder.io/v4",
-		"go.kubebuilder.io/v3-alpha":   "go.kubebuilder.io/v4",
-		"go.kubebuilder.io/v2":         "go.kubebuilder.io/v4",
-		"helm.kubebuilder.io/v1-alpha": "helm.kubebuilder.io/v2-alpha",
+		"go.kubebuilder.io/v3":       pluginGoKubebuilderV4,
+		"go.kubebuilder.io/v3-alpha": pluginGoKubebuilderV4,
+		"go.kubebuilder.io/v2":       pluginGoKubebuilderV4,
+		pluginHelmKubebuilderV1Alpha: pluginHelmKubebuilderV2Alpha,
 	}
 
 	// Replace outdated plugins and exit after the first replacement
@@ -473,7 +486,7 @@ func getInitArgs(s store.Store, opts *Generate, tempLicenseFile string) []string
 	}
 
 	if len(plugins) > 0 {
-		args = append(args, "--plugins", strings.Join(plugins, ","))
+		args = append(args, flagPlugins, strings.Join(plugins, ","))
 	}
 	if domain := s.Config().GetDomain(); domain != "" {
 		args = append(args, "--domain", domain)
@@ -555,7 +568,7 @@ func getDeployImageOptions(resourceData deployimagev1alpha1.ResourceData) []stri
 // Creates an API resource.
 // Controllers are scaffolded separately to support multiple controllers per API.
 func createAPI(res resource.Resource) error {
-	args := append([]string{"create", "api"}, getGVKFlags(res)...)
+	args := append([]string{kubebuilderSubcommandCreate, kubebuilderSubcommandAPI}, getGVKFlags(res)...)
 	args = append(args, getAPIResourceFlags(res)...)
 
 	// Add the external API flags if the resource is external
@@ -596,7 +609,7 @@ func createControllers(res resource.Resource) error {
 
 // Creates a single controller for a resource with a specific name.
 func createControllerWithName(res resource.Resource, controllerName string) error {
-	args := append([]string{"create", "api"}, getGVKFlags(res)...)
+	args := append([]string{kubebuilderSubcommandCreate, kubebuilderSubcommandAPI}, getGVKFlags(res)...)
 
 	// Always set --resource=false since we're only creating the controller
 	args = append(args, "--resource=false")
@@ -721,7 +734,7 @@ func grafanaConfigMigrate(src, des string) error {
 
 // Edits the project to include the Grafana plugin.
 func kubebuilderGrafanaEdit() error {
-	args := []string{"edit", "--plugins", plugin.KeyFor(grafanav1alpha.Plugin{})}
+	args := []string{kubebuilderSubcommandEdit, flagPlugins, plugin.KeyFor(grafanav1alpha.Plugin{})}
 	if err := util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Grafana plugin: %w", err)
 	}
@@ -744,7 +757,7 @@ func kubebuilderHelmEditWithConfig(s store.Store) error {
 
 	// Use tracked configuration values
 	pluginKey := plugin.KeyFor(helmv2alpha.Plugin{})
-	args := []string{"edit", "--plugins", pluginKey}
+	args := []string{kubebuilderSubcommandEdit, flagPlugins, pluginKey}
 	if cfg.ManifestsFile != "" {
 		args = append(args, "--manifests", cfg.ManifestsFile)
 	}
@@ -767,7 +780,7 @@ func kubebuilderHelmEdit(isV2Alpha bool) error {
 		pluginKey = plugin.KeyFor(helmv1alpha.Plugin{})
 	}
 
-	args := []string{"edit", "--plugins", pluginKey}
+	args := []string{kubebuilderSubcommandEdit, flagPlugins, pluginKey}
 	if err := util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Helm plugin: %w", err)
 	}

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -94,6 +94,18 @@ type fakeStore struct {
 
 func (f *fakeStore) Config() config.Config { return f.cfg }
 
+const (
+	exampleDomain      = "example.com"
+	fooKind            = "Foo"
+	exampleKind        = "Example"
+	fixtureTest        = "test"
+	certManagerAPIPath = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certificateKind    = "Certificate"
+	certManagerGroup   = "cert-manager"
+	examplesDir        = "examples"
+	exampleRepo        = "github.com/example/repo"
+)
+
 func TestGenerateHelpers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Generate helpers Suite")
@@ -333,43 +345,48 @@ var _ = Describe("generate: file-helpers", func() {
 })
 
 var _ = Describe("generate: get-args-helpers", func() {
+	const (
+		fooDomain = "foo.com"
+		barRepo   = "bar"
+	)
+
 	// getInitArgs
 	Describe("getInitArgs", func() {
 		Context("for outdated plugins", func() {
 			When("v3 plugin is used", func() {
 				It("should return correct args for plugins, domain, repo", func() {
-					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3"}, domain: "foo.com", repo: "bar"}
+					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3"}, domain: fooDomain, repo: barRepo}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo))
 				})
 			})
 
 			When("alpha plugin is used", func() {
 				It("should return correct args for plugins, domain, repo", func() {
-					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3-alpha"}, domain: "foo.com", repo: "bar"}
+					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v3-alpha"}, domain: fooDomain, repo: barRepo}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo))
 				})
 			})
 
 			When("helm v1-alpha plugin is used", func() {
 				It("should replace with helm v2-alpha", func() {
 					cfg := &fakeConfig{
-						pluginChain: []string{"go.kubebuilder.io/v4", "helm.kubebuilder.io/v1-alpha"},
-						domain:      "foo.com",
-						repo:        "bar",
+						pluginChain: []string{pluginGoKubebuilderV4, pluginHelmKubebuilderV1Alpha},
+						domain:      fooDomain,
+						repo:        barRepo,
 					}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
 					Expect(args).To(ContainElements(
 						"--skip-go-version-check",
-						"--plugins", ContainSubstring("helm.kubebuilder.io/v2-alpha"),
-						"--domain", "foo.com", "--repo", "bar"))
-					Expect(args).NotTo(ContainElement(ContainSubstring("helm.kubebuilder.io/v1-alpha")))
+						flagPlugins, ContainSubstring(pluginHelmKubebuilderV2Alpha),
+						"--domain", fooDomain, "--repo", barRepo))
+					Expect(args).NotTo(ContainElement(ContainSubstring(pluginHelmKubebuilderV1Alpha)))
 				})
 			})
 		})
@@ -377,84 +394,84 @@ var _ = Describe("generate: get-args-helpers", func() {
 		Context("for latest plugins", func() {
 			When("latest plugin (v4) is used", func() {
 				It("returns correct args for plugins, domain, repo", func() {
-					cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v4"}, domain: "foo.com", repo: "bar"}
+					cfg := &fakeConfig{pluginChain: []string{pluginGoKubebuilderV4}, domain: fooDomain, repo: barRepo}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo))
 				})
 			})
 
 			When("project name is set", func() {
 				It("returns correct args including project name", func() {
 					cfg := &fakeConfig{
-						pluginChain: []string{"go.kubebuilder.io/v4"},
-						domain:      "foo.com",
-						repo:        "bar",
+						pluginChain: []string{pluginGoKubebuilderV4},
+						domain:      fooDomain,
+						repo:        barRepo,
 						projectName: "my-project",
 					}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar", "--project-name", "my-project"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo, "--project-name", "my-project"))
 				})
 			})
 
 			When("multigroup flag is enabled", func() {
 				It("includes --multigroup in init args", func() {
 					cfg := &fakeConfig{
-						pluginChain: []string{"go.kubebuilder.io/v4"},
-						domain:      "foo.com",
-						repo:        "bar",
+						pluginChain: []string{pluginGoKubebuilderV4},
+						domain:      fooDomain,
+						repo:        barRepo,
 						multigroup:  true,
 					}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar", "--multigroup"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo, "--multigroup"))
 				})
 			})
 
 			When("namespaced flag is enabled", func() {
 				It("includes --namespaced in init args", func() {
 					cfg := &fakeConfig{
-						pluginChain: []string{"go.kubebuilder.io/v4"},
-						domain:      "foo.com",
-						repo:        "bar",
+						pluginChain: []string{pluginGoKubebuilderV4},
+						domain:      fooDomain,
+						repo:        barRepo,
 						namespaced:  true,
 					}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar", "--namespaced"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo, "--namespaced"))
 				})
 			})
 
 			When("both multigroup and namespaced are enabled", func() {
 				It("includes both flags in init args", func() {
 					cfg := &fakeConfig{
-						pluginChain: []string{"go.kubebuilder.io/v4"},
-						domain:      "foo.com",
-						repo:        "bar",
+						pluginChain: []string{pluginGoKubebuilderV4},
+						domain:      fooDomain,
+						repo:        barRepo,
 						multigroup:  true,
 						namespaced:  true,
 					}
 					store := &fakeStore{cfg: cfg}
 					args := getInitArgs(store, &Generate{SkipGoVersionCheck: true}, "")
-					Expect(args).To(ContainElements("--skip-go-version-check", "--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-						"--domain", "foo.com", "--repo", "bar", "--multigroup", "--namespaced"))
+					Expect(args).To(ContainElements("--skip-go-version-check", flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+						"--domain", fooDomain, "--repo", barRepo, "--multigroup", "--namespaced"))
 				})
 			})
 		})
 
 		Context("when skipGoVersionCheck is false", func() {
 			It("does not include --skip-go-version-check", func() {
-				cfg := &fakeConfig{pluginChain: []string{"go.kubebuilder.io/v4"}, domain: "foo.com", repo: "bar"}
+				cfg := &fakeConfig{pluginChain: []string{pluginGoKubebuilderV4}, domain: fooDomain, repo: barRepo}
 				store := &fakeStore{cfg: cfg}
 				args := getInitArgs(store, &Generate{SkipGoVersionCheck: false}, "")
 				Expect(args).NotTo(ContainElement("--skip-go-version-check"))
-				Expect(args).To(ContainElements("--plugins", ContainSubstring("go.kubebuilder.io/v4"),
-					"--domain", "foo.com", "--repo", "bar"))
+				Expect(args).To(ContainElements(flagPlugins, ContainSubstring(pluginGoKubebuilderV4),
+					"--domain", fooDomain, "--repo", barRepo))
 			})
 		})
 	})
@@ -463,20 +480,22 @@ var _ = Describe("generate: get-args-helpers", func() {
 	Context("getGVKFlags", func() {
 		It("returns correct flags", func() {
 			res := resource.Resource{Plural: "foos"}
-			res.Group = "example.com"
+			res.Group = exampleDomain
 			res.Version = "v1"
-			res.Kind = "Foo"
+			res.Kind = fooKind
 			flags := getGVKFlags(res)
-			Expect(flags).To(ContainElements("--plural", "foos", "--group", "example.com", "--version", "v1", "--kind", "Foo"))
+			Expect(flags).To(ContainElements(
+				"--plural", "foos", "--group", exampleDomain, "--version", "v1", "--kind", fooKind,
+			))
 		})
 	})
 
 	// getGVKFlagsFromDeployImage
 	Context("getGVKFlagsFromDeployImage", func() {
 		It("returns correct flags", func() {
-			rd := deployimagev1alpha1.ResourceData{Group: "example.com", Version: "v1", Kind: "Foo"}
+			rd := deployimagev1alpha1.ResourceData{Group: exampleDomain, Version: "v1", Kind: fooKind}
 			flags := getGVKFlagsFromDeployImage(rd)
-			Expect(flags).To(ContainElements("--group", "example.com", "--version", "v1", "--kind", "Foo"))
+			Expect(flags).To(ContainElements("--group", exampleDomain, "--version", "v1", "--kind", fooKind))
 		})
 	})
 
@@ -487,12 +506,12 @@ var _ = Describe("generate: get-args-helpers", func() {
 			rd.Options.Image = "test-kubebuilder"
 			rd.Options.ContainerCommand = "echo 'Hello'"
 			rd.Options.ContainerPort = "8000"
-			rd.Options.RunAsUser = "test"
+			rd.Options.RunAsUser = fixtureTest
 			opts := getDeployImageOptions(rd)
 			Expect(opts).To(ContainElements("--image=test-kubebuilder",
 				"--image-container-command=echo 'Hello'",
 				"--image-container-port=8000",
-				"--run-as-user=test",
+				"--run-as-user="+fixtureTest,
 				"--plugins=deploy-image.go.kubebuilder.io/v1-alpha"))
 		})
 	})
@@ -528,7 +547,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 		It("returns correct flags for specified resources", func() {
 			res := resource.Resource{
 				Path:     "external/test",
-				GVK:      resource.GVK{Group: "example.com", Version: "v1", Kind: "Example", Domain: "test"},
+				GVK:      resource.GVK{Group: exampleDomain, Version: "v1", Kind: exampleKind, Domain: fixtureTest},
 				External: true,
 				Webhooks: &resource.Webhooks{
 					Validation: true,
@@ -538,15 +557,18 @@ var _ = Describe("generate: get-args-helpers", func() {
 				},
 			}
 			flags := getWebhookResourceFlags(res)
-			Expect(flags).To(ContainElements("--external-api-path", "external/test", "--external-api-domain", "test",
-				"--programmatic-validation", "--defaulting", "--conversion", "--spoke", "v2"))
+			Expect(flags).To(ContainElements(
+				"--external-api-path", "external/test",
+				"--external-api-domain", fixtureTest,
+				"--programmatic-validation", "--defaulting", "--conversion", "--spoke", "v2",
+			))
 		})
 
 		It("returns correct flags for external resources with module version", func() {
 			res := resource.Resource{
-				Path:     "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1",
+				Path:     certManagerAPIPath,
 				Module:   "github.com/cert-manager/cert-manager@v1.18.2",
-				GVK:      resource.GVK{Group: "cert-manager", Version: "v1", Kind: "Certificate", Domain: "io"},
+				GVK:      resource.GVK{Group: certManagerGroup, Version: "v1", Kind: certificateKind, Domain: "io"},
 				External: true,
 				Webhooks: &resource.Webhooks{
 					Defaulting: true,
@@ -554,7 +576,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 			}
 			flags := getWebhookResourceFlags(res)
 			Expect(flags).To(ContainElement("--external-api-path"))
-			Expect(flags).To(ContainElement("github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"))
+			Expect(flags).To(ContainElement(certManagerAPIPath))
 			Expect(flags).To(ContainElement("--external-api-domain"))
 			Expect(flags).To(ContainElement("io"))
 			Expect(flags).To(ContainElement("--external-api-module"))
@@ -564,9 +586,9 @@ var _ = Describe("generate: get-args-helpers", func() {
 
 		It("returns correct flags for external resources WITHOUT module version", func() {
 			res := resource.Resource{
-				Path:     "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1",
+				Path:     certManagerAPIPath,
 				Module:   "", // No module specified
-				GVK:      resource.GVK{Group: "cert-manager", Version: "v1", Kind: "Certificate", Domain: "io"},
+				GVK:      resource.GVK{Group: certManagerGroup, Version: "v1", Kind: certificateKind, Domain: "io"},
 				External: true,
 				Webhooks: &resource.Webhooks{
 					Defaulting: true,
@@ -574,7 +596,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 			}
 			flags := getWebhookResourceFlags(res)
 			Expect(flags).To(ContainElement("--external-api-path"))
-			Expect(flags).To(ContainElement("github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"))
+			Expect(flags).To(ContainElement(certManagerAPIPath))
 			Expect(flags).To(ContainElement("--external-api-domain"))
 			Expect(flags).To(ContainElement("io"))
 			Expect(flags).NotTo(ContainElement("--external-api-module"))
@@ -612,8 +634,8 @@ var _ = Describe("generate: create-helpers", func() {
 		Context("Without External flag", func() {
 			It("runs kubebuilder create api successfully for a resource", func() {
 				res := resource.Resource{
-					GVK:        resource.GVK{Group: "example.com", Version: "v1", Kind: "Example", Domain: "test"},
-					Plural:     "examples",
+					GVK:        resource.GVK{Group: exampleDomain, Version: "v1", Kind: exampleKind, Domain: fixtureTest},
+					Plural:     examplesDir,
 					API:        &resource.API{Namespaced: true},
 					Controller: true,
 				}
@@ -625,8 +647,8 @@ var _ = Describe("generate: create-helpers", func() {
 		Context("With External flag set", func() {
 			It("runs kubebuilder create api successfully for a resource", func() {
 				res := resource.Resource{
-					GVK:        resource.GVK{Group: "example.com", Version: "v1", Kind: "Example", Domain: "external"},
-					Plural:     "examples",
+					GVK:        resource.GVK{Group: exampleDomain, Version: "v1", Kind: exampleKind, Domain: "external"},
+					Plural:     examplesDir,
 					API:        &resource.API{Namespaced: true},
 					Controller: true,
 					External:   true,
@@ -638,12 +660,12 @@ var _ = Describe("generate: create-helpers", func() {
 
 			It("runs kubebuilder create api successfully with module version", func() {
 				res := resource.Resource{
-					GVK:        resource.GVK{Group: "cert-manager", Version: "v1", Kind: "Certificate", Domain: "io"},
+					GVK:        resource.GVK{Group: certManagerGroup, Version: "v1", Kind: certificateKind, Domain: "io"},
 					Plural:     "certificates",
 					API:        nil, // External resources typically don't scaffold API
 					Controller: true,
 					External:   true,
-					Path:       "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1",
+					Path:       certManagerAPIPath,
 					Module:     "github.com/cert-manager/cert-manager@v1.18.2",
 				}
 				// Run createAPI and verify no errors
@@ -652,12 +674,12 @@ var _ = Describe("generate: create-helpers", func() {
 
 			It("runs kubebuilder create api successfully WITHOUT module version", func() {
 				res := resource.Resource{
-					GVK:        resource.GVK{Group: "cert-manager", Version: "v1", Kind: "Certificate", Domain: "io"},
+					GVK:        resource.GVK{Group: certManagerGroup, Version: "v1", Kind: certificateKind, Domain: "io"},
 					Plural:     "certificates",
 					API:        nil,
 					Controller: true,
 					External:   true,
-					Path:       "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1",
+					Path:       certManagerAPIPath,
 					Module:     "", // No module specified
 				}
 				// Run createAPI and verify no errors
@@ -670,8 +692,8 @@ var _ = Describe("generate: create-helpers", func() {
 	Describe("createWebhook", func() {
 		It("runs kubebuilder create webhook successfully for a resource", func() {
 			res := resource.Resource{
-				GVK:      resource.GVK{Group: "example.com", Version: "v1", Kind: "Example", Domain: "test"},
-				Plural:   "examples",
+				GVK:      resource.GVK{Group: exampleDomain, Version: "v1", Kind: exampleKind, Domain: fixtureTest},
+				Plural:   examplesDir,
 				Webhooks: &resource.Webhooks{WebhookVersion: "v1"},
 			}
 			// Run createWebhook and verify no errors
@@ -680,8 +702,8 @@ var _ = Describe("generate: create-helpers", func() {
 
 		It("ignores web creation if webhook resource is empty", func() {
 			res := resource.Resource{
-				GVK:      resource.GVK{Group: "example.com", Version: "v1", Kind: "Example", Domain: "test"},
-				Plural:   "examples",
+				GVK:      resource.GVK{Group: exampleDomain, Version: "v1", Kind: exampleKind, Domain: fixtureTest},
+				Plural:   examplesDir,
 				Webhooks: &resource.Webhooks{},
 			}
 			// Run createWebhook and verify no errors
@@ -692,9 +714,9 @@ var _ = Describe("generate: create-helpers", func() {
 	Describe("createAPIWithDeployImage", func() {
 		It("runs kubebuilder create api successfully with deploy image", func() {
 			resourceData := deployimagev1alpha1.ResourceData{
-				Group:   "example.com",
+				Group:   exampleDomain,
 				Version: "v1",
-				Kind:    "Example",
+				Kind:    exampleKind,
 			}
 			resourceData.Options.Image = "example-image"
 			resourceData.Options.ContainerCommand = "run"
@@ -708,10 +730,10 @@ var _ = Describe("generate: create-helpers", func() {
 			// This test validates that deploy-image plugin can work with external APIs
 			// even without pinned versions (backward compatibility)
 			resourceData := deployimagev1alpha1.ResourceData{
-				Group:   "cert-manager",
+				Group:   certManagerGroup,
 				Domain:  "io",
 				Version: "v1",
-				Kind:    "Certificate",
+				Kind:    certificateKind,
 			}
 			resourceData.Options.Image = "busybox:1.36.1"
 			resourceData.Options.RunAsUser = "1001"
@@ -724,7 +746,7 @@ var _ = Describe("generate: create-helpers", func() {
 			// deploy-image plugin still works correctly
 			// Note: The release field is stored in the Resource, not in DeployImage's ResourceData
 			resourceData := deployimagev1alpha1.ResourceData{
-				Group:   "example.com",
+				Group:   exampleDomain,
 				Version: "v1",
 				Kind:    "Memcached",
 			}
@@ -776,9 +798,9 @@ var _ = Describe("generate: kubebuilder", func() {
 	Context("kubebuilderInit", func() {
 		It("runs kubebuilder init successfully", func() {
 			cfg := &fakeConfig{
-				pluginChain: []string{"go.kubebuilder.io/v4"},
-				domain:      "example.com",
-				repo:        "github.com/example/repo",
+				pluginChain: []string{pluginGoKubebuilderV4},
+				domain:      exampleDomain,
+				repo:        exampleRepo,
 			}
 			store := &fakeStore{cfg: cfg}
 			Expect(kubebuilderInit(store, &Generate{SkipGoVersionCheck: true}, "")).To(Succeed())
@@ -789,8 +811,8 @@ var _ = Describe("generate: kubebuilder", func() {
 		It("runs kubebuilder create successfully for resources", func() {
 			cfg := &fakeConfig{
 				resources: []resource.Resource{
-					{Plural: "foos", GVK: resource.GVK{Group: "example.com", Version: "v1", Kind: "Foo"}},
-					{Plural: "bars", GVK: resource.GVK{Group: "example.com", Version: "v1", Kind: "Bar"}},
+					{Plural: "foos", GVK: resource.GVK{Group: exampleDomain, Version: "v1", Kind: fooKind}},
+					{Plural: "bars", GVK: resource.GVK{Group: exampleDomain, Version: "v1", Kind: "Bar"}},
 				},
 			}
 			store := &fakeStore{cfg: cfg}
@@ -816,7 +838,7 @@ var _ = Describe("generate: kubebuilder", func() {
 
 var _ = Describe("generate: hasHelmPlugin", func() {
 	It("returns true if v2-alpha plugin present", func() {
-		cfg := &fakeConfig{plugins: map[string]any{"helm.kubebuilder.io/v2-alpha": true}}
+		cfg := &fakeConfig{plugins: map[string]any{pluginHelmKubebuilderV2Alpha: true}}
 		store := &fakeStore{cfg: cfg}
 		hasPlugin, isV2Alpha := hasHelmPlugin(store)
 		Expect(hasPlugin).To(BeTrue())
@@ -824,7 +846,7 @@ var _ = Describe("generate: hasHelmPlugin", func() {
 	})
 
 	It("returns true if v1-alpha plugin present", func() {
-		cfg := &fakeConfig{plugins: map[string]any{"helm.kubebuilder.io/v1-alpha": true}}
+		cfg := &fakeConfig{plugins: map[string]any{pluginHelmKubebuilderV1Alpha: true}}
 		store := &fakeStore{cfg: cfg}
 		hasPlugin, isV2Alpha := hasHelmPlugin(store)
 		Expect(hasPlugin).To(BeTrue())
@@ -844,9 +866,9 @@ var _ = Describe("generate: boilerplate preservation", func() {
 	Describe("getInitArgs with boilerplate handling", func() {
 		It("should include --license none when no boilerplate exists", func() {
 			cfg := &fakeConfig{
-				pluginChain: []string{"go.kubebuilder.io/v4"},
-				domain:      "example.com",
-				repo:        "github.com/example/repo",
+				pluginChain: []string{pluginGoKubebuilderV4},
+				domain:      exampleDomain,
+				repo:        exampleRepo,
 			}
 			store := &fakeStore{cfg: cfg}
 			args := getInitArgs(store, &Generate{}, "") // tempLicenseFile = "" (no boilerplate)
@@ -865,9 +887,9 @@ var _ = Describe("generate: boilerplate preservation", func() {
 
 		It("should use --license-file when temp file is provided", func() {
 			cfg := &fakeConfig{
-				pluginChain: []string{"go.kubebuilder.io/v4"},
-				domain:      "example.com",
-				repo:        "github.com/example/repo",
+				pluginChain: []string{pluginGoKubebuilderV4},
+				domain:      exampleDomain,
+				repo:        exampleRepo,
 			}
 			store := &fakeStore{cfg: cfg}
 			args := getInitArgs(store, &Generate{}, "/tmp/preserved-license.txt") // tempLicenseFile provided
@@ -889,9 +911,9 @@ var _ = Describe("generate: boilerplate preservation", func() {
 
 		It("should always include either --license-file or --license none", func() {
 			cfg := &fakeConfig{
-				pluginChain: []string{"go.kubebuilder.io/v4"},
-				domain:      "example.com",
-				repo:        "github.com/example/repo",
+				pluginChain: []string{pluginGoKubebuilderV4},
+				domain:      exampleDomain,
+				repo:        exampleRepo,
 			}
 			store := &fakeStore{cfg: cfg}
 
@@ -909,6 +931,12 @@ var _ = Describe("generate: boilerplate preservation", func() {
 })
 
 var _ = Describe("generate: migrate-plugins", func() {
+	const (
+		grafanaPluginKey     = "grafana.kubebuilder.io/v1-alpha"
+		autoupdatePluginKey  = "autoupdate.kubebuilder.io/v1-alpha"
+		deployImagePluginKey = "deploy-image.kubebuilder.io/v1-alpha"
+	)
+
 	var (
 		kbc         *utils.TestContext
 		tmpDir      string
@@ -937,7 +965,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 
 	Context("migrateGrafanaPlugin", func() {
 		It("skips migration as Grafana plugin not found", func() {
-			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: "grafana.kubebuilder.io/v1-alpha"}}
+			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: grafanaPluginKey}}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateGrafanaPlugin(store, "src", "dest")).To(Succeed())
 		})
@@ -945,7 +973,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("returns error if decoding Grafana plugin config fails", func() {
 			cfg := &fakeConfig{
 				pluginErr: fmt.Errorf("decoding error"),
-				plugins:   map[string]any{"grafana.kubebuilder.io/v1-alpha": true},
+				plugins:   map[string]any{grafanaPluginKey: true},
 			}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateGrafanaPlugin(store, "src", "dest")).NotTo(Succeed())
@@ -968,7 +996,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 			})
 
 			It("migrates Grafana plugin successfully", func() {
-				cfg := &fakeConfig{plugins: map[string]any{"grafana.kubebuilder.io/v1-alpha": true}}
+				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
 				store := &fakeStore{cfg: cfg}
 				Expect(migrateGrafanaPlugin(store, src, dest)).To(Succeed())
 				b, err := os.ReadFile(filepath.Join(dest, "grafana/custom-metrics/config.yaml"))
@@ -980,7 +1008,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 
 	Context("migrateAutoUpdatePlugin", func() {
 		It("skips migration as AutoUpdate plugin not found", func() {
-			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: "autoupdate.kubebuilder.io/v1-alpha"}}
+			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: autoupdatePluginKey}}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateAutoUpdatePlugin(store)).To(Succeed())
 		})
@@ -988,7 +1016,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("returns error if failed to decode Auto Update plugin", func() {
 			cfg := &fakeConfig{
 				pluginErr: fmt.Errorf("decoding error"),
-				plugins:   map[string]any{"autoupdate.kubebuilder.io/v1-alpha": true},
+				plugins:   map[string]any{autoupdatePluginKey: true},
 			}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateAutoUpdatePlugin(store)).NotTo(Succeed())
@@ -997,7 +1025,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("migrates Auto Update plugin successfully without UseGHModels", func() {
 			cfg := &fakeConfig{
 				plugins: map[string]any{
-					"autoupdate.kubebuilder.io/v1-alpha": autoupdatev1alpha.PluginConfig{UseGHModels: false},
+					autoupdatePluginKey: autoupdatev1alpha.PluginConfig{UseGHModels: false},
 				},
 			}
 			store := &fakeStore{cfg: cfg}
@@ -1007,7 +1035,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("migrates Auto Update plugin successfully with UseGHModels enabled", func() {
 			cfg := &fakeConfig{
 				plugins: map[string]any{
-					"autoupdate.kubebuilder.io/v1-alpha": autoupdatev1alpha.PluginConfig{UseGHModels: true},
+					autoupdatePluginKey: autoupdatev1alpha.PluginConfig{UseGHModels: true},
 				},
 			}
 			store := &fakeStore{cfg: cfg}
@@ -1017,7 +1045,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 
 	Context("migrateDeployImagePlugin", func() {
 		It("returns error if failed to decode Deploy Image plugin", func() {
-			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: "deploy-image.kubebuilder.io/v1-alpha"}}
+			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: deployImagePluginKey}}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateDeployImagePlugin(store)).To(Succeed())
 		})
@@ -1025,26 +1053,26 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("returns error if decoding Deploy Image plugin config fails", func() {
 			cfg := &fakeConfig{
 				pluginErr: fmt.Errorf("decoding error"),
-				plugins:   map[string]any{"deploy-image.kubebuilder.io/v1-alpha": true},
+				plugins:   map[string]any{deployImagePluginKey: true},
 			}
 			store := &fakeStore{cfg: cfg}
 			Expect(migrateDeployImagePlugin(store)).NotTo(Succeed())
 		})
 
 		It("migrates Deploy Image plugin successfully", func() {
-			cfg := &fakeConfig{plugins: map[string]any{"deploy-image.kubebuilder.io/v1-alpha": true}}
+			cfg := &fakeConfig{plugins: map[string]any{deployImagePluginKey: true}}
 			store := &fakeStore{cfg: cfg}
 
 			// Mock resources for the plugin
 			resources := []deployimagev1alpha1.ResourceData{
 				{
-					Group:   "example.com",
+					Group:   exampleDomain,
 					Version: "v1",
-					Kind:    "Example",
+					Kind:    exampleKind,
 				},
 			}
 
-			cfg.pluginChain = []string{"deploy-image.kubebuilder.io/v1-alpha"}
+			cfg.pluginChain = []string{deployImagePluginKey}
 			store.cfg = cfg
 
 			// Use the mocked resources

--- a/internal/cli/alpha/internal/update/helpers/conflict.go
+++ b/internal/cli/alpha/internal/update/helpers/conflict.go
@@ -237,18 +237,26 @@ func hasGoConflictInFiles(conflicts map[string]bool) bool {
 	return false
 }
 
+const (
+	makeTargetManifests = "manifests"
+	makeTargetGenerate  = "generate"
+	makeTargetFmt       = "fmt"
+	makeTargetVet       = "vet"
+	makeTargetLintFix   = "lint-fix"
+)
+
 // DecideMakeTargets applies simple policy over the summary.
 func DecideMakeTargets(cs ConflictSummary) []string {
-	all := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
+	all := []string{makeTargetManifests, makeTargetGenerate, makeTargetFmt, makeTargetVet, makeTargetLintFix}
 	if cs.Makefile {
 		return nil
 	}
 	keep := make([]string, 0, len(all))
 	for _, t := range all {
-		if cs.API && (t == "manifests" || t == "generate") {
+		if cs.API && (t == makeTargetManifests || t == makeTargetGenerate) {
 			continue
 		}
-		if cs.AnyGo && (t == "fmt" || t == "vet" || t == "lint-fix") {
+		if cs.AnyGo && (t == makeTargetFmt || t == makeTargetVet || t == makeTargetLintFix) {
 			continue
 		}
 		keep = append(keep, t)

--- a/internal/cli/alpha/internal/update/helpers/conflict_test.go
+++ b/internal/cli/alpha/internal/update/helpers/conflict_test.go
@@ -72,7 +72,9 @@ var _ = Describe("Conflict Detection", func() {
 			cs := ConflictSummary{Makefile: false, API: false, AnyGo: false}
 			targets := DecideMakeTargets(cs)
 
-			expected := []string{"manifests", "generate", "fmt", "vet", "lint-fix"}
+			expected := []string{
+				makeTargetManifests, makeTargetGenerate, makeTargetFmt, makeTargetVet, makeTargetLintFix,
+			}
 			Expect(targets).To(Equal(expected))
 		})
 

--- a/internal/cli/version/version.go
+++ b/internal/cli/version/version.go
@@ -28,6 +28,11 @@ const (
 	unknown                 = "unknown"
 	develVersion            = "(devel)"
 	kubernetesVendorVersion = "1.36.0"
+
+	vcsKeyRevision = "vcs.revision"
+	vcsKeyTime     = "vcs.time"
+	vcsKeyModified = "vcs.modified"
+	vcsValueTrue   = "true"
 )
 
 type Version struct {
@@ -87,12 +92,12 @@ func (v *Version) applyVCSMetadata(settings []debug.BuildSetting) {
 
 	for _, s := range settings {
 		switch s.Key {
-		case "vcs.revision":
+		case vcsKeyRevision:
 			v.GitCommit = s.Value
-		case "vcs.time":
+		case vcsKeyTime:
 			v.BuildDate = s.Value
-		case "vcs.modified":
-			isDirty = (s.Value == "true")
+		case vcsKeyModified:
+			isDirty = (s.Value == vcsValueTrue)
 		}
 	}
 

--- a/internal/cli/version/version_test.go
+++ b/internal/cli/version/version_test.go
@@ -22,6 +22,13 @@ import (
 	"testing"
 )
 
+const (
+	testGitCommit             = "abcdef123"
+	testGitCommitDirty        = "abcdef123-dirty"
+	testKubebuilderV410       = "v4.10.4"
+	testKubebuilderVersion135 = "1.35.0"
+)
+
 func TestNew(t *testing.T) {
 	t.Run("Environment variable override", func(t *testing.T) {
 		expectedVersion := "v9.9.9-test"
@@ -51,8 +58,8 @@ func TestNew(t *testing.T) {
 	t.Run("VCS metadata resolution with tagged release", func(t *testing.T) {
 		v := &Version{KubeBuilderVersion: "v1.0.0"}
 		settings := []debug.BuildSetting{
-			{Key: "vcs.revision", Value: "abcdef123"},
-			{Key: "vcs.modified", Value: "true"},
+			{Key: vcsKeyRevision, Value: testGitCommit},
+			{Key: vcsKeyModified, Value: vcsValueTrue},
 		}
 
 		v.applyVCSMetadata(settings)
@@ -82,11 +89,11 @@ func TestGetKubeBuilderVersion(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"strips v prefix", "v1.35.0", "1.35.0"},
-		{"handles no prefix", "1.35.0", "1.35.0"},
-		{"preserves devel", "(devel)", "(devel)"},
+		{"strips v prefix", "v" + testKubebuilderVersion135, testKubebuilderVersion135},
+		{"handles no prefix", testKubebuilderVersion135, testKubebuilderVersion135},
+		{"preserves devel", develVersion, develVersion},
 		{"handles empty", "", ""},
-		{"handles dirty suffix", "v1.35.0-dirty", "1.35.0-dirty"},
+		{"handles dirty suffix", "v" + testKubebuilderVersion135 + "-dirty", testKubebuilderVersion135 + "-dirty"},
 	}
 
 	for _, tc := range testCases {
@@ -105,7 +112,7 @@ func TestResolveMainVersion(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"Valid Tag", "v4.10.4", "v4.10.4"},
+		{"Valid Tag", testKubebuilderV410, testKubebuilderV410},
 		{"Development Build", "", develVersion},
 	}
 
@@ -130,37 +137,37 @@ func TestApplyVCSMetadata(t *testing.T) {
 	}{
 		{
 			name:           "Clean release build",
-			initialVersion: "v4.10.4",
+			initialVersion: testKubebuilderV410,
 			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: "abcdef123"},
-				{Key: "vcs.time", Value: "2025-12-27T18:00:00Z"},
-				{Key: "vcs.modified", Value: "false"},
+				{Key: vcsKeyRevision, Value: testGitCommit},
+				{Key: vcsKeyTime, Value: "2025-12-27T18:00:00Z"},
+				{Key: vcsKeyModified, Value: "false"},
 			},
-			expectCommit:  "abcdef123",
-			expectVersion: "v4.10.4",
+			expectCommit:  testGitCommit,
+			expectVersion: testKubebuilderV410,
 			expectDate:    "2025-12-27T18:00:00Z",
 		},
 		{
 			name:           "Dirty development build",
 			initialVersion: develVersion,
 			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: "abcdef123"},
-				{Key: "vcs.modified", Value: "true"},
-				{Key: "vcs.time", Value: "2025-12-29T19:30:00Z"},
+				{Key: vcsKeyRevision, Value: testGitCommit},
+				{Key: vcsKeyModified, Value: vcsValueTrue},
+				{Key: vcsKeyTime, Value: "2025-12-29T19:30:00Z"},
 			},
-			expectCommit:  "abcdef123-dirty",
-			expectVersion: "(devel)",
+			expectCommit:  testGitCommitDirty,
+			expectVersion: develVersion,
 			expectDate:    "2025-12-29T19:30:00Z",
 		},
 		{
 			name:           "Dirty tagged release (GoReleaser scenario)",
 			initialVersion: "v4.5.3-rc.1",
 			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: "abcdef123"},
-				{Key: "vcs.modified", Value: "true"},
-				{Key: "vcs.time", Value: "2025-12-30T10:00:00Z"},
+				{Key: vcsKeyRevision, Value: testGitCommit},
+				{Key: vcsKeyModified, Value: vcsValueTrue},
+				{Key: vcsKeyTime, Value: "2025-12-30T10:00:00Z"},
 			},
-			expectCommit:  "abcdef123-dirty",
+			expectCommit:  testGitCommitDirty,
 			expectVersion: "v4.5.3-rc.1", // Stays clean for tagged releases
 			expectDate:    "2025-12-30T10:00:00Z",
 		},
@@ -168,11 +175,11 @@ func TestApplyVCSMetadata(t *testing.T) {
 			name:           "Dirty pseudo-version",
 			initialVersion: "v1.2.4-0.20191109021931-daa7c04131f5",
 			settings: []debug.BuildSetting{
-				{Key: "vcs.revision", Value: "abcdef123"},
-				{Key: "vcs.modified", Value: "true"},
+				{Key: vcsKeyRevision, Value: testGitCommit},
+				{Key: vcsKeyModified, Value: vcsValueTrue},
 			},
-			expectCommit:  "abcdef123-dirty",
-			expectVersion: "(devel)", // Pseudo-versions become (devel) when dirty
+			expectCommit:  testGitCommitDirty,
+			expectVersion: develVersion, // Pseudo-versions become (devel) when dirty
 			expectDate:    "",
 		},
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -40,6 +40,10 @@ const (
 
 	pluginsFlag        = "plugins"
 	projectVersionFlag = "project-version"
+
+	kubebuilderCommandName = "kubebuilder"
+	pluginGoKubebuilderV4  = "go.kubebuilder.io/v4"
+	pluginGoKubebuilderV2  = "go.kubebuilder.io/v2"
 )
 
 // CLI is the command line utility that is used to scaffold kubebuilder project files.
@@ -126,7 +130,7 @@ func New(options ...Option) (*CLI, error) {
 func newCLI(options ...Option) (*CLI, error) {
 	// Default CLI options.
 	c := &CLI{
-		commandName: "kubebuilder",
+		commandName: kubebuilderCommandName,
 		description: `CLI tool for building Kubernetes extensions and tools.
 `,
 		plugins:        make(map[string]plugin.Plugin),
@@ -285,9 +289,9 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 	}
 
 	replacements := []pluginReplacement{
-		{"go.kubebuilder.io/v2", "go.kubebuilder.io/v4"},
-		{"go.kubebuilder.io/v3", "go.kubebuilder.io/v4"},
-		{"go.kubebuilder.io/v3-alpha", "go.kubebuilder.io/v4"},
+		{pluginGoKubebuilderV2, pluginGoKubebuilderV4},
+		{"go.kubebuilder.io/v3", pluginGoKubebuilderV4},
+		{"go.kubebuilder.io/v3-alpha", pluginGoKubebuilderV4},
 	}
 
 	content, err := afero.ReadFile(fs, path)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -141,6 +141,15 @@ type captureSubcommand struct {
 func (c *captureSubcommand) Scaffold(machinery.Filesystem) error { return nil }
 
 var _ = Describe("CLI", func() {
+	const (
+		pluginGoV1           = "go/v1"
+		pluginExampleV2      = "example/v2"
+		pluginTestV1         = "test/v1"
+		deployImageFooPlugin = "deploy-image.foo.example.com/v1-alpha"
+		deployImageBarPlugin = "deploy-image.bar.example.com/v1-alpha"
+		subcommandExtra      = "extra"
+	)
+
 	var (
 		c              *CLI
 		projectVersion config.Version
@@ -189,9 +198,9 @@ var _ = Describe("CLI", func() {
 
 			Expect(tuples).To(HaveLen(2))
 			Expect(tuples[0].key).To(Equal("deploy-image.go.kubebuilder.io/v1-alpha"))
-			Expect(tuples[0].configKey).To(Equal("deploy-image.foo.example.com/v1-alpha"))
+			Expect(tuples[0].configKey).To(Equal(deployImageFooPlugin))
 			Expect(tuples[1].key).To(Equal("deploy-image.go.kubebuilder.io/v1-alpha"))
-			Expect(tuples[1].configKey).To(Equal("deploy-image.bar.example.com/v1-alpha"))
+			Expect(tuples[1].configKey).To(Equal(deployImageBarPlugin))
 		})
 	})
 
@@ -199,8 +208,8 @@ var _ = Describe("CLI", func() {
 		It("temporarily reorders the plugin chain while invoking bundled subcommands", func() {
 			cfg := cfgv3.New()
 			Expect(cfg.SetPluginChain([]string{
-				"deploy-image.foo.example.com/v1-alpha",
-				"deploy-image.bar.example.com/v1-alpha",
+				deployImageFooPlugin,
+				deployImageBarPlugin,
 			})).To(Succeed())
 
 			store := &fakeStore{cfg: cfg}
@@ -210,8 +219,8 @@ var _ = Describe("CLI", func() {
 			factory := executionHooksFactory{
 				store: store,
 				subcommands: []keySubcommandTuple{
-					{configKey: "deploy-image.foo.example.com/v1-alpha", subcommand: first},
-					{configKey: "deploy-image.bar.example.com/v1-alpha", subcommand: second},
+					{configKey: deployImageFooPlugin, subcommand: first},
+					{configKey: deployImageBarPlugin, subcommand: second},
 				},
 				errorMessage: "test",
 			}
@@ -222,11 +231,11 @@ var _ = Describe("CLI", func() {
 				return nil
 			}, "scaffold")
 			Expect(callErr).NotTo(HaveOccurred())
-			Expect(first.lastChain[0]).To(Equal("deploy-image.foo.example.com/v1-alpha"))
-			Expect(second.lastChain[0]).To(Equal("deploy-image.bar.example.com/v1-alpha"))
+			Expect(first.lastChain[0]).To(Equal(deployImageFooPlugin))
+			Expect(second.lastChain[0]).To(Equal(deployImageBarPlugin))
 			Expect(store.Config().GetPluginChain()).To(Equal([]string{
-				"deploy-image.foo.example.com/v1-alpha",
-				"deploy-image.bar.example.com/v1-alpha",
+				deployImageFooPlugin,
+				deployImageBarPlugin,
 			}))
 		})
 	})
@@ -284,7 +293,7 @@ plugins:
 	Context("getInfoFromConfig", func() {
 		When("having a single plugin in the layout field", func() {
 			It("should succeed", func() {
-				pluginChain := []string{"go.kubebuilder.io/v4"}
+				pluginChain := []string{pluginGoKubebuilderV4}
 				projectConfig := cfgv3.New()
 				Expect(projectConfig.SetPluginChain(pluginChain)).To(Succeed())
 
@@ -296,7 +305,7 @@ plugins:
 
 		When("having multiple plugins in the layout field", func() {
 			It("should succeed", func() {
-				pluginChain := []string{"go.kubebuilder.io/v2", "deploy-image.go.kubebuilder.io/v1-alpha"}
+				pluginChain := []string{pluginGoKubebuilderV2, "deploy-image.go.kubebuilder.io/v1-alpha"}
 
 				projectConfig := cfgv3.New()
 				Expect(projectConfig.SetPluginChain(pluginChain)).To(Succeed())
@@ -341,7 +350,7 @@ plugins:
 
 		When(fmt.Sprintf("--%s flag is set", pluginsFlag), func() {
 			It("should succeed using one plugin key", func() {
-				pluginKeys := []string{"go/v1"}
+				pluginKeys := []string{pluginGoV1}
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 
 				Expect(c.getInfoFromFlags(false)).To(Succeed())
@@ -350,7 +359,7 @@ plugins:
 			})
 
 			It("should succeed using more than one plugin key", func() {
-				pluginKeys := []string{"go/v1", "example/v2", "test/v1"}
+				pluginKeys := []string{pluginGoV1, pluginExampleV2, pluginTestV1}
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 
 				Expect(c.getInfoFromFlags(false)).To(Succeed())
@@ -359,7 +368,7 @@ plugins:
 			})
 
 			It("should succeed using more than one plugin key with spaces", func() {
-				pluginKeys := []string{"go/v1", "example/v2", "test/v1"}
+				pluginKeys := []string{pluginGoV1, pluginExampleV2, pluginTestV1}
 				setPluginsFlag(strings.Join(pluginKeys, ", "))
 
 				Expect(c.getInfoFromFlags(false)).To(Succeed())
@@ -392,7 +401,7 @@ plugins:
 
 		When(fmt.Sprintf("--%s and --%s flags are set", pluginsFlag, projectVersionFlag), func() {
 			It("should succeed using one plugin key", func() {
-				pluginKeys := []string{"go/v1"}
+				pluginKeys := []string{pluginGoV1}
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 				setProjectVersionFlag(projectVersion.String())
 
@@ -402,7 +411,7 @@ plugins:
 			})
 
 			It("should succeed using more than one plugin key", func() {
-				pluginKeys := []string{"go/v1", "example/v2", "test/v1"}
+				pluginKeys := []string{pluginGoV1, pluginExampleV2, pluginTestV1}
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 				setProjectVersionFlag(projectVersion.String())
 
@@ -412,7 +421,7 @@ plugins:
 			})
 
 			It("should succeed using more than one plugin key with spaces", func() {
-				pluginKeys := []string{"go/v1", "example/v2", "test/v1"}
+				pluginKeys := []string{pluginGoV1, pluginExampleV2, pluginTestV1}
 				setPluginsFlag(strings.Join(pluginKeys, ", "))
 				setProjectVersionFlag(projectVersion.String())
 
@@ -459,7 +468,7 @@ plugins:
 		var pluginKeys []string
 
 		BeforeEach(func() {
-			pluginKeys = []string{"go.kubebuilder.io/v2"}
+			pluginKeys = []string{pluginGoKubebuilderV2}
 		})
 
 		It("should be a no-op if already have plugin keys", func() {
@@ -716,7 +725,7 @@ plugins:
 
 		When("providing extra commands", func() {
 			It("should create a valid CLI for non-conflicting ones", func() {
-				extraCommand := &cobra.Command{Use: "extra"}
+				extraCommand := &cobra.Command{Use: subcommandExtra}
 				c, err = New(
 					WithPlugins(&golangv4.Plugin{}),
 					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
@@ -727,7 +736,7 @@ plugins:
 			})
 
 			It("should return an error for conflicting ones", func() {
-				extraCommand := &cobra.Command{Use: "init"}
+				extraCommand := &cobra.Command{Use: kubebuilderSubcommandInit}
 				c, err = New(
 					WithPlugins(&golangv4.Plugin{}),
 					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
@@ -739,7 +748,7 @@ plugins:
 
 		When("providing extra alpha commands", func() {
 			It("should create a valid CLI for non-conflicting ones", func() {
-				extraAlphaCommand := &cobra.Command{Use: "extra"}
+				extraAlphaCommand := &cobra.Command{Use: subcommandExtra}
 				c, err = New(
 					WithPlugins(&golangv4.Plugin{}),
 					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
@@ -758,7 +767,7 @@ plugins:
 			})
 
 			It("should return an error for conflicting ones", func() {
-				extraAlphaCommand := &cobra.Command{Use: "extra"}
+				extraAlphaCommand := &cobra.Command{Use: subcommandExtra}
 				_, err = New(
 					WithPlugins(&golangv4.Plugin{}),
 					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -30,6 +30,13 @@ import (
 )
 
 var _ = Describe("cmd_helpers", func() {
+	const (
+		flagKey1      = "key1"
+		flagKey2      = "key2"
+		flagKey3      = "key3"
+		flagValueTrue = "true"
+		flagForce     = "--force"
+	)
 	Context("error types", func() {
 		It("noResolvedPluginError should return correct message", func() {
 			err := noResolvedPluginError{}
@@ -38,8 +45,8 @@ var _ = Describe("cmd_helpers", func() {
 		})
 
 		It("noAvailablePluginError should return correct message with subcommand", func() {
-			err := noAvailablePluginError{subcommand: "init"}
-			Expect(err.Error()).To(ContainSubstring("init"))
+			err := noAvailablePluginError{subcommand: kubebuilderSubcommandInit}
+			Expect(err.Error()).To(ContainSubstring(kubebuilderSubcommandInit))
 			Expect(err.Error()).To(ContainSubstring("do not provide any"))
 		})
 	})
@@ -77,38 +84,38 @@ var _ = Describe("cmd_helpers", func() {
 
 	Context("moveKeyToFront", func() {
 		It("should handle empty chain", func() {
-			result := moveKeyToFront([]string{}, "key1")
-			Expect(result).To(Equal([]string{"key1"}))
+			result := moveKeyToFront([]string{}, flagKey1)
+			Expect(result).To(Equal([]string{flagKey1}))
 		})
 
 		It("should not change chain when key is already at front", func() {
-			chain := []string{"key1", "key2", "key3"}
-			result := moveKeyToFront(chain, "key1")
+			chain := []string{flagKey1, flagKey2, flagKey3}
+			result := moveKeyToFront(chain, flagKey1)
 			Expect(result).To(Equal(chain))
 		})
 
 		It("should move key to front when it exists in chain", func() {
-			chain := []string{"key1", "key2", "key3"}
-			result := moveKeyToFront(chain, "key2")
-			Expect(result).To(Equal([]string{"key2", "key1", "key3"}))
+			chain := []string{flagKey1, flagKey2, flagKey3}
+			result := moveKeyToFront(chain, flagKey2)
+			Expect(result).To(Equal([]string{flagKey2, flagKey1, flagKey3}))
 		})
 
 		It("should move key to front from end of chain", func() {
-			chain := []string{"key1", "key2", "key3"}
-			result := moveKeyToFront(chain, "key3")
-			Expect(result).To(Equal([]string{"key3", "key1", "key2"}))
+			chain := []string{flagKey1, flagKey2, flagKey3}
+			result := moveKeyToFront(chain, flagKey3)
+			Expect(result).To(Equal([]string{flagKey3, flagKey1, flagKey2}))
 		})
 
 		It("should add key to front when not in chain", func() {
-			chain := []string{"key1", "key2"}
-			result := moveKeyToFront(chain, "key3")
-			Expect(result).To(Equal([]string{"key3", "key1", "key2"}))
+			chain := []string{flagKey1, flagKey2}
+			result := moveKeyToFront(chain, flagKey3)
+			Expect(result).To(Equal([]string{flagKey3, flagKey1, flagKey2}))
 		})
 
 		It("should remove duplicate when moving key to front", func() {
-			chain := []string{"key1", "key2", "key2"}
-			result := moveKeyToFront(chain, "key2")
-			Expect(result).To(Equal([]string{"key2", "key1"}))
+			chain := []string{flagKey1, flagKey2, flagKey2}
+			result := moveKeyToFront(chain, flagKey2)
+			Expect(result).To(Equal([]string{flagKey2, flagKey1}))
 		})
 	})
 
@@ -375,7 +382,7 @@ var _ = Describe("cmd_helpers", func() {
 				"force": {tmpFS.Lookup("force").Value},
 			}
 
-			Expect(flags.Parse([]string{"--force", "true"})).NotTo(HaveOccurred())
+			Expect(flags.Parse([]string{flagForce, flagValueTrue})).NotTo(HaveOccurred())
 			Expect(mainVal).To(BeTrue())
 			Expect(dupVal).To(BeFalse())
 
@@ -396,7 +403,7 @@ var _ = Describe("cmd_helpers", func() {
 			Expect(mergeFlagSetInto(cmdFlags, pluginA, duplicateValues, "pluginA/v1", firstPluginByFlag)).NotTo(HaveOccurred())
 			Expect(mergeFlagSetInto(cmdFlags, pluginB, duplicateValues, "pluginB/v1", firstPluginByFlag)).NotTo(HaveOccurred())
 
-			Expect(cmdFlags.Parse([]string{"--force", "true"})).NotTo(HaveOccurred())
+			Expect(cmdFlags.Parse([]string{flagForce, flagValueTrue})).NotTo(HaveOccurred())
 			syncDuplicateFlags(cmdFlags, duplicateValues)
 			Expect(forceA).To(BeTrue(), "plugin A must receive the value passed by the user")
 			Expect(forceB).To(BeTrue(), "plugin B must receive the same value as the command")
@@ -431,7 +438,7 @@ var _ = Describe("cmd_helpers", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.duplicateFlagValues["force"]).To(HaveLen(1), "second plugin's Value recorded as duplicate")
 
-			Expect(cmd.ParseFlags([]string{"--force", "true"})).NotTo(HaveOccurred())
+			Expect(cmd.ParseFlags([]string{flagForce, flagValueTrue})).NotTo(HaveOccurred())
 			syncDuplicateFlags(cmd.Flags(), result.duplicateFlagValues)
 			Expect(pluginA.Force).To(BeTrue(), "first plugin (flag on command) receives value")
 			Expect(pluginB.Force).To(BeTrue(), "second plugin (duplicate) receives same value after sync")

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -31,7 +31,7 @@ var _ = Describe("init", func() {
 			plugin2 := newMockPlugin("another.plugin", "3", config.Version{Number: 3}, config.Version{Number: 4})
 
 			cli := CLI{
-				commandName: "kubebuilder",
+				commandName: kubebuilderCommandName,
 				plugins: map[string]plugin.Plugin{
 					plugin.KeyFor(plugin1): plugin1,
 					plugin.KeyFor(plugin2): plugin2,
@@ -65,7 +65,7 @@ var _ = Describe("init", func() {
 
 		It("should return empty string when no plugins", func() {
 			cli := CLI{
-				commandName: "kubebuilder",
+				commandName: kubebuilderCommandName,
 				plugins:     map[string]plugin.Plugin{},
 			}
 

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
+const kubebuilderSubcommandInit = "init"
+
 var _ = Describe("Discover external plugins", func() {
 	Context("with valid plugins root path", func() {
 		var (
@@ -467,8 +469,8 @@ var _ = Describe("Discover external plugins", func() {
 			oldArgs := os.Args
 			defer func() { os.Args = oldArgs }()
 			os.Args = []string{
-				"kubebuilder",
-				"init",
+				kubebuilderCommandName,
+				kubebuilderSubcommandInit,
 				"--plugins",
 				"myexternalplugin/v1",
 				"--domain",
@@ -490,8 +492,8 @@ var _ = Describe("Discover external plugins", func() {
 			))
 
 			Expect(args).ShouldNot(ContainElements(
-				"kubebuilder",
-				"init",
+				kubebuilderCommandName,
+				kubebuilderSubcommandInit,
 				"--plugins",
 				"myexternalplugin/v1",
 			))

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -195,7 +195,7 @@ func (c CLI) getPluginTableFilteredWithOptions(filter func(plugin.Plugin) bool, 
 
 		// For subcommands, skip default scaffold and its component plugins
 		if excludeDefaultScaffold {
-			if pluginKey == "go.kubebuilder.io/v4" ||
+			if pluginKey == pluginGoKubebuilderV4 ||
 				pluginKey == "kustomize.common.kubebuilder.io/v2" {
 				continue
 			}

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -38,6 +38,13 @@ var _ = Describe("Cfg", func() {
 		repo   = "myrepo"
 		name   = "ProjectName"
 
+		resourceGroup = "group"
+		resourceKind  = "Kind"
+		apiVersion    = "v1beta1"
+		dataKey1      = "data-1"
+		pluginValue1  = "plugin value 1"
+		pluginValue2  = "plugin value 2"
+
 		otherDomain = "other.domain"
 		otherRepo   = "otherrepo"
 		otherName   = "OtherProjectName"
@@ -144,9 +151,9 @@ var _ = Describe("Cfg", func() {
 		BeforeEach(func() {
 			res = resource.Resource{
 				GVK: resource.GVK{
-					Group:   "group",
+					Group:   resourceGroup,
 					Version: "v1",
-					Kind:    "Kind",
+					Kind:    resourceKind,
 				},
 				Plural: "kinds",
 				Path:   "api/v1",
@@ -260,9 +267,9 @@ var _ = Describe("Cfg", func() {
 		It("UpdateResource should update it if the resource already exists", func() {
 			r := resource.Resource{
 				GVK: resource.GVK{
-					Group:   "group",
+					Group:   resourceGroup,
 					Version: "v1",
-					Kind:    "Kind",
+					Kind:    resourceKind,
 				},
 				Path: "api/v1",
 			}
@@ -302,7 +309,7 @@ var _ = Describe("Cfg", func() {
 						Version: res.Version,
 						Kind:    res.Kind,
 					},
-					API: &resource.API{CRDVersion: "v1beta1"},
+					API: &resource.API{CRDVersion: apiVersion},
 				},
 				resource.Resource{
 					GVK: resource.GVK{
@@ -315,7 +322,7 @@ var _ = Describe("Cfg", func() {
 			)
 			versions := c.ListCRDVersions()
 			slices.Sort(versions) // ListCRDVersions has no order guarantee so sorting for reproducibility
-			Expect(versions).To(Equal([]string{"v1", "v1beta1"}))
+			Expect(versions).To(Equal([]string{"v1", apiVersion}))
 		})
 
 		It("ListWebhookVersions should return an empty list with no tracked resources", func() {
@@ -330,7 +337,7 @@ var _ = Describe("Cfg", func() {
 						Version: res.Version,
 						Kind:    res.Kind,
 					},
-					Webhooks: &resource.Webhooks{WebhookVersion: "v1beta1"},
+					Webhooks: &resource.Webhooks{WebhookVersion: apiVersion},
 				},
 				resource.Resource{
 					GVK: resource.GVK{
@@ -343,7 +350,7 @@ var _ = Describe("Cfg", func() {
 			)
 			versions := c.ListWebhookVersions()
 			slices.Sort(versions) // ListWebhookVersions has no order guarantee so sorting for reproducibility
-			Expect(versions).To(Equal([]string{"v1", "v1beta1"}))
+			Expect(versions).To(Equal([]string{"v1", apiVersion}))
 		})
 	})
 
@@ -380,7 +387,7 @@ var _ = Describe("Cfg", func() {
 				PluginChain: pluginChain,
 				Plugins: pluginConfigs{
 					key: map[string]any{
-						"data-1": "",
+						dataKey1: "",
 					},
 				},
 			}
@@ -392,14 +399,14 @@ var _ = Describe("Cfg", func() {
 				PluginChain: pluginChain,
 				Plugins: pluginConfigs{
 					key: map[string]any{
-						"data-1": "plugin value 1",
-						"data-2": "plugin value 2",
+						dataKey1: pluginValue1,
+						"data-2": pluginValue2,
 					},
 				},
 			}
 			pluginCfg = PluginConfig{
-				Data1: "plugin value 1",
-				Data2: "plugin value 2",
+				Data1: pluginValue1,
+				Data2: pluginValue2,
 			}
 		})
 
@@ -463,14 +470,14 @@ var _ = Describe("Cfg", func() {
 				Resources: []resource.Resource{
 					{
 						GVK: resource.GVK{
-							Group:   "group",
+							Group:   resourceGroup,
 							Version: "v1",
-							Kind:    "Kind",
+							Kind:    resourceKind,
 						},
 					},
 					{
 						GVK: resource.GVK{
-							Group:   "group",
+							Group:   resourceGroup,
 							Version: "v1",
 							Kind:    "Kind2",
 						},
@@ -480,9 +487,9 @@ var _ = Describe("Cfg", func() {
 					},
 					{
 						GVK: resource.GVK{
-							Group:   "group",
+							Group:   resourceGroup,
 							Version: "v1-beta",
-							Kind:    "Kind",
+							Kind:    resourceKind,
 						},
 						Plural:   "kindes",
 						API:      nil,
@@ -492,7 +499,7 @@ var _ = Describe("Cfg", func() {
 						GVK: resource.GVK{
 							Group:   "group2",
 							Version: "v1",
-							Kind:    "Kind",
+							Kind:    resourceKind,
 						},
 						API: &resource.API{
 							CRDVersion: "v1",
@@ -509,11 +516,11 @@ var _ = Describe("Cfg", func() {
 				},
 				Plugins: pluginConfigs{
 					"plugin-x": map[string]any{
-						"data-1": "single plugin datum",
+						dataKey1: "single plugin datum",
 					},
 					"plugin-y/v1": map[string]any{
-						"data-1": "plugin value 1",
-						"data-2": "plugin value 2",
+						dataKey1: pluginValue1,
+						"data-2": pluginValue2,
 						"data-3": []string{"plugin value 3", "plugin value 4"},
 					},
 				},

--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -22,12 +22,15 @@ import (
 	"strings"
 )
 
-const kbPrefix = "+kubebuilder:scaffold:"
+const (
+	kbPrefix  = "+kubebuilder:scaffold:"
+	goFileExt = ".go"
+)
 
 var commentsByExt = map[string]string{
-	".go":   "//",
-	".yaml": "#",
-	".yml":  "#",
+	goFileExt: "//",
+	".yaml":   "#",
+	".yml":    "#",
 	// When adding additional file extensions, update also the NewMarkerFor documentation and error
 }
 

--- a/pkg/machinery/mixins_delim_test.go
+++ b/pkg/machinery/mixins_delim_test.go
@@ -59,6 +59,8 @@ var _ = Describe("TemplateMixin Delimiters", func() {
 })
 
 var _ = Describe("Mixins injection behaviors", func() {
+	const existing = "existing"
+
 	Context("DomainMixin", func() {
 		It("should not overwrite existing domain", func() {
 			tmp := DomainMixin{Domain: "existing.domain"}
@@ -89,9 +91,9 @@ var _ = Describe("Mixins injection behaviors", func() {
 
 	Context("ProjectNameMixin", func() {
 		It("should not overwrite existing project name", func() {
-			tmp := ProjectNameMixin{ProjectName: "existing"}
+			tmp := ProjectNameMixin{ProjectName: existing}
 			tmp.InjectProjectName("new")
-			Expect(tmp.ProjectName).To(Equal("existing"))
+			Expect(tmp.ProjectName).To(Equal(existing))
 		})
 
 		It("should inject project name when empty", func() {
@@ -103,9 +105,9 @@ var _ = Describe("Mixins injection behaviors", func() {
 
 	Context("BoilerplateMixin", func() {
 		It("should not overwrite existing boilerplate", func() {
-			tmp := BoilerplateMixin{Boilerplate: "existing"}
+			tmp := BoilerplateMixin{Boilerplate: existing}
 			tmp.InjectBoilerplate("new")
-			Expect(tmp.Boilerplate).To(Equal("existing"))
+			Expect(tmp.Boilerplate).To(Equal(existing))
 		})
 
 		It("should inject boilerplate when empty", func() {
@@ -117,10 +119,10 @@ var _ = Describe("Mixins injection behaviors", func() {
 
 	Context("ResourceMixin", func() {
 		It("should not overwrite existing resource", func() {
-			existing := &resource.Resource{GVK: resource.GVK{Group: "existing"}}
-			tmp := ResourceMixin{Resource: existing}
+			existingRes := &resource.Resource{GVK: resource.GVK{Group: existing}}
+			tmp := ResourceMixin{Resource: existingRes}
 			tmp.InjectResource(&resource.Resource{GVK: resource.GVK{Group: "new"}})
-			Expect(tmp.Resource.Group).To(Equal("existing"))
+			Expect(tmp.Resource.Group).To(Equal(existing))
 		})
 
 		It("should inject resource when nil", func() {

--- a/pkg/machinery/mixins_test.go
+++ b/pkg/machinery/mixins_test.go
@@ -186,6 +186,12 @@ var _ = Describe("BoilerplateMixin", func() {
 })
 
 var _ = Describe("ResourceMixin", func() {
+	const (
+		group  = "group"
+		domain = "my.domain"
+		kind   = "Kind"
+	)
+
 	var (
 		res *resource.Resource
 		tmp mockTemplate
@@ -193,10 +199,10 @@ var _ = Describe("ResourceMixin", func() {
 
 	BeforeEach(func() {
 		res = &resource.Resource{GVK: resource.GVK{
-			Group:   "group",
-			Domain:  "my.domain",
+			Group:   group,
+			Domain:  domain,
 			Version: "v1",
-			Kind:    "Kind",
+			Kind:    kind,
 		}}
 
 		tmp = mockTemplate{}

--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -231,7 +231,7 @@ func doTemplate(t Template) ([]byte, error) {
 
 	// TODO(adirio): move go-formatting to write step
 	// gofmt the imports
-	if filepath.Ext(t.GetPath()) == ".go" {
+	if filepath.Ext(t.GetPath()) == goFileExt {
 		var err error
 		if b, err = imports.Process(t.GetPath(), b, &options); err != nil {
 			return nil, fmt.Errorf("failed to process template: %w", err)

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -440,14 +440,14 @@ func init() {
 				Expect(err).To(MatchError(errType))
 			},
 			Entry("should fail if inserting into a model that fails when a file exists and it does exist",
-				FileAlreadyExistsError{path: "filename"},
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: "filename", ifExistsAction: Error}},
-				fakeInserter{fakeBuilder: fakeBuilder{path: "filename"}},
+				FileAlreadyExistsError{path: path},
+				&fakeTemplate{fakeBuilder: fakeBuilder{path: path, ifExistsAction: Error}},
+				fakeInserter{fakeBuilder: fakeBuilder{path: path}},
 			),
 			Entry("should fail if inserting into a model with unknown behavior if the file exists and it does exist",
-				UnknownIfExistsActionError{path: "filename", ifExistsAction: -1},
-				&fakeTemplate{fakeBuilder: fakeBuilder{path: "filename", ifExistsAction: -1}},
-				fakeInserter{fakeBuilder: fakeBuilder{path: "filename"}},
+				UnknownIfExistsActionError{path: path, ifExistsAction: -1},
+				&fakeTemplate{fakeBuilder: fakeBuilder{path: path, ifExistsAction: -1}},
+				fakeInserter{fakeBuilder: fakeBuilder{path: path}},
 			),
 		)
 

--- a/pkg/model/resource/api_test.go
+++ b/pkg/model/resource/api_test.go
@@ -78,7 +78,7 @@ var _ = Describe("API", func() {
 
 			It("should fail if previously set and provided CRD versions do not match", func() {
 				api = API{CRDVersion: v1}
-				other = API{CRDVersion: "v1beta1"}
+				other = API{CRDVersion: v1beta1}
 				Expect(api.Update(&other)).NotTo(Succeed())
 			})
 		})

--- a/pkg/model/resource/controller_test.go
+++ b/pkg/model/resource/controller_test.go
@@ -20,6 +20,17 @@ import (
 	"testing"
 )
 
+const (
+	controller1        = "controller-1"
+	controller2        = "controller-2"
+	captainBackup      = "captainbackup"
+	captainBackupKebab = "captain-backup"
+	crewGroup          = "crew"
+	captainKind        = "Captain"
+	captainsPlural     = "captains"
+	myKind             = "MyKind"
+)
+
 func TestController_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -48,7 +59,7 @@ func TestController_Validate(t *testing.T) {
 		},
 		{
 			name:    "valid controller name with numbers",
-			ctrl:    Controller{Name: "controller-1"},
+			ctrl:    Controller{Name: controller1},
 			wantErr: false,
 		},
 	}
@@ -82,16 +93,16 @@ func TestControllers_Validate(t *testing.T) {
 		{
 			name: "valid controllers",
 			ctrls: &Controllers{
-				{Name: "controller-1"},
-				{Name: "controller-2"},
+				{Name: controller1},
+				{Name: controller2},
 			},
 			wantErr: false,
 		},
 		{
 			name: "duplicate controller names",
 			ctrls: &Controllers{
-				{Name: "controller-1"},
-				{Name: "controller-1"},
+				{Name: controller1},
+				{Name: controller1},
 			},
 			wantErr: true,
 		},
@@ -105,16 +116,16 @@ func TestControllers_Validate(t *testing.T) {
 		{
 			name: "normalization collision: removes hyphens",
 			ctrls: &Controllers{
-				{Name: "captainbackup"},
-				{Name: "captain-backup"},
+				{Name: captainBackup},
+				{Name: captainBackupKebab},
 			},
 			wantErr: true,
 		},
 		{
 			name: "normalization collision: case insensitive",
 			ctrls: &Controllers{
-				{Name: "captainbackup"},
-				{Name: "captainbackup"}, // Will be caught as exact duplicate first
+				{Name: captainBackup},
+				{Name: captainBackup}, // Will be caught as exact duplicate first
 			},
 			wantErr: true,
 		},
@@ -132,8 +143,8 @@ func TestControllers_Validate(t *testing.T) {
 
 func TestControllers_HasController(t *testing.T) {
 	ctrls := &Controllers{
-		{Name: "controller-1"},
-		{Name: "controller-2"},
+		{Name: controller1},
+		{Name: controller2},
 	}
 
 	tests := []struct {
@@ -141,11 +152,11 @@ func TestControllers_HasController(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "controller-1",
+			name: controller1,
 			want: true,
 		},
 		{
-			name: "controller-2",
+			name: controller2,
 			want: true,
 		},
 		{
@@ -174,22 +185,22 @@ func TestControllers_AddController(t *testing.T) {
 		{
 			name:    "add to nil controllers",
 			initial: nil,
-			addName: "controller-1",
+			addName: controller1,
 			wantErr: true,
 		},
 		{
 			name:    "add valid controller",
 			initial: &Controllers{},
-			addName: "controller-1",
+			addName: controller1,
 			wantErr: false,
 			wantLen: 1,
 		},
 		{
 			name: "add duplicate controller",
 			initial: &Controllers{
-				{Name: "controller-1"},
+				{Name: controller1},
 			},
-			addName: "controller-1",
+			addName: controller1,
 			wantErr: true,
 			wantLen: 1,
 		},
@@ -227,21 +238,21 @@ func TestResource_Update_WithControllers(t *testing.T) {
 			name: "update resource without controllers with one that has controllers",
 			base: Resource{
 				GVK: GVK{
-					Group:   "crew",
+					Group:   crewGroup,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
-				Plural: "captains",
+				Plural: captainsPlural,
 			},
 			other: Resource{
 				GVK: GVK{
-					Group:   "crew",
+					Group:   crewGroup,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
-				Plural: "captains",
+				Plural: captainsPlural,
 				Controllers: &Controllers{
-					{Name: "captain-backup"},
+					{Name: captainBackupKebab},
 				},
 			},
 			wantErr: false,
@@ -251,24 +262,24 @@ func TestResource_Update_WithControllers(t *testing.T) {
 			name: "update resource with controllers with another controller",
 			base: Resource{
 				GVK: GVK{
-					Group:   "crew",
+					Group:   crewGroup,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
-				Plural: "captains",
+				Plural: captainsPlural,
 				Controllers: &Controllers{
 					{Name: "captain"},
 				},
 			},
 			other: Resource{
 				GVK: GVK{
-					Group:   "crew",
+					Group:   crewGroup,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
-				Plural: "captains",
+				Plural: captainsPlural,
 				Controllers: &Controllers{
-					{Name: "captain-backup"},
+					{Name: captainBackupKebab},
 				},
 			},
 			wantErr: false,
@@ -278,22 +289,22 @@ func TestResource_Update_WithControllers(t *testing.T) {
 			name: "update with nil other controllers",
 			base: Resource{
 				GVK: GVK{
-					Group:   "crew",
+					Group:   crewGroup,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
-				Plural: "captains",
+				Plural: captainsPlural,
 				Controllers: &Controllers{
 					{Name: "captain"},
 				},
 			},
 			other: Resource{
 				GVK: GVK{
-					Group:   "crew",
+					Group:   crewGroup,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
-				Plural: "captains",
+				Plural: captainsPlural,
 			},
 			wantErr: false,
 			wantLen: 1,
@@ -328,18 +339,18 @@ func TestResource_GetControllerNames(t *testing.T) {
 		{
 			name: "resource with new Controllers field",
 			resource: Resource{
-				GVK: GVK{Kind: "MyKind"},
+				GVK: GVK{Kind: myKind},
 				Controllers: &Controllers{
-					{Name: "controller-1"},
-					{Name: "controller-2"},
+					{Name: controller1},
+					{Name: controller2},
 				},
 			},
-			want: []string{"controller-1", "controller-2"},
+			want: []string{controller1, controller2},
 		},
 		{
 			name: "resource with legacy Controller bool",
 			resource: Resource{
-				GVK:        GVK{Kind: "MyKind"},
+				GVK:        GVK{Kind: myKind},
 				Controller: true,
 			},
 			want: []string{"mykind"},
@@ -347,14 +358,14 @@ func TestResource_GetControllerNames(t *testing.T) {
 		{
 			name: "resource with no controllers",
 			resource: Resource{
-				GVK: GVK{Kind: "MyKind"},
+				GVK: GVK{Kind: myKind},
 			},
 			want: nil,
 		},
 		{
 			name: "resource with both fields (new takes precedence)",
 			resource: Resource{
-				GVK:        GVK{Kind: "MyKind"},
+				GVK:        GVK{Kind: myKind},
 				Controller: true,
 				Controllers: &Controllers{
 					{Name: "custom-controller"},

--- a/pkg/model/resource/gvk_test.go
+++ b/pkg/model/resource/gvk_test.go
@@ -30,6 +30,7 @@ var _ = Describe("GVK", func() {
 		version         = "v1"
 		kind            = "Kind"
 		internalVersion = "__internal"
+		invalidGVKChars = "_*?"
 	)
 
 	var gvk GVK
@@ -53,9 +54,9 @@ var _ = Describe("GVK", func() {
 			func(gvk GVK) { Expect(gvk.Validate()).NotTo(Succeed()) },
 			// Ensure that the rest of the fields are valid to check each part
 			Entry("Group (uppercase)", GVK{Group: "Group", Domain: domain, Version: version, Kind: kind}),
-			Entry("Group (non-alpha characters)", GVK{Group: "_*?", Domain: domain, Version: version, Kind: kind}),
+			Entry("Group (non-alpha characters)", GVK{Group: invalidGVKChars, Domain: domain, Version: version, Kind: kind}),
 			Entry("Domain (uppercase)", GVK{Group: group, Domain: "Domain", Version: version, Kind: kind}),
-			Entry("Domain (non-alpha characters)", GVK{Group: group, Domain: "_*?", Version: version, Kind: kind}),
+			Entry("Domain (non-alpha characters)", GVK{Group: group, Domain: invalidGVKChars, Version: version, Kind: kind}),
 			Entry("Group and Domain (empty)", GVK{Group: "", Domain: "", Version: version, Kind: kind}),
 			Entry("Version (empty)", GVK{Group: group, Domain: domain, Version: "", Kind: kind}),
 			Entry("Version (wrong prefix)", GVK{Group: group, Domain: domain, Version: "-example.com", Kind: kind}),
@@ -68,7 +69,7 @@ var _ = Describe("GVK", func() {
 			Entry("Kind (lowercase)", GVK{Group: group, Domain: domain, Version: version, Kind: "kind"}),
 			Entry("Kind (starts with number)", GVK{Group: group, Domain: domain, Version: version, Kind: "1Kind"}),
 			Entry("Kind (ends with `-`)", GVK{Group: group, Domain: domain, Version: version, Kind: "Kind-"}),
-			Entry("Kind (non-alpha characters)", GVK{Group: group, Domain: domain, Version: version, Kind: "_*?"}),
+			Entry("Kind (non-alpha characters)", GVK{Group: group, Domain: domain, Version: version, Kind: invalidGVKChars}),
 			Entry("Kind (too long)",
 				GVK{Group: group, Domain: domain, Version: version, Kind: strings.Repeat("a", 64)}),
 		)

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -25,12 +25,12 @@ import (
 
 var _ = Describe("Resource", func() {
 	const (
-		group   = "group"
-		domain  = "test.io"
-		version = "v1"
-		kind    = "Kind"
-		plural  = "kinds"
-		v1beta1 = "v1beta1"
+		group         = "group"
+		domain        = "test.io"
+		version       = "v1"
+		kind          = "Kind"
+		plural        = "kinds"
+		invalidPlural = "plural"
 	)
 
 	var (
@@ -96,10 +96,10 @@ var _ = Describe("Resource", func() {
 		DescribeTable("should fail for invalid Resources",
 			func(res Resource) { Expect(res.Validate()).NotTo(Succeed()) },
 			// Ensure that the rest of the fields are valid to check each part
-			Entry("invalid GVK", Resource{GVK: GVK{}, Plural: "plural"}),
+			Entry("invalid GVK", Resource{GVK: GVK{}, Plural: invalidPlural}),
 			Entry("invalid Plural", Resource{GVK: gvk, Plural: "Plural"}),
-			Entry("invalid API", Resource{GVK: gvk, Plural: "plural", API: &API{CRDVersion: "1"}}),
-			Entry("invalid Webhooks", Resource{GVK: gvk, Plural: "plural", Webhooks: &Webhooks{WebhookVersion: "1"}}),
+			Entry("invalid API", Resource{GVK: gvk, Plural: invalidPlural, API: &API{CRDVersion: "1"}}),
+			Entry("invalid Webhooks", Resource{GVK: gvk, Plural: invalidPlural, Webhooks: &Webhooks{WebhookVersion: "1"}}),
 		)
 	})
 

--- a/pkg/model/resource/suite_test.go
+++ b/pkg/model/resource/suite_test.go
@@ -23,7 +23,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const v1 = "v1"
+const (
+	v1      = "v1"
+	v1beta1 = "v1beta1"
+)
 
 func TestResource(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/pkg/model/resource/webhooks_test.go
+++ b/pkg/model/resource/webhooks_test.go
@@ -23,6 +23,10 @@ import (
 
 //nolint:dupl
 var _ = Describe("Webhooks", func() {
+	const (
+		customDefaultingPath = "/custom-defaulting"
+		customValidationPath = "/custom-validation"
+	)
 	Context("Validate", func() {
 		It("should succeed for a valid Webhooks", func() {
 			Expect(Webhooks{WebhookVersion: v1}.Validate()).To(Succeed())
@@ -102,7 +106,7 @@ var _ = Describe("Webhooks", func() {
 
 			It("should fail if previously set and provided webhooks versions do not match", func() {
 				webhook = Webhooks{WebhookVersion: v1}
-				other = Webhooks{WebhookVersion: "v1beta1"}
+				other = Webhooks{WebhookVersion: v1beta1}
 				Expect(webhook.Update(&other)).NotTo(Succeed())
 			})
 		})
@@ -200,9 +204,9 @@ var _ = Describe("Webhooks", func() {
 		Context("Custom webhook paths", func() {
 			It("should set the defaulting path if provided and not previously set", func() {
 				webhook = Webhooks{}
-				other = Webhooks{DefaultingPath: "/custom-defaulting"}
+				other = Webhooks{DefaultingPath: customDefaultingPath}
 				Expect(webhook.Update(&other)).To(Succeed())
-				Expect(webhook.DefaultingPath).To(Equal("/custom-defaulting"))
+				Expect(webhook.DefaultingPath).To(Equal(customDefaultingPath))
 			})
 
 			It("should update the defaulting path if other provides a new one", func() {
@@ -214,9 +218,9 @@ var _ = Describe("Webhooks", func() {
 
 			It("should set the validation path if provided and not previously set", func() {
 				webhook = Webhooks{}
-				other = Webhooks{ValidationPath: "/custom-validation"}
+				other = Webhooks{ValidationPath: customValidationPath}
 				Expect(webhook.Update(&other)).To(Succeed())
-				Expect(webhook.ValidationPath).To(Equal("/custom-validation"))
+				Expect(webhook.ValidationPath).To(Equal(customValidationPath))
 			})
 
 			It("should update the validation path if other provides a new one", func() {
@@ -331,8 +335,8 @@ var _ = Describe("Webhooks", func() {
 				Validation:     true,
 				Conversion:     true,
 				Spoke:          []string{"v1", "v2"},
-				DefaultingPath: "/custom-defaulting",
-				ValidationPath: "/custom-validation",
+				DefaultingPath: customDefaultingPath,
+				ValidationPath: customValidationPath,
 			}
 			other := webhook.Copy()
 
@@ -352,13 +356,13 @@ var _ = Describe("Webhooks", func() {
 				Validation:     true,
 				Conversion:     true,
 				Spoke:          []string{"v1", "v2"},
-				DefaultingPath: "/custom-defaulting",
-				ValidationPath: "/custom-validation",
+				DefaultingPath: customDefaultingPath,
+				ValidationPath: customValidationPath,
 			}
 			other := webhook.Copy()
 
 			// Modify the copy
-			other.WebhookVersion = "v1beta1"
+			other.WebhookVersion = v1beta1
 			other.Defaulting = false
 			other.Validation = false
 			other.Conversion = false
@@ -373,8 +377,8 @@ var _ = Describe("Webhooks", func() {
 			Expect(webhook.Validation).To(BeTrue())
 			Expect(webhook.Conversion).To(BeTrue())
 			Expect(webhook.Spoke).To(Equal([]string{"v1", "v2"}))
-			Expect(webhook.DefaultingPath).To(Equal("/custom-defaulting"))
-			Expect(webhook.ValidationPath).To(Equal("/custom-validation"))
+			Expect(webhook.DefaultingPath).To(Equal(customDefaultingPath))
+			Expect(webhook.ValidationPath).To(Equal(customValidationPath))
 		})
 
 		It("should handle nil Spoke slice", func() {

--- a/pkg/plugin/helpers_test.go
+++ b/pkg/plugin/helpers_test.go
@@ -27,6 +27,9 @@ import (
 )
 
 const (
+	testPluginDeployImageGo   = "deploy-image.go.kubebuilder.io"
+	testPluginGoKubebuilderV4 = "go.kubebuilder.io/v4"
+
 	short = "go"
 	name  = "go.kubebuilder.io"
 	key   = "go.kubebuilder.io/v1"
@@ -189,11 +192,11 @@ var _ = Describe("CommonSupportedProjectVersions", func() {
 var _ = Describe("GetPluginKeyForConfig", func() {
 	It("should return the plugin's own key when it's in the plugin chain", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{
-			"go.kubebuilder.io/v4",
+			testPluginGoKubebuilderV4,
 			"deploy-image.go.kubebuilder.io/v1-alpha",
 		}
 		Expect(GetPluginKeyForConfig(pluginChain, plugin)).To(Equal("deploy-image.go.kubebuilder.io/v1-alpha"))
@@ -201,11 +204,11 @@ var _ = Describe("GetPluginKeyForConfig", func() {
 
 	It("should return the bundle key when plugin is wrapped in a bundle", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{
-			"go.kubebuilder.io/v4",
+			testPluginGoKubebuilderV4,
 			"deploy-image.my-domain/v1-alpha",
 		}
 		Expect(GetPluginKeyForConfig(pluginChain, plugin)).To(Equal("deploy-image.my-domain/v1-alpha"))
@@ -213,22 +216,22 @@ var _ = Describe("GetPluginKeyForConfig", func() {
 
 	It("should fallback to plugin's own key when no match in chain", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{
-			"go.kubebuilder.io/v4",
+			testPluginGoKubebuilderV4,
 		}
 		Expect(GetPluginKeyForConfig(pluginChain, plugin)).To(Equal("deploy-image.go.kubebuilder.io/v1-alpha"))
 	})
 
 	It("should match on base name and version", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{
-			"go.kubebuilder.io/v4",
+			testPluginGoKubebuilderV4,
 			"deploy-image.operator-sdk.io/v1-alpha",
 		}
 		Expect(GetPluginKeyForConfig(pluginChain, plugin)).To(Equal("deploy-image.operator-sdk.io/v1-alpha"))
@@ -236,11 +239,11 @@ var _ = Describe("GetPluginKeyForConfig", func() {
 
 	It("should not match if version differs", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{
-			"go.kubebuilder.io/v4",
+			testPluginGoKubebuilderV4,
 			"deploy-image.my-domain/v2-alpha",
 		}
 		Expect(GetPluginKeyForConfig(pluginChain, plugin)).To(Equal("deploy-image.go.kubebuilder.io/v1-alpha"))
@@ -248,11 +251,11 @@ var _ = Describe("GetPluginKeyForConfig", func() {
 
 	It("should not match if base name differs", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{
-			"go.kubebuilder.io/v4",
+			testPluginGoKubebuilderV4,
 			"other-plugin.my-domain/v1-alpha",
 		}
 		Expect(GetPluginKeyForConfig(pluginChain, plugin)).To(Equal("deploy-image.go.kubebuilder.io/v1-alpha"))
@@ -260,7 +263,7 @@ var _ = Describe("GetPluginKeyForConfig", func() {
 
 	It("should choose the first matching bundle when multiple candidates exist", func() {
 		plugin := mockPlugin{
-			name:    "deploy-image.go.kubebuilder.io",
+			name:    testPluginDeployImageGo,
 			version: Version{Number: 1, Stage: stage.Alpha},
 		}
 		pluginChain := []string{

--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -190,11 +190,22 @@ func (m *mockValidMEOutputGetter) GetExecOutput(_ []byte, _ string) ([]byte, err
 }
 
 const (
-	externalPlugin = "myexternalplugin.sh"
-	floatVal       = "float"
+	argDomain               = "--domain"
+	pluginScriptPath        = "test.sh"
+	universeFileName        = "file"
+	pluginGoKubebuilderV4   = "go.kubebuilder.io/v4"
+	pluginGoKubebuilderV3   = "go.kubebuilder.io/v3"
+	pluginDeclarativeGoV1   = "declarative.go.kubebuilder.io/v1"
+	pluginKustomizeCommonV2 = "kustomize.common.kubebuilder.io/v2"
+	pluginCLI               = "cli.plugin/v1"
+	kindMyKind              = "MyKind"
+	exampleDomain           = "example.com"
+	apiGroupApps            = "apps"
 )
 
 var _ = Describe("Run external plugin using Scaffold", func() {
+	const externalPlugin = "myexternalplugin.sh"
+
 	Context("with valid mock values", func() {
 		const filePerm os.FileMode = 755
 		var (
@@ -226,7 +237,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			_, err = fs.FS.Stat(pluginFilePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			args = []string{"--domain", "example.com"}
+			args = []string{argDomain, exampleDomain}
 		})
 
 		AfterEach(func() {
@@ -293,7 +304,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			pluginFileName = externalPlugin
-			args = []string{"--domain", "example.com"}
+			args = []string{argDomain, exampleDomain}
 		})
 
 		It("should return error upon running init subcommand on the external plugin", func() {
@@ -397,7 +408,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 				for _, flag := range flags {
 					Expect(flagset.Lookup(flag.Name)).NotTo(BeNil())
 					// we parse floats as float64 Go type so this check will account for that
-					if flag.Type != floatVal {
+					if flag.Type != flagTypeFloat {
 						Expect(flagset.Lookup(flag.Name).Value.Type()).To(Equal(flag.Type))
 					} else {
 						Expect(flagset.Lookup(flag.Name).Value.Type()).To(Equal("float64"))
@@ -533,7 +544,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 	Context("Flag Parsing Filter Functions", func() {
 		It("gvk(Arg/Flag)Filter should filter out (--)group, (--)version, (--)kind", func() {
 			for _, toBeFiltered := range []string{
-				"group", "version", "kind",
+				flagNameGroup, flagNameVersion, flagNameKind,
 			} {
 				Expect(gvkArgFilter("--" + toBeFiltered)).To(BeFalse())
 				Expect(gvkArgFilter(toBeFiltered)).To(BeFalse())
@@ -545,11 +556,11 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 		})
 
 		It("helpArgFilter should filter out (--)help", func() {
-			Expect(helpArgFilter("--help")).To(BeFalse())
-			Expect(helpArgFilter("help")).To(BeFalse())
+			Expect(helpArgFilter(argHelp)).To(BeFalse())
+			Expect(helpArgFilter(flagNameHelp)).To(BeFalse())
 			Expect(helpArgFilter("somerandomflag")).To(BeTrue())
-			Expect(helpFlagFilter(external.Flag{Name: "--help"})).To(BeFalse())
-			Expect(helpFlagFilter(external.Flag{Name: "help"})).To(BeFalse())
+			Expect(helpFlagFilter(external.Flag{Name: argHelp})).To(BeFalse())
+			Expect(helpFlagFilter(external.Flag{Name: flagNameHelp})).To(BeFalse())
 			Expect(helpFlagFilter(external.Flag{Name: "somerandomflag"})).To(BeTrue())
 		})
 	})
@@ -566,16 +577,16 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 
 		BeforeEach(func() {
 			args = []string{
-				"--domain", "something.com",
+				argDomain, "something.com",
 				"--boolean",
 				"--another", "flag",
-				"--help",
-				"--group", "somegroup",
-				"--kind", "somekind",
-				"--version", "someversion",
+				argHelp,
+				argGroup, "somegroup",
+				argKind, "somekind",
+				argVersion, "someversion",
 			}
 			forbidden = []string{
-				"help", "group", "kind", "version",
+				flagNameHelp, flagNameGroup, flagNameKind, flagNameVersion,
 			}
 
 			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
@@ -632,7 +643,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			for _, flag := range filteredFlags {
 				Expect(fs.Lookup(flag.Name)).NotTo(BeNil())
 				// we parse floats as float64 Go type so this check will account for that
-				if flag.Type != floatVal {
+				if flag.Type != flagTypeFloat {
 					Expect(fs.Lookup(flag.Name).Value.Type()).To(Equal(flag.Type))
 				} else {
 					Expect(fs.Lookup(flag.Name).Value.Type()).To(Equal("float64"))
@@ -792,17 +803,17 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}{
 				{
 					path:    "./",
-					name:    "file",
+					name:    universeFileName,
 					content: "level 0 file",
 				},
 				{
 					path:    "dir/",
-					name:    "file",
+					name:    universeFileName,
 					content: "level 1 file",
 				},
 				{
 					path:    "dir/subdir",
-					name:    "file",
+					name:    universeFileName,
 					content: "level 2 file",
 				},
 			}
@@ -841,15 +852,15 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 				It("keeps the CLI-provided chain when config omits pluginChain", func() {
 					sub := caseData.new()
 
-					cliChain := []string{"cli.plugin/v1"}
+					cliChain := []string{pluginCLI}
 					sub.SetPluginChain(cliChain)
 
 					cliChain[0] = "mutated"
-					Expect(caseData.get(sub)).To(Equal([]string{"cli.plugin/v1"}))
+					Expect(caseData.get(sub)).To(Equal([]string{pluginCLI}))
 
 					cfg := v3.New()
 					Expect(sub.InjectConfig(cfg)).To(Succeed())
-					Expect(caseData.get(sub)).To(Equal([]string{"cli.plugin/v1"}))
+					Expect(caseData.get(sub)).To(Equal([]string{pluginCLI}))
 
 					sub.SetPluginChain(nil)
 					Expect(caseData.get(sub)).To(BeNil())
@@ -857,7 +868,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 
 				It("prefers the config plugin chain when present", func() {
 					sub := caseData.new()
-					sub.SetPluginChain([]string{"cli.plugin/v1"})
+					sub.SetPluginChain([]string{pluginCLI})
 
 					cfg := v3.New()
 					expected := []string{"config.plugin/v2"}
@@ -890,14 +901,14 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			i := initSubcommand{
-				Path:        "test.sh",
-				Args:        []string{"--domain", "example.com"},
-				pluginChain: []string{"go.kubebuilder.io/v4", "kustomize.common.kubebuilder.io/v2"},
+				Path:        pluginScriptPath,
+				Args:        []string{argDomain, exampleDomain},
+				pluginChain: []string{pluginGoKubebuilderV4, pluginKustomizeCommonV2},
 			}
 
 			err := i.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v4", "kustomize.common.kubebuilder.io/v2"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV4, pluginKustomizeCommonV2}))
 		})
 
 		It("should pass plugin chain to create api subcommand", func() {
@@ -906,14 +917,14 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			c := createAPISubcommand{
-				Path:        "test.sh",
-				Args:        []string{"--group", "apps", "--version", "v1", "--kind", "MyKind"},
-				pluginChain: []string{"go.kubebuilder.io/v4"},
+				Path:        pluginScriptPath,
+				Args:        []string{argGroup, apiGroupApps, argVersion, "v1", argKind, kindMyKind},
+				pluginChain: []string{pluginGoKubebuilderV4},
 			}
 
 			err := c.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v4"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV4}))
 		})
 
 		It("should pass plugin chain to create webhook subcommand", func() {
@@ -922,14 +933,14 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			w := createWebhookSubcommand{
-				Path:        "test.sh",
-				Args:        []string{"--group", "apps", "--version", "v1", "--kind", "MyKind"},
-				pluginChain: []string{"go.kubebuilder.io/v3"},
+				Path:        pluginScriptPath,
+				Args:        []string{argGroup, apiGroupApps, argVersion, "v1", argKind, kindMyKind},
+				pluginChain: []string{pluginGoKubebuilderV3},
 			}
 
 			err := w.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v3"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV3}))
 		})
 
 		It("should pass plugin chain to edit subcommand", func() {
@@ -938,14 +949,14 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			e := editSubcommand{
-				Path:        "test.sh",
+				Path:        pluginScriptPath,
 				Args:        []string{"--multigroup"},
-				pluginChain: []string{"go.kubebuilder.io/v4", "declarative.go.kubebuilder.io/v1"},
+				pluginChain: []string{pluginGoKubebuilderV4, pluginDeclarativeGoV1},
 			}
 
 			err := e.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v4", "declarative.go.kubebuilder.io/v1"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV4, pluginDeclarativeGoV1}))
 		})
 	})
 
@@ -984,7 +995,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			_, err = fs.FS.Stat(pluginFilePath)
 			Expect(err).ToNot(HaveOccurred())
 
-			args = []string{"--domain", "example.com"}
+			args = []string{argDomain, exampleDomain}
 
 			cfg = &v3.Cfg{
 				Version:    v3.Version,
@@ -993,7 +1004,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 				Name:       "test-project",
 			}
 
-			expectedChain = []string{"go.kubebuilder.io/v4", "kustomize.common.kubebuilder.io/v2"}
+			expectedChain = []string{pluginGoKubebuilderV4, pluginKustomizeCommonV2}
 			Expect(cfg.SetPluginChain(expectedChain)).To(Succeed())
 		})
 
@@ -1105,18 +1116,18 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			cfg := &v3.Cfg{Version: v3.Version}
-			Expect(cfg.SetPluginChain([]string{"go.kubebuilder.io/v4", "kustomize.common.kubebuilder.io/v2"})).To(Succeed())
+			Expect(cfg.SetPluginChain([]string{pluginGoKubebuilderV4, pluginKustomizeCommonV2})).To(Succeed())
 
 			i := initSubcommand{
-				Path: "test.sh",
-				Args: []string{"--domain", "example.com"},
+				Path: pluginScriptPath,
+				Args: []string{argDomain, exampleDomain},
 			}
 
 			Expect(i.InjectConfig(cfg)).To(Succeed())
 
 			err := i.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v4", "kustomize.common.kubebuilder.io/v2"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV4, pluginKustomizeCommonV2}))
 		})
 
 		It("should pass plugin chain to create api subcommand", func() {
@@ -1125,18 +1136,18 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			cfg := &v3.Cfg{Version: v3.Version}
-			Expect(cfg.SetPluginChain([]string{"go.kubebuilder.io/v4"})).To(Succeed())
+			Expect(cfg.SetPluginChain([]string{pluginGoKubebuilderV4})).To(Succeed())
 
 			c := createAPISubcommand{
-				Path: "test.sh",
-				Args: []string{"--group", "apps", "--version", "v1", "--kind", "MyKind"},
+				Path: pluginScriptPath,
+				Args: []string{argGroup, apiGroupApps, argVersion, "v1", argKind, kindMyKind},
 			}
 
 			Expect(c.InjectConfig(cfg)).To(Succeed())
 
 			err := c.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v4"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV4}))
 		})
 
 		It("should pass plugin chain to create webhook subcommand", func() {
@@ -1145,18 +1156,18 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			cfg := &v3.Cfg{Version: v3.Version}
-			Expect(cfg.SetPluginChain([]string{"go.kubebuilder.io/v3"})).To(Succeed())
+			Expect(cfg.SetPluginChain([]string{pluginGoKubebuilderV3})).To(Succeed())
 
 			w := createWebhookSubcommand{
-				Path: "test.sh",
-				Args: []string{"--group", "apps", "--version", "v1", "--kind", "MyKind"},
+				Path: pluginScriptPath,
+				Args: []string{argGroup, apiGroupApps, argVersion, "v1", argKind, kindMyKind},
 			}
 
 			Expect(w.InjectConfig(cfg)).To(Succeed())
 
 			err := w.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v3"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV3}))
 		})
 
 		It("should pass plugin chain to edit subcommand", func() {
@@ -1165,10 +1176,10 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 			}
 
 			cfg := &v3.Cfg{Version: v3.Version}
-			Expect(cfg.SetPluginChain([]string{"go.kubebuilder.io/v4", "declarative.go.kubebuilder.io/v1"})).To(Succeed())
+			Expect(cfg.SetPluginChain([]string{pluginGoKubebuilderV4, pluginDeclarativeGoV1})).To(Succeed())
 
 			e := editSubcommand{
-				Path: "test.sh",
+				Path: pluginScriptPath,
 				Args: []string{"--multigroup"},
 			}
 
@@ -1176,7 +1187,7 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 
 			err := e.Scaffold(fs)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pluginChainCaptured).To(Equal([]string{"go.kubebuilder.io/v4", "declarative.go.kubebuilder.io/v1"}))
+			Expect(pluginChainCaptured).To(Equal([]string{pluginGoKubebuilderV4, pluginDeclarativeGoV1}))
 		})
 	})
 })
@@ -1185,13 +1196,13 @@ func getFlags() []external.Flag {
 	return []external.Flag{
 		{
 			Name:    "captain",
-			Type:    "string",
+			Type:    flagTypeString,
 			Usage:   "specify the ship captain",
 			Default: "jack-sparrow",
 		},
 		{
 			Name:    "sail",
-			Type:    "bool",
+			Type:    flagTypeBool,
 			Usage:   "deploy the sail",
 			Default: "false",
 		},
@@ -1228,7 +1239,7 @@ var _ = Describe("Plugin", func() {
 				{Number: 3},
 			},
 			Path: "/path/to/plugin",
-			Args: []string{"--flag", "value"},
+			Args: []string{argFlag, argValue},
 		}
 	})
 
@@ -1250,7 +1261,7 @@ var _ = Describe("Plugin", func() {
 		initSub, ok := sub.(*initSubcommand)
 		Expect(ok).To(BeTrue())
 		Expect(initSub.Path).To(Equal("/path/to/plugin"))
-		Expect(initSub.Args).To(Equal([]string{"--flag", "value"}))
+		Expect(initSub.Args).To(Equal([]string{argFlag, argValue}))
 	})
 
 	It("should return create API subcommand", func() {
@@ -1259,7 +1270,7 @@ var _ = Describe("Plugin", func() {
 		apiSub, ok := sub.(*createAPISubcommand)
 		Expect(ok).To(BeTrue())
 		Expect(apiSub.Path).To(Equal("/path/to/plugin"))
-		Expect(apiSub.Args).To(Equal([]string{"--flag", "value"}))
+		Expect(apiSub.Args).To(Equal([]string{argFlag, argValue}))
 	})
 
 	It("should return create webhook subcommand", func() {
@@ -1268,7 +1279,7 @@ var _ = Describe("Plugin", func() {
 		webhookSub, ok := sub.(*createWebhookSubcommand)
 		Expect(ok).To(BeTrue())
 		Expect(webhookSub.Path).To(Equal("/path/to/plugin"))
-		Expect(webhookSub.Args).To(Equal([]string{"--flag", "value"}))
+		Expect(webhookSub.Args).To(Equal([]string{argFlag, argValue}))
 	})
 
 	It("should return edit subcommand", func() {
@@ -1277,7 +1288,7 @@ var _ = Describe("Plugin", func() {
 		editSub, ok := sub.(*editSubcommand)
 		Expect(ok).To(BeTrue())
 		Expect(editSub.Path).To(Equal("/path/to/plugin"))
-		Expect(editSub.Args).To(Equal([]string{"--flag", "value"}))
+		Expect(editSub.Args).To(Equal([]string{argFlag, argValue}))
 	})
 
 	It("should return empty deprecation warning", func() {

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -39,6 +39,17 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"
 )
 
+const (
+	flagTypeBool   = "bool"
+	flagTypeString = "string"
+	flagTypeFloat  = "float"
+
+	flagNameGroup   = "group"
+	flagNameVersion = "version"
+	flagNameKind    = "kind"
+	flagNameHelp    = "help"
+)
+
 var outputGetter ExecOutputGetter = &execOutputGetter{}
 
 const defaultMetadataTemplate = `
@@ -256,13 +267,13 @@ func bindSpecificFlags(fs *pflag.FlagSet, flags []external.Flag) {
 	// Only bind flags returned by the external plugin
 	for _, flag := range flags {
 		switch flag.Type {
-		case "bool":
+		case flagTypeBool:
 			defaultValue, _ := strconv.ParseBool(flag.Default)
 			_ = fs.Bool(flag.Name, defaultValue, flag.Usage)
 		case "int":
 			defaultValue, _ := strconv.Atoi(flag.Default)
 			_ = fs.Int(flag.Name, defaultValue, flag.Usage)
-		case "float":
+		case flagTypeFloat:
 			defaultValue, _ := strconv.ParseFloat(flag.Default, 64)
 			_ = fs.Float64(flag.Name, defaultValue, flag.Usage)
 		default:
@@ -320,7 +331,7 @@ var (
 	gvkArgFilter = func(arg string) bool {
 		arg = strings.Replace(arg, "--", "", 1)
 		return !slices.Contains([]string{
-			"group", "version", "kind",
+			flagNameGroup, flagNameVersion, flagNameKind,
 		}, arg)
 	}
 
@@ -331,7 +342,7 @@ var (
 	// helpArgFilter filters out any flag named "help" as its already bound
 	helpArgFilter = func(arg string) bool {
 		arg = strings.Replace(arg, "--", "", 1)
-		return arg != "help"
+		return arg != flagNameHelp
 	}
 )
 

--- a/pkg/plugins/external/helpers_test.go
+++ b/pkg/plugins/external/helpers_test.go
@@ -23,25 +23,38 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"
 )
 
+const (
+	argGroup       = "--group"
+	argVersion     = "--version"
+	argKind        = "--kind"
+	argHelp        = "--help"
+	argFlag        = "--flag"
+	argCustom      = "--custom"
+	flagNameCustom = "custom"
+	argFlag1       = "--flag1"
+	argFlag2       = "--flag2"
+	argValue       = "value"
+)
+
 var _ = Describe("helpers", func() {
 	Context("isBooleanFlag", func() {
 		It("should return true when next arg starts with --", func() {
-			args := []string{"--flag1", "--flag2", "value"}
+			args := []string{argFlag1, argFlag2, argValue}
 			Expect(isBooleanFlag(0, args)).To(BeTrue())
 		})
 
 		It("should return true when at end of args", func() {
-			args := []string{"--flag1", "--flag2"}
+			args := []string{argFlag1, argFlag2}
 			Expect(isBooleanFlag(1, args)).To(BeTrue())
 		})
 
 		It("should return false when next arg is a value", func() {
-			args := []string{"--flag1", "value", "--flag2"}
+			args := []string{argFlag1, argValue, argFlag2}
 			Expect(isBooleanFlag(0, args)).To(BeFalse())
 		})
 
 		It("should return true for last argument", func() {
-			args := []string{"--flag"}
+			args := []string{argFlag}
 			Expect(isBooleanFlag(0, args)).To(BeTrue())
 		})
 	})
@@ -51,39 +64,39 @@ var _ = Describe("helpers", func() {
 
 		BeforeEach(func() {
 			testFlags = []external.Flag{
-				{Name: "group", Type: "string"},
-				{Name: "version", Type: "string"},
-				{Name: "kind", Type: "string"},
-				{Name: "custom", Type: "string"},
-				{Name: "help", Type: "bool"},
+				{Name: flagNameGroup, Type: flagTypeString},
+				{Name: flagNameVersion, Type: flagTypeString},
+				{Name: flagNameKind, Type: flagTypeString},
+				{Name: flagNameCustom, Type: flagTypeString},
+				{Name: flagNameHelp, Type: flagTypeBool},
 			}
 		})
 
 		It("should filter flags based on single filter", func() {
 			filter := func(flag external.Flag) bool {
-				return flag.Name != "group"
+				return flag.Name != flagNameGroup
 			}
 			result := filterFlags(testFlags, []externalFlagFilterFunc{filter})
 
 			Expect(result).To(HaveLen(4))
 			for _, flag := range result {
-				Expect(flag.Name).NotTo(Equal("group"))
+				Expect(flag.Name).NotTo(Equal(flagNameGroup))
 			}
 		})
 
 		It("should filter flags based on multiple filters", func() {
 			filter1 := func(flag external.Flag) bool {
-				return flag.Name != "group"
+				return flag.Name != flagNameGroup
 			}
 			filter2 := func(flag external.Flag) bool {
-				return flag.Name != "help"
+				return flag.Name != flagNameHelp
 			}
 			result := filterFlags(testFlags, []externalFlagFilterFunc{filter1, filter2})
 
 			Expect(result).To(HaveLen(3))
-			Expect(result).To(ContainElement(external.Flag{Name: "version", Type: "string"}))
-			Expect(result).To(ContainElement(external.Flag{Name: "kind", Type: "string"}))
-			Expect(result).To(ContainElement(external.Flag{Name: "custom", Type: "string"}))
+			Expect(result).To(ContainElement(external.Flag{Name: flagNameVersion, Type: flagTypeString}))
+			Expect(result).To(ContainElement(external.Flag{Name: flagNameKind, Type: flagTypeString}))
+			Expect(result).To(ContainElement(external.Flag{Name: flagNameCustom, Type: flagTypeString}))
 		})
 
 		It("should return empty when all flags filtered out", func() {
@@ -105,26 +118,26 @@ var _ = Describe("helpers", func() {
 
 	Context("filterArgs", func() {
 		It("should filter args based on single filter", func() {
-			args := []string{"--group", "--version", "--custom", "--help"}
+			args := []string{argGroup, argVersion, argCustom, argHelp}
 			filter := func(arg string) bool {
-				return arg != "--group"
+				return arg != argGroup
 			}
 			result := filterArgs(args, []argFilterFunc{filter})
 
-			Expect(result).To(Equal([]string{"--version", "--custom", "--help"}))
+			Expect(result).To(Equal([]string{argVersion, argCustom, argHelp}))
 		})
 
 		It("should filter args based on multiple filters", func() {
-			args := []string{"--group", "--version", "--custom"}
+			args := []string{argGroup, argVersion, argCustom}
 			filter1 := func(arg string) bool {
-				return arg != "--group"
+				return arg != argGroup
 			}
 			filter2 := func(arg string) bool {
-				return arg != "--version"
+				return arg != argVersion
 			}
 			result := filterArgs(args, []argFilterFunc{filter1, filter2})
 
-			Expect(result).To(Equal([]string{"--custom"}))
+			Expect(result).To(Equal([]string{argCustom}))
 		})
 
 		It("should return empty when all args filtered out", func() {
@@ -148,60 +161,60 @@ var _ = Describe("helpers", func() {
 
 	Context("gvkArgFilter", func() {
 		It("should filter out group flag", func() {
-			Expect(gvkArgFilter("group")).To(BeFalse())
-			Expect(gvkArgFilter("--group")).To(BeFalse())
+			Expect(gvkArgFilter(flagNameGroup)).To(BeFalse())
+			Expect(gvkArgFilter(argGroup)).To(BeFalse())
 		})
 
 		It("should filter out version flag", func() {
-			Expect(gvkArgFilter("version")).To(BeFalse())
-			Expect(gvkArgFilter("--version")).To(BeFalse())
+			Expect(gvkArgFilter(flagNameVersion)).To(BeFalse())
+			Expect(gvkArgFilter(argVersion)).To(BeFalse())
 		})
 
 		It("should filter out kind flag", func() {
-			Expect(gvkArgFilter("kind")).To(BeFalse())
-			Expect(gvkArgFilter("--kind")).To(BeFalse())
+			Expect(gvkArgFilter(flagNameKind)).To(BeFalse())
+			Expect(gvkArgFilter(argKind)).To(BeFalse())
 		})
 
 		It("should allow other flags", func() {
-			Expect(gvkArgFilter("custom")).To(BeTrue())
-			Expect(gvkArgFilter("--custom")).To(BeTrue())
+			Expect(gvkArgFilter(flagNameCustom)).To(BeTrue())
+			Expect(gvkArgFilter(argCustom)).To(BeTrue())
 			Expect(gvkArgFilter("domain")).To(BeTrue())
 		})
 	})
 
 	Context("gvkFlagFilter", func() {
 		It("should filter out group, version, kind flags", func() {
-			Expect(gvkFlagFilter(external.Flag{Name: "group"})).To(BeFalse())
-			Expect(gvkFlagFilter(external.Flag{Name: "version"})).To(BeFalse())
-			Expect(gvkFlagFilter(external.Flag{Name: "kind"})).To(BeFalse())
+			Expect(gvkFlagFilter(external.Flag{Name: flagNameGroup})).To(BeFalse())
+			Expect(gvkFlagFilter(external.Flag{Name: flagNameVersion})).To(BeFalse())
+			Expect(gvkFlagFilter(external.Flag{Name: flagNameKind})).To(BeFalse())
 		})
 
 		It("should allow other flags", func() {
-			Expect(gvkFlagFilter(external.Flag{Name: "custom"})).To(BeTrue())
+			Expect(gvkFlagFilter(external.Flag{Name: flagNameCustom})).To(BeTrue())
 			Expect(gvkFlagFilter(external.Flag{Name: "domain"})).To(BeTrue())
 		})
 	})
 
 	Context("helpArgFilter", func() {
 		It("should filter out help flag", func() {
-			Expect(helpArgFilter("help")).To(BeFalse())
-			Expect(helpArgFilter("--help")).To(BeFalse())
+			Expect(helpArgFilter(flagNameHelp)).To(BeFalse())
+			Expect(helpArgFilter(argHelp)).To(BeFalse())
 		})
 
 		It("should allow other flags", func() {
-			Expect(helpArgFilter("custom")).To(BeTrue())
-			Expect(helpArgFilter("--custom")).To(BeTrue())
+			Expect(helpArgFilter(flagNameCustom)).To(BeTrue())
+			Expect(helpArgFilter(argCustom)).To(BeTrue())
 			Expect(helpArgFilter("helpful")).To(BeTrue())
 		})
 	})
 
 	Context("helpFlagFilter", func() {
 		It("should filter out help flag", func() {
-			Expect(helpFlagFilter(external.Flag{Name: "help"})).To(BeFalse())
+			Expect(helpFlagFilter(external.Flag{Name: flagNameHelp})).To(BeFalse())
 		})
 
 		It("should allow other flags", func() {
-			Expect(helpFlagFilter(external.Flag{Name: "custom"})).To(BeTrue())
+			Expect(helpFlagFilter(external.Flag{Name: flagNameCustom})).To(BeTrue())
 			Expect(helpFlagFilter(external.Flag{Name: "helpful"})).To(BeTrue())
 		})
 	})

--- a/pkg/plugins/golang/deploy-image/v1alpha1/api_test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api_test.go
@@ -47,8 +47,8 @@ var _ = Describe("createAPISubcommand", func() {
 		subCmd.options = &goPlugin.Options{}
 		res = &resource.Resource{
 			GVK: resource.GVK{
-				Group:   "example.com",
-				Domain:  "test.io",
+				Group:   exampleDomain,
+				Domain:  testIODomain,
 				Version: "v1alpha1",
 				Kind:    "Memcached",
 			},
@@ -97,7 +97,7 @@ var _ = Describe("createAPISubcommand", func() {
 
 		It("should check for cmd/main.go in go/v4 projects", func() {
 			subCmd.image = "busybox:1.36.1"
-			_ = cfg.SetPluginChain([]string{"go.kubebuilder.io/v4"})
+			_ = cfg.SetPluginChain([]string{pluginGoKubebuilder})
 
 			tmpDir, err := os.MkdirTemp("", "deploy-image-test")
 			Expect(err).NotTo(HaveOccurred())
@@ -152,7 +152,7 @@ var _ = Describe("createAPISubcommand", func() {
 			firstRes := resource.Resource{
 				GVK: resource.GVK{
 					Group:   "ship",
-					Domain:  "test.io",
+					Domain:  testIODomain,
 					Version: "v1",
 					Kind:    "Frigate",
 				},
@@ -161,7 +161,7 @@ var _ = Describe("createAPISubcommand", func() {
 			}
 			Expect(cfg.AddResource(firstRes)).To(Succeed())
 
-			res.Group = "example.com"
+			res.Group = exampleDomain
 			res.Plural = "memcacheds"
 
 			err := subCmd.InjectResource(res)
@@ -176,7 +176,7 @@ var _ = Describe("createAPISubcommand", func() {
 			firstRes := resource.Resource{
 				GVK: resource.GVK{
 					Group:   "ship",
-					Domain:  "test.io",
+					Domain:  testIODomain,
 					Version: "v1",
 					Kind:    "Frigate",
 				},
@@ -185,7 +185,7 @@ var _ = Describe("createAPISubcommand", func() {
 			}
 			Expect(cfg.AddResource(firstRes)).To(Succeed())
 
-			res.Group = "example.com"
+			res.Group = exampleDomain
 
 			Expect(subCmd.InjectResource(res)).To(Succeed())
 		})

--- a/pkg/plugins/golang/deploy-image/v1alpha1/plugin_test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/plugin_test.go
@@ -22,6 +22,13 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
+const (
+	exampleDomain       = "example.com"
+	testIODomain        = "test.io"
+	pluginGoKubebuilder = "go.kubebuilder.io/v4"
+	pluginDeployImage   = "deploy-image.go.kubebuilder.io/v1-alpha"
+)
+
 // TestGetPluginKeyForConfigIntegration tests that the plugin correctly resolves
 // its key based on the plugin chain, supporting custom bundle names.
 func TestGetPluginKeyForConfigIntegration(t *testing.T) {
@@ -35,38 +42,38 @@ func TestGetPluginKeyForConfigIntegration(t *testing.T) {
 	}{
 		{
 			name:        "exact match",
-			pluginChain: []string{"go.kubebuilder.io/v4", "deploy-image.go.kubebuilder.io/v1-alpha"},
-			expected:    "deploy-image.go.kubebuilder.io/v1-alpha",
+			pluginChain: []string{pluginGoKubebuilder, pluginDeployImage},
+			expected:    pluginDeployImage,
 			description: "When plugin is used directly, it should use its own key",
 		},
 		{
 			name:        "bundle match with custom domain",
-			pluginChain: []string{"go.kubebuilder.io/v4", "deploy-image.custom-domain/v1-alpha"},
+			pluginChain: []string{pluginGoKubebuilder, "deploy-image.custom-domain/v1-alpha"},
 			expected:    "deploy-image.custom-domain/v1-alpha",
 			description: "When plugin is wrapped in bundle with custom domain, it should use bundle's key",
 		},
 		{
 			name:        "bundle match with operator-sdk domain",
-			pluginChain: []string{"go.kubebuilder.io/v4", "deploy-image.operator-sdk.io/v1-alpha"},
+			pluginChain: []string{pluginGoKubebuilder, "deploy-image.operator-sdk.io/v1-alpha"},
 			expected:    "deploy-image.operator-sdk.io/v1-alpha",
 			description: "When plugin is wrapped in operator-sdk bundle, it should use bundle's key",
 		},
 		{
 			name:        "no match - fallback to plugin key",
-			pluginChain: []string{"go.kubebuilder.io/v4"},
-			expected:    "deploy-image.go.kubebuilder.io/v1-alpha",
+			pluginChain: []string{pluginGoKubebuilder},
+			expected:    pluginDeployImage,
 			description: "When no matching key in chain, fallback to plugin's own key",
 		},
 		{
 			name:        "version mismatch - fallback",
-			pluginChain: []string{"go.kubebuilder.io/v4", "deploy-image.custom-domain/v2-alpha"},
-			expected:    "deploy-image.go.kubebuilder.io/v1-alpha",
+			pluginChain: []string{pluginGoKubebuilder, "deploy-image.custom-domain/v2-alpha"},
+			expected:    pluginDeployImage,
 			description: "When version doesn't match, fallback to plugin's own key",
 		},
 		{
 			name:        "base name mismatch - fallback",
-			pluginChain: []string{"go.kubebuilder.io/v4", "other-plugin.custom-domain/v1-alpha"},
-			expected:    "deploy-image.go.kubebuilder.io/v1-alpha",
+			pluginChain: []string{pluginGoKubebuilder, "other-plugin.custom-domain/v1-alpha"},
+			expected:    pluginDeployImage,
 			description: "When base name doesn't match, fallback to plugin's own key",
 		},
 		{

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -122,6 +122,12 @@ func (s *apiScaffolder) Scaffold() error {
 	}
 
 	if err := scaffold.Execute(
+		&controllers.Conditions{},
+	); err != nil {
+		return fmt.Errorf("error scaffolding controller status reasons: %w", err)
+	}
+
+	if err := scaffold.Execute(
 		controller,
 	); err != nil {
 		return fmt.Errorf("error scaffolding controller: %w", err)

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -204,12 +204,12 @@ func (s *apiScaffolder) updateMainByAddingEventRecorder(defaultMainPath string) 
 
 // updateControllerCode will update the code generate on the template to add the Container information
 func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) error {
+	containerName := strings.ToLower(s.resource.Kind) + "ContainerName"
+
 	if err := util.ReplaceInFile(
 		controller.Path,
 		"//TODO: scaffold container",
-		fmt.Sprintf(containerTemplate, // value for the image
-			strings.ToLower(s.resource.Kind), // value for the name of the container
-		),
+		fmt.Sprintf(containerTemplate, containerName),
 	); err != nil {
 		return fmt.Errorf("error scaffolding container in the controller path %q: %w",
 			controller.Path, err)
@@ -258,7 +258,7 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 			fmt.Sprintf(
 				portTemplate,
 				strings.ToLower(s.resource.Kind),
-				strings.ToLower(s.resource.Kind)),
+				containerName),
 		); err != nil {
 			return fmt.Errorf("error scaffolding container port in the controller path %q: %w",
 				controller.Path,
@@ -309,7 +309,7 @@ func (s *apiScaffolder) scaffoldCreateAPIFromGolang() error {
 
 const containerTemplate = `Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "%s",
+						Name:            %s,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
@@ -333,7 +333,7 @@ const commandTemplate = `
 const portTemplate = `
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: %s.Spec.ContainerPort,
-							Name:          "%s",
+							Name:          %s,
 						}},`
 
 const recorderTemplate = `

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/conditions.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/conditions.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	log "log/slog"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ machinery.Template = &Conditions{}
+
+// Conditions scaffolds shared metav1.Condition constants for deploy-image controllers in this package.
+type Conditions struct {
+	machinery.TemplateMixin
+	machinery.MultiGroupMixin
+	machinery.BoilerplateMixin
+	machinery.ResourceMixin
+}
+
+// SetTemplateDefaults implements machinery.Template
+func (f *Conditions) SetTemplateDefaults() error {
+	if f.Path == "" {
+		if f.MultiGroup && f.Resource.Group != "" {
+			f.Path = filepath.Join("internal", "controller", "%[group]", "conditions.go")
+		} else {
+			f.Path = filepath.Join("internal", "controller", "conditions.go")
+		}
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+	log.Info(f.Path)
+
+	f.TemplateBody = conditionsTemplate
+	f.IfExistsAction = machinery.SkipFile
+
+	return nil
+}
+
+const conditionsTemplate = `{{ .Boilerplate }}
+
+{{if and .MultiGroup .Resource.Group }}
+package {{ .Resource.PackageName }}
+{{else}}
+package controller
+{{end}}
+
+const (
+	reasonReconciling = "Reconciling"
+	reasonFinalizing  = "Finalizing"
+)
+`

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller-test.go
@@ -34,8 +34,7 @@ type ControllerTest struct {
 	machinery.BoilerplateMixin
 	machinery.ResourceMixin
 
-	Port        string
-	PackageName string
+	Port string
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -50,7 +49,6 @@ func (f *ControllerTest) SetTemplateDefaults() error {
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 	log.Info(f.Path)
 
-	f.PackageName = "controller"
 	f.IfExistsAction = machinery.OverwriteFile
 
 	log.Info("creating import for resource", "resource", f.Resource.Path)
@@ -61,7 +59,11 @@ func (f *ControllerTest) SetTemplateDefaults() error {
 
 const controllerTestTemplate = `{{ .Boilerplate }}
 
-package {{ if and .MultiGroup .Resource.Group }}{{ .Resource.PackageName }}{{ else }}{{ .PackageName }}{{ end }}
+{{if and .MultiGroup .Resource.Group }}
+package {{ .Resource.PackageName }}
+{{else}}
+package controller
+{{end}}
 
 import (
 	"context"
@@ -196,7 +198,7 @@ var _ = Describe("{{ .Resource.Kind }} controller", func() {
 				HaveField("Type", Equal(typeAvailable{{ .Resource.Kind }})), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailable{{ .Resource.Kind }})
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailable{{ .Resource.Kind }})
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailable{{ .Resource.Kind }})
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailable{{ .Resource.Kind }})
 		})
 	})
 })

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -97,6 +97,8 @@ import (
 
 const {{ lower .Resource.Kind }}Finalizer = "{{ .Resource.Group }}.{{ .Resource.Domain }}/finalizer"
 
+const {{ lower .Resource.Kind }}ContainerName = "{{ lower .Resource.Kind }}"
+
 // Definitions to manage status conditions
 const (
 	// typeAvailable{{ .Resource.Kind }} represents the status of the Deployment reconciliation

--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/internal/templates/controllers/controller.go
@@ -37,8 +37,6 @@ type Controller struct {
 	machinery.NamespacedMixin
 
 	ControllerRuntimeVersion string
-
-	PackageName string
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -53,8 +51,6 @@ func (f *Controller) SetTemplateDefaults() error {
 	f.Path = f.Resource.Replacer().Replace(f.Path)
 	log.Info(f.Path)
 
-	f.PackageName = "controller"
-
 	log.Info("creating import for resource", "resource_path", f.Resource.Path)
 	f.TemplateBody = controllerTemplate
 
@@ -67,7 +63,11 @@ func (f *Controller) SetTemplateDefaults() error {
 //nolint:lll
 const controllerTemplate = `{{ .Boilerplate }}
 
-package {{ if and .MultiGroup .Resource.Group }}{{ .Resource.PackageName }}{{ else }}{{ .PackageName }}{{ end }}
+{{if and .MultiGroup .Resource.Group }}
+package {{ .Resource.PackageName }}
+{{else}}
+package controller
+{{end}}
 
 import (
 	"context"
@@ -164,7 +164,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	
 	if len({{ lower .Resource.Kind }}.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }}, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }}, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
 			log.Error(err, "Failed to update {{ .Resource.Kind }} status")
 			return ctrl.Result{}, err
@@ -202,7 +202,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeDegraded{{ .Resource.Kind }},
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", {{ lower .Resource.Kind }}.Name)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -228,7 +228,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 			}
 
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeDegraded{{ .Resource.Kind }},
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", {{ lower .Resource.Kind }}.Name)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -262,7 +262,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }},
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", {{ lower .Resource.Kind }}.Name, err)})
 
 			if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {
@@ -337,7 +337,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&{{ lower .Resource.Kind }}.Status.Conditions, metav1.Condition{Type: typeAvailable{{ .Resource.Kind }},
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", {{ lower .Resource.Kind }}.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, {{ lower .Resource.Kind }}); err != nil {

--- a/pkg/plugins/golang/go_version_test.go
+++ b/pkg/plugins/golang/go_version_test.go
@@ -24,6 +24,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	goPrereleaseAlpha = "alpha1"
+	goPrereleaseBeta  = "beta1"
+	goPrereleaseRC    = "rc1"
+)
+
 var _ = Describe("GoVersion", func() {
 	Context("String", func() {
 		It("patch is not empty", func() {
@@ -80,17 +86,17 @@ var _ = Describe("GoVersion", func() {
 			Entry("for alpha release", "go1.15alpha1", GoVersion{
 				major:      1,
 				minor:      15,
-				prerelease: "alpha1",
+				prerelease: goPrereleaseAlpha,
 			}),
 			Entry("for beta release", "go1.15beta1", GoVersion{
 				major:      1,
 				minor:      15,
-				prerelease: "beta1",
+				prerelease: goPrereleaseBeta,
 			}),
 			Entry("for release candidate", "go1.15rc1", GoVersion{
 				major:      1,
 				minor:      15,
-				prerelease: "rc1",
+				prerelease: goPrereleaseRC,
 			}),
 		)
 

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -25,30 +25,32 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
+const k8sIODomainSuffix = "k8s.io"
+
 var coreGroups = map[string]string{
-	"admission":             "k8s.io",
-	"admissionregistration": "k8s.io",
+	"admission":             k8sIODomainSuffix,
+	"admissionregistration": k8sIODomainSuffix,
 	"apps":                  "",
-	"auditregistration":     "k8s.io",
-	"apiextensions":         "k8s.io",
-	"authentication":        "k8s.io",
-	"authorization":         "k8s.io",
+	"auditregistration":     k8sIODomainSuffix,
+	"apiextensions":         k8sIODomainSuffix,
+	"authentication":        k8sIODomainSuffix,
+	"authorization":         k8sIODomainSuffix,
 	"autoscaling":           "",
 	"batch":                 "",
-	"certificates":          "k8s.io",
-	"coordination":          "k8s.io",
+	"certificates":          k8sIODomainSuffix,
+	"coordination":          k8sIODomainSuffix,
 	"core":                  "",
-	"events":                "k8s.io",
+	"events":                k8sIODomainSuffix,
 	"extensions":            "",
-	"imagepolicy":           "k8s.io",
-	"networking":            "k8s.io",
-	"node":                  "k8s.io",
-	"metrics":               "k8s.io",
+	"imagepolicy":           k8sIODomainSuffix,
+	"networking":            k8sIODomainSuffix,
+	"node":                  k8sIODomainSuffix,
+	"metrics":               k8sIODomainSuffix,
 	"policy":                "",
-	"rbac.authorization":    "k8s.io",
-	"scheduling":            "k8s.io",
-	"setting":               "k8s.io",
-	"storage":               "k8s.io",
+	"rbac.authorization":    k8sIODomainSuffix,
+	"scheduling":            k8sIODomainSuffix,
+	"setting":               k8sIODomainSuffix,
+	"storage":               k8sIODomainSuffix,
 }
 
 // Options contains the information required to build a new resource.Resource.

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Options", func() {
 			domain  = "test.io"
 			version = "v1"
 			kind    = "FirstMate"
+			plural  = "firstmates"
 		)
 
 		var (
@@ -64,7 +65,7 @@ var _ = Describe("Options", func() {
 
 					res := resource.Resource{
 						GVK:      gvk,
-						Plural:   "firstmates",
+						Plural:   plural,
 						API:      &resource.API{},
 						Webhooks: &resource.Webhooks{},
 					}
@@ -142,7 +143,7 @@ var _ = Describe("Options", func() {
 							Version: version,
 							Kind:    kind,
 						},
-						Plural:   "firstmates",
+						Plural:   plural,
 						API:      &resource.API{},
 						Webhooks: &resource.Webhooks{},
 					}
@@ -182,7 +183,7 @@ var _ = Describe("Options", func() {
 							Version: version,
 							Kind:    kind,
 						},
-						Plural:   "firstmates",
+						Plural:   plural,
 						API:      &resource.API{},
 						Webhooks: &resource.Webhooks{},
 					}

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -27,6 +27,15 @@ import (
 	goPlugin "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
 )
 
+const (
+	crewGroup   = "crew"
+	testIO      = "test.io"
+	captainKind = "Captain"
+	captains    = "captains"
+	shipGroup   = "ship"
+	frigateKind = "Frigate"
+)
+
 var _ = Describe("createAPISubcommand", func() {
 	var (
 		subCmd *createAPISubcommand
@@ -45,12 +54,12 @@ var _ = Describe("createAPISubcommand", func() {
 
 		res = &resource.Resource{
 			GVK: resource.GVK{
-				Group:   "crew",
-				Domain:  "test.io",
+				Group:   crewGroup,
+				Domain:  testIO,
 				Version: "v1",
-				Kind:    "Captain",
+				Kind:    captainKind,
 			},
-			Plural:   "captains",
+			Plural:   captains,
 			API:      &resource.API{},
 			Webhooks: &resource.Webhooks{},
 		}
@@ -114,18 +123,18 @@ var _ = Describe("createAPISubcommand", func() {
 
 		firstRes := resource.Resource{
 			GVK: resource.GVK{
-				Group:   "ship",
-				Domain:  "test.io",
+				Group:   shipGroup,
+				Domain:  testIO,
 				Version: "v1",
-				Kind:    "Frigate",
+				Kind:    frigateKind,
 			},
 			Plural: "frigates",
 			API:    &resource.API{CRDVersion: "v1"},
 		}
 		Expect(cfg.AddResource(firstRes)).To(Succeed())
 
-		res.Group = "crew"
-		res.Plural = "captains"
+		res.Group = crewGroup
+		res.Plural = captains
 
 		err := subCmd.InjectResource(res)
 
@@ -141,17 +150,17 @@ var _ = Describe("createAPISubcommand", func() {
 
 		firstRes := resource.Resource{
 			GVK: resource.GVK{
-				Group:   "ship",
-				Domain:  "test.io",
+				Group:   shipGroup,
+				Domain:  testIO,
 				Version: "v1",
-				Kind:    "Frigate",
+				Kind:    frigateKind,
 			},
 			Plural: "frigates",
 			API:    &resource.API{CRDVersion: "v1"},
 		}
 		Expect(cfg.AddResource(firstRes)).To(Succeed())
 
-		res.Group = "crew"
+		res.Group = crewGroup
 
 		Expect(subCmd.InjectResource(res)).To(Succeed())
 	})

--- a/pkg/plugins/golang/v4/scaffolds/init.go
+++ b/pkg/plugins/golang/v4/scaffolds/init.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	// GolangciLintVersion is the golangci-lint version to be used in the project
-	GolangciLintVersion = "v2.11.4"
+	GolangciLintVersion = "v2.12.2"
 	// ControllerRuntimeVersion is the kubernetes-sigs/controller-runtime version to be used in the project
 	ControllerRuntimeVersion = "v0.24.1"
 	// ControllerToolsVersion is the kubernetes-sigs/controller-tools version to be used in the project

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_test_template.go
@@ -91,13 +91,16 @@ import (
 var _ = Describe("{{ .Resource.Kind }} Controller", func() {
 	Context("When reconciling a resource", func() {
 		{{ if .DoAPI -}}
-		const resourceName = "test-resource"
+		const (
+			resourceName          = "test-resource"
+			resourceNamespace     = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default",  // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		{{ lower .Resource.Kind }} := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
 
@@ -108,7 +111,7 @@ var _ = Describe("{{ .Resource.Kind }} Controller", func() {
 				resource := &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_updater.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_updater.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
@@ -155,8 +156,8 @@ func (f *WebhookTestUpdater) addVariableToBlock(content, varName, typeName strin
 // detectIndentationInBlock extracts indentation from existing code
 func (f *WebhookTestUpdater) detectIndentationInBlock(blockContent string) string {
 	lines := strings.Split(blockContent, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
+	for _, v := range slices.Backward(lines) {
+		line := v
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" && trimmed != "var" && trimmed != "(" {
 			trimmedLeft := strings.TrimLeft(line, " \t")

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -41,12 +41,12 @@ var _ = Describe("createWebhookSubcommand", func() {
 		subCmd.options = &goPlugin.Options{}
 		res = &resource.Resource{
 			GVK: resource.GVK{
-				Group:   "crew",
-				Domain:  "test.io",
+				Group:   crewGroup,
+				Domain:  testIO,
 				Version: "v1",
-				Kind:    "Captain",
+				Kind:    captainKind,
 			},
-			Plural:   "captains",
+			Plural:   captains,
 			Webhooks: &resource.Webhooks{},
 		}
 	})
@@ -86,20 +86,20 @@ var _ = Describe("createWebhookSubcommand", func() {
 		BeforeEach(func() {
 			res = &resource.Resource{
 				GVK: resource.GVK{
-					Group:   "crew",
-					Domain:  "test.io",
+					Group:   crewGroup,
+					Domain:  testIO,
 					Version: "v1",
-					Kind:    "Captain",
+					Kind:    captainKind,
 				},
 			}
 
 			for _, version := range []string{"v1", "v2", "v1beta1"} {
 				r := resource.Resource{
 					GVK: resource.GVK{
-						Group:   "crew",
-						Domain:  "test.io",
+						Group:   crewGroup,
+						Domain:  testIO,
 						Version: version,
-						Kind:    "Captain",
+						Kind:    captainKind,
 					},
 					API: &resource.API{CRDVersion: "v1"},
 				}
@@ -119,10 +119,10 @@ var _ = Describe("createWebhookSubcommand", func() {
 		It("should return false for different group", func() {
 			differentRes := resource.Resource{
 				GVK: resource.GVK{
-					Group:   "ship",
-					Domain:  "test.io",
+					Group:   shipGroup,
+					Domain:  testIO,
 					Version: "v1",
-					Kind:    "Frigate",
+					Kind:    frigateKind,
 				},
 				API: &resource.API{CRDVersion: "v1"},
 			}
@@ -135,8 +135,8 @@ var _ = Describe("createWebhookSubcommand", func() {
 		It("should return false for different kind", func() {
 			differentRes := resource.Resource{
 				GVK: resource.GVK{
-					Group:   "crew",
-					Domain:  "test.io",
+					Group:   crewGroup,
+					Domain:  testIO,
 					Version: "v1",
 					Kind:    "Pirate",
 				},

--- a/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/helm/v1alpha/scaffolds/edit.go
@@ -259,6 +259,8 @@ func (s *editScaffolder) extractWebhooksFromGeneratedFiles() (mutatingWebhooks [
 	return mutatingWebhooks, validatingWebhooks, nil
 }
 
+const helmChartRBACSubDir = "rbac"
+
 // Helper function to copy files from config/ to dist/chart/templates/
 func (s *editScaffolder) copyConfigFiles() error {
 	configDirs := []struct {
@@ -266,7 +268,7 @@ func (s *editScaffolder) copyConfigFiles() error {
 		DestDir string
 		SubDir  string
 	}{
-		{"config/rbac", "dist/chart/templates/rbac", "rbac"},
+		{"config/rbac", "dist/chart/templates/rbac", helmChartRBACSubDir},
 		{"config/crd/bases", "dist/chart/templates/crd", "crd"},
 		{"config/network-policy", "dist/chart/templates/network-policy", "networkPolicy"},
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -28,6 +28,29 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor"
 )
 
+const (
+	testContainerNameManager          = "manager"
+	testContainerImageController      = "controller:latest"
+	testYAMLFieldName                 = "name"
+	testYAMLFieldImage                = "image"
+	testYAMLFieldArgs                 = "args"
+	testYAMLFieldSecretName           = "secretName"
+	testYAMLFieldPorts                = "ports"
+	testYAMLFieldMountPath            = "mountPath"
+	testYAMLFieldReadOnly             = "readOnly"
+	testYAMLFieldSecret               = "secret"
+	testSecretNameApp                 = "app-secret"
+	testYAMLFieldNamespace            = "namespace"
+	testYAMLFieldLabels               = "labels"
+	testLabelAppKubernetesIOName      = "app.kubernetes.io/name"
+	testLabelAppKubernetesIOManagedBy = "app.kubernetes.io/managed-by"
+	testProjectName                   = "test-project"
+	testNamespaceTestSystem           = "test-system"
+	testNamespaceTestProjectSystem    = "test-project-system"
+	testManagedByKustomize            = "kustomize"
+	testWebhookCertsVolume            = "webhook-certs"
+)
+
 var _ = Describe("ChartConverter", func() {
 	var (
 		converter *ChartConverter
@@ -44,7 +67,7 @@ var _ = Describe("ChartConverter", func() {
 		deployment.SetAPIVersion("apps/v1")
 		deployment.SetKind("Deployment")
 		deployment.SetName("test-controller")
-		deployment.SetNamespace("test-system")
+		deployment.SetNamespace(testNamespaceTestSystem)
 
 		// Set deployment spec
 		err := unstructured.SetNestedField(deployment.Object, int64(1), "spec", "replicas")
@@ -57,14 +80,14 @@ var _ = Describe("ChartConverter", func() {
 
 		// Create converter
 		converter = NewChartConverter(
-			resources, "test-project", "test-project", "test-system", "dist", make(map[string]string),
+			resources, testProjectName, testProjectName, testNamespaceTestSystem, "dist", make(map[string]string),
 		)
 	})
 
 	Context("NewChartConverter", func() {
 		It("should create a converter with correct properties", func() {
 			Expect(converter.resources).To(Equal(resources))
-			Expect(converter.detectedPrefix).To(Equal("test-project"))
+			Expect(converter.detectedPrefix).To(Equal(testProjectName))
 			Expect(converter.outputDir).To(Equal("dist"))
 		})
 	})
@@ -76,7 +99,7 @@ var _ = Describe("ChartConverter", func() {
 			serviceAccount.SetAPIVersion("v1")
 			serviceAccount.SetKind("ServiceAccount")
 			serviceAccount.SetName("test-sa")
-			serviceAccount.SetNamespace("test-system")
+			serviceAccount.SetNamespace(testNamespaceTestSystem)
 			resources.ServiceAccount = serviceAccount
 
 			// Add RBAC resources to test rbac directory creation
@@ -106,13 +129,13 @@ var _ = Describe("ChartConverter", func() {
 			metricsSvc1.SetAPIVersion("v1")
 			metricsSvc1.SetKind("Service")
 			metricsSvc1.SetName("test-project-controller-manager-metrics-service")
-			metricsSvc1.SetNamespace("test-system")
+			metricsSvc1.SetNamespace(testNamespaceTestSystem)
 
 			metricsSvc2 := &unstructured.Unstructured{}
 			metricsSvc2.SetAPIVersion("v1")
 			metricsSvc2.SetKind("Service")
 			metricsSvc2.SetName("test-project-controller-manager-metrics-service")
-			metricsSvc2.SetNamespace("test-system")
+			metricsSvc2.SetNamespace(testNamespaceTestSystem)
 
 			// Add both to resources; organizer will place them into the metrics group
 			resources.Services = append(resources.Services, metricsSvc1, metricsSvc2)
@@ -136,10 +159,10 @@ var _ = Describe("ChartConverter", func() {
 			// Set up deployment with environment variables
 			containers := []any{
 				map[string]any{
-					"name":            "manager",
-					"image":           "controller:latest",
-					"imagePullPolicy": "IfNotPresent",
-					"args": []any{
+					testYAMLFieldName:  testContainerNameManager,
+					testYAMLFieldImage: testContainerImageController,
+					"imagePullPolicy":  "IfNotPresent",
+					testYAMLFieldArgs: []any{
 						"--metrics-bind-address=:8443",
 						"--leader-elect",
 						"--custom-flag=value",
@@ -148,8 +171,8 @@ var _ = Describe("ChartConverter", func() {
 					},
 					"env": []any{
 						map[string]any{
-							"name":  "TEST_ENV",
-							"value": "test-value",
+							testYAMLFieldName: "TEST_ENV",
+							"value":           "test-value",
 						},
 					},
 					"resources": map[string]any{
@@ -172,17 +195,17 @@ var _ = Describe("ChartConverter", func() {
 
 			Expect(config).NotTo(BeNil())
 			Expect(config).To(HaveKey("env"))
-			Expect(config).To(HaveKey("image"))
+			Expect(config).To(HaveKey(testYAMLFieldImage))
 			Expect(config).To(HaveKey("resources"))
-			Expect(config).To(HaveKey("args"))
+			Expect(config).To(HaveKey(testYAMLFieldArgs))
 
-			imageConfig, ok := config["image"].(map[string]any)
+			imageConfig, ok := config[testYAMLFieldImage].(map[string]any)
 			Expect(ok).To(BeTrue())
 			Expect(imageConfig["repository"]).To(Equal("controller"))
 			Expect(imageConfig["tag"]).To(Equal("latest"))
 			Expect(imageConfig["pullPolicy"]).To(Equal("IfNotPresent"))
 
-			args, ok := config["args"].([]any)
+			args, ok := config[testYAMLFieldArgs].([]any)
 			Expect(ok).To(BeTrue())
 			Expect(args).To(ContainElement("--leader-elect"))
 			Expect(args).To(ContainElement("--custom-flag=value"))
@@ -194,9 +217,9 @@ var _ = Describe("ChartConverter", func() {
 			// Set up deployment with port-related args
 			containers := []any{
 				map[string]any{
-					"name":  "manager",
-					"image": "controller:latest",
-					"args": []any{
+					testYAMLFieldName:  testContainerNameManager,
+					testYAMLFieldImage: testContainerImageController,
+					testYAMLFieldArgs: []any{
 						"--metrics-bind-address=:8443",
 						"--health-probe-bind-address=:8081",
 						"--leader-elect",
@@ -222,13 +245,13 @@ var _ = Describe("ChartConverter", func() {
 			// Set up deployment with webhook container port
 			containers := []any{
 				map[string]any{
-					"name":  "manager",
-					"image": "controller:latest",
-					"ports": []any{
+					testYAMLFieldName:  testContainerNameManager,
+					testYAMLFieldImage: testContainerImageController,
+					testYAMLFieldPorts: []any{
 						map[string]any{
-							"containerPort": int64(9443),
-							"name":          "webhook-server",
-							"protocol":      "TCP",
+							"containerPort":   int64(9443),
+							testYAMLFieldName: "webhook-server",
+							"protocol":        "TCP",
 						},
 					},
 				},
@@ -251,17 +274,17 @@ var _ = Describe("ChartConverter", func() {
 			// Set up deployment with custom ports
 			containers := []any{
 				map[string]any{
-					"name":  "manager",
-					"image": "controller:latest",
-					"args": []any{
+					testYAMLFieldName:  testContainerNameManager,
+					testYAMLFieldImage: testContainerImageController,
+					testYAMLFieldArgs: []any{
 						"--metrics-bind-address=:9090",
 						"--health-probe-bind-address=:9091",
 					},
-					"ports": []any{
+					testYAMLFieldPorts: []any{
 						map[string]any{
-							"containerPort": int64(9444),
-							"name":          "webhook-server",
-							"protocol":      "TCP",
+							"containerPort":   int64(9444),
+							testYAMLFieldName: "webhook-server",
+							"protocol":        "TCP",
 						},
 					},
 				},
@@ -285,13 +308,13 @@ var _ = Describe("ChartConverter", func() {
 			// Set up deployment with image pull secrets
 			containers := []any{
 				map[string]any{
-					"name":  "manager",
-					"image": "controller:latest",
+					testYAMLFieldName:  testContainerNameManager,
+					testYAMLFieldImage: testContainerImageController,
 				},
 			}
 			imagePullSecrets := []any{
 				map[string]any{
-					"name": "test-secret",
+					testYAMLFieldName: "test-secret",
 				},
 			}
 			// Set the image pull secrets
@@ -322,39 +345,39 @@ var _ = Describe("ChartConverter", func() {
 
 			// But should not have container-level fields (env, args, resources, etc.)
 			Expect(config).NotTo(HaveKey("env"))
-			Expect(config).NotTo(HaveKey("args"))
+			Expect(config).NotTo(HaveKey(testYAMLFieldArgs))
 			Expect(config).NotTo(HaveKey("resources"))
-			Expect(config).NotTo(HaveKey("image"))
+			Expect(config).NotTo(HaveKey(testYAMLFieldImage))
 		})
 
 		It("should extract extraVolumes and extraVolumeMounts excluding webhook and metrics", func() {
 			volumes := []any{
 				map[string]any{
-					"name":   "webhook-certs",
-					"secret": map[string]any{"secretName": "webhook-server-cert"},
+					testYAMLFieldName:   testWebhookCertsVolume,
+					testYAMLFieldSecret: map[string]any{testYAMLFieldSecretName: "webhook-server-cert"},
 				},
 				map[string]any{
-					"name":   "custom-volume",
-					"secret": map[string]any{"secretName": "my-secret"},
+					testYAMLFieldName:   "custom-volume",
+					testYAMLFieldSecret: map[string]any{testYAMLFieldSecretName: "my-secret"},
 				},
 			}
 			volumeMounts := []any{
 				map[string]any{
-					"name":      "webhook-certs",
-					"mountPath": "/tmp/k8s-webhook-server/serving-certs",
-					"readOnly":  true,
+					testYAMLFieldName:      testWebhookCertsVolume,
+					testYAMLFieldMountPath: "/tmp/k8s-webhook-server/serving-certs",
+					testYAMLFieldReadOnly:  true,
 				},
 				map[string]any{
-					"name":      "custom-volume",
-					"mountPath": "/etc/my-secrets",
-					"readOnly":  true,
+					testYAMLFieldName:      "custom-volume",
+					testYAMLFieldMountPath: "/etc/my-secrets",
+					testYAMLFieldReadOnly:  true,
 				},
 			}
 			containers := []any{
 				map[string]any{
-					"name":         "manager",
-					"image":        "controller:latest",
-					"volumeMounts": volumeMounts,
+					testYAMLFieldName:  testContainerNameManager,
+					testYAMLFieldImage: testContainerImageController,
+					"volumeMounts":     volumeMounts,
 				},
 			}
 			err := unstructured.SetNestedSlice(
@@ -382,22 +405,43 @@ var _ = Describe("ChartConverter", func() {
 			extraMounts, ok := config["extraVolumeMounts"].([]any)
 			Expect(ok).To(BeTrue())
 			Expect(extraMounts).To(HaveLen(1))
-			Expect(extraMounts[0]).To(HaveKeyWithValue("mountPath", "/etc/my-secrets"))
+			Expect(extraMounts[0]).To(HaveKeyWithValue(testYAMLFieldMountPath, "/etc/my-secrets"))
 		})
 
 		It("should not add webhook-certs or metrics-certs to extraVolumes or extraVolumeMounts", func() {
 			volumes := []any{
-				map[string]any{"name": "webhook-certs", "secret": map[string]any{"secretName": "webhook-server-cert"}},
-				map[string]any{"name": "metrics-certs", "secret": map[string]any{"secretName": "metrics-server-cert"}},
-				map[string]any{"name": "app-secret", "secret": map[string]any{"secretName": "app-secret"}},
+				map[string]any{
+					testYAMLFieldName:   testWebhookCertsVolume,
+					testYAMLFieldSecret: map[string]any{testYAMLFieldSecretName: "webhook-server-cert"},
+				},
+				map[string]any{
+					testYAMLFieldName:   "metrics-certs",
+					testYAMLFieldSecret: map[string]any{testYAMLFieldSecretName: "metrics-server-cert"},
+				},
+				map[string]any{
+					testYAMLFieldName:   testSecretNameApp,
+					testYAMLFieldSecret: map[string]any{testYAMLFieldSecretName: testSecretNameApp},
+				},
 			}
 			volumeMounts := []any{
-				map[string]any{"name": "webhook-certs", "mountPath": "/tmp/webhook", "readOnly": true},
-				map[string]any{"name": "metrics-certs", "mountPath": "/tmp/metrics", "readOnly": true},
-				map[string]any{"name": "app-secret", "mountPath": "/etc/app", "readOnly": true},
+				map[string]any{
+					testYAMLFieldName: testWebhookCertsVolume, testYAMLFieldMountPath: "/tmp/webhook",
+					testYAMLFieldReadOnly: true,
+				},
+				map[string]any{
+					testYAMLFieldName: "metrics-certs", testYAMLFieldMountPath: "/tmp/metrics",
+					testYAMLFieldReadOnly: true,
+				},
+				map[string]any{
+					testYAMLFieldName: testSecretNameApp, testYAMLFieldMountPath: "/etc/app",
+					testYAMLFieldReadOnly: true,
+				},
 			}
 			containers := []any{
-				map[string]any{"name": "manager", "image": "controller:latest", "volumeMounts": volumeMounts},
+				map[string]any{
+					testYAMLFieldName: testContainerNameManager, testYAMLFieldImage: testContainerImageController,
+					"volumeMounts": volumeMounts,
+				},
 			}
 			err := unstructured.SetNestedSlice(resources.Deployment.Object, volumes, "spec", "template", "spec", "volumes")
 			Expect(err).NotTo(HaveOccurred())
@@ -409,11 +453,11 @@ var _ = Describe("ChartConverter", func() {
 			extraVols, ok := config["extraVolumes"].([]any)
 			Expect(ok).To(BeTrue())
 			Expect(extraVols).To(HaveLen(1))
-			Expect(extraVols[0]).To(HaveKeyWithValue("name", "app-secret"))
+			Expect(extraVols[0]).To(HaveKeyWithValue("name", testSecretNameApp))
 			extraMounts, ok := config["extraVolumeMounts"].([]any)
 			Expect(ok).To(BeTrue())
 			Expect(extraMounts).To(HaveLen(1))
-			Expect(extraMounts[0]).To(HaveKeyWithValue("name", "app-secret"))
+			Expect(extraMounts[0]).To(HaveKeyWithValue("name", testSecretNameApp))
 		})
 
 		It("should extract deployment replicas", func() {
@@ -447,7 +491,7 @@ var _ = Describe("ChartConverter", func() {
 		It("should extract priorityClassName from pod spec", func() {
 			// Set up deployment with priorityClassName
 			containers := []any{
-				map[string]any{"name": "manager", "image": "controller:latest"},
+				map[string]any{testYAMLFieldName: testContainerNameManager, testYAMLFieldImage: testContainerImageController},
 			}
 			err := unstructured.SetNestedSlice(resources.Deployment.Object, containers, "spec", "template", "spec", "containers")
 			Expect(err).NotTo(HaveOccurred())
@@ -464,7 +508,7 @@ var _ = Describe("ChartConverter", func() {
 		It("should extract topologySpreadConstraints from pod spec", func() {
 			// Set up deployment with topologySpreadConstraints
 			containers := []any{
-				map[string]any{"name": "manager", "image": "controller:latest"},
+				map[string]any{testYAMLFieldName: testContainerNameManager, testYAMLFieldImage: testContainerImageController},
 			}
 			topologySpreadConstraints := []any{
 				map[string]any{
@@ -473,7 +517,7 @@ var _ = Describe("ChartConverter", func() {
 					"whenUnsatisfiable": "DoNotSchedule",
 					"labelSelector": map[string]any{
 						"matchLabels": map[string]any{
-							"app": "manager",
+							"app": testContainerNameManager,
 						},
 					},
 				},
@@ -496,7 +540,7 @@ var _ = Describe("ChartConverter", func() {
 		It("should extract terminationGracePeriodSeconds from pod spec", func() {
 			// Set up deployment with terminationGracePeriodSeconds
 			containers := []any{
-				map[string]any{"name": "manager", "image": "controller:latest"},
+				map[string]any{testYAMLFieldName: testContainerNameManager, testYAMLFieldImage: testContainerImageController},
 			}
 			err := unstructured.SetNestedSlice(resources.Deployment.Object, containers, "spec", "template", "spec", "containers")
 			Expect(err).NotTo(HaveOccurred())
@@ -554,13 +598,13 @@ var _ = Describe("ChartConverter", func() {
 			configMap.SetAPIVersion("v1")
 			configMap.SetKind("ConfigMap")
 			configMap.SetName("custom-config")
-			configMap.SetNamespace("test-system")
+			configMap.SetNamespace(testNamespaceTestSystem)
 			configMap.Object["metadata"] = map[string]any{
-				"name":      "custom-config",
-				"namespace": "test-system",
-				"labels": map[string]any{
-					"app.kubernetes.io/name":       "test-project",
-					"app.kubernetes.io/managed-by": "kustomize",
+				testYAMLFieldName:      "custom-config",
+				testYAMLFieldNamespace: testNamespaceTestSystem,
+				testYAMLFieldLabels: map[string]any{
+					testLabelAppKubernetesIOName:      testProjectName,
+					testLabelAppKubernetesIOManagedBy: testManagedByKustomize,
 				},
 			}
 			configMap.Object["data"] = map[string]any{
@@ -602,17 +646,17 @@ var _ = Describe("ChartConverter", func() {
 			customService.SetAPIVersion("v1")
 			customService.SetKind("Service")
 			customService.SetName("custom-service")
-			customService.SetNamespace("test-project-system")
+			customService.SetNamespace(testNamespaceTestProjectSystem)
 			customService.Object["metadata"] = map[string]any{
-				"name":      "custom-service",
-				"namespace": "test-project-system",
-				"labels": map[string]any{
-					"app.kubernetes.io/name":       "test-project",
-					"app.kubernetes.io/managed-by": "kustomize",
+				testYAMLFieldName:      "custom-service",
+				testYAMLFieldNamespace: testNamespaceTestProjectSystem,
+				testYAMLFieldLabels: map[string]any{
+					testLabelAppKubernetesIOName:      testProjectName,
+					testLabelAppKubernetesIOManagedBy: testManagedByKustomize,
 				},
 			}
 			customService.Object["spec"] = map[string]any{
-				"ports": []any{
+				testYAMLFieldPorts: []any{
 					map[string]any{
 						"port":       8080,
 						"targetPort": 8080,
@@ -645,13 +689,13 @@ var _ = Describe("ChartConverter", func() {
 			secret.SetAPIVersion("v1")
 			secret.SetKind("Secret")
 			secret.SetName("custom-secret")
-			secret.SetNamespace("test-system")
+			secret.SetNamespace(testNamespaceTestSystem)
 			secret.Object["metadata"] = map[string]any{
-				"name":      "custom-secret",
-				"namespace": "test-system",
-				"labels": map[string]any{
-					"app.kubernetes.io/name":       "test-project",
-					"app.kubernetes.io/managed-by": "kustomize",
+				testYAMLFieldName:      "custom-secret",
+				testYAMLFieldNamespace: testNamespaceTestSystem,
+				testYAMLFieldLabels: map[string]any{
+					testLabelAppKubernetesIOName:      testProjectName,
+					testLabelAppKubernetesIOManagedBy: testManagedByKustomize,
 				},
 			}
 			secret.Object["data"] = map[string]any{
@@ -691,30 +735,30 @@ var _ = Describe("ChartConverter", func() {
 			configMap.SetAPIVersion("v1")
 			configMap.SetKind("ConfigMap")
 			configMap.SetName("config1")
-			configMap.SetNamespace("test-project-system")
+			configMap.SetNamespace(testNamespaceTestProjectSystem)
 			configMap.Object["metadata"] = map[string]any{
-				"name":      "config1",
-				"namespace": "test-project-system",
+				testYAMLFieldName:      "config1",
+				testYAMLFieldNamespace: testNamespaceTestProjectSystem,
 			}
 
 			secret := &unstructured.Unstructured{}
 			secret.SetAPIVersion("v1")
 			secret.SetKind("Secret")
 			secret.SetName("secret1")
-			secret.SetNamespace("test-project-system")
+			secret.SetNamespace(testNamespaceTestProjectSystem)
 			secret.Object["metadata"] = map[string]any{
-				"name":      "secret1",
-				"namespace": "test-project-system",
+				testYAMLFieldName:      "secret1",
+				testYAMLFieldNamespace: testNamespaceTestProjectSystem,
 			}
 
 			customService := &unstructured.Unstructured{}
 			customService.SetAPIVersion("v1")
 			customService.SetKind("Service")
 			customService.SetName("custom-svc")
-			customService.SetNamespace("test-project-system")
+			customService.SetNamespace(testNamespaceTestProjectSystem)
 			customService.Object["metadata"] = map[string]any{
-				"name":      "custom-svc",
-				"namespace": "test-project-system",
+				testYAMLFieldName:      "custom-svc",
+				testYAMLFieldNamespace: testNamespaceTestProjectSystem,
 			}
 
 			resources.Other = []*unstructured.Unstructured{configMap, secret}
@@ -737,13 +781,13 @@ var _ = Describe("ChartConverter", func() {
 			configMap.SetAPIVersion("v1")
 			configMap.SetKind("ConfigMap")
 			configMap.SetName("test-config")
-			configMap.SetNamespace("test-system")
+			configMap.SetNamespace(testNamespaceTestSystem)
 			configMap.Object["metadata"] = map[string]any{
-				"name":      "test-config",
-				"namespace": "test-system",
-				"labels": map[string]any{
-					"app.kubernetes.io/name":       "test-project",
-					"app.kubernetes.io/managed-by": "kustomize",
+				testYAMLFieldName:      "test-config",
+				testYAMLFieldNamespace: testNamespaceTestSystem,
+				testYAMLFieldLabels: map[string]any{
+					testLabelAppKubernetesIOName:      testProjectName,
+					testLabelAppKubernetesIOManagedBy: testManagedByKustomize,
 				},
 			}
 
@@ -777,10 +821,10 @@ var _ = Describe("ChartConverter", func() {
 			webhookService.SetAPIVersion("v1")
 			webhookService.SetKind("Service")
 			webhookService.SetName("test-project-webhook-service")
-			webhookService.SetNamespace("test-project-system")
+			webhookService.SetNamespace(testNamespaceTestProjectSystem)
 			webhookService.Object["metadata"] = map[string]any{
-				"name":      "test-project-webhook-service",
-				"namespace": "test-project-system",
+				testYAMLFieldName:      "test-project-webhook-service",
+				testYAMLFieldNamespace: testNamespaceTestProjectSystem,
 			}
 
 			// Create metrics service
@@ -788,10 +832,10 @@ var _ = Describe("ChartConverter", func() {
 			metricsService.SetAPIVersion("v1")
 			metricsService.SetKind("Service")
 			metricsService.SetName("test-project-controller-manager-metrics-service")
-			metricsService.SetNamespace("test-project-system")
+			metricsService.SetNamespace(testNamespaceTestProjectSystem)
 			metricsService.Object["metadata"] = map[string]any{
-				"name":      "test-project-controller-manager-metrics-service",
-				"namespace": "test-project-system",
+				testYAMLFieldName:      "test-project-controller-manager-metrics-service",
+				testYAMLFieldNamespace: testNamespaceTestProjectSystem,
 			}
 
 			resources.Services = []*unstructured.Unstructured{webhookService, metricsService}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -89,13 +89,27 @@ func MakeYamlContent(match string) string {
 	return match
 }
 
+const (
+	k8sObjectSpecField     = "spec"
+	k8sObjectTemplateField = "template"
+)
+
+var (
+	podTemplateContainersPath = []string{
+		k8sObjectSpecField, k8sObjectTemplateField, k8sObjectSpecField, "containers",
+	}
+	podTemplateInitContainersPath = []string{
+		k8sObjectSpecField, k8sObjectTemplateField, k8sObjectSpecField, "initContainers",
+	}
+)
+
 // ExtractContainerNames returns the set of container and initContainer names declared in a
 // Deployment (or any Pod-template-bearing resource).
 func ExtractContainerNames(resource *unstructured.Unstructured) map[string]bool {
 	names := map[string]bool{}
 	for _, fieldPath := range [][]string{
-		{"spec", "template", "spec", "containers"},
-		{"spec", "template", "spec", "initContainers"},
+		podTemplateContainersPath,
+		podTemplateInitContainersPath,
 	} {
 		val, found, err := unstructured.NestedFieldNoCopy(resource.Object, fieldPath...)
 		if err != nil || !found {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -19,6 +19,7 @@ package appliers
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1340,8 +1341,8 @@ func detectChildIndent(lines []string, parentIndent string) string {
 	// Scan backwards to find the first child entry with indentation > parent
 	parentIndentLen := len(parentIndent)
 
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
+	for _, v := range slices.Backward(lines) {
+		line := v
 		trimmed := strings.TrimSpace(line)
 
 		// Skip empty lines and Helm template directives

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
@@ -18,6 +18,7 @@ package appliers
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -256,8 +257,8 @@ func extractKeysFromLines(lines []string) []string {
 
 	// Find section start by scanning backwards to the nearest header
 	sectionStart := 0
-	for i := len(lines) - 1; i >= 0; i-- {
-		trimmed := strings.TrimSpace(lines[i])
+	for i, v := range slices.Backward(lines) {
+		trimmed := strings.TrimSpace(v)
 		// Stop at section headers - this is where our current section began
 		if trimmed == common.YamlKeyLabels || trimmed == common.YamlKeyAnnotations {
 			sectionStart = i + 1 // Start extracting from the line after the header

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -26,6 +26,15 @@ import (
 )
 
 const (
+	testProjectName                 = "test-project"
+	testProjectSystemNamespace      = "test-project-system"
+	testRoleNamespaceInfrastructure = "infrastructure"
+	testRoleNamespaceUsers          = "users"
+	testManagerRoleName             = "manager-role"
+	testManagerRoleInfrastructure   = "manager-role-infrastructure"
+	testManagerRoleUsers            = "manager-role-users"
+	testManagerRoleBindingUsers     = "manager-rolebinding-users"
+
 	// Test expectation constants for test-project.resourceName templates
 	expectedIssuerName = `name: {{ include "test-project.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}`
 )
@@ -35,9 +44,9 @@ var _ = Describe("Templater", func() {
 
 	BeforeEach(func() {
 		templater = &Templater{
-			detectedPrefix:   "test-project",
-			chartName:        "test-project",
-			managerNamespace: "test-project-system",
+			detectedPrefix:   testProjectName,
+			chartName:        testProjectName,
+			managerNamespace: testProjectSystemNamespace,
 			roleNamespaces:   nil,
 		}
 	})
@@ -1563,7 +1572,7 @@ spec:
 			configMapResource.SetAPIVersion("v1")
 			configMapResource.SetKind("ConfigMap")
 			configMapResource.SetName("template-config")
-			configMapResource.SetNamespace("test-project-system")
+			configMapResource.SetNamespace(testProjectSystemNamespace)
 
 			// ANY resource can have Go template syntax that needs escaping
 			// Examples: ConfigMaps with notification templates, Secrets with webhook URLs,
@@ -1853,12 +1862,12 @@ subjects:
 			roleResource := &unstructured.Unstructured{}
 			roleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
 			roleResource.SetKind("ClusterRole")
-			roleResource.SetName("manager-role")
+			roleResource.SetName(testManagerRoleName)
 
-			// Scenario: manager namespace is "user", CRD resource is "users"
+			// Scenario: manager namespace is "user", CRD resource is testRoleNamespaceUsers
 			customTemplater := &Templater{
-				detectedPrefix:   "test-project",
-				chartName:        "test-project",
+				detectedPrefix:   testProjectName,
+				chartName:        testProjectName,
 				managerNamespace: "user", // Short namespace that appears as substring
 				roleNamespaces:   nil,
 			}
@@ -1903,8 +1912,8 @@ rules:
 		It("should handle edge case where namespace is substring of multiple fields", func() {
 			// Test more edge cases: namespace "app" appears in "applications", "apps", etc.
 			customTemplater := &Templater{
-				detectedPrefix:   "test-project",
-				chartName:        "test-project",
+				detectedPrefix:   testProjectName,
+				chartName:        testProjectName,
 				managerNamespace: "app",
 				roleNamespaces:   nil,
 			}
@@ -2649,9 +2658,9 @@ spec:
 
 		It("should handle custom kustomize prefix", func() {
 			customPrefixTemplater := &Templater{
-				detectedPrefix:   "ln",           // Custom short prefix from kustomize
-				chartName:        "test-project", // Chart/project name
-				managerNamespace: "ln-system",    // Manager namespace
+				detectedPrefix:   "ln",            // Custom short prefix from kustomize
+				chartName:        testProjectName, // Chart/project name
+				managerNamespace: "ln-system",     // Manager namespace
 				roleNamespaces:   nil,
 			}
 
@@ -3927,18 +3936,18 @@ metadata:
 		It("should preserve role-specific namespace deployments using .Values.rbac.roleNamespaces", func() {
 			// Simulate role-namespace mappings
 			roleNamespaces := map[string]string{
-				"manager-role-infrastructure": "infrastructure",
-				"manager-role-users":          "users",
+				testManagerRoleInfrastructure: testRoleNamespaceInfrastructure,
+				testManagerRoleUsers:          testRoleNamespaceUsers,
 			}
 
-			multiNsTemplater := NewTemplater("test-project", "test-project", "test-project-system", roleNamespaces)
+			multiNsTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, roleNamespaces)
 
 			// Role in infrastructure namespace
 			infraRole := &unstructured.Unstructured{}
 			infraRole.SetAPIVersion("rbac.authorization.k8s.io/v1")
 			infraRole.SetKind("Role")
-			infraRole.SetName("manager-role-infrastructure")
-			infraRole.SetNamespace("infrastructure")
+			infraRole.SetName(testManagerRoleInfrastructure)
+			infraRole.SetNamespace(testRoleNamespaceInfrastructure)
 
 			infraContent := `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -3952,9 +3961,8 @@ rules:
 
 			infraResult := multiNsTemplater.ApplyHelmSubstitutions(infraContent, infraRole)
 
-			// Should template to index .Values.rbac.roleNamespaces "manager-role-infrastructure" with default fallback
-			expectedNs := `namespace: {{ index .Values.rbac.roleNamespaces ` +
-				`"manager-role-infrastructure" | default "infrastructure" }}`
+			expectedNs := `namespace: {{ index .Values.rbac.roleNamespaces "` + testManagerRoleInfrastructure +
+				`" | default "` + testRoleNamespaceInfrastructure + `" }}`
 			Expect(infraResult).To(ContainSubstring(expectedNs))
 			// Should NOT use .Release.Namespace
 			Expect(infraResult).NotTo(ContainSubstring("namespace: {{ .Release.Namespace }}"))
@@ -3962,17 +3970,17 @@ rules:
 
 		It("should preserve namespace in RoleBinding subjects for multi-namespace RBAC", func() {
 			roleNamespaces := map[string]string{
-				"manager-rolebinding-users": "users",
+				testManagerRoleBindingUsers: testRoleNamespaceUsers,
 			}
 
-			multiNsTemplater := NewTemplater("test-project", "test-project", "test-project-system", roleNamespaces)
+			multiNsTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, roleNamespaces)
 
 			// RoleBinding in users namespace
 			usersBinding := &unstructured.Unstructured{}
 			usersBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")
 			usersBinding.SetKind("RoleBinding")
-			usersBinding.SetName("manager-rolebinding-users")
-			usersBinding.SetNamespace("users")
+			usersBinding.SetName(testManagerRoleBindingUsers)
+			usersBinding.SetNamespace(testRoleNamespaceUsers)
 
 			bindingContent := `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -3990,21 +3998,21 @@ subjects:
 
 			result := multiNsTemplater.ApplyHelmSubstitutions(bindingContent, usersBinding)
 
-			// RoleBinding namespace should use index .Values.rbac.roleNamespaces with binding name as key and default fallback
 			Expect(result).To(ContainSubstring(
-				`namespace: {{ index .Values.rbac.roleNamespaces "manager-rolebinding-users" | default "users" }}`))
+				`namespace: {{ index .Values.rbac.roleNamespaces "` + testManagerRoleBindingUsers +
+					`" | default "` + testRoleNamespaceUsers + `" }}`))
 			// Subject namespace should use .Release.Namespace (manager namespace)
 			Expect(result).To(ContainSubstring("namespace: {{ .Release.Namespace }}"))
 		})
 
 		It("should handle multiple role-namespace mappings simultaneously", func() {
 			roleNamespaces := map[string]string{
-				"manager-role-infrastructure": "infrastructure",
-				"manager-role-users":          "users",
+				testManagerRoleInfrastructure: testRoleNamespaceInfrastructure,
+				testManagerRoleUsers:          testRoleNamespaceUsers,
 				"manager-role-monitoring":     "monitoring",
 			}
 
-			multiNsTemplater := NewTemplater("test-project", "test-project", "test-project-system", roleNamespaces)
+			multiNsTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, roleNamespaces)
 
 			// Role in monitoring namespace
 			monitoringRole := &unstructured.Unstructured{}
@@ -4032,15 +4040,15 @@ rules:
 
 		It("should handle role names with hyphens correctly", func() {
 			roleNamespaces := map[string]string{
-				"manager-role": "app-infrastructure",
+				testManagerRoleName: "app-infrastructure",
 			}
 
-			multiNsTemplater := NewTemplater("test-project", "test-project", "test-project-system", roleNamespaces)
+			multiNsTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, roleNamespaces)
 
 			roleResource := &unstructured.Unstructured{}
 			roleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
 			roleResource.SetKind("Role")
-			roleResource.SetName("manager-role")
+			roleResource.SetName(testManagerRoleName)
 			roleResource.SetNamespace("app-infrastructure")
 
 			content := `apiVersion: rbac.authorization.k8s.io/v1
@@ -4055,17 +4063,17 @@ rules:
 
 			result := multiNsTemplater.ApplyHelmSubstitutions(content, roleResource)
 
-			// Role name is used as key with default fallback
 			Expect(result).To(ContainSubstring(
-				`namespace: {{ index .Values.rbac.roleNamespaces "manager-role" | default "app-infrastructure" }}`))
+				`namespace: {{ index .Values.rbac.roleNamespaces "` + testManagerRoleName +
+					`" | default "app-infrastructure" }}`))
 		})
 
 		It("should preserve DNS references for role-specific namespaces", func() {
 			roleNamespaces := map[string]string{
-				"manager-role": "infrastructure",
+				testManagerRoleName: testRoleNamespaceInfrastructure,
 			}
 
-			multiNsTemplater := NewTemplater("test-project", "test-project", "test-project-system", roleNamespaces)
+			multiNsTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, roleNamespaces)
 
 			configMap := &unstructured.Unstructured{}
 			configMap.SetAPIVersion("v1")
@@ -4087,17 +4095,17 @@ data:
 
 		It("should preserve resource references within role resources", func() {
 			roleNamespaces := map[string]string{
-				"manager-role": "infrastructure",
+				testManagerRoleName: testRoleNamespaceInfrastructure,
 			}
 
-			multiNsTemplater := NewTemplater("test-project", "test-project", "test-project-system", roleNamespaces)
+			multiNsTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, roleNamespaces)
 
 			// Role that has a reference to a resource in its namespace
 			role := &unstructured.Unstructured{}
 			role.SetAPIVersion("rbac.authorization.k8s.io/v1")
 			role.SetKind("Role")
-			role.SetName("manager-role")
-			role.SetNamespace("infrastructure")
+			role.SetName(testManagerRoleName)
+			role.SetNamespace(testRoleNamespaceInfrastructure)
 
 			content := `apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4110,16 +4118,16 @@ rules: []`
 
 			result := multiNsTemplater.ApplyHelmSubstitutions(content, role)
 
-			// Resource reference should be templated with index and default fallback
 			Expect(result).To(ContainSubstring(
-				`{{ index .Values.rbac.roleNamespaces "manager-role" | default "infrastructure" }}/serving-cert`))
+				`{{ index .Values.rbac.roleNamespaces "` + testManagerRoleName +
+					`" | default "` + testRoleNamespaceInfrastructure + `" }}/serving-cert`))
 		})
 	})
 
 	Context("ServiceAccount configuration", func() {
 		Context("when managing ServiceAccount creation via values.yaml", func() {
 			It("allows toggling ServiceAccount installation with enable flag", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4142,7 +4150,7 @@ metadata:
 			})
 
 			It("supports custom annotations for cloud provider integrations", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4164,7 +4172,7 @@ metadata:
 			})
 
 			It("supports custom labels without duplicating existing standard labels", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4188,7 +4196,7 @@ metadata:
 			})
 
 			It("merges custom annotations with existing annotations without duplication", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4222,7 +4230,7 @@ metadata:
 
 		Context("when using default ServiceAccount with nameOverride/fullnameOverride", func() {
 			It("respects nameOverride and fullnameOverride for default ServiceAccount name", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4240,7 +4248,7 @@ metadata:
 			})
 
 			It("ensures ServiceAccount name matches across all resource references", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				deployment := &unstructured.Unstructured{}
 				deployment.SetAPIVersion("apps/v1")
@@ -4263,7 +4271,7 @@ spec:
 
 		Context("when binding RBAC permissions to ServiceAccount", func() {
 			It("references ServiceAccount consistently in RoleBinding subjects", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				roleBinding := &unstructured.Unstructured{}
 				roleBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")
@@ -4290,7 +4298,7 @@ subjects:
 			})
 
 			It("references ServiceAccount consistently in ClusterRoleBinding subjects", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				clusterRoleBinding := &unstructured.Unstructured{}
 				clusterRoleBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")
@@ -4319,7 +4327,7 @@ subjects:
 
 		Context("when handling project names with prefixes", func() {
 			It("templates ServiceAccount name correctly with project prefix", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4337,7 +4345,7 @@ metadata:
 			})
 
 			It("templates Deployment serviceAccountName field correctly with project prefix", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				deployment := &unstructured.Unstructured{}
 				deployment.SetAPIVersion("apps/v1")
@@ -4358,7 +4366,7 @@ spec:
 			})
 
 			It("templates RoleBinding subjects correctly with project prefix", func() {
-				templater := NewTemplater("test-project", "test-project", "test-project-system", nil)
+				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				roleBinding := &unstructured.Unstructured{}
 				roleBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
@@ -25,13 +25,15 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
+const helmChartOutputDir = "dist"
+
 var _ = Describe("NetworkPolicy", func() {
 	Context("SetTemplateDefaults", func() {
 		var networkPolicy *NetworkPolicy
 
 		BeforeEach(func() {
 			networkPolicy = &NetworkPolicy{
-				OutputDir: "dist",
+				OutputDir: helmChartOutputDir,
 				Force:     true,
 			}
 			networkPolicy.InjectProjectName("test-project")
@@ -101,10 +103,10 @@ var _ = Describe("NetworkPolicy", func() {
 			fs := afero.NewMemMapFs()
 			scaffold := machinery.NewScaffold(machinery.Filesystem{FS: fs}, machinery.WithConfig(cfg))
 			err := scaffold.Execute(&NetworkPolicy{
-				OutputDir: "dist",
+				OutputDir: helmChartOutputDir,
 			}, &NetworkPolicy{
 				Webhook:   true,
-				OutputDir: "dist",
+				OutputDir: helmChartOutputDir,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/notes_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/notes_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Notes", func() {
 
 		BeforeEach(func() {
 			notes = &Notes{
-				OutputDir: "dist",
+				OutputDir: helmChartOutputDir,
 				Force:     true,
 			}
 			notes.InjectProjectName("test-project")

--- a/testdata/project-v4-multigroup/.custom-gcl.yml
+++ b/testdata/project-v4-multigroup/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/testdata/project-v4-multigroup/Makefile
+++ b/testdata/project-v4-multigroup/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/testdata/project-v4-multigroup/internal/controller/crew/captain_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/captain_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Captain Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		captain := &crewv1.Captain{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Captain Controller", func() {
 				resource := &crewv1.Captain{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
@@ -42,6 +42,8 @@ import (
 
 const busyboxFinalizer = "example.com.testproject.org/finalizer"
 
+const busyboxContainerName = "busybox"
+
 // Definitions to manage status conditions
 const (
 	// typeAvailableBusybox represents the status of the Deployment reconciliation
@@ -369,7 +371,7 @@ func (r *BusyboxReconciler) deploymentForBusybox(
 					},
 					Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "busybox",
+						Name:            busyboxContainerName,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller.go
@@ -100,7 +100,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")
 			return ctrl.Result{}, err
@@ -138,7 +138,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -164,7 +164,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -198,7 +198,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", busybox.Name, err)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -273,7 +273,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", busybox.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, busybox); err != nil {

--- a/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/busybox_controller_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Busybox controller", func() {
 				HaveField("Type", Equal(typeAvailableBusybox)), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailableBusybox)
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailableBusybox)
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailableBusybox)
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailableBusybox)
 		})
 	})
 })

--- a/testdata/project-v4-multigroup/internal/controller/example.com/conditions.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/conditions.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package examplecom
+
+const (
+	reasonReconciling = "Reconciling"
+	reasonFinalizing  = "Finalizing"
+)

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
@@ -100,7 +100,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
@@ -138,7 +138,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -164,7 +164,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -198,7 +198,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -273,7 +273,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, memcached); err != nil {

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller.go
@@ -42,6 +42,8 @@ import (
 
 const memcachedFinalizer = "example.com.testproject.org/finalizer"
 
+const memcachedContainerName = "memcached"
+
 // Definitions to manage status conditions
 const (
 	// typeAvailableMemcached represents the status of the Deployment reconciliation
@@ -369,7 +371,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 					},
 					Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "memcached",
+						Name:            memcachedContainerName,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
@@ -385,7 +387,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: memcached.Spec.ContainerPort,
-							Name:          "memcached",
+							Name:          memcachedContainerName,
 						}},
 						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},

--- a/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/memcached_controller_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Memcached controller", func() {
 				HaveField("Type", Equal(typeAvailableMemcached)), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailableMemcached)
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailableMemcached)
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailableMemcached)
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailableMemcached)
 		})
 	})
 })

--- a/testdata/project-v4-multigroup/internal/controller/example.com/wordpress_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/wordpress_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Wordpress Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		wordpress := &examplecomv1.Wordpress{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Wordpress Controller", func() {
 				resource := &examplecomv1.Wordpress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/bar_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Bar Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		bar := &fizv1.Bar{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Bar Controller", func() {
 				resource := &fizv1.Bar{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/healthcheckpolicy_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("HealthCheckPolicy Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		healthcheckpolicy := &foopolicyv1.HealthCheckPolicy{}
 
@@ -49,7 +52,7 @@ var _ = Describe("HealthCheckPolicy Controller", func() {
 				resource := &foopolicyv1.HealthCheckPolicy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/foo/bar_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/bar_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Bar Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		bar := &foov1.Bar{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Bar Controller", func() {
 				resource := &foov1.Bar{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/kraken_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Kraken Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		kraken := &seacreaturesv1beta1.Kraken{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Kraken Controller", func() {
 				resource := &seacreaturesv1beta1.Kraken{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/leviathan_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Leviathan Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		leviathan := &seacreaturesv1beta2.Leviathan{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Leviathan Controller", func() {
 				resource := &seacreaturesv1beta2.Leviathan{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/cruiser_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Cruiser Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		cruiser := &shipv2alpha1.Cruiser{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Cruiser Controller", func() {
 				resource := &shipv2alpha1.Cruiser{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/destroyer_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Destroyer Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		destroyer := &shipv1.Destroyer{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Destroyer Controller", func() {
 				resource := &shipv1.Destroyer{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/frigate_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Frigate Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		frigate := &shipv1beta1.Frigate{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Frigate Controller", func() {
 				resource := &shipv1beta1.Frigate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4-with-plugins/.custom-gcl.yml
+++ b/testdata/project-v4-with-plugins/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/testdata/project-v4-with-plugins/Makefile
+++ b/testdata/project-v4-with-plugins/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
@@ -42,6 +42,8 @@ import (
 
 const busyboxFinalizer = "example.com.testproject.org/finalizer"
 
+const busyboxContainerName = "busybox"
+
 // Definitions to manage status conditions
 const (
 	// typeAvailableBusybox represents the status of the Deployment reconciliation
@@ -369,7 +371,7 @@ func (r *BusyboxReconciler) deploymentForBusybox(
 					},
 					Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "busybox",
+						Name:            busyboxContainerName,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller.go
@@ -100,7 +100,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if len(busybox.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, busybox); err != nil {
 			log.Error(err, "Failed to update Busybox status")
 			return ctrl.Result{}, err
@@ -138,7 +138,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -164,7 +164,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeDegradedBusybox,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", busybox.Name)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -198,7 +198,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", busybox.Name, err)})
 
 			if err := r.Status().Update(ctx, busybox); err != nil {
@@ -273,7 +273,7 @@ func (r *BusyboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&busybox.Status.Conditions, metav1.Condition{Type: typeAvailableBusybox,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", busybox.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, busybox); err != nil {

--- a/testdata/project-v4-with-plugins/internal/controller/busybox_controller_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/busybox_controller_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Busybox controller", func() {
 				HaveField("Type", Equal(typeAvailableBusybox)), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailableBusybox)
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailableBusybox)
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailableBusybox)
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailableBusybox)
 		})
 	})
 })

--- a/testdata/project-v4-with-plugins/internal/controller/conditions.go
+++ b/testdata/project-v4-with-plugins/internal/controller/conditions.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+const (
+	reasonReconciling = "Reconciling"
+	reasonFinalizing  = "Finalizing"
+)

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
@@ -100,7 +100,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if len(memcached.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
+		meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached, Status: metav1.ConditionUnknown, Reason: reasonReconciling, Message: "Starting reconciliation"})
 		if err = r.Status().Update(ctx, memcached); err != nil {
 			log.Error(err, "Failed to update Memcached status")
 			return ctrl.Result{}, err
@@ -138,7 +138,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// Let's add here a status "Downgrade" to reflect that this resource began its process to be terminated.
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionUnknown, Reason: "Finalizing",
+				Status: metav1.ConditionUnknown, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Performing finalizer operations for the custom resource: %s ", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -164,7 +164,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeDegradedMemcached,
-				Status: metav1.ConditionTrue, Reason: "Finalizing",
+				Status: metav1.ConditionTrue, Reason: reasonFinalizing,
 				Message: fmt.Sprintf("Finalizer operations for custom resource %s name were successfully accomplished", memcached.Name)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -198,7 +198,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 			// The following implementation will update the status
 			meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-				Status: metav1.ConditionFalse, Reason: "Reconciling",
+				Status: metav1.ConditionFalse, Reason: reasonReconciling,
 				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", memcached.Name, err)})
 
 			if err := r.Status().Update(ctx, memcached); err != nil {
@@ -273,7 +273,7 @@ func (r *MemcachedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// The following implementation will update the status
 	meta.SetStatusCondition(&memcached.Status.Conditions, metav1.Condition{Type: typeAvailableMemcached,
-		Status: metav1.ConditionTrue, Reason: "Reconciling",
+		Status: metav1.ConditionTrue, Reason: reasonReconciling,
 		Message: fmt.Sprintf("Deployment for custom resource (%s) with %d replicas created successfully", memcached.Name, desiredReplicas)})
 
 	if err := r.Status().Update(ctx, memcached); err != nil {

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller.go
@@ -42,6 +42,8 @@ import (
 
 const memcachedFinalizer = "example.com.testproject.org/finalizer"
 
+const memcachedContainerName = "memcached"
+
 // Definitions to manage status conditions
 const (
 	// typeAvailableMemcached represents the status of the Deployment reconciliation
@@ -369,7 +371,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 					},
 					Containers: []corev1.Container{{
 						Image:           image,
-						Name:            "memcached",
+						Name:            memcachedContainerName,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						// Ensure restrictive context for the container
 						// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
@@ -385,7 +387,7 @@ func (r *MemcachedReconciler) deploymentForMemcached(
 						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: memcached.Spec.ContainerPort,
-							Name:          "memcached",
+							Name:          memcachedContainerName,
 						}},
 						Command: []string{"memcached", "--memory-limit=64", "-o", "modern", "-v"},
 					}},

--- a/testdata/project-v4-with-plugins/internal/controller/memcached_controller_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/memcached_controller_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Memcached controller", func() {
 				HaveField("Type", Equal(typeAvailableMemcached)), &conditions))
 			Expect(conditions).To(HaveLen(1), "Multiple conditions of type %s", typeAvailableMemcached)
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "condition %s", typeAvailableMemcached)
-			Expect(conditions[0].Reason).To(Equal("Reconciling"), "condition %s", typeAvailableMemcached)
+			Expect(conditions[0].Reason).To(Equal(reasonReconciling), "condition %s", typeAvailableMemcached)
 		})
 	})
 })

--- a/testdata/project-v4-with-plugins/internal/controller/wordpress_controller_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/wordpress_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Wordpress Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		wordpress := &examplecomv1.Wordpress{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Wordpress Controller", func() {
 				resource := &examplecomv1.Wordpress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4/.custom-gcl.yml
+++ b/testdata/project-v4/.custom-gcl.yml
@@ -3,7 +3,7 @@
 # with all the plugins listed below.
 #
 # See: https://golangci-lint.run/plugins/module-plugins/
-version: v2.11.4
+version: v2.12.2
 plugins:
   # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
   - module: "sigs.k8s.io/logtools"

--- a/testdata/project-v4/Makefile
+++ b/testdata/project-v4/Makefile
@@ -204,7 +204,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)

--- a/testdata/project-v4/internal/controller/admiral_controller_test.go
+++ b/testdata/project-v4/internal/controller/admiral_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Admiral Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		admiral := &crewv1.Admiral{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Admiral Controller", func() {
 				resource := &crewv1.Admiral{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4/internal/controller/captain_controller_test.go
+++ b/testdata/project-v4/internal/controller/captain_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Captain Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		captain := &crewv1.Captain{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Captain Controller", func() {
 				resource := &crewv1.Captain{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4/internal/controller/firstmate_controller_test.go
+++ b/testdata/project-v4/internal/controller/firstmate_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("FirstMate Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		firstmate := &crewv1.FirstMate{}
 
@@ -49,7 +52,7 @@ var _ = Describe("FirstMate Controller", func() {
 				resource := &crewv1.FirstMate{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}

--- a/testdata/project-v4/internal/controller/sailor_controller_test.go
+++ b/testdata/project-v4/internal/controller/sailor_controller_test.go
@@ -32,13 +32,16 @@ import (
 
 var _ = Describe("Sailor Controller", func() {
 	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		const (
+			resourceName      = "test-resource"
+			resourceNamespace = "default"
+		)
 
 		ctx := context.Background()
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: resourceNamespace,
 		}
 		sailor := &crewv1.Sailor{}
 
@@ -49,7 +52,7 @@ var _ = Describe("Sailor Controller", func() {
 				resource := &crewv1.Sailor{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
-						Namespace: "default",
+						Namespace: resourceNamespace,
 					},
 					// TODO(user): Specify other spec details if needed.
 				}


### PR DESCRIPTION
## Summary

- Bump `golangci-lint` to **v2.12.2** and fix `goconst` violations across CLI code, scaffolds, testdata, and book samples.
- No linter rules were added, removed, or changed.

## Scaffold

- **go/v4**: add a `resourceNamespace` constant alongside `resourceName` in controller tests.
- **deploy-image**:
  - Introduce shared condition `Reason` constants in `conditions.go`.
  - Use `{kind}ContainerName` only for container and port names.

## Other

- Fix lint issues in the Kubebuilder CLI, plugins, and sample projects.
- Update book samples in **getting-started** and **multiversion-tutorial** to satisfy `goconst`.

Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/5676