### PR TITLE
⚠️ 🐛 fix(helm/v2alpha): Renamed the manager install toggle from manager.enabled to manager.enable so it matches the other chart options (webhook.enable, metrics.enable, etc.)

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -1,4 +1,4 @@
-{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}
+{{- if or (not (hasKey .Values.manager "enable")) (.Values.manager.enable) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -11,7 +11,7 @@
 manager:
   ## Set to false to skip manager installation
   ##
-  enabled: true
+  enable: true
 
   replicas: 1
 

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -1,4 +1,4 @@
-{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}
+{{- if or (not (hasKey .Values.manager "enable")) (.Values.manager.enable) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -11,7 +11,7 @@
 manager:
   ## Set to false to skip manager installation
   ##
-  enabled: true
+  enable: true
 
   replicas: 1
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -1,4 +1,4 @@
-{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}
+{{- if or (not (hasKey .Values.manager "enable")) (.Values.manager.enable) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -11,7 +11,7 @@
 manager:
   ## Set to false to skip manager installation
   ##
-  enabled: true
+  enable: true
 
   replicas: 1
 

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -189,7 +189,7 @@ helm install my-release ./dist/chart --namespace my-project-system --create-name
 Install only CRDs and RBAC:
 
 ```bash
-helm install my-release ./dist/chart --set manager.enabled=false --set webhook.enable=false
+helm install my-release ./dist/chart --set manager.enable=false --set webhook.enable=false
 ```
 
 Install without webhooks:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -62,10 +62,10 @@ func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructu
 		return HandleServiceConditionalWrappers(yamlContent, name)
 	case kind == common.KindDeployment:
 		// Manager deployment conditional allows backward compatibility:
-		// enabled when manager.enabled key is absent OR when explicitly true
+		// enabled when manager.enable key is absent OR when explicitly true
 		if IsManagerDeployment(resource) {
 			return fmt.Sprintf(
-				"{{- if or (not (hasKey .Values.manager \"enabled\")) (.Values.manager.enabled) }}\n%s\n{{- end }}\n",
+				"{{- if or (not (hasKey .Values.manager \"enable\")) (.Values.manager.enable) }}\n%s\n{{- end }}\n",
 				yamlContent,
 			)
 		}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -1010,7 +1010,7 @@ spec:
 			Expect(result).To(ContainSubstring(expectedAnnotations))
 		})
 
-		It("should add manager.enabled conditional for manager Deployments", func() {
+		It("should add manager.enable conditional for manager Deployments", func() {
 			deploymentResource := &unstructured.Unstructured{}
 			deploymentResource.SetAPIVersion("apps/v1")
 			deploymentResource.SetKind("Deployment")
@@ -1026,13 +1026,13 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
 
-			// Should be wrapped with manager.enabled conditional that defaults to true when key is absent
-			expectedConditional := `{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}`
+			// Should be wrapped with manager.enable conditional that defaults to true when key is absent
+			expectedConditional := `{{- if or (not (hasKey .Values.manager "enable")) (.Values.manager.enable) }}`
 			Expect(result).To(ContainSubstring(expectedConditional))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
-		It("should not add manager.enabled conditional for non-manager Deployments", func() {
+		It("should not add manager.enable conditional for non-manager Deployments", func() {
 			deploymentResource := &unstructured.Unstructured{}
 			deploymentResource.SetAPIVersion("apps/v1")
 			deploymentResource.SetKind("Deployment")
@@ -1048,10 +1048,10 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
 
-			// Should NOT be wrapped with manager.enabled conditional
-			expectedConditional := `{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}`
+			// Should NOT be wrapped with manager.enable conditional
+			expectedConditional := `{{- if or (not (hasKey .Values.manager "enable")) (.Values.manager.enable) }}`
 			Expect(result).NotTo(ContainSubstring(expectedConditional))
-			Expect(result).NotTo(ContainSubstring(".Values.manager.enabled"))
+			Expect(result).NotTo(ContainSubstring(".Values.manager.enable"))
 		})
 	})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -84,7 +84,7 @@ func (f *HelmValues) generateValues() string {
 manager:
   ## Set to false to skip manager installation
   ##
-  enabled: true
+  enable: true
 
 `)
 

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -1,4 +1,4 @@
-{{- if or (not (hasKey .Values.manager "enabled")) (.Values.manager.enabled) }}
+{{- if or (not (hasKey .Values.manager "enable")) (.Values.manager.enable) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -11,7 +11,7 @@
 manager:
   ## Set to false to skip manager installation
   ##
-  enabled: true
+  enable: true
 
   replicas: 1
 


### PR DESCRIPTION
## Summary

Renames the Helm chart manager install toggle from `manager.enabled` to `manager.enable` so it matches the other feature flags (`webhook.enable`, `metrics.enable`, `certManager.enable`, etc.).

## Breaking change

Existing charts and install commands that use `manager.enabled` must be updated. After upgrading Kubebuilder, run `kubebuilder edit --plugins=helm/v2-alpha` to regenerate the chart templates, then replace `manager.enabled` with `manager.enable` in your `values.yaml`. If you override the setting via Helm, update any usages of `--set manager.enabled=false` to `--set manager.enable=false`.
