### PR TITLE
WIP 🐛 fix(helm/v2-alpha): Respect --force for default ServiceMonitor file

### DIFF
--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -26,7 +26,7 @@ Many users prefer Helm for packaging and upgrades. This plugin converts `dist/in
 - Preserves environment variables, labels, annotations, and patches
 - Organizes templates to match your `config/` directory layout
 - Includes only configurable parameters in `values.yaml`
-- Never overwrites `Chart.yaml`; preserves `values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`, `network-policy/allow-metrics-traffic.yaml`, and `network-policy/allow-webhook-traffic.yaml` unless you use `--force`
+- Never overwrites `Chart.yaml`; preserves `values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`, `network-policy/allow-metrics-traffic.yaml`, `network-policy/allow-webhook-traffic.yaml`, and `prometheus/controller-manager-metrics-monitor.yaml` unless you use `--force`
 - Adds default `ServiceMonitor` and `NetworkPolicy` templates when kustomize output does not provide them
 - Places custom resources in `templates/extras/` with Helm templating
 
@@ -351,7 +351,7 @@ Optional fields in `values.yaml` use Helm conditionals. Comment them out to excl
 |---------------------|-----------------------------------------------------------------------------|
 | **--manifests**     | Path to YAML file containing Kubernetes manifests (default: `dist/install.yaml`) |
 | **--output-dir** string | Output directory for chart (default: `dist`)                                |
-| **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`, `network-policy/allow-metrics-traffic.yaml`, `network-policy/allow-webhook-traffic.yaml`) |
+| **--force**         | Regenerates preserved files except `Chart.yaml` (`values.yaml`, `NOTES.txt`, `_helpers.tpl`, `.helmignore`, `test-chart.yml`, `network-policy/allow-metrics-traffic.yaml`, `network-policy/allow-webhook-traffic.yaml`, `prometheus/controller-manager-metrics-monitor.yaml`) |
 
 <aside class="note" role="note">
 <p class="note-title"> Examples </p>

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -82,8 +82,8 @@ when the kustomize output does not provide them. When enabled, adds Helm helpers
 
 **NOTE**: Chart.yaml is never overwritten (contains user-managed version info).
 Without --force, the plugin also preserves values.yaml, NOTES.txt, _helpers.tpl, .helmignore,
-.github/workflows/test-chart.yml, network-policy/allow-metrics-traffic.yaml, and
-network-policy/allow-webhook-traffic.yaml.
+.github/workflows/test-chart.yml, network-policy/allow-metrics-traffic.yaml,
+network-policy/allow-webhook-traffic.yaml, and prometheus/controller-manager-metrics-monitor.yaml.
 All other template files in templates/ are always regenerated to match your current
 kustomize output. Use --force to regenerate all files except Chart.yaml.
 

--- a/pkg/plugins/optional/helm/v2alpha/edit_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit_test.go
@@ -75,6 +75,7 @@ version: "3"
 
 			Expect(meta.Description).To(ContainSubstring("Generate a Helm chart"))
 			Expect(meta.Description).To(ContainSubstring("kustomize"))
+			Expect(meta.Examples).To(ContainSubstring("prometheus/controller-manager-metrics-monitor.yaml"))
 			Expect(meta.Examples).NotTo(BeEmpty())
 		})
 	})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -53,7 +53,11 @@ func (f *ServiceMonitor) SetTemplateDefaults() error {
 	chartName := f.ProjectName
 	f.TemplateBody = fmt.Sprintf(serviceMonitorTemplate, chartName, chartName, chartName, chartName)
 
-	f.IfExistsAction = machinery.OverwriteFile
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
 
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("ServiceMonitor", func() {
+	Context("SetTemplateDefaults", func() {
+		var serviceMonitor *ServiceMonitor
+
+		BeforeEach(func() {
+			serviceMonitor = &ServiceMonitor{
+				OutputDir: "dist",
+				Force:     true,
+			}
+			serviceMonitor.InjectProjectName("test-project")
+		})
+
+		It("should set the correct path", func() {
+			err := serviceMonitor.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceMonitor.Path).To(Equal("dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml"))
+		})
+
+		It("should set OverwriteFile action when Force is true", func() {
+			err := serviceMonitor.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceMonitor.IfExistsAction).To(Equal(machinery.OverwriteFile))
+		})
+
+		It("should set SkipFile action when Force is false", func() {
+			serviceMonitor.Force = false
+			err := serviceMonitor.SetTemplateDefaults()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceMonitor.IfExistsAction).To(Equal(machinery.SkipFile))
+		})
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/force_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/force_integration_test.go
@@ -136,7 +136,7 @@ spec:
 	})
 
 	Context("when --force flag is NOT used", func() {
-		It("should NOT overwrite existing Chart.yaml, values.yaml, .helmignore, _helpers.tpl, NOTES.txt, test-chart.yml, and allow-metrics-traffic.yaml", func() {
+		It("should NOT overwrite existing Chart.yaml, values.yaml, .helmignore, _helpers.tpl, NOTES.txt, test-chart.yml, allow-metrics-traffic.yaml, and controller-manager-metrics-monitor.yaml", func() {
 			// First generation with force=false
 			scaffolder := scaffolds.NewChartScaffolder(projectConfig, false, manifestsFile, outputDir)
 			scaffolder.InjectFS(fs)
@@ -151,6 +151,9 @@ spec:
 			notesPath := filepath.Join(tmpDir, outputDir, "chart", "templates", "NOTES.txt")
 			networkPolicyPath := filepath.Join(
 				tmpDir, outputDir, "chart", "templates", "network-policy", "allow-metrics-traffic.yaml",
+			)
+			serviceMonitorPath := filepath.Join(
+				tmpDir, outputDir, "chart", "templates", "prometheus", "controller-manager-metrics-monitor.yaml",
 			)
 			testChartPath := filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml")
 
@@ -167,6 +170,8 @@ spec:
 			Expect(err).NotTo(HaveOccurred())
 			_, err = os.ReadFile(networkPolicyPath)
 			Expect(err).NotTo(HaveOccurred())
+			_, err = os.ReadFile(serviceMonitorPath)
+			Expect(err).NotTo(HaveOccurred())
 			_, err = os.ReadFile(testChartPath)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -177,6 +182,7 @@ spec:
 			customHelpersContent := "# CUSTOM HELPERS TPL\n{{/* custom helper */}}\n"
 			customNotesContent := "# CUSTOM NOTES\nMy custom install notes\n"
 			customNetworkPolicyContent := "# CUSTOM NETWORK POLICY\n"
+			customServiceMonitorContent := "# CUSTOM SERVICE MONITOR\n"
 			customTestChartContent := "# CUSTOM TEST CHART\nname: Custom Workflow\n"
 
 			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
@@ -190,6 +196,8 @@ spec:
 			err = os.WriteFile(notesPath, []byte(customNotesContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(networkPolicyPath, []byte(customNetworkPolicyContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(serviceMonitorPath, []byte(customServiceMonitorContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(testChartPath, []byte(customTestChartContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
@@ -228,6 +236,13 @@ spec:
 				"allow-metrics-traffic.yaml should not be overwritten without --force",
 			)
 
+			serviceMonitorContent, err := os.ReadFile(serviceMonitorPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(serviceMonitorContent)).To(
+				Equal(customServiceMonitorContent),
+				"controller-manager-metrics-monitor.yaml should not be overwritten without --force",
+			)
+
 			testChartContent, err := os.ReadFile(testChartPath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(testChartContent)).To(Equal(customTestChartContent), "test-chart.yml should not be overwritten without --force")
@@ -251,6 +266,9 @@ spec:
 			networkPolicyPath := filepath.Join(
 				tmpDir, outputDir, "chart", "templates", "network-policy", "allow-metrics-traffic.yaml",
 			)
+			serviceMonitorPath := filepath.Join(
+				tmpDir, outputDir, "chart", "templates", "prometheus", "controller-manager-metrics-monitor.yaml",
+			)
 			testChartPath := filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml")
 
 			// Modify all protected files with custom content
@@ -260,6 +278,7 @@ spec:
 			customHelpersContent := "# CUSTOM HELPERS TPL\n{{/* custom helper */}}\n"
 			customNotesContent := "# CUSTOM NOTES\nMy custom install notes\n"
 			customNetworkPolicyContent := "# CUSTOM NETWORK POLICY\n"
+			customServiceMonitorContent := "# CUSTOM SERVICE MONITOR\n"
 			customTestChartContent := "# CUSTOM TEST CHART\nname: Custom Workflow\n"
 
 			err = os.WriteFile(chartPath, []byte(customChartContent), 0o644)
@@ -273,6 +292,8 @@ spec:
 			err = os.WriteFile(notesPath, []byte(customNotesContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(networkPolicyPath, []byte(customNetworkPolicyContent), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(serviceMonitorPath, []byte(customServiceMonitorContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 			err = os.WriteFile(testChartPath, []byte(customTestChartContent), 0o644)
 			Expect(err).NotTo(HaveOccurred())
@@ -317,6 +338,17 @@ spec:
 			Expect(string(networkPolicyContent)).To(
 				ContainSubstring("kind: NetworkPolicy"),
 				"allow-metrics-traffic.yaml should contain the generated policy",
+			)
+
+			serviceMonitorContent, err := os.ReadFile(serviceMonitorPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(serviceMonitorContent)).NotTo(
+				Equal(customServiceMonitorContent),
+				"controller-manager-metrics-monitor.yaml should be overwritten with --force",
+			)
+			Expect(string(serviceMonitorContent)).To(
+				ContainSubstring("kind: ServiceMonitor"),
+				"controller-manager-metrics-monitor.yaml should contain the generated monitor",
 			)
 
 			testChartContent, err := os.ReadFile(testChartPath)


### PR DESCRIPTION
Ensures that ServiceMonitor templates follow the same behavior of Network Policies (introduced 
Follow-up to https://github.com/kubernetes-sigs/kubebuilder/pull/5708) which either is added when not found, preserving user customizations during chart regeneration instead of overwriting them.