### PR TITLE
⚠️ fix(helm/v2alpha): standardize feature toggle naming from enable to enabled

### DIFF
--- a/.github/workflows/test-helm-samples.yml
+++ b/.github/workflows/test-helm-samples.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Deploy manager via Helm
         working-directory: testdata/project-v4-with-plugins
         run: |
-          make helm-deploy IMG=controller:latest HELM_EXTRA_ARGS="--set prometheus.enable=true"
+          make helm-deploy IMG=controller:latest HELM_EXTRA_ARGS="--set prometheus.enabled=true"
 
       - name: Check Helm release status
         working-directory: testdata/project-v4-with-plugins

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -51,11 +51,11 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enable is false and serviceAccount.name is set, use that name.
+If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}
+{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.enable .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enable }}
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enable }}
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
       - args:
-        {{- if .Values.metrics.enable }}
+        {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
         {{- if not .Values.metrics.secure }}
         - --metrics-secure=false
@@ -87,10 +87,10 @@ spec:
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
-        {{- if and .Values.certManager.enable .Values.metrics.enable }}
+        {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         {{- end }}
-        {{- if .Values.certManager.enable }}
+        {{- if .Values.certManager.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         {{- end }}
         command:
@@ -135,12 +135,12 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-          {{- if and .Values.certManager.enable .Values.metrics.enable }}
+          {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
           - mountPath: /tmp/k8s-metrics-server/metrics-certs
             name: metrics-certs
             readOnly: true
           {{- end }}
-          {{- if .Values.certManager.enable }}
+          {{- if .Values.certManager.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: webhook-certs
             readOnly: true
@@ -159,7 +159,7 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-        {{- if and .Values.certManager.enable .Values.metrics.enable }}
+        {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - name: metrics-certs
           secret:
             items:
@@ -172,7 +172,7 @@ spec:
             optional: false
             secretName: metrics-server-cert
         {{- end }}
-        {{- if .Values.certManager.enable }}
+        {{- if .Values.certManager.enabled }}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.enable }}
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enable }}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}
+{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enable }}
+{{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,7 +21,7 @@ spec:
     {{- if .Values.metrics.secure }}
     tlsConfig:
       serverName: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
-      {{- if .Values.certManager.enable }}
+      {{- if .Values.certManager.enabled }}
       ca:
         secret:
           key: ca.crt

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enable false }}
+{{- if ne .Values.serviceAccount.enabled false }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-role.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/metrics-reader.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/metrics-reader.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "mutating-webhook-configuration" "context" $) }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -118,16 +118,16 @@ rbac:
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
-    enable: false
+    enabled: false
 
 ## ServiceAccount configuration
 ##
 serviceAccount:
   # Install default ServiceAccount provided
-  enable: true
+  enabled: true
 
-  ## Existing ServiceAccount name (only when enable=false)
-  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ## Existing ServiceAccount name (only when enabled=false)
+  ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
 
@@ -143,7 +143,7 @@ serviceAccount:
 ##
 crd:
   # Install CRDs with the chart
-  enable: true
+  enabled: true
   # Keep CRDs when uninstalling
   keep: true
 
@@ -151,7 +151,7 @@ crd:
 ## Enable to expose /metrics endpoint
 ##
 metrics:
-  enable: true
+  enabled: true
   # Metrics server port
   port: 8443
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
@@ -162,12 +162,12 @@ metrics:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-  enable: true
+  enabled: true
 
 ## Webhook server configuration
 ##
 webhook:
-  enable: true
+  enabled: true
   # Webhook server port
   port: 9443
 
@@ -175,11 +175,11 @@ webhook:
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enable: false
+  enabled: false
 
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##
 networkPolicy:
-  enable: false
+  enabled: false
 

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
@@ -51,11 +51,11 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enable is false and serviceAccount.name is set, use that name.
+If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}
+{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/crd/memcacheds.cache.example.com.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/crd/memcacheds.cache.example.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
       - args:
-        {{- if .Values.metrics.enable }}
+        {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
         {{- if not .Values.metrics.secure }}
         - --metrics-secure=false

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.enable }}
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enable }}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enable }}
+{{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,7 +21,7 @@ spec:
     {{- if .Values.metrics.secure }}
     tlsConfig:
       serverName: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
-      {{- if .Values.certManager.enable }}
+      {{- if .Values.certManager.enabled }}
       ca:
         secret:
           name: metrics-server-cert

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enable false }}
+{{- if ne .Values.serviceAccount.enabled false }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-admin-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-editor-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-viewer-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/memcached-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/metrics-auth-role.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/metrics-auth-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/metrics-reader.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/metrics-reader.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -118,16 +118,16 @@ rbac:
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
-    enable: false
+    enabled: false
 
 ## ServiceAccount configuration
 ##
 serviceAccount:
   # Install default ServiceAccount provided
-  enable: true
+  enabled: true
 
-  ## Existing ServiceAccount name (only when enable=false)
-  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ## Existing ServiceAccount name (only when enabled=false)
+  ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
 
@@ -143,7 +143,7 @@ serviceAccount:
 ##
 crd:
   # Install CRDs with the chart
-  enable: true
+  enabled: true
   # Keep CRDs when uninstalling
   keep: true
 
@@ -151,7 +151,7 @@ crd:
 ## Enable to expose /metrics endpoint
 ##
 metrics:
-  enable: true
+  enabled: true
   # Metrics server port
   port: 8443
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
@@ -162,17 +162,17 @@ metrics:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-  enable: false
+  enabled: false
 
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enable: false
+  enabled: false
 
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##
 networkPolicy:
-  enable: false
+  enabled: false
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -51,11 +51,11 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enable is false and serviceAccount.name is set, use that name.
+If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}
+{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.enable .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enable }}
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enable }}
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
       - args:
-        {{- if .Values.metrics.enable }}
+        {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
         {{- if not .Values.metrics.secure }}
         - --metrics-secure=false
@@ -87,10 +87,10 @@ spec:
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
-        {{- if and .Values.certManager.enable .Values.metrics.enable }}
+        {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         {{- end }}
-        {{- if .Values.certManager.enable }}
+        {{- if .Values.certManager.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         {{- end }}
         command:
@@ -135,12 +135,12 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-          {{- if and .Values.certManager.enable .Values.metrics.enable }}
+          {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
           - mountPath: /tmp/k8s-metrics-server/metrics-certs
             name: metrics-certs
             readOnly: true
           {{- end }}
-          {{- if .Values.certManager.enable }}
+          {{- if .Values.certManager.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: webhook-certs
             readOnly: true
@@ -159,7 +159,7 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-        {{- if and .Values.certManager.enable .Values.metrics.enable }}
+        {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - name: metrics-certs
           secret:
             items:
@@ -172,7 +172,7 @@ spec:
             optional: false
             secretName: metrics-server-cert
         {{- end }}
-        {{- if .Values.certManager.enable }}
+        {{- if .Values.certManager.enabled }}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.enable }}
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enable }}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}
+{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enable }}
+{{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,7 +21,7 @@ spec:
     {{- if .Values.metrics.secure }}
     tlsConfig:
       serverName: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
-      {{- if .Values.certManager.enable }}
+      {{- if .Values.certManager.enabled }}
       ca:
         secret:
           key: ca.crt

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enable false }}
+{{- if ne .Values.serviceAccount.enabled false }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/cronjob-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-role.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/metrics-reader.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/metrics-reader.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "mutating-webhook-configuration" "context" $) }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -118,16 +118,16 @@ rbac:
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
-    enable: false
+    enabled: false
 
 ## ServiceAccount configuration
 ##
 serviceAccount:
   # Install default ServiceAccount provided
-  enable: true
+  enabled: true
 
-  ## Existing ServiceAccount name (only when enable=false)
-  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ## Existing ServiceAccount name (only when enabled=false)
+  ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
 
@@ -143,7 +143,7 @@ serviceAccount:
 ##
 crd:
   # Install CRDs with the chart
-  enable: true
+  enabled: true
   # Keep CRDs when uninstalling
   keep: true
 
@@ -151,7 +151,7 @@ crd:
 ## Enable to expose /metrics endpoint
 ##
 metrics:
-  enable: true
+  enabled: true
   # Metrics server port
   port: 8443
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
@@ -162,12 +162,12 @@ metrics:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-  enable: true
+  enabled: true
 
 ## Webhook server configuration
 ##
 webhook:
-  enable: true
+  enabled: true
   # Webhook server port
   port: 9443
 
@@ -175,11 +175,11 @@ webhook:
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enable: false
+  enabled: false
 
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##
 networkPolicy:
-  enable: false
+  enabled: false
 

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -189,19 +189,19 @@ helm install my-release ./dist/chart --namespace my-project-system --create-name
 Install only CRDs and RBAC:
 
 ```bash
-helm install my-release ./dist/chart --set manager.enabled=false --set webhook.enable=false
+helm install my-release ./dist/chart --set manager.enabled=false --set webhook.enabled=false
 ```
 
 Install without webhooks:
 
 ```bash
-helm install my-release ./dist/chart --set webhook.enable=false --set certManager.enable=false
+helm install my-release ./dist/chart --set webhook.enabled=false --set certManager.enabled=false
 ```
 
 Install with NetworkPolicy resources:
 
 ```bash
-helm install my-release ./dist/chart --set networkPolicy.enable=true
+helm install my-release ./dist/chart --set networkPolicy.enabled=true
 ```
 
 ### Extra volumes
@@ -210,7 +210,7 @@ Add volumes and volume mounts to the manager deployment beyond webhook and metri
 
 Volumes in your kustomize configuration (`config/manager/manager.yaml` or patches) are written to the chart template. When the manager has extra volumes, `values.yaml` includes `manager.extraVolumes` and `manager.extraVolumeMounts` fields. Use these to add more volumes at install time.
 
-Webhook and metrics certificates (`webhook-certs`, `metrics-certs`) are managed separately and controlled by `certManager.enable` and `metrics.enable`.
+Webhook and metrics certificates (`webhook-certs`, `metrics-certs`) are managed separately and controlled by `certManager.enabled` and (for metrics TLS) `metrics.enabled` + `metrics.secure`.
 
 ### Metrics configuration
 
@@ -219,7 +219,7 @@ Webhook and metrics certificates (`webhook-certs`, `metrics-certs`) are managed 
 Control transport security and authentication for the metrics endpoint (default: `true`).
 
 When `true`:
-- Uses HTTPS with TLS certificates (when `certManager.enable=true`)
+- Uses HTTPS with TLS certificates (when `certManager.enabled=true`)
 - Creates `metrics-auth-role` ClusterRole for authentication
 - ServiceMonitor uses HTTPS
 
@@ -237,9 +237,9 @@ The `metrics-auth-role` and `metrics-reader` are always ClusterRoles, even when 
 
 ### NetworkPolicy configuration
 
-Set `networkPolicy.enable: true` to install NetworkPolicy resources for the manager pod.
+Set `networkPolicy.enabled: true` to install NetworkPolicy resources for the manager pod.
 
-When the kustomize output includes `NetworkPolicy` resources, the plugin converts them into chart templates and sets `networkPolicy.enable: true`. When no `NetworkPolicy` resources are present in the kustomize output, the plugin generates default templates for metrics traffic, and also for webhook traffic when webhooks are detected in the provided kustomize input files.
+When the kustomize output includes `NetworkPolicy` resources, the plugin converts them into chart templates and sets `networkPolicy.enabled: true`. When no `NetworkPolicy` resources are present in the kustomize output, the plugin generates default templates for metrics traffic, and also for webhook traffic when webhooks are detected in the provided kustomize input files.
 
 ### Custom labels and annotations
 
@@ -247,13 +247,13 @@ Add custom labels and annotations using `manager.labels`, `manager.annotations`,
 
 ### ServiceAccount configuration
 
-Set `serviceAccount.enable: true` (default) to create a ServiceAccount. Set `serviceAccount.enable: false` to use an existing one.
+Set `serviceAccount.enabled: true` (default) to create a ServiceAccount. Set `serviceAccount.enabled: false` to use an existing one.
 
 Add annotations for cloud provider integrations:
 
 ```yaml
 serviceAccount:
-  enable: true
+  enabled: true
   annotations:
     iam.gke.io/gcp-service-account: my-operator@project.iam.gserviceaccount.com
 ```
@@ -307,7 +307,7 @@ rbac:
     "manager-rolebinding-users": "users"
 
   helpers:
-    enable: false
+    enabled: false
 ```
 
 Override namespaces at deployment using a values file:
@@ -339,7 +339,7 @@ helm install my-operator ./dist/chart \
 <aside class="note" role="note">
 <p class="note-title">Helper roles and optional values</p>
 
-Set `rbac.helpers.enable: true` to create admin, editor, and viewer roles for Custom Resources.
+Set `rbac.helpers.enabled: true` to create admin, editor, and viewer roles for Custom Resources.
 
 Optional fields in `values.yaml` use Helm conditionals. Comment them out to exclude them from deployed manifests.
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ChartScaffolder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			rendered := string(content)
-			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 			Expect(rendered).To(ContainSubstring("kind: NetworkPolicy"))
 			Expect(rendered).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))
@@ -52,7 +52,7 @@ var _ = Describe("ChartScaffolder", func() {
 
 			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: false"))
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: false"))
 		})
 
 		It("should add generic metrics and webhook NetworkPolicies when no policy exists", func() {
@@ -95,7 +95,7 @@ var _ = Describe("ChartScaffolder", func() {
 			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			rendered := string(content)
-			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 			Expect(rendered).To(ContainSubstring("metrics: enabled"))
 			Expect(rendered).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
@@ -104,7 +104,7 @@ var _ = Describe("ChartScaffolder", func() {
 
 			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: true"))
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: true"))
 		})
 
 		It("should place all NetworkPolicies from kustomize output in the network-policy directory", func() {
@@ -122,7 +122,7 @@ var _ = Describe("ChartScaffolder", func() {
 				"dist/chart/templates/network-policy/allow-metrics-traffic.yaml",
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(metricsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(string(metricsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 			Expect(string(metricsPolicy)).To(ContainSubstring("metrics: enabled"))
 			Expect(string(metricsPolicy)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
@@ -131,7 +131,7 @@ var _ = Describe("ChartScaffolder", func() {
 				"dist/chart/templates/network-policy/allow-dns-traffic.yaml",
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(dnsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(string(dnsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 			Expect(string(dnsPolicy)).To(ContainSubstring("dns: enabled"))
 			Expect(string(dnsPolicy)).To(ContainSubstring("port: 5353"))
 
@@ -141,13 +141,13 @@ var _ = Describe("ChartScaffolder", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(webhookPolicy)).To(ContainSubstring(
-				"{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+				"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}"))
 			Expect(string(webhookPolicy)).To(ContainSubstring("webhook: enabled"))
 			Expect(string(webhookPolicy)).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
 
 			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: true"))
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: true"))
 		})
 
 		It("should add new kustomize NetworkPolicies after fallback policies were scaffolded", func() {
@@ -190,13 +190,13 @@ var _ = Describe("ChartScaffolder", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(webhookPolicy)).To(ContainSubstring(
-				"{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+				"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}"))
 			Expect(string(webhookPolicy)).To(ContainSubstring("webhook: enabled"))
 			Expect(string(webhookPolicy)).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
 
 			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enable: false"))
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: false"))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -39,25 +39,28 @@ func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructu
 	case kind == common.KindCRD:
 		// Add resource-policy annotation to prevent deletion on helm uninstall
 		yamlContent = InjectCRDResourcePolicyAnnotation(yamlContent)
-		return fmt.Sprintf("{{- if .Values.crd.enable }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if .Values.crd.enabled }}\n%s{{- end }}\n", yamlContent)
 	case kind == common.KindCertificate && apiVersion == common.APIVersionCertManager:
 		return HandleCertificateConditionalWrappers(yamlContent, name)
 	case kind == common.KindIssuer && apiVersion == common.APIVersionCertManager:
-		return fmt.Sprintf("{{- if .Values.certManager.enable }}\n%s\n{{- end }}", yamlContent)
+		return fmt.Sprintf("{{- if .Values.certManager.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceMonitor && apiVersion == common.APIVersionMonitoring:
 		// CRITICAL: newline before {{- end }} prevents whitespace chomping from eating content
-		return fmt.Sprintf("{{- if .Values.prometheus.enable }}\n%s\n{{- end }}", yamlContent)
+		return fmt.Sprintf("{{- if .Values.prometheus.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindNetworkPolicy && apiVersion == common.APIVersionNetworking:
 		if strings.HasSuffix(name, "allow-webhook-traffic") {
-			return fmt.Sprintf("{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}\n%s\n{{- end }}", yamlContent)
+			return fmt.Sprintf(
+				"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}\n%s\n{{- end }}",
+				yamlContent,
+			)
 		}
-		return fmt.Sprintf("{{- if .Values.networkPolicy.enable }}\n%s\n{{- end }}", yamlContent)
+		return fmt.Sprintf("{{- if .Values.networkPolicy.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceAccount, kind == common.KindRole, kind == common.KindClusterRole,
 		kind == common.KindRoleBinding, kind == common.KindClusterRoleBinding:
 		return HandleRBACConditionalWrappers(yamlContent, kind, name)
 	case kind == common.KindValidatingWebhook || kind == common.KindMutatingWebhook:
 		yamlContent = MakeWebhookAnnotationsConditional(yamlContent)
-		return fmt.Sprintf("{{- if .Values.webhook.enable }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if .Values.webhook.enabled }}\n%s{{- end }}\n", yamlContent)
 	case kind == common.KindService:
 		return HandleServiceConditionalWrappers(yamlContent, name)
 	case kind == common.KindDeployment:
@@ -82,21 +85,21 @@ func HandleCertificateConditionalWrappers(yamlContent, name string) string {
 	if isMetricsCert {
 		// Metrics certificates require certManager AND metrics.secure=true (TLS enabled)
 		return fmt.Sprintf(
-			"{{- if and .Values.certManager.enable .Values.metrics.enable .Values.metrics.secure }}\n%s{{- end }}\n",
+			"{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n",
 			yamlContent)
 	}
 	// Webhook serving certificates only need certManager
-	return fmt.Sprintf("{{- if .Values.certManager.enable }}\n%s{{- end }}", yamlContent)
+	return fmt.Sprintf("{{- if .Values.certManager.enabled }}\n%s{{- end }}", yamlContent)
 }
 
 // HandleServiceConditionalWrappers handles conditional logic for Service resources.
 // Uses suffix matching to avoid false positives when project name contains service types.
 func HandleServiceConditionalWrappers(yamlContent, name string) string {
 	if strings.HasSuffix(name, "-metrics-service") || strings.HasSuffix(name, "-controller-manager-metrics-service") {
-		return fmt.Sprintf("{{- if .Values.metrics.enable }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if .Values.metrics.enabled }}\n%s{{- end }}\n", yamlContent)
 	}
 	if strings.HasSuffix(name, "-webhook-service") {
-		return fmt.Sprintf("{{- if .Values.webhook.enable }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if .Values.webhook.enabled }}\n%s{{- end }}\n", yamlContent)
 	}
 	return yamlContent
 }
@@ -126,19 +129,19 @@ func HandleRBACConditionalWrappers(yamlContent, kind, name string) string {
 	}
 
 	if isHelper {
-		return fmt.Sprintf("{{- if .Values.rbac.helpers.enable }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if .Values.rbac.helpers.enabled }}\n%s{{- end }}\n", yamlContent)
 	}
 	if isMetricsAuthRole {
 		// Only needed when secure metrics enabled (authn via TokenReview/SubjectAccessReview)
-		return fmt.Sprintf("{{- if and .Values.metrics.enable .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if and .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
 	}
 	if isMetricsReader {
 		// Only needed when secure metrics enabled (uses nonResourceURLs for /metrics access)
-		return fmt.Sprintf("{{- if and .Values.metrics.enable .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if and .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
 	}
 	if isMetricsAuthBinding {
 		// Binding for metrics-auth-role, only needed when secure metrics enabled
-		return fmt.Sprintf("{{- if and .Values.metrics.enable .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
+		return fmt.Sprintf("{{- if and .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
 	}
 	// Essential RBAC (manager, leader-election) - always created
 	return yamlContent
@@ -250,7 +253,7 @@ func InjectCRDResourcePolicyAnnotation(yamlContent string) string {
 	return yamlContent
 }
 
-// MakeWebhookAnnotationsConditional makes cert-manager annotations conditional on .Values.certManager.enable.
+// MakeWebhookAnnotationsConditional makes cert-manager annotations conditional on .Values.certManager.enabled.
 func MakeWebhookAnnotationsConditional(yamlContent string) string {
 	// Find cert-manager.io/inject-ca-from annotation and make it conditional
 	if strings.Contains(yamlContent, "cert-manager.io/inject-ca-from") {
@@ -267,7 +270,7 @@ func MakeWebhookAnnotationsConditional(yamlContent string) string {
 			// Extract the annotation line with proper indentation
 			annotationLine := strings.TrimSpace(match)
 
-			return fmt.Sprintf("%s{{- if .Values.certManager.enable }}\n%s%s\n%s{{- end }}",
+			return fmt.Sprintf("%s{{- if .Values.certManager.enabled }}\n%s%s\n%s{{- end }}",
 				indent, indent, annotationLine, indent)
 		})
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -79,7 +79,7 @@ func MakeYamlContent(match string) string {
 
 		// Reconstruct the block with conditional wrapper at child indent
 		var result strings.Builder
-		fmt.Fprintf(&result, "%s{{- if .Values.certManager.enable }}\n", childIndent)
+		fmt.Fprintf(&result, "%s{{- if .Values.certManager.enabled }}\n", childIndent)
 		for _, line := range lines {
 			result.WriteString("  " + line + "\n")
 		}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -679,7 +679,7 @@ func templateControllerManagerArgs(yamlContent string) string {
 			metricsIndent = itemIndent
 		}
 		builder.WriteString(metricsIndent)
-		builder.WriteString("{{- if .Values.metrics.enable }}\n")
+		builder.WriteString("{{- if .Values.metrics.enabled }}\n")
 		builder.WriteString(metricsLine)
 		builder.WriteString("\n")
 		builder.WriteString(metricsIndent)
@@ -1369,7 +1369,7 @@ func detectChildIndent(lines []string, parentIndent string) string {
 
 // MakeContainerArgsConditional makes webhook-cert-path and metrics-cert-path args conditional.
 func MakeContainerArgsConditional(yamlContent string) string {
-	// Make webhook-cert-path arg conditional on certManager.enable
+	// Make webhook-cert-path arg conditional on certManager.enabled
 	if strings.Contains(yamlContent, "--webhook-cert-path") {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		webhookArgPattern := regexp.MustCompile(`([ \t]+)-\s*--webhook-cert-path=[^\n]*`)
@@ -1381,12 +1381,12 @@ func MakeContainerArgsConditional(yamlContent string) string {
 			}
 
 			argLine := strings.TrimSpace(match)
-			return fmt.Sprintf("%s{{- if .Values.certManager.enable }}\n%s%s\n%s{{- end }}",
+			return fmt.Sprintf("%s{{- if .Values.certManager.enabled }}\n%s%s\n%s{{- end }}",
 				indent, indent, argLine, indent)
 		})
 	}
 
-	// Make metrics-cert-path arg conditional on certManager.enable AND metrics.enable
+	// Make metrics-cert-path arg conditional on certManager.enabled AND metrics.enabled AND metrics.secure
 	if strings.Contains(yamlContent, "--metrics-cert-path") {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		metricsArgPattern := regexp.MustCompile(`([ \t]+)-\s*--metrics-cert-path=[^\n]*`)
@@ -1398,7 +1398,8 @@ func MakeContainerArgsConditional(yamlContent string) string {
 			}
 
 			argLine := strings.TrimSpace(match)
-			return fmt.Sprintf("%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n%s%s\n%s{{- end }}",
+			return fmt.Sprintf(
+				"%s{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}\n%s%s\n%s{{- end }}",
 				indent, indent, argLine, indent)
 		})
 	}
@@ -1406,9 +1407,9 @@ func MakeContainerArgsConditional(yamlContent string) string {
 	return yamlContent
 }
 
-// MakeWebhookVolumesConditional makes webhook volumes conditional on certManager.enable.
+// MakeWebhookVolumesConditional makes webhook volumes conditional on certManager.enabled.
 func MakeWebhookVolumesConditional(yamlContent string) string {
-	// Make webhook volumes conditional on certManager.enable
+	// Make webhook volumes conditional on certManager.enabled
 	if strings.Contains(yamlContent, "webhook-certs") && strings.Contains(yamlContent, "secretName: webhook-server-cert") {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		volumePattern := regexp.MustCompile(`([ \t]+)-\s*name:\s*webhook-certs[\s\S]*?secretName:\s*webhook-server-cert`)
@@ -1418,9 +1419,9 @@ func MakeWebhookVolumesConditional(yamlContent string) string {
 	return yamlContent
 }
 
-// MakeWebhookVolumeMountsConditional makes webhook volumeMounts conditional on certManager.enable.
+// MakeWebhookVolumeMountsConditional makes webhook volumeMounts conditional on certManager.enabled.
 func MakeWebhookVolumeMountsConditional(yamlContent string) string {
-	// Make webhook volumeMounts conditional on certManager.enable
+	// Make webhook volumeMounts conditional on certManager.enabled
 	webhookCertsPath := "/tmp/k8s-webhook-server/serving-certs"
 	if strings.Contains(yamlContent, "webhook-certs") && strings.Contains(yamlContent, webhookCertsPath) {
 		// Match only spaces/tabs for indent to avoid consuming the newline
@@ -1432,9 +1433,9 @@ func MakeWebhookVolumeMountsConditional(yamlContent string) string {
 	return yamlContent
 }
 
-// MakeMetricsVolumesConditional makes metrics volumes conditional on certManager.enable AND metrics.enable.
+// MakeMetricsVolumesConditional wraps metrics volumes with the metrics TLS conditional.
 func MakeMetricsVolumesConditional(yamlContent string) string {
-	// Make metrics volumes conditional on certManager.enable AND metrics.enable
+	// Make metrics volumes conditional on certManager.enabled AND metrics.enabled AND metrics.secure
 	if strings.Contains(yamlContent, "metrics-certs") && strings.Contains(yamlContent, "secretName: metrics-server-cert") {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		volumePattern := regexp.MustCompile(`([ \t]+)-\s*name:\s*metrics-certs[\s\S]*?secretName:\s*metrics-server-cert`)
@@ -1457,7 +1458,8 @@ func MakeMetricsVolumesConditional(yamlContent string) string {
 
 				// Reconstruct the block with conditional wrapper at child indent
 				var result strings.Builder
-				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n", childIndent)
+				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enabled"+
+					" .Values.metrics.enabled .Values.metrics.secure }}\n", childIndent)
 				for _, line := range lines {
 					result.WriteString("  " + line + "\n")
 				}
@@ -1471,9 +1473,9 @@ func MakeMetricsVolumesConditional(yamlContent string) string {
 	return yamlContent
 }
 
-// MakeMetricsVolumeMountsConditional makes metrics volumeMounts conditional on certManager.enable AND metrics.enable.
+// MakeMetricsVolumeMountsConditional wraps metrics volumeMounts with the metrics TLS conditional.
 func MakeMetricsVolumeMountsConditional(yamlContent string) string {
-	// Make metrics volumeMounts conditional on certManager.enable AND metrics.enable
+	// Make metrics volumeMounts conditional on certManager.enabled AND metrics.enabled AND metrics.secure
 	metricsCertsPath := "/tmp/k8s-metrics-server/metrics-certs"
 	if strings.Contains(yamlContent, "metrics-certs") && strings.Contains(yamlContent, metricsCertsPath) {
 		// Match only spaces/tabs for indent to avoid consuming the newline
@@ -1498,7 +1500,8 @@ func MakeMetricsVolumeMountsConditional(yamlContent string) string {
 
 				// Reconstruct the block with conditional wrapper at child indent
 				var result strings.Builder
-				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enable .Values.metrics.enable }}\n", childIndent)
+				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enabled"+
+					" .Values.metrics.enabled .Values.metrics.secure }}\n", childIndent)
 				for _, line := range lines {
 					result.WriteString("  " + line + "\n")
 				}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/metrics.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/metrics.go
@@ -122,7 +122,7 @@ func MakeServiceMonitorBearerTokenConditional(yamlContent string) string {
 }
 
 // MakeServiceMonitorCertManagerConditional handles cert-manager conditional logic for ServiceMonitor.
-// It wraps cert-manager specific fields with {{- if .Values.certManager.enable }} when default
+// It wraps cert-manager specific fields with {{- if .Values.certManager.enabled }} when default
 // cert-manager secrets are detected. Custom certificate secrets are preserved as-is.
 // If no certificate fields are found, it converts insecureSkipVerify: false to true.
 func MakeServiceMonitorCertManagerConditional(yamlContent string) string {
@@ -234,7 +234,7 @@ func MakeServiceMonitorCertManagerConditional(yamlContent string) string {
 	return strings.Join(result, "\n")
 }
 
-// wrapCertManagerFields wraps cert-manager certificate fields with the certManager.enable conditional.
+// wrapCertManagerFields wraps cert-manager certificate fields with the certManager.enabled conditional.
 func wrapCertManagerFields(certFields, nonCertLines []string, baseIndent int) []string {
 	indentStr := strings.Repeat(" ", baseIndent+2)
 	result := make([]string, 0, len(nonCertLines)+len(certFields)+4)
@@ -247,7 +247,7 @@ func wrapCertManagerFields(certFields, nonCertLines []string, baseIndent int) []
 	}
 
 	// Wrap cert fields with cert-manager conditional and template insecureSkipVerify
-	result = append(result, indentStr+"{{- if .Values.certManager.enable }}")
+	result = append(result, indentStr+"{{- if .Values.certManager.enabled }}")
 	result = append(result, certFields...)
 	result = append(result, indentStr+"insecureSkipVerify: false")
 	result = append(result, indentStr+"{{- else }}")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
@@ -102,7 +102,7 @@ func TemplateServiceAccountNameInDeployment(detectedPrefix, chartName, yamlConte
 func TemplateServiceAccount(detectedPrefix, chartName, yamlContent string) string {
 	yamlContent = AddServiceAccountLabelsAndAnnotations(yamlContent)
 	yamlContent = TemplateServiceAccountName(detectedPrefix, chartName, yamlContent)
-	yamlContent = WrapServiceAccountWithEnableConditional(yamlContent)
+	yamlContent = WrapServiceAccountWithEnabledConditional(yamlContent)
 	return yamlContent
 }
 
@@ -122,14 +122,14 @@ func TemplateServiceAccountName(detectedPrefix, chartName, yamlContent string) s
 	return yamlContent
 }
 
-// WrapServiceAccountWithEnableConditional wraps SA in serviceAccount.enable conditional.
-func WrapServiceAccountWithEnableConditional(yamlContent string) string {
+// WrapServiceAccountWithEnabledConditional wraps SA in serviceAccount.enabled conditional.
+func WrapServiceAccountWithEnabledConditional(yamlContent string) string {
 	// Ensure yamlContent ends with newline so {{- end }} is on its own line
 	if !strings.HasSuffix(yamlContent, "\n") {
 		yamlContent += "\n"
 	}
 	// Default to enabled, but allow an explicit false to disable ServiceAccount creation
-	return "{{- if ne .Values.serviceAccount.enable false }}\n" + yamlContent + "{{- end }}\n"
+	return "{{- if ne .Values.serviceAccount.enabled false }}\n" + yamlContent + "{{- end }}\n"
 }
 
 // AddServiceAccountLabelsAndAnnotations adds custom labels/annotations with omit() filtering.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -110,12 +110,12 @@ webhooks:
 			result := templater.ApplyHelmSubstitutions(content, resource)
 
 			// Should have proper conditional formatting without extra spaces
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 			Expect(result).To(ContainSubstring("cert-manager.io/inject-ca-from:"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 
 			// Should NOT have extra blank lines or improper indentation
-			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enable }}\n\n"))
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enabled }}\n\n"))
 			Expect(result).NotTo(ContainSubstring("cert-manager.io/inject-ca-from:\n\n"))
 		})
 
@@ -191,7 +191,7 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
 
-			Expect(result).To(ContainSubstring("{{- if .Values.metrics.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.metrics.enabled }}"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=:{{ .Values.metrics.port }}"))
 			Expect(result).To(ContainSubstring("{{- if not .Values.metrics.secure }}"))
 			Expect(result).To(ContainSubstring("- --metrics-secure=false"))
@@ -233,11 +233,12 @@ spec:
 			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
 
 			// Should have conditional blocks for webhook certs
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 			Expect(result).To(ContainSubstring("mountPath: /tmp/k8s-webhook-server/serving-certs"))
 
 			// Should have conditional blocks for metrics certs
-			Expect(result).To(ContainSubstring("{{- if and .Values.certManager.enable .Values.metrics.enable }}"))
+			metricsSecureCond := "{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}"
+			Expect(result).To(ContainSubstring(metricsSecureCond))
 			Expect(result).To(ContainSubstring("mountPath: /tmp/k8s-metrics-server/metrics-certs"))
 		})
 
@@ -530,8 +531,8 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
 
-			// Should be wrapped with prometheus enable conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.prometheus.enable }}"))
+			// Should be wrapped with prometheus enabled conditional
+			Expect(result).To(ContainSubstring("{{- if .Values.prometheus.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -553,7 +554,7 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
 
-			Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -575,7 +576,7 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
 
-			Expect(result).To(ContainSubstring("{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -592,7 +593,7 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
 
-			Expect(result).NotTo(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 		})
 
 		It("should template ServiceMonitor port and scheme based on metrics.secure", func() {
@@ -674,7 +675,7 @@ spec:
 			Expect(result).To(ContainSubstring("scheme: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}"))
 		})
 
-		It("should wrap ServiceMonitor with certManager.enable conditional when using default cert-manager secret", func() {
+		It("should wrap ServiceMonitor with certManager.enabled conditional when using default cert-manager secret", func() {
 			serviceMonitorResource := &unstructured.Unstructured{}
 			serviceMonitorResource.SetAPIVersion("monitoring.coreos.com/v1")
 			serviceMonitorResource.SetKind("ServiceMonitor")
@@ -707,7 +708,7 @@ spec:
 			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
 
 			// Should have cert-manager conditional (using default cert-manager secret)
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 
 			// Should preserve secret names
 			Expect(result).To(ContainSubstring("name: metrics-server-cert"))
@@ -751,7 +752,7 @@ spec:
 			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
 
 			// Should NOT have cert-manager conditional (custom secrets)
-			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 			Expect(result).NotTo(ContainSubstring("{{- else }}"))
 
 			// Custom secret names should be preserved as-is
@@ -785,7 +786,7 @@ spec:
 			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
 
 			// Should NOT have cert-manager conditional (no cert-manager fields detected)
-			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 
 			// Should preserve insecureSkipVerify: true as-is
 			Expect(result).To(ContainSubstring("insecureSkipVerify: true"))
@@ -819,7 +820,7 @@ spec:
 			Expect(result).NotTo(ContainSubstring("insecureSkipVerify: false"))
 
 			// Should NOT have cert-manager conditional (no cert-manager fields)
-			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 		})
 
 		It("should add metrics conditional for metrics services", func() {
@@ -835,8 +836,8 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, serviceResource)
 
-			// Should be wrapped with metrics enable conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.metrics.enable }}"))
+			// Should be wrapped with metrics enabled conditional
+			Expect(result).To(ContainSubstring("{{- if .Values.metrics.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -853,8 +854,8 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, certResource)
 
-			// Should be wrapped with certManager enable conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			// Should be wrapped with certManager enabled conditional
+			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -874,7 +875,7 @@ metadata:
 			// Should be wrapped with certManager, metrics, AND metrics.secure conditionals
 			// Metrics certs only needed when using HTTPS (metrics.secure=true)
 			Expect(result).To(ContainSubstring(
-				"{{- if and .Values.certManager.enable .Values.metrics.enable .Values.metrics.secure }}"))
+				"{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -911,8 +912,8 @@ metadata:
 
 			webhookResult := templater.ApplyHelmSubstitutions(webhookContent, serviceResource)
 
-			// Should wrap webhook service with webhook.enable conditional
-			Expect(webhookResult).To(ContainSubstring("{{- if .Values.webhook.enable }}"))
+			// Should wrap webhook service with webhook.enabled conditional
+			Expect(webhookResult).To(ContainSubstring("{{- if .Values.webhook.enabled }}"))
 			Expect(webhookResult).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -929,8 +930,8 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, mutatingWebhookResource)
 
-			// Webhook configurations should be conditional on webhook.enable
-			Expect(result).To(ContainSubstring("{{- if .Values.webhook.enable }}"))
+			// Webhook configurations should be conditional on webhook.enabled
+			Expect(result).To(ContainSubstring("{{- if .Values.webhook.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -949,14 +950,14 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, validatingWebhookResource)
 
-			// Webhook configurations should be wrapped with webhook.enable
-			Expect(result).To(ContainSubstring("{{- if .Values.webhook.enable }}"))
+			// Webhook configurations should be wrapped with webhook.enabled
+			Expect(result).To(ContainSubstring("{{- if .Values.webhook.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
-			// Cert-manager annotation should still be conditional on certManager.enable
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enable }}"))
+			// Cert-manager annotation should still be conditional on certManager.enabled
+			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 		})
 
-		It("should add crd.enable conditional and resource-policy annotation for CRDs", func() {
+		It("should add crd.enabled conditional and resource-policy annotation for CRDs", func() {
 			crdResource := &unstructured.Unstructured{}
 			crdResource.SetAPIVersion("apiextensions.k8s.io/v1")
 			crdResource.SetKind("CustomResourceDefinition")
@@ -971,8 +972,8 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, crdResource)
 
-			// Should be wrapped with crd.enable conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.crd.enable }}"))
+			// Should be wrapped with crd.enabled conditional
+			Expect(result).To(ContainSubstring("{{- if .Values.crd.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 			// Should have resource-policy annotation for helm uninstall protection
 			Expect(result).To(ContainSubstring("{{- if .Values.crd.keep }}"))
@@ -1003,8 +1004,8 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, crdResource)
 
-			// Should be wrapped with crd.enable conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.crd.enable }}"))
+			// Should be wrapped with crd.enabled conditional
+			Expect(result).To(ContainSubstring("{{- if .Values.crd.enabled }}"))
 			// Should have resource-policy annotation
 			Expect(result).To(ContainSubstring("{{- if .Values.crd.keep }}"))
 			Expect(result).To(ContainSubstring(`"helm.sh/resource-policy": keep`))
@@ -1079,7 +1080,7 @@ metadata:
 			result := templater.ApplyHelmSubstitutions(content, clusterRoleResource)
 
 			// Should be wrapped with rbac.helpers conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.rbac.helpers.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.rbac.helpers.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -1097,7 +1098,7 @@ metadata:
 			result := templater.ApplyHelmSubstitutions(content, bindingResource)
 
 			// Should be wrapped with rbac.helpers conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.rbac.helpers.enable }}"))
+			Expect(result).To(ContainSubstring("{{- if .Values.rbac.helpers.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 	})
@@ -2890,7 +2891,7 @@ spec:
           readOnly: true
 `
 			result := templater.ApplyHelmSubstitutions(content, deployment)
-			Expect(result).To(ContainSubstring(".Values.certManager.enable"))
+			Expect(result).To(ContainSubstring(".Values.certManager.enabled"))
 			Expect(result).To(ContainSubstring(".Values.manager.extraVolumes"))
 			Expect(result).To(ContainSubstring("app-secret-1"))
 		})
@@ -3879,7 +3880,7 @@ subjects:
 			Expect(result).NotTo(ContainSubstring("ClusterRoleBinding"))
 		})
 
-		It("should wrap metrics-auth ClusterRole with metrics.enable AND metrics.secure conditional", func() {
+		It("should wrap metrics-auth ClusterRole with metrics.enabled AND metrics.secure conditional", func() {
 			metricsRoleResource := &unstructured.Unstructured{}
 			metricsRoleResource.SetAPIVersion("rbac.authorization.k8s.io/v1")
 			metricsRoleResource.SetKind("ClusterRole")
@@ -3899,8 +3900,8 @@ rules:
 
 			result := templater.ApplyHelmSubstitutions(content, metricsRoleResource)
 
-			// Should wrap with metrics.enable AND metrics.secure conditional
-			Expect(result).To(ContainSubstring("{{- if and .Values.metrics.enable .Values.metrics.secure }}"))
+			// Should wrap with metrics.enabled AND metrics.secure conditional
+			Expect(result).To(ContainSubstring("{{- if and .Values.metrics.enabled .Values.metrics.secure }}"))
 			// Should NOT have rbac.create
 			Expect(result).NotTo(ContainSubstring("{{- if and .Values.rbac.create"))
 			// Metrics auth role is ALWAYS ClusterRole (never namespace-scoped)
@@ -4126,7 +4127,7 @@ rules: []`
 
 	Context("ServiceAccount configuration", func() {
 		Context("when managing ServiceAccount creation via values.yaml", func() {
-			It("allows toggling ServiceAccount installation with enable flag", func() {
+			It("allows toggling ServiceAccount installation with serviceAccount.enabled flag", func() {
 				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
@@ -4145,7 +4146,7 @@ metadata:
 
 				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
 
-				Expect(result).To(ContainSubstring("{{- if ne .Values.serviceAccount.enable false }}"))
+				Expect(result).To(ContainSubstring("{{- if ne .Values.serviceAccount.enabled false }}"))
 				Expect(result).To(ContainSubstring("{{- end }}"))
 			})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -122,11 +122,12 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{` + "`" + `{{/*
 ServiceAccount name to use.
-If serviceAccount.enable is false and serviceAccount.name is set, use that name.
+If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}` + "`" + `}}
 {{` + "`" + `{{- define "%s.serviceAccountName" -}}` + "`" + `}}
-{{` + "`" + `{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}` + "`" + `}}
+{{` + "`" + `{{- if and (not (.Values.serviceAccount.enabled | default true))` +
+	` .Values.serviceAccount.name }}` + "`" + `}}
 {{` + "`" + `{{- .Values.serviceAccount.name }}` + "`" + `}}
 {{` + "`" + `{{- else }}` + "`" + `}}
 {{` + "`" + `{{- include "%s.resourceName" (dict "suffix" "controller-manager" "context" .) }}` + "`" + `}}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
@@ -37,7 +37,7 @@ var _ = Describe("HelmHelpers", func() {
 
 			Expect(templateBody).To(ContainSubstring(`{{- define "test-project.serviceAccountName" -}}`))
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}`))
+				`{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}`))
 			Expect(templateBody).To(ContainSubstring(`{{- .Values.serviceAccount.name }}`))
 			Expect(templateBody).To(ContainSubstring(
 				`{{- include "test-project.resourceName" (dict "suffix" "controller-manager" "context" .) }}`))
@@ -70,7 +70,7 @@ var _ = Describe("HelmHelpers", func() {
 			templateBody := helpers.TemplateBody
 
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}`))
+				`{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}`))
 			Expect(templateBody).To(ContainSubstring(
 				`{{- .Values.serviceAccount.name }}`))
 		})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
@@ -69,7 +69,7 @@ func (f *NetworkPolicy) SetTemplateDefaults() error {
 	return nil
 }
 
-const networkPolicyTemplate = `{{` + "`" + `{{- if .Values.networkPolicy.enable }}` + "`" + `}}
+const networkPolicyTemplate = `{{` + "`" + `{{- if .Values.networkPolicy.enabled }}` + "`" + `}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -97,7 +97,7 @@ spec:
 `
 
 const webhookNetworkPolicyTemplate = `{{` + "`" +
-	`{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}` + "`" + `}}
+	`{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}` + "`" + `}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
@@ -65,11 +65,11 @@ var _ = Describe("NetworkPolicy", func() {
 			Expect(networkPolicy.IfExistsAction).To(Equal(machinery.SkipFile))
 		})
 
-		It("should generate a metrics NetworkPolicy guarded by networkPolicy.enable", func() {
+		It("should generate a metrics NetworkPolicy guarded by networkPolicy.enabled", func() {
 			err := networkPolicy.SetTemplateDefaults()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(networkPolicy.TemplateBody).To(ContainSubstring("{{`{{- if .Values.networkPolicy.enable }}`}}"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring("{{`{{- if .Values.networkPolicy.enabled }}`}}"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring("kind: NetworkPolicy"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
 				`name: {{ "{{ include \"test-project.resourceName\" ` +
@@ -87,7 +87,7 @@ var _ = Describe("NetworkPolicy", func() {
 
 			Expect(networkPolicy.Path).To(Equal("dist/chart/templates/network-policy/allow-webhook-traffic.yaml"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
-				"{{`{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}`}}"))
+				"{{`{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}`}}"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
 				`name: {{ "{{ include \"test-project.resourceName\" ` +
 					`(dict \"suffix\" \"allow-webhook-traffic\" \"context\" $) }}" }}`))
@@ -118,14 +118,14 @@ var _ = Describe("NetworkPolicy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			webhookPolicy := string(content)
 
-			Expect(metricsPolicy).To(ContainSubstring("{{- if .Values.networkPolicy.enable }}"))
+			Expect(metricsPolicy).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
 			Expect(metricsPolicy).To(ContainSubstring(`{{ include "test-project.name" . }}`))
 			Expect(metricsPolicy).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))
 			Expect(metricsPolicy).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
 			Expect(webhookPolicy).To(ContainSubstring(
-				"{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}"))
+				"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}"))
 			Expect(webhookPolicy).To(ContainSubstring(`{{ include "test-project.name" . }}`))
 			Expect(webhookPolicy).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-webhook-traffic" "context" $) }}`))

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -58,7 +58,7 @@ func (f *ServiceMonitor) SetTemplateDefaults() error {
 	return nil
 }
 
-const serviceMonitorTemplate = `{{` + "`" + `{{- if .Values.prometheus.enable }}` + "`" + `}}
+const serviceMonitorTemplate = `{{` + "`" + `{{- if .Values.prometheus.enabled }}` + "`" + `}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -86,7 +86,7 @@ spec:
 	`{{ "{{ include \"%s.resourceName\" " }}` +
 	`{{ "(dict \"suffix\" \"controller-manager-metrics-service\" \"context\" $) }}" }}.` +
 	`{{ "{{ .Release.Namespace }}" }}.svc
-      {{ "{{- if .Values.certManager.enable }}" }}
+      {{ "{{- if .Values.certManager.enabled }}" }}
       ca:
         secret:
           name: metrics-server-cert

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -114,7 +114,7 @@ manager:
 ##
 crd:
   # Install CRDs with the chart
-  enable: true
+  enabled: true
   # Keep CRDs when uninstalling
   keep: true
 
@@ -133,7 +133,7 @@ crd:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-  enable: true
+  enabled: true
 
 `)
 	} else {
@@ -141,7 +141,7 @@ certManager:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-  enable: false
+  enabled: false
 
 `)
 	}
@@ -156,7 +156,7 @@ certManager:
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enable: false
+  enabled: false
 
 `)
 
@@ -168,7 +168,7 @@ prometheus:
 ##
 networkPolicy:
 `)
-	fmt.Fprintf(&buf, "  enable: %t\n\n", networkPolicyEnabled)
+	fmt.Fprintf(&buf, "  enabled: %t\n\n", networkPolicyEnabled)
 
 	return buf.String()
 }
@@ -524,7 +524,7 @@ rbac:
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
-    enable: false
+    enabled: false
 
 `)
 }
@@ -535,10 +535,10 @@ func (f *HelmValues) addServiceAccountSection(buf *bytes.Buffer) {
 ##
 serviceAccount:
   # Install default ServiceAccount provided
-  enable: true
+  enabled: true
 
-  ## Existing ServiceAccount name (only when enable=false)
-  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ## Existing ServiceAccount name (only when enabled=false)
+  ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
 
@@ -570,7 +570,7 @@ func (f *HelmValues) addMetricsSection(buf *bytes.Buffer) {
 ##
 metrics:
 `)
-	fmt.Fprintf(buf, "  enable: %t\n", enableMetrics)
+	fmt.Fprintf(buf, "  enabled: %t\n", enableMetrics)
 	buf.WriteString(`  # Metrics server port
 `)
 	fmt.Fprintf(buf, "  port: %d\n", port)
@@ -591,7 +591,7 @@ func (f *HelmValues) addWebhookSection(buf *bytes.Buffer) {
 	buf.WriteString(`## Webhook server configuration
 ##
 webhook:
-  enable: true
+  enabled: true
   # Webhook server port
 `)
 	fmt.Fprintf(buf, "  port: %d\n\n", port)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
@@ -29,7 +29,7 @@ const testProjectName = "test-project"
 
 var _ = Describe("HelmValues", func() {
 	Describe("NetworkPolicy section", func() {
-		It("should default networkPolicy.enable to false when no NetworkPolicy resources exist", func() {
+		It("should default networkPolicy.enabled to false when no NetworkPolicy resources exist", func() {
 			values := &HelmValues{
 				Extraction: nil,
 			}
@@ -37,10 +37,10 @@ var _ = Describe("HelmValues", func() {
 
 			result := values.generateValues()
 
-			Expect(result).To(ContainSubstring("networkPolicy:\n  enable: false"))
+			Expect(result).To(ContainSubstring("networkPolicy:\n  enabled: false"))
 		})
 
-		It("should set networkPolicy.enable to true when NetworkPolicy resources are detected", func() {
+		It("should set networkPolicy.enabled to true when NetworkPolicy resources are detected", func() {
 			values := &HelmValues{
 				Extraction: &extractor.Extraction{
 					Features: extractor.FeatureSet{
@@ -52,10 +52,10 @@ var _ = Describe("HelmValues", func() {
 
 			result := values.generateValues()
 
-			Expect(result).To(ContainSubstring("networkPolicy:\n  enable: true"))
+			Expect(result).To(ContainSubstring("networkPolicy:\n  enabled: true"))
 		})
 
-		It("should set networkPolicy.enable to false when HasNetworkPolicy is false", func() {
+		It("should set networkPolicy.enabled to false when HasNetworkPolicy is false", func() {
 			values := &HelmValues{
 				Extraction: &extractor.Extraction{
 					Features: extractor.FeatureSet{
@@ -67,7 +67,7 @@ var _ = Describe("HelmValues", func() {
 
 			result := values.generateValues()
 
-			Expect(result).To(ContainSubstring("networkPolicy:\n  enable: false"))
+			Expect(result).To(ContainSubstring("networkPolicy:\n  enabled: false"))
 		})
 	})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -183,8 +183,7 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			valuesPath := filepath.Join(chartPath, "values.yaml")
 			valuesContent, err := afero.ReadFile(afero.NewOsFs(), valuesPath)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(valuesContent)).To(ContainSubstring("certManager:"))
-			Expect(string(valuesContent)).To(ContainSubstring("enable: true"))
+			Expect(string(valuesContent)).To(ContainSubstring("certManager:\n  enabled: true"))
 		})
 	})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
@@ -1118,7 +1118,7 @@ spec:
 				"unescaped Go templates should not exist in default values")
 
 			// Helm templates we add should still work (not escaped)
-			Expect(crdStr).To(ContainSubstring("{{- if .Values.crd.enable }}"),
+			Expect(crdStr).To(ContainSubstring("{{- if .Values.crd.enabled }}"),
 				"Helm conditional should be present and NOT escaped")
 			Expect(crdStr).To(ContainSubstring("namespace: {{ .Release.Namespace }}"),
 				"Helm namespace template should be present and NOT escaped")

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -51,11 +51,11 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enable is false and serviceAccount.name is set, use that name.
+If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project-v4-with-plugins.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enable | default true)) .Values.serviceAccount.name }}
+{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.enable .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enable }}
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enable }}
+{{- if .Values.certManager.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/busyboxes.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/busyboxes.example.com.testproject.org.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/memcacheds.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/memcacheds.example.com.testproject.org.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/wordpresses.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/wordpresses.example.com.testproject.org.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
       - args:
-        {{- if .Values.metrics.enable }}
+        {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
         {{- if not .Values.metrics.secure }}
         - --metrics-secure=false
@@ -87,7 +87,7 @@ spec:
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
-        {{- if .Values.certManager.enable }}
+        {{- if .Values.certManager.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         {{- end }}
         command:
@@ -146,7 +146,7 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-          {{- if .Values.certManager.enable }}
+          {{- if .Values.certManager.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: webhook-certs
             readOnly: true
@@ -165,7 +165,7 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-        {{- if .Values.certManager.enable }}
+        {{- if .Values.certManager.enabled }}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/testdata/project-v4-with-plugins/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/metrics/controller-manager-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.enable }}
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enable }}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.networkPolicy.enable .Values.webhook.enable }}
+{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enable }}
+{{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,7 +21,7 @@ spec:
     {{- if .Values.metrics.secure }}
     tlsConfig:
       serverName: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
-      {{- if .Values.certManager.enable }}
+      {{- if .Values.certManager.enabled }}
       ca:
         secret:
           name: metrics-server-cert

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-admin-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-editor-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-viewer-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/busybox-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enable false }}
+{{- if ne .Values.serviceAccount.enabled false }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-admin-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-editor-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-viewer-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/memcached-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics-auth-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics-auth-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics-reader.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/metrics-reader.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-admin-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-editor-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-viewer-role.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/wordpress-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "project-v4-with-plugins.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -135,16 +135,16 @@ rbac:
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
-    enable: false
+    enabled: false
 
 ## ServiceAccount configuration
 ##
 serviceAccount:
   # Install default ServiceAccount provided
-  enable: true
+  enabled: true
 
-  ## Existing ServiceAccount name (only when enable=false)
-  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ## Existing ServiceAccount name (only when enabled=false)
+  ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
 
@@ -160,7 +160,7 @@ serviceAccount:
 ##
 crd:
   # Install CRDs with the chart
-  enable: true
+  enabled: true
   # Keep CRDs when uninstalling
   keep: true
 
@@ -168,7 +168,7 @@ crd:
 ## Enable to expose /metrics endpoint
 ##
 metrics:
-  enable: true
+  enabled: true
   # Metrics server port
   port: 8443
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
@@ -179,12 +179,12 @@ metrics:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-  enable: true
+  enabled: true
 
 ## Webhook server configuration
 ##
 webhook:
-  enable: true
+  enabled: true
   # Webhook server port
   port: 9443
 
@@ -192,11 +192,11 @@ webhook:
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enable: false
+  enabled: false
 
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##
 networkPolicy:
-  enable: false
+  enabled: false
 


### PR DESCRIPTION
Standardizes all Helm chart feature toggle fields from `enable` to `enabled` across the `helm/v2-alpha` plugin, aligning with ecosystem convention is enabled. This pattern is used across the vast majority of popular charts (Bitnami, ingress-nginx, Prometheus, Grafana, cert-manager, etc.), is documented by Helm Standards' https://www.helmstandards.com/blog/helm-value-naming-conventions  analysis of thousands of Artifact Hub charts, and is what Helm users generally expect.

Affected toggles: `crd`, `certManager`, `prometheus`, `networkPolicy`, `webhook`, `metrics`, `serviceAccount`, `rbac.helpers`.

## Migration for existing projects ( kubebuilder edit --plugins=helm/v2-alpha and rename *.enable -> *.enabled )

If you already have a chart generated by `helm/v2-alpha`, update your `values.yaml` and any custom `--set` flags:

```yaml
# Before
certManager:
  enable: true
metrics:
  enable: true
webhook:
  enable: true

# After
certManager:
  enabled: true
metrics:
  enabled: true
webhook:
  enabled: true
```

Regenerate your chart to pick up the new field names:

```bash
kubebuilder edit --plugins=helm/v2-alpha --force
```

And update the values.yaml by replacing the enable toggled with enabled.
Also, if you have any CI, pipeline ensure that they are changed to use enable**d** instead of enable.

Closes #5732
