### PR TITLE
🐛 fix(templates): update serviceAccountName condition to use string com…

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -55,7 +55,7 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
+{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enabled false }}
+{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
@@ -55,7 +55,7 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
+{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enabled false }}
+{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -55,7 +55,7 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
+{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enabled false }}
+{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
@@ -128,8 +128,10 @@ func WrapServiceAccountWithEnabledConditional(yamlContent string) string {
 	if !strings.HasSuffix(yamlContent, "\n") {
 		yamlContent += "\n"
 	}
-	// Default to enabled, but allow an explicit false to disable ServiceAccount creation
-	return "{{- if ne .Values.serviceAccount.enabled false }}\n" + yamlContent + "{{- end }}\n"
+	// Default to enabled, but allow an explicit false to disable ServiceAccount creation.
+	// Compare via toString so the guard matches the serviceAccountName helper exactly and never
+	// pipes the boolean through default (which would swallow an explicit false).
+	return "{{- if ne (.Values.serviceAccount.enabled | toString) \"false\" }}\n" + yamlContent + "{{- end }}\n"
 }
 
 // AddServiceAccountLabelsAndAnnotations adds custom labels/annotations with omit() filtering.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -4146,7 +4146,7 @@ metadata:
 
 				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
 
-				Expect(result).To(ContainSubstring("{{- if ne .Values.serviceAccount.enabled false }}"))
+				Expect(result).To(ContainSubstring(`{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}`))
 				Expect(result).To(ContainSubstring("{{- end }}"))
 			})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -126,7 +126,7 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}` + "`" + `}}
 {{` + "`" + `{{- define "%s.serviceAccountName" -}}` + "`" + `}}
-{{` + "`" + `{{- if and (not (.Values.serviceAccount.enabled | default true))` +
+{{` + "`" + `{{- if and (eq (.Values.serviceAccount.enabled | toString) "false")` +
 	` .Values.serviceAccount.name }}` + "`" + `}}
 {{` + "`" + `{{- .Values.serviceAccount.name }}` + "`" + `}}
 {{` + "`" + `{{- else }}` + "`" + `}}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
@@ -37,7 +37,7 @@ var _ = Describe("HelmHelpers", func() {
 
 			Expect(templateBody).To(ContainSubstring(`{{- define "test-project.serviceAccountName" -}}`))
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}`))
+				`{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}`))
 			Expect(templateBody).To(ContainSubstring(`{{- .Values.serviceAccount.name }}`))
 			Expect(templateBody).To(ContainSubstring(
 				`{{- include "test-project.resourceName" (dict "suffix" "controller-manager" "context" .) }}`))
@@ -70,7 +70,7 @@ var _ = Describe("HelmHelpers", func() {
 			templateBody := helpers.TemplateBody
 
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}`))
+				`{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}`))
 			Expect(templateBody).To(ContainSubstring(
 				`{{- .Values.serviceAccount.name }}`))
 		})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -329,6 +330,48 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 						"app.kubernetes.io/name label should not be hardcoded in "+file.Name())
 				}
 			}
+		})
+	})
+
+	Context("ServiceAccount name resolution (rendered)", func() {
+		renderChart := func(setArgs ...string) string {
+			if _, err := exec.LookPath("helm"); err != nil {
+				Skip("helm binary not found on PATH; skipping render-based test")
+			}
+
+			kustomizeYAML := createKustomizeForServiceAccountRender("test-project")
+			Expect(setupKustomizeFile(manifestsFile, kustomizeYAML)).To(Succeed())
+
+			scaffolderBase = scaffolds.NewChartScaffolder(projectConfig, false, manifestsFile, outputDir)
+			scaffolderBase.InjectFS(fs)
+			Expect(scaffolderBase.Scaffold()).To(Succeed())
+
+			chartPath := filepath.Join(tmpDir, outputDir, "chart")
+			args := append([]string{"template", "my-release", chartPath, "--namespace", "my-namespace"}, setArgs...)
+			out, err := exec.Command("helm", args...).CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", string(out))
+			return string(out)
+		}
+
+		It("uses the external ServiceAccount name when enabled=false and name is set", func() {
+			rendered := renderChart("--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa")
+
+			By("the Deployment references the external ServiceAccount, not the generated name")
+			Expect(rendered).To(ContainSubstring("serviceAccountName: external-sa"))
+			Expect(rendered).NotTo(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
+
+			By("no ServiceAccount manifest is created since enabled=false")
+			Expect(rendered).NotTo(ContainSubstring("kind: ServiceAccount"))
+		})
+
+		It("falls back to the generated name when serviceAccount config is left at defaults", func() {
+			rendered := renderChart()
+
+			By("the Deployment uses the generated controller-manager name")
+			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
+
+			By("the default ServiceAccount manifest is created")
+			Expect(rendered).To(ContainSubstring("kind: ServiceAccount"))
 		})
 	})
 
@@ -712,6 +755,87 @@ spec:
           capabilities:
             drop:
             - ALL
+`
+}
+
+// createKustomizeForServiceAccountRender produces a kustomize output complete enough to render
+// cleanly with `helm template` (full pod template metadata, resources, security context) while
+// including a ServiceAccount and ClusterRole so the chart exercises the serviceAccountName helper.
+func createKustomizeForServiceAccountRender(projectName string) string {
+	return `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ` + projectName + `-manager-role
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --leader-elect
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: ` + projectName + `-controller-manager
 `
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -373,6 +373,14 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			By("the default ServiceAccount manifest is created")
 			Expect(rendered).To(ContainSubstring("kind: ServiceAccount"))
 		})
+
+		It("uses the generated name when enabled=true even if serviceAccount.name is set", func() {
+			rendered := renderChart("--set", "serviceAccount.enabled=true", "--set", "serviceAccount.name=custom-sa")
+
+			By("the external name is ignored while the chart manages its own ServiceAccount")
+			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
+			Expect(rendered).NotTo(ContainSubstring("serviceAccountName: custom-sa"))
+		})
 	})
 
 	Context("Custom Output Directory", func() {
@@ -758,85 +766,30 @@ spec:
 `
 }
 
-// createKustomizeForServiceAccountRender produces a kustomize output complete enough to render
-// cleanly with `helm template` (full pod template metadata, resources, security context) while
-// including a ServiceAccount and ClusterRole so the chart exercises the serviceAccountName helper.
+// createKustomizeForServiceAccountRender extends createBasicKustomizeOutput (Namespace +
+// ServiceAccount + Deployment) with the only two pieces the serviceAccountName render tests need:
+//   - a pod-template annotations block, so the chart renders cleanly under `helm template` instead
+//     of nil-pointering on .Values.manager.pod.annotations (the generator emits an unguarded
+//     reference when the source pod template has no annotations); and
+//   - an explicit serviceAccountName on the pod spec, which is what the helper rewrites.
 func createKustomizeForServiceAccountRender(projectName string) string {
-	return `---
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: ` + projectName + `
-  name: ` + projectName + `-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: ` + projectName + `
-  name: ` + projectName + `-controller-manager
-  namespace: ` + projectName + `-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: ` + projectName + `-manager-role
-  labels:
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: ` + projectName + `
-rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: ` + projectName + `
-    control-plane: controller-manager
-  name: ` + projectName + `-controller-manager
-  namespace: ` + projectName + `-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      control-plane: controller-manager
-  template:
-    metadata:
+	return strings.Replace(
+		createBasicKustomizeOutput(projectName),
+		`    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:`,
+		`    metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:
-      containers:
-      - name: manager
-        image: controller:latest
-        imagePullPolicy: IfNotPresent
-        args:
-        - --leader-elect
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-      serviceAccountName: ` + projectName + `-controller-manager
-`
+      serviceAccountName: `+projectName+`-controller-manager
+      containers:`,
+		1,
+	)
 }
 
 func setupKustomizeFile(filePath, content string) error {

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -55,7 +55,7 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project-v4-with-plugins.serviceAccountName" -}}
-{{- if and (not (.Values.serviceAccount.enabled | default true)) .Values.serviceAccount.name }}
+{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enabled false }}
+{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
…parison

Fix service account name condition logic

Updates the Helm chart template helper to correctly handle the `serviceAccount.enabled` condition when it is explicitly set to `false`. Previously, the logic relied on a default value which could lead to incorrect service account name resolution.

This change also introduces integration tests to verify the correct behavior of service account name resolution under different configurations, ensuring that the external service account name is used when specified and that the default name is used otherwise.

Fixes: #5751 

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
