### PR TITLE
🌱  Rename depguard sort rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
   settings:
     depguard:
       rules:
-        forbid-pkg-errors:
+        forbid-sort-pkg:
           deny:
             - pkg: sort
               desc: Should be replaced with slices package


### PR DESCRIPTION
## Description
Rename the depguard rule that blocks the `sort` package from `forbid-pkg-errors` to `forbid-sort-pkg` so the rule name matches the package it targets. This is a config-only cleanup with no behavior change.

Fixes #5741

## Verification
- `grep -RIn "forbid-pkg-errors\|forbid-sort-pkg\|pkg: sort" . --exclude-dir=.git --exclude-dir=bin --exclude-dir=vendor`
- `ruby -ryaml -e 'YAML.load_file(".golangci.yml"); puts "yaml ok"'`\n- `git diff --check`\n\nNote: `golangci-lint` and `yamllint` were not installed in this local environment.