### PR TITLE
fix: correct nil StartTime comparator in CronJob tutorial sort

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -396,16 +396,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(failedJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range failedJobs {
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
@@ -423,16 +427,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(successfulJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range successfulJobs {
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -396,16 +396,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(failedJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range failedJobs {
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
@@ -423,16 +427,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(successfulJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range successfulJobs {
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {

--- a/hack/docs/internal/cronjob-tutorial/controller_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/controller_implementation.go
@@ -385,16 +385,20 @@ const controllerReconcileLogic = `log := logf.FromContext(ctx)
 		slices.SortStableFunc(failedJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range failedJobs {
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
@@ -412,16 +416,20 @@ const controllerReconcileLogic = `log := logf.FromContext(ctx)
 		slices.SortStableFunc(successfulJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range successfulJobs {
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {


### PR DESCRIPTION
## What

Fixes the asymmetric nil-handling in the `slices.SortStableFunc` comparators added by #5265.

## The Bug

The current comparator violates `cmp(a,b) == -cmp(b,a)`:
- `cmp(nil, non-nil)` returns `1` (explicit)
- `cmp(non-nil, nil)` returns `0` (both `Before` checks are false)

This also **flips** the original `sort.Slice` behavior: nil-`StartTime` jobs now sort to the end (kept by history limits) instead of the beginning (pruned first).

## The Fix

Replace with a consistent switch-based comparator that handles all nil combinations explicitly and preserves nil-first ordering:

```go
switch {
case aStartTime == nil && bStartTime == nil:
    return 0
case aStartTime == nil:
    return -1
case bStartTime == nil:
    return 1
case aStartTime.Before(bStartTime):
    return -1
case bStartTime.Before(aStartTime):
    return 1
default:
    return 0
}
```

## Files Changed

All 3 files from the issue, both call sites (failedJobs + successfulJobs) in each:
- `docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go`
- `docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go`
- `hack/docs/internal/cronjob-tutorial/controller_implementation.go`

Closes: #5744

> **Note:** Testing the history-limit pruning path with envtest (as suggested in the issue) would be a great follow-up. This PR focuses on the comparator fix itself to keep the scope tight.