### PR TITLE
🌱 Make fix-docs portable across GNU and BSD sed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,16 @@ Following the targets that can be used to test your changes locally.
 
 **NOTE** `make verify-lint` requires a local installation of `golangci-lint`. More info: https://github.com/golangci/golangci-lint#install
 
+### macOS notes
+
+If you run the documentation targets on macOS, install the required tools first:
+
+```shell
+brew install bash mdbook
+```
+
+The docs cleanup targets support both BSD `sed` and GNU `sed`, so you do not need to replace the system `sed`.
+
 ### Running e2e tests locally
 
 See that you can run `test-e2e-local` to setup Kind and run e2e tests locally.

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,9 @@ generate-charts: build ## Re-generate the helm chart testdata and docs samples
 fix-docs: ## Fix documentation issues (accessibility + trailing spaces)
 	./hack/docs/fix_note_accessibility.sh
 	@echo "Removing trailing spaces from markdown files..."
-	@find . -type f -name "*.md" -exec sed -i.bak 's/[[:space:]]*$$//' {} +
-	@find . -type f -name "*.md.bak" -delete
+	@backup_ext=".kubebuilder-fix-docs.bak"; \
+	find . -type f -name "*.md" -exec sed -i"$${backup_ext}" 's/[[:space:]]*$$//' {} +; \
+	find . -type f -name "*$${backup_ext}" -delete
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,8 @@ generate-charts: build ## Re-generate the helm chart testdata and docs samples
 fix-docs: ## Fix documentation issues (accessibility + trailing spaces)
 	./hack/docs/fix_note_accessibility.sh
 	@echo "Removing trailing spaces from markdown files..."
-	@find . -type f -name "*.md" -exec sed -i '' 's/[[:space:]]*$$//' {} +
+	@find . -type f -name "*.md" -exec sed -i.bak 's/[[:space:]]*$$//' {} +
+	@find . -type f -name "*.md.bak" -delete
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter


### PR DESCRIPTION
Fixes #5746

What
`fix-docs` used `sed -i ''`, so `make generate-docs` blew up on Linux. Kinda annoying, tiny fix tho.

This switches the trailing space cleanup to `sed -i.bak` and removes the temp `.bak` files after. Same behavior, works on GNU and BSD `sed`.

Repro
1. On `master`, run `make generate-docs`
2. It reaches `make fix-docs`
3. It fails with `sed: can't read s/[[:space:]]*$//: No such file or directory`

Checks
- `make fix-docs`
- `make install && make generate-docs`
- `make test-unit`

Note
`make lint-fix` still fails on current `master` because of existing `goconst` findings in `pkg/cli/*`, unrelated to this change.