### PR TITLE
🐛 fix(CLI/test): Preserve namespaced scope on edit

### DIFF
--- a/pkg/plugins/golang/v4/edit_test.go
+++ b/pkg/plugins/golang/v4/edit_test.go
@@ -139,6 +139,66 @@ var _ = Describe("editSubcommand", func() {
 		})
 	})
 
+	// PreScaffold -> Scaffold
+	Context("edit should not flip scope when its flag is omitted", func() {
+		var (
+			fs     *pflag.FlagSet
+			mockFS machinery.Filesystem
+		)
+
+		BeforeEach(func() {
+			fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+			subCmd.BindFlags(fs)
+
+			// Only set namespaced project
+			Expect(cfg.SetNamespaced()).To(Succeed())
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+
+			memFS := afero.NewMemMapFs()
+			mockFS = machinery.Filesystem{FS: memFS}
+
+			// Reads the Dockerfile
+			Expect(afero.WriteFile(memFS, "Dockerfile", []byte("FROM golang:1.23"), 0o644)).To(Succeed())
+
+			// Seed a namespace-scoped RBAC role
+			Expect(afero.WriteFile(memFS, filepath.Join("config", "rbac", "role.yaml"),
+				[]byte("kind: Role\n"), 0o644)).To(Succeed())
+		})
+
+		It("keeps namespaced: true and the Role intact on `edit --multigroup`", func() {
+			// Only --multigroup is passed
+			Expect(fs.Set("multigroup", "true")).To(Succeed())
+
+			Expect(subCmd.PreScaffold(mockFS)).To(Succeed())
+			Expect(subCmd.Scaffold(mockFS)).To(Succeed())
+
+			// Enable PROJECT state: multigroup
+			Expect(cfg.IsMultiGroup()).To(BeTrue(), "multigroup should be enabled by the flag")
+			Expect(cfg.IsNamespaced()).To(BeTrue(), "namespaced must be preserved, not cleared")
+
+			// Ignore RBAC re-written
+			content, err := afero.ReadFile(mockFS.FS, filepath.Join("config", "rbac", "role.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("kind: Role\n"),
+				"role.yaml must not be overwritten with a ClusterRole")
+		})
+
+		It("keeps namespaced: true on `edit --license apache2`", func() {
+			// Set license-only
+			Expect(fs.Set("license", "apache2")).To(Succeed())
+
+			Expect(subCmd.PreScaffold(mockFS)).To(Succeed())
+			Expect(subCmd.Scaffold(mockFS)).To(Succeed())
+
+			Expect(cfg.IsNamespaced()).To(BeTrue(), "namespaced must be preserved, not cleared")
+
+			content, err := afero.ReadFile(mockFS.FS, filepath.Join("config", "rbac", "role.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("kind: Role\n"),
+				"role.yaml must not be overwritten with a ClusterRole")
+		})
+	})
+
 	Context("Boilerplate update", func() {
 		var (
 			fs     machinery.Filesystem


### PR DESCRIPTION
When running `edit --multigroup` or `edit --license`, the scaffold should not inadvertently clear the namespaced scope.

This change adds tests to ensure that the `namespaced` setting in the project configuration is preserved when these flags are used, and that the RBAC Role is not overwritten with a ClusterRole.

Fixes: #5752 

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
