### PR TITLE
🐛 fix(helm/v2-alpha): prevent edit hang on malformed dist/install.yaml

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -292,7 +292,7 @@ func (p *editSubcommand) extractNamespaceFromManifests() string {
 			if err == io.EOF {
 				break
 			}
-			continue
+			break
 		}
 
 		// Check if this is a Deployment (manager)

--- a/pkg/plugins/optional/helm/v2alpha/edit_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit_test.go
@@ -284,8 +284,6 @@ jobs:
 			editCmd.outputDir = common.DefaultOutputDir
 		})
 
-
-
 		AfterEach(func() {
 			// Clean up temp directory
 			if tmpDir != "" {
@@ -425,31 +423,31 @@ helm-rollback: ## Rollback to previous Helm release.
 			Expect(err.Error()).To(ContainSubstring("makefile not found"))
 		})
 	})
-    Context("extractNamespaceFromManifests", func() {
-        It("should return default namespace for malformed YAML", func() {
-            tmpDir, err := os.MkdirTemp("", "helm-malformed-*")
-            Expect(err).NotTo(HaveOccurred())
-            defer os.RemoveAll(tmpDir)
-    
-            manifestsFile := filepath.Join(tmpDir, "install.yaml")
-    
-            malformedYAML := `
+	Context("extractNamespaceFromManifests", func() {
+		It("should return default namespace for malformed YAML", func() {
+			tmpDir, err := os.MkdirTemp("", "helm-malformed-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			manifestsFile := filepath.Join(tmpDir, "install.yaml")
+
+			malformedYAML := `
     apiVersion: v1
     kind: Namespace
     metadata:
       name: test-system
     invalid: [
     `
-    
-            err = os.WriteFile(manifestsFile, []byte(malformedYAML), 0644)
-            Expect(err).NotTo(HaveOccurred())
-    
-            editCmd.manifestsFile = manifestsFile
-    
-            namespace := editCmd.extractNamespaceFromManifests()
-    
-            Expect(namespace).To(Equal("test-project-system"))
-        })
-    })
+
+			err = os.WriteFile(manifestsFile, []byte(malformedYAML), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			editCmd.manifestsFile = manifestsFile
+
+			namespace := editCmd.extractNamespaceFromManifests()
+
+			Expect(namespace).To(Equal("test-project-system"))
+		})
+	})
 
 })

--- a/pkg/plugins/optional/helm/v2alpha/edit_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit_test.go
@@ -284,6 +284,8 @@ jobs:
 			editCmd.outputDir = common.DefaultOutputDir
 		})
 
+
+
 		AfterEach(func() {
 			// Clean up temp directory
 			if tmpDir != "" {
@@ -423,4 +425,31 @@ helm-rollback: ## Rollback to previous Helm release.
 			Expect(err.Error()).To(ContainSubstring("makefile not found"))
 		})
 	})
+    Context("extractNamespaceFromManifests", func() {
+        It("should return default namespace for malformed YAML", func() {
+            tmpDir, err := os.MkdirTemp("", "helm-malformed-*")
+            Expect(err).NotTo(HaveOccurred())
+            defer os.RemoveAll(tmpDir)
+    
+            manifestsFile := filepath.Join(tmpDir, "install.yaml")
+    
+            malformedYAML := `
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: test-system
+    invalid: [
+    `
+    
+            err = os.WriteFile(manifestsFile, []byte(malformedYAML), 0644)
+            Expect(err).NotTo(HaveOccurred())
+    
+            editCmd.manifestsFile = manifestsFile
+    
+            namespace := editCmd.extractNamespaceFromManifests()
+    
+            Expect(namespace).To(Equal("test-project-system"))
+        })
+    })
+
 })


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite loop in `extractNamespaceFromManifests` when parsing a malformed `dist/install.yaml`.

Previously, YAML decode errors other than `io.EOF` were handled using `continue`. Since the YAML decoder returns the same error repeatedly after a syntax failure, the loop never makes progress and `kubebuilder edit --plugins=helm/v2-alpha` can hang indefinitely.

This change stops processing on non-EOF decode errors by replacing `continue` with `break`, allowing the function to fall back to the default namespace (`<project>-system`), which is already the expected behavior for other parsing failures.

## Changes

- Replace `continue` with `break` for non-EOF YAML decode errors.
- Add a regression test for malformed YAML input.
- Verify fallback to the default namespace when manifest parsing fails.

## Testing

```bash
go test ./pkg/plugins/optional/helm/v2alpha -v
```

Result:

- 22/22 tests passed
- 0 failures
- 0 pending
- 0 skipped

Fixes #5750
