### PR TITLE
✨ (go/v4) Add depguard linter to golangci.yml

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -28,6 +29,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings

--- a/docs/book/src/getting-started/testdata/project/.golangci.yml
+++ b/docs/book/src/getting-started/testdata/project/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -28,6 +29,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings

--- a/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -28,6 +29,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/golangci.go
@@ -48,6 +48,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -71,6 +72,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings

--- a/testdata/project-v4-multigroup/.golangci.yml
+++ b/testdata/project-v4-multigroup/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -28,6 +29,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings

--- a/testdata/project-v4-with-plugins/.golangci.yml
+++ b/testdata/project-v4-with-plugins/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -28,6 +29,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings

--- a/testdata/project-v4/.golangci.yml
+++ b/testdata/project-v4/.golangci.yml
@@ -5,6 +5,7 @@ linters:
   default: none
   enable:
     - copyloopvar
+    - depguard
     - dupl
     - errcheck
     - ginkgolinter
@@ -28,6 +29,12 @@ linters:
       logcheck:
         type: "module"
         description: Checks Go logging calls for Kubernetes logging conventions.
+    depguard:
+      rules:
+        forbid-sort-pkg:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     revive:
       rules:
         - name: comment-spacings


### PR DESCRIPTION
Enables the depguard linter in the golangci.yml configuration files across multiple test projects. This linter enforces specific dependency rules, in this case, forbidding the use of the 'sort' package in favor of the 'slices' package. This promotes the use of more modern and potentially efficient Go standard library features.

Closes: #5742 

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
