### PR TITLE
🐛 (API) Preserve external plugin flag values containing double hyphens

### DIFF
--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -179,7 +179,7 @@ func parseExternalPluginArgs() (args []string) {
 	// Loop through os.Args and only get flags and their values that should be passed to the plugins
 	// this also removes the --plugins flag and its values from the list passed to the external plugin
 	for i := range os.Args {
-		if strings.HasPrefix(os.Args[i], "--") && os.Args[i] != "--plugins" {
+		if strings.HasPrefix(os.Args[i], "--") && os.Args[i] != "--plugins" && !strings.HasPrefix(os.Args[i], "--plugins=") {
 			args = append(args, os.Args[i])
 
 			// Don't go out of bounds and don't append the next value if it is a flag

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -179,11 +179,11 @@ func parseExternalPluginArgs() (args []string) {
 	// Loop through os.Args and only get flags and their values that should be passed to the plugins
 	// this also removes the --plugins flag and its values from the list passed to the external plugin
 	for i := range os.Args {
-		if strings.Contains(os.Args[i], "--") && !strings.Contains(os.Args[i], "--plugins") {
+		if strings.HasPrefix(os.Args[i], "--") && os.Args[i] != "--plugins" {
 			args = append(args, os.Args[i])
 
 			// Don't go out of bounds and don't append the next value if it is a flag
-			if i+1 < len(os.Args) && !strings.Contains(os.Args[i+1], "--") {
+			if i+1 < len(os.Args) && !strings.HasPrefix(os.Args[i+1], "--") {
 				args = append(args, os.Args[i+1])
 			}
 		}

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -496,6 +496,29 @@ var _ = Describe("Discover external plugins", func() {
 				"myexternalplugin/v1",
 			))
 		})
+
+		It("should preserve flag values that contain a double hyphen", func() {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"kubebuilder",
+				"init",
+				"--plugins",
+				"myexternalplugin/v1",
+				"--repo",
+				"github.com/example/my--operator",
+				"--domain",
+				"xn--bcher-kva.example",
+			}
+
+			args := parseExternalPluginArgs()
+			Expect(args).To(Equal([]string{
+				"--repo",
+				"github.com/example/my--operator",
+				"--domain",
+				"xn--bcher-kva.example",
+			}))
+		})
 	})
 })
 

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -519,6 +519,25 @@ var _ = Describe("Discover external plugins", func() {
 				"xn--bcher-kva.example",
 			}))
 		})
+
+		It("should not forward --plugins=<value> (equals form) to external plugins", func() {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"kubebuilder",
+				"init",
+				"--plugins=myexternalplugin/v1",
+				"--domain",
+				"example.com",
+			}
+
+			args := parseExternalPluginArgs()
+			Expect(args).Should(ContainElements(
+				"--domain",
+				"example.com",
+			))
+			Expect(args).ShouldNot(ContainElement("--plugins=myexternalplugin/v1"))
+		})
 	})
 })
 

--- a/pkg/plugins/external/helpers.go
+++ b/pkg/plugins/external/helpers.go
@@ -228,7 +228,7 @@ func getExternalPluginFlags(req external.PluginRequest, path string) ([]external
 // isBooleanFlag is a helper function to determine if an argument flag is a boolean flag
 func isBooleanFlag(argIndex int, args []string) bool {
 	return argIndex+1 < len(args) &&
-		strings.Contains(args[argIndex+1], "--") ||
+		strings.HasPrefix(args[argIndex+1], "--") ||
 		argIndex+1 >= len(args)
 }
 
@@ -239,7 +239,7 @@ func bindAllFlags(fs *pflag.FlagSet, args []string) {
 
 	// Bind all flags passed in
 	for i := range args {
-		if strings.Contains(args[i], "--") {
+		if strings.HasPrefix(args[i], "--") {
 			flag := strings.Replace(args[i], "--", "", 1)
 			// Check if the flag is a boolean flag
 			if isBooleanFlag(i, args) {

--- a/pkg/plugins/external/helpers_test.go
+++ b/pkg/plugins/external/helpers_test.go
@@ -19,6 +19,7 @@ package external
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin/external"
 )
@@ -40,9 +41,30 @@ var _ = Describe("helpers", func() {
 			Expect(isBooleanFlag(0, args)).To(BeFalse())
 		})
 
+		It("should return false when next arg is a value containing a double hyphen", func() {
+			args := []string{"--repo", "github.com/example/my--operator", "--domain", "example.com"}
+			Expect(isBooleanFlag(0, args)).To(BeFalse())
+		})
+
 		It("should return true for last argument", func() {
 			args := []string{"--flag"}
 			Expect(isBooleanFlag(0, args)).To(BeTrue())
+		})
+	})
+
+	Context("bindAllFlags", func() {
+		It("binds string flags when their values contain a double hyphen", func() {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+
+			bindAllFlags(fs, []string{
+				"--repo", "github.com/example/my--operator",
+				"--domain", "example.com",
+			})
+
+			Expect(fs.Lookup("repo")).NotTo(BeNil())
+			Expect(fs.Lookup("repo").Value.Type()).To(Equal("string"))
+			Expect(fs.Lookup("domain")).NotTo(BeNil())
+			Expect(fs.Lookup("domain").Value.Type()).To(Equal("string"))
 		})
 	})
 


### PR DESCRIPTION
Small fix for external plugin flag parsing.

If a forwarded flag value contains `--`, kubebuilder can treat that value like a new flag. In the fallback external plugin path that means `--repo github.com/example/my--operator` may get bound as `bool` instead of `string`. Tiny footgun, kinda sneaky.

This switches flag detection from substring checks to prefix checks, and adds regression tests for arg forwarding and fallback flag binding.

Repro:
1. Hit the fallback path in external plugin flag binding.
2. Pass `--repo github.com/example/my--operator` or `--domain xn--bcher-kva.example`.
3. Before this patch, `repo` can be parsed as a bool flag.
4. After this patch, it stays a string.

Tests:
`make lint-fix`
`make test-unit`
