### PR TITLE
📖 (go/v4): Enhance create webhook command help 

### DIFF
--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -93,24 +93,26 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 		"Run 'make generate' after generating files (enabled by default; use --make=false to disable)")
 
 	fs.StringVar(&p.options.Plural, "plural", "",
-		"Resource irregular plural form (e.g., 'people' for 'Person'); auto-detected if not provided")
+		"Resource irregular plural form (e.g., 'people' for 'Person'); auto-detected from resource kind if not provided")
 
 	fs.BoolVar(&p.options.DoDefaulting, "defaulting", false,
-		"If set, scaffold the defaulting webhook")
+		"If set, scaffold defaulting webhook")
 	fs.BoolVar(&p.options.DoValidation, "programmatic-validation", false,
-		"If set, scaffold the validating webhook")
+		"If set, scaffold validating webhook")
 	fs.BoolVar(&p.options.DoConversion, "conversion", false,
-		"If set, scaffold the conversion webhook")
+		"If set, scaffold conversion webhook")
 
 	fs.StringSliceVar(&p.options.Spoke, "spoke",
 		nil,
 		"Comma-separated list of spoke versions to be added to the conversion webhook (e.g., --spoke v1,v2)")
 
 	fs.StringVar(&p.options.DefaultingPath, "defaulting-path", "",
-		"Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path); only valid with --defaulting")
+		"[Optional] Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path). "+
+			"Only valid with --defaulting")
 
 	fs.StringVar(&p.options.ValidationPath, "validation-path", "",
-		"Custom path for the validation webhook (e.g., /my-custom-validate-path); only valid with --programmatic-validation")
+		"[Optional] Custom path for the validation webhook (e.g., /my-custom-validate-path). "+
+			"Only valid with --programmatic-validation")
 
 	// TODO: remove for go/v5
 	fs.BoolVar(&p.isLegacyPath, "legacy", false,


### PR DESCRIPTION
This PR improves the CLI help text for the `kubebuilder create webhook` command to align with the project's CLI description standards defined in `.agents/skills/cli-descriptions/SKILL.md`.

### Changes Made

Updated flag descriptions in `pkg/plugins/golang/v4/webhook.go` to follow consistent patterns:

1. **`--plural`**: Clarified auto-detection source ("auto-detected from resource kind if not provided")
2. **`--defaulting`**: Removed unnecessary article ("scaffold defaulting webhook" instead of "scaffold the defaulting webhook")
3. **`--programmatic-validation`**: Removed unnecessary article ("scaffold validating webhook")
4. **`--conversion`**: Removed unnecessary article ("scaffold conversion webhook")
5. **`--defaulting-path`**: Added `[Optional]` prefix and improved punctuation
6. **`--validation-path`**: Added `[Optional]` prefix and improved punctuation

### Motivation

The changes ensure that:
- Boolean flags follow the "If set, <action>" pattern
- Optional flags are clearly marked with `[Optional]` prefix
- Auto-detection behavior explicitly states the source
- Punctuation is consistent (periods instead of semicolons)

### Standards Applied

All changes follow the CLI Description Standards in `.agents/skills/cli-descriptions/SKILL.md`:
- Boolean flags (default false): Lines 32-46
- Optional value flags: Lines 121-132
- Value flags with auto-detection: Lines 108-119

### Test Plan
 go build ./... passes locally.
 Confirmed changes getting reflected in `kubebuilder alpha generate --help`


**Closes part of: https://github.com/kubernetes-sigs/kubebuilder/issues/5446**

**Note**: This PR only updates help text and does not change any command functionality or behavior.