### PR TITLE
🐛 (CLI) fix: correct wrong capture group and fix typos in error messages

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/scaffolds/api.go
@@ -231,7 +231,7 @@ func (s *apiScaffolder) updateControllerCode(controller controllers.Controller) 
 								},
 							},
 						},`, fmt.Sprintf(commandTemplate, res)); err != nil {
-			return fmt.Errorf("error scaffolding command in the  controller path %q: %w",
+			return fmt.Errorf("error scaffolding command in the controller path %q: %w",
 				controller.Path, err)
 		}
 	}

--- a/pkg/plugins/golang/go_version.go
+++ b/pkg/plugins/golang/go_version.go
@@ -75,7 +75,7 @@ func (v *GoVersion) parse(verStr string) error {
 	if m[3] != "" {
 		v.patch, err = strconv.Atoi(m[3])
 		if err != nil {
-			return fmt.Errorf("error parsing patch version %q: %w", m[2], err)
+			return fmt.Errorf("error parsing patch version %q: %w", m[3], err)
 		}
 	}
 

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -183,7 +183,7 @@ func (s *editScaffolder) Scaffold() error {
 	if err == nil && len(configItems) > 0 {
 		templatesBuilder = append(templatesBuilder, &templates.CustomMetricsDashManifest{Items: configItems})
 	} else if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error on scaffolding manifest for custom metris:\n%v", err)
+		_, _ = fmt.Fprintf(os.Stderr, "Error on scaffolding manifest for custom metrics:\n%v", err)
 	}
 
 	if err = scaffold.Execute(templatesBuilder...); err != nil {


### PR DESCRIPTION
Three small fixes in error strings.

**go_version.go** - wrong capture group in the error message for patch version parsing. The regex has 4 groups (major, minor, patch, pre); when `strconv.Atoi` fails on `m[3]` (patch), the message was quoting `m[2]` (minor) instead, so you'd see the wrong value in the error.

Reproduce:
```go
var v GoVersion
_ = v.parse("go1.15.99999999999999999999") // overflows int
// before: error parsing patch version "15": ...
// after:  error parsing patch version "99999999999999999999": ...
```

**edit.go** - `"custom metris"` -> `"custom metrics"` (typo in stderr output)

**api.go** - double space in `"in the  controller path"` error string