### PR TITLE
🌱Enforce golangci-lint formatting in verify-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ lint: golangci-lint ## Run golangci-lint linter
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 	$(GOLANGCI_LINT) run --fix
 
+.PHONY: lint-fmt
+lint-fmt: golangci-lint ## Verify Go code is formatted
+	$(GOLANGCI_LINT) fmt --diff
+
 
 # Lint all YAML: testdata files (yamllint-yaml) + Helm-rendered charts (yamllint-helm).
 # Repo YAML uses .yamllint; Helm output uses .yamllint-helm.
@@ -250,7 +254,7 @@ kube-linter: install-helm install-kube-linter ## Lint all Helm charts with kube-
 verify: verify-lint verify-license verify-sample-permissions verify-testdata verify-docs verify-helm ## Run all verification checks
 
 .PHONY: verify-lint
-verify-lint: verify-lint-config yamllint-yaml ## Run linting checks (config, YAML). Note: golangci-lint run is done via CI action for PR comments
+verify-lint: verify-lint-config lint-fmt yamllint-yaml ## Run linting checks (config, format, YAML). Note: golangci-lint run is done via CI action for PR comments
 
 .PHONY: verify-lint-config
 verify-lint-config: golangci-lint ## Verify golangci-lint linter configuration

--- a/docs/book/utils/markerdocs/main.go
+++ b/docs/book/utils/markerdocs/main.go
@@ -50,12 +50,12 @@ func maybeDetails(help *DetailedHelp) toHTML {
 			summary(optionalClasses{"no-details": help.Details == ""},
 				Text(help.Summary)),
 			// NB(directxman12): if we don't wrap with newlines, markdown won't be parsed
-			Text(wrapWithNewlines(help.Details)))}
+			Text(wrapWithNewlines(help.Details))),
+	}
 }
 
 // markerTemplate returns HTML describing the documentation for a given marker.
 func markerTemplate(marker *MarkerDoc) toHTML {
-
 	// the marker name
 	term := dt(classes{"literal", "name"},
 		Text("// +"+marker.Name))
@@ -83,7 +83,8 @@ func markerTemplate(marker *MarkerDoc) toHTML {
 			dd(optionalClasses{"argument": true, "type": true, "optional": field.Optional},
 				argType(&field.Argument)),
 			dd(classes{"description"},
-				maybeDetails(&field.DetailedHelp))})
+				maybeDetails(&field.DetailedHelp)),
+		})
 	}
 
 	// the help (displayed in both modes)

--- a/pkg/plugins/golang/v4/scaffolds/webhook_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook_test.go
@@ -31,9 +31,7 @@ import (
 )
 
 var _ = Describe("Webhook Incremental Scaffolding", func() {
-	var (
-		kbc *utils.TestContext
-	)
+	var kbc *utils.TestContext
 
 	BeforeEach(func() {
 		var err error
@@ -315,7 +313,7 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 	})`
 			modified = strings.Replace(modified, "	})\n\n	AfterEach(func() {", customCode+"\n\n	AfterEach(func() {", 1)
 
-			err = os.WriteFile(testFile, []byte(modified), 0644)
+			err = os.WriteFile(testFile, []byte(modified), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("customizing: adding custom implementation to webhook")
@@ -331,7 +329,7 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 		testcustom.Spec.Replicas = &replicas
 	}`)
 
-			err = os.WriteFile(webhookFile, []byte(modifiedWebhook), 0644)
+			err = os.WriteFile(webhookFile, []byte(modifiedWebhook), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("adding validation webhook WITHOUT --force")
@@ -401,7 +399,7 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			modified := strings.ReplaceAll(string(content), "// TODO (user): Add any setup logic common to all tests\n", "")
 			modified = strings.ReplaceAll(modified, "// TODO (user): Add any teardown logic common to all tests\n", "")
 
-			err = os.WriteFile(testFile, []byte(modified), 0644)
+			err = os.WriteFile(testFile, []byte(modified), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("adding defaulting webhook WITHOUT --force")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go
@@ -1380,9 +1380,9 @@ spec:
 `
 			// Write kustomize output to file
 			manifestsPath := filepath.Join("dist", "install.yaml")
-			err := fs.FS.MkdirAll(filepath.Dir(manifestsPath), 0755)
+			err := fs.FS.MkdirAll(filepath.Dir(manifestsPath), 0o755)
 			Expect(err).NotTo(HaveOccurred())
-			err = afero.WriteFile(fs.FS, manifestsPath, []byte(kustomizeOutput), 0644)
+			err = afero.WriteFile(fs.FS, manifestsPath, []byte(kustomizeOutput), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("parsing the kustomize output")


### PR DESCRIPTION
Summary
- Add a `lint-fmt` target that runs `golangci-lint fmt --diff`.
- Wire `lint-fmt` into `verify-lint` so CI validates formatter output.
- Apply the current formatter output to the three Go files that were not clean.

Reproduction
- On `master`, `golangci-lint fmt --diff` reports formatting diffs in:
  - `docs/book/utils/markerdocs/main.go`
  - `pkg/plugins/golang/v4/scaffolds/webhook_test.go`
  - `pkg/plugins/optional/helm/v2alpha/scaffolds/test/extras_integration_test.go`

Root cause
- The repo configures formatters under `formatters:` for golangci-lint v2, but `golangci-lint run` does not execute them.
- `make verify-lint` validated the config and YAML files, while the PR workflow runs `golangci-lint run`, so neither path enforced `golangci-lint fmt`.

Changes
- Add `make lint-fmt` as the formatting verification target.
- Make `verify-lint` depend on `lint-fmt`.
- Run `golangci-lint fmt` once to make the existing files pass the new check.

Tests
- `make lint-fmt`
- `make verify-lint-config`
- `make verify-lint` runs `verify-lint-config` and `lint-fmt`, then stops at `yamllint-yaml` because this local environment does not have the `docker` command required by that target.

Screenshots/Logs
- Not applicable; this is a Makefile and formatting change.
- Relevant local log for the partial `make verify-lint` run: `/bin/sh: docker: command not found`.

Fixes #5743
