### PR TITLE
🐛 fix(helm/v2-alpha): strip custom volumes from manager template to prevent duplication

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/internal/common/consts.go
+++ b/pkg/plugins/optional/helm/v2alpha/internal/common/consts.go
@@ -55,6 +55,12 @@ const (
 	YamlKeyTemplate    = "template:"
 )
 
+// Manager container resolution constants
+const (
+	DefaultContainerAnnotation  = "kubectl.kubernetes.io/default-container"
+	DefaultManagerContainerName = "manager"
+)
+
 // Standard Kubernetes/Helm label keys
 const (
 	LabelKeyAppName      = "app.kubernetes.io/name:"

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
 // DeploymentExtractor extracts deployment configuration for values.yaml.
@@ -87,7 +89,7 @@ func (d *DeploymentExtractor) ExtractDeploymentConfig(deployment *unstructured.U
 		extractTopologySpreadConstraints(specMap, configMap)
 		extractTerminationGracePeriodSeconds(specMap, configMap)
 
-		container := firstManagerContainer(specMap)
+		container := findManagerContainer(specMap, managerContainerName(deployment))
 		if container != nil {
 			extractContainerEnv(container, configMap)
 			extractContainerImage(container, configMap)
@@ -268,7 +270,16 @@ func extractPodAffinity(specMap map[string]any, config map[string]any) {
 	config["podAffinity"] = result
 }
 
-func firstManagerContainer(specMap map[string]any) map[string]any {
+func managerContainerName(deployment *unstructured.Unstructured) string {
+	ann, _, _ := unstructured.NestedStringMap(deployment.Object,
+		"spec", "template", "metadata", "annotations")
+	if name := ann[common.DefaultContainerAnnotation]; name != "" {
+		return name
+	}
+	return common.DefaultManagerContainerName
+}
+
+func findManagerContainer(specMap map[string]any, targetName string) map[string]any {
 	containers, found, err := unstructured.NestedFieldNoCopy(specMap, "containers")
 	if !found || err != nil {
 		return nil
@@ -279,12 +290,20 @@ func firstManagerContainer(specMap map[string]any) map[string]any {
 		return nil
 	}
 
-	firstContainer, ok := containersList[0].(map[string]any)
-	if !ok {
-		return nil
+	for _, c := range containersList {
+		container, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := container["name"].(string); name == targetName {
+			return container
+		}
 	}
 
-	return firstContainer
+	if first, ok := containersList[0].(map[string]any); ok {
+		return first
+	}
+	return nil
 }
 
 func extractContainerEnv(container map[string]any, config map[string]any) {
@@ -515,6 +534,46 @@ func extractExtraVolumeMounts(container map[string]any, config map[string]any) {
 	if len(extra) > 0 {
 		config["extraVolumeMounts"] = extra
 	}
+}
+
+// StripCustomVolumes removes custom (non-system) volumes and volume mounts from the deployment
+// so they only appear via Helm values templates. Call this after ExtractDeploymentConfig.
+func (d *DeploymentExtractor) StripCustomVolumes(deployment *unstructured.Unstructured) {
+	if deployment == nil {
+		return
+	}
+	specMap := extractDeploymentSpec(deployment)
+	if specMap == nil {
+		return
+	}
+	retainSystemEntries(specMap, "volumes")
+	container := findManagerContainer(specMap, managerContainerName(deployment))
+	if container != nil {
+		retainSystemEntries(container, "volumeMounts")
+	}
+}
+
+func retainSystemEntries(m map[string]any, key string) {
+	items, found, err := unstructured.NestedFieldNoCopy(m, key)
+	if !found || err != nil {
+		return
+	}
+	itemsList, ok := items.([]any)
+	if !ok || len(itemsList) == 0 {
+		return
+	}
+	system := make([]any, 0, len(itemsList))
+	for _, item := range itemsList {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := entry["name"].(string)
+		if _, isDefault := defaultWebhookMetricsVolumeNames[name]; isDefault {
+			system = append(system, item)
+		}
+	}
+	m[key] = system
 }
 
 // extractDeploymentReplicas extracts the replicas count from the deployment spec.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -22,6 +22,76 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const (
+	keyName         = "name"
+	keyReplicas     = "replicas"
+	keySecretName   = "secretName"
+	keyConfigMap    = "configMap"
+	keyImage        = "image"
+	keySecret       = "secret"
+	keyVolumeMounts = "volumeMounts"
+	keyMountPath    = "mountPath"
+
+	valAppsV1          = "apps/v1"
+	valDeployment      = "Deployment"
+	valTestDeploy      = "test-deployment"
+	valManager         = "manager"
+	valControllerImage = "controller:latest"
+	valAppConfig       = "app-config"
+	valAppSecret       = "app-secret"
+	valMyConfig        = "my-config"
+	valMySecret        = "my-secret"
+	valWebhookCert     = "webhook-certs"
+	valMetricsCert     = "metrics-certs"
+	valWebhookSecret   = "webhook-server-cert"
+	valSidecar         = "sidecar"
+	valMountConfig     = "/etc/config"
+	valMountCerts      = "/certs"
+	valMountMetrics    = "/metrics"
+
+	annotationDefaultContainer = "kubectl.kubernetes.io/default-container"
+)
+
+type deploymentOpts struct {
+	containers  []map[string]any
+	volumes     []any
+	annotations map[string]string
+}
+
+func makeDeployment(opts deploymentOpts) *unstructured.Unstructured {
+	podSpec := map[string]any{}
+	if opts.containers != nil {
+		cs := make([]any, len(opts.containers))
+		for i, c := range opts.containers {
+			cs[i] = c
+		}
+		podSpec["containers"] = cs
+	}
+	if opts.volumes != nil {
+		podSpec["volumes"] = opts.volumes
+	}
+	template := map[string]any{"spec": podSpec}
+	if opts.annotations != nil {
+		template["metadata"] = map[string]any{
+			"annotations": opts.annotations,
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": valAppsV1,
+			"kind":       valDeployment,
+			"metadata":   map[string]any{keyName: valTestDeploy},
+			"spec": map[string]any{
+				"template": template,
+			},
+		},
+	}
+}
+
+func podSpec(d *unstructured.Unstructured) map[string]any {
+	return d.Object["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)
+}
+
 var _ = Describe("DeploymentExtractor", func() {
 	Describe("ExtractDeploymentConfig replicas handling", func() {
 		var (
@@ -30,141 +100,269 @@ var _ = Describe("DeploymentExtractor", func() {
 		)
 
 		BeforeEach(func() {
-			deployment = &unstructured.Unstructured{
-				Object: map[string]any{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"metadata": map[string]any{
-						"name": "test-deployment",
-					},
-					"spec": map[string]any{
-						"template": map[string]any{
-							"spec": map[string]any{
-								"containers": []any{
-									map[string]any{
-										"name":  "manager",
-										"image": "controller:latest",
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			deployment = makeDeployment(deploymentOpts{
+				containers: []map[string]any{{
+					keyName: valManager, keyImage: valControllerImage,
+				}},
+			})
 			extractor = &DeploymentExtractor{}
 		})
 
-		Context("when replicas is not set", func() {
-			It("should return nil for replicas", func() {
-				result := extractor.ExtractDeploymentConfig(deployment)
-				Expect(result.Manager.Replicas).To(BeNil())
-			})
+		It("should return nil when replicas is not set", func() {
+			result := extractor.ExtractDeploymentConfig(deployment)
+			Expect(result.Manager.Replicas).To(BeNil())
 		})
 
-		Context("when replicas is set to 0 (scale-to-zero)", func() {
-			It("should preserve the zero value", func() {
-				deployment.Object["spec"].(map[string]any)["replicas"] = int64(0)
-
-				result := extractor.ExtractDeploymentConfig(deployment)
-
-				Expect(result.Manager.Replicas).NotTo(BeNil())
-				Expect(*result.Manager.Replicas).To(Equal(0))
-			})
+		It("should preserve scale-to-zero", func() {
+			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(0)
+			result := extractor.ExtractDeploymentConfig(deployment)
+			Expect(result.Manager.Replicas).NotTo(BeNil())
+			Expect(*result.Manager.Replicas).To(Equal(0))
 		})
 
-		Context("when replicas is set to 1", func() {
-			It("should extract replicas value as 1", func() {
-				deployment.Object["spec"].(map[string]any)["replicas"] = int64(1)
-
-				result := extractor.ExtractDeploymentConfig(deployment)
-
-				Expect(result.Manager.Replicas).NotTo(BeNil())
-				Expect(*result.Manager.Replicas).To(Equal(1))
-			})
-		})
-
-		Context("when replicas is set to 3", func() {
-			It("should extract replicas value as 3", func() {
-				deployment.Object["spec"].(map[string]any)["replicas"] = int64(3)
-
-				result := extractor.ExtractDeploymentConfig(deployment)
-
-				Expect(result.Manager.Replicas).NotTo(BeNil())
-				Expect(*result.Manager.Replicas).To(Equal(3))
-			})
+		It("should extract replicas value", func() {
+			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(3)
+			result := extractor.ExtractDeploymentConfig(deployment)
+			Expect(result.Manager.Replicas).NotTo(BeNil())
+			Expect(*result.Manager.Replicas).To(Equal(3))
 		})
 	})
 
 	Describe("ExtractPortFromArg", func() {
-		Context("when argument has valid port format", func() {
-			It("should extract port from :PORT format", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:8443")
-				Expect(port).To(Equal(8443))
+		DescribeTable("valid formats",
+			func(arg string, expected int) {
+				Expect(ExtractPortFromArg(arg)).To(Equal(expected))
+			},
+			Entry(":PORT", "--metrics-bind-address=:8443", 8443),
+			Entry("HOST:PORT", "--metrics-bind-address=0.0.0.0:8080", 8080),
+			Entry("localhost:PORT", "--metrics-bind-address=127.0.0.1:9090", 9090),
+			Entry("IPv6", "--webhook-port=[::1]:9443", 9443),
+			Entry("min valid port", "--metrics-bind-address=:1", 1),
+			Entry("max valid port", "--metrics-bind-address=:65535", 65535),
+			Entry("multiple colons (IPv6)", "--metrics-bind-address=::1:8443", 8443),
+		)
+
+		DescribeTable("invalid formats",
+			func(arg string) {
+				Expect(ExtractPortFromArg(arg)).To(Equal(0))
+			},
+			Entry("missing equals", "--metrics-bind-address:8443"),
+			Entry("non-numeric", "--metrics-bind-address=:abc"),
+			Entry("too low", "--metrics-bind-address=:0"),
+			Entry("too high", "--metrics-bind-address=:99999"),
+			Entry("empty port", "--metrics-bind-address=:"),
+			Entry("missing value", "--metrics-bind-address="),
+		)
+	})
+
+	Describe("ExtractDeploymentConfig extraVolumes extraction", func() {
+		It("should extract custom volumes without mutating the deployment", func() {
+			deployment := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+					map[string]any{keyName: valAppSecret, keySecret: map[string]any{keySecretName: valMySecret}},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
+						map[string]any{keyName: valAppSecret, keyMountPath: "/etc/secret"},
+					},
+				}},
 			})
 
-			It("should extract port from HOST:PORT format", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=0.0.0.0:8080")
-				Expect(port).To(Equal(8080))
-			})
-
-			It("should extract port from localhost:PORT format", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=127.0.0.1:9090")
-				Expect(port).To(Equal(9090))
-			})
-
-			It("should extract port from IPv6 format", func() {
-				port := ExtractPortFromArg("--webhook-port=[::1]:9443")
-				Expect(port).To(Equal(9443))
-			})
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.ExtraVolumes).To(HaveLen(2))
+			Expect(config.Manager.ExtraVolumeMounts).To(HaveLen(2))
+			Expect(podSpec(deployment)["volumes"].([]any)).To(HaveLen(2), "extraction should not mutate")
 		})
 
-		Context("when argument has invalid format", func() {
-			It("should return 0 for missing equals sign", func() {
-				port := ExtractPortFromArg("--metrics-bind-address:8443")
-				Expect(port).To(Equal(0))
+		It("should separate system and custom volumes", func() {
+			deployment := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecret}},
+					map[string]any{keyName: valMetricsCert, keySecret: map[string]any{keySecretName: "metrics-server-cert"}},
+					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valWebhookCert, keyMountPath: valMountCerts},
+						map[string]any{keyName: valMetricsCert, keyMountPath: valMountMetrics},
+						map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
+					},
+				}},
 			})
 
-			It("should return 0 for non-numeric port", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:abc")
-				Expect(port).To(Equal(0))
-			})
-
-			It("should return 0 for port out of valid range (too low)", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:0")
-				Expect(port).To(Equal(0))
-			})
-
-			It("should return 0 for port out of valid range (too high)", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:99999")
-				Expect(port).To(Equal(0))
-			})
-
-			It("should return 0 for empty port", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:")
-				Expect(port).To(Equal(0))
-			})
-
-			It("should return 0 for missing port value", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=")
-				Expect(port).To(Equal(0))
-			})
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.ExtraVolumes).To(HaveLen(1))
+			Expect(config.Manager.ExtraVolumeMounts).To(HaveLen(1))
 		})
 
-		Context("when handling edge cases", func() {
-			It("should handle port at minimum valid value", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:1")
-				Expect(port).To(Equal(1))
+		It("should return nil when only system volumes exist", func() {
+			deployment := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert},
+					map[string]any{keyName: valMetricsCert},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valWebhookCert, keyMountPath: valMountCerts},
+						map[string]any{keyName: valMetricsCert, keyMountPath: valMountMetrics},
+					},
+				}},
 			})
 
-			It("should handle port at maximum valid value", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=:65535")
-				Expect(port).To(Equal(65535))
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.ExtraVolumes).To(BeNil())
+			Expect(config.Manager.ExtraVolumeMounts).To(BeNil())
+		})
+	})
+
+	Describe("StripCustomVolumes", func() {
+		It("should remove all custom volumes and leave empty slice", func() {
+			deployment := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
+					},
+				}},
 			})
 
-			It("should handle multiple colons (IPv6)", func() {
-				port := ExtractPortFromArg("--metrics-bind-address=::1:8443")
-				Expect(port).To(Equal(8443))
+			(&DeploymentExtractor{}).StripCustomVolumes(deployment)
+
+			spec := podSpec(deployment)
+			Expect(spec["volumes"].([]any)).To(BeEmpty())
+			container := spec["containers"].([]any)[0].(map[string]any)
+			Expect(container["volumeMounts"].([]any)).To(BeEmpty())
+		})
+
+		It("should keep system volumes and strip custom ones", func() {
+			deployment := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecret}},
+					map[string]any{keyName: valMetricsCert, keySecret: map[string]any{keySecretName: "metrics-server-cert"}},
+					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valWebhookCert, keyMountPath: valMountCerts},
+						map[string]any{keyName: valMetricsCert, keyMountPath: valMountMetrics},
+						map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
+					},
+				}},
 			})
+
+			(&DeploymentExtractor{}).StripCustomVolumes(deployment)
+
+			spec := podSpec(deployment)
+			volumes := spec["volumes"].([]any)
+			Expect(volumes).To(HaveLen(2))
+			Expect(volumes[0].(map[string]any)["name"]).To(Equal(valWebhookCert))
+			Expect(volumes[1].(map[string]any)["name"]).To(Equal(valMetricsCert))
+		})
+	})
+
+	Describe("Manager container resolution", func() {
+		It("should use the default-container annotation to find the manager", func() {
+			deployment := makeDeployment(deploymentOpts{
+				annotations: map[string]string{
+					annotationDefaultContainer: "controller-test",
+				},
+				containers: []map[string]any{
+					{keyName: "controller-test", keyImage: valControllerImage},
+				},
+			})
+
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.Image.Repository).To(Equal("controller"))
+			Expect(config.Manager.Image.Tag).To(Equal("latest"))
+		})
+
+		It("should find the manager when a sidecar is before it", func() {
+			deployment := makeDeployment(deploymentOpts{
+				annotations: map[string]string{
+					annotationDefaultContainer: valManager,
+				},
+				containers: []map[string]any{
+					{keyName: valSidecar, keyImage: "sidecar:v1"},
+					{keyName: valManager, keyImage: valControllerImage},
+				},
+			})
+
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.Image.Repository).To(Equal("controller"))
+		})
+
+		It("should fall back to 'manager' name when annotation is missing", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{keyName: valSidecar, keyImage: "sidecar:v1"},
+					{keyName: valManager, keyImage: valControllerImage},
+				},
+			})
+
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.Image.Repository).To(Equal("controller"))
+		})
+
+		It("should fall back to containers[0] when no name matches", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{keyName: "custom-name", keyImage: valControllerImage},
+				},
+			})
+
+			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(config.Manager.Image.Repository).To(Equal("controller"))
+		})
+
+		It("should strip volumes from the correct container with sidecar before manager", func() {
+			deployment := makeDeployment(deploymentOpts{
+				annotations: map[string]string{
+					annotationDefaultContainer: valManager,
+				},
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecret}},
+					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+				},
+				containers: []map[string]any{
+					{
+						keyName: valSidecar,
+						keyVolumeMounts: []any{
+							map[string]any{keyName: "sidecar-vol", keyMountPath: "/sidecar"},
+						},
+					},
+					{
+						keyName: valManager,
+						keyVolumeMounts: []any{
+							map[string]any{keyName: valWebhookCert, keyMountPath: valMountCerts},
+							map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
+						},
+					},
+				},
+			})
+
+			(&DeploymentExtractor{}).StripCustomVolumes(deployment)
+
+			spec := podSpec(deployment)
+			volumes := spec["volumes"].([]any)
+			Expect(volumes).To(HaveLen(1))
+			Expect(volumes[0].(map[string]any)["name"]).To(Equal(valWebhookCert))
+
+			sidecar := spec["containers"].([]any)[0].(map[string]any)
+			Expect(sidecar["volumeMounts"].([]any)).To(HaveLen(1), "sidecar mounts should be untouched")
+
+			manager := spec["containers"].([]any)[1].(map[string]any)
+			managerMounts := manager["volumeMounts"].([]any)
+			Expect(managerMounts).To(HaveLen(1))
+			Expect(managerMounts[0].(map[string]any)["name"]).To(Equal(valWebhookCert))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/extractor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/extractor.go
@@ -82,6 +82,10 @@ func (e *Extractor) Extract(resources *ResourceSet, projectName string) *Extract
 	features := e.featuresExtractor.DetectFeatures(resources, metadata.DetectedPrefix, metadata.ManagerNamespace)
 	values := e.deploymentExtractor.ExtractDeploymentConfig(resources.Deployment)
 
+	// Strip custom volumes from deployment after extraction so they only
+	// appear via Helm values templates, not as literal entries in the manifest.
+	e.deploymentExtractor.StripCustomVolumes(resources.Deployment)
+
 	return &Extraction{
 		Metadata: metadata,
 		Features: features,

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter.go
@@ -106,14 +106,6 @@ func dedupeResources(resources []*unstructured.Unstructured) []*unstructured.Uns
 	return out
 }
 
-// ExtractDeploymentConfig extracts configuration values from the deployment for values.yaml.
-func (c *ChartConverter) ExtractDeploymentConfig() map[string]any {
-	deploymentExtractor := extractor.DeploymentExtractor{}
-	valuesConfig := deploymentExtractor.ExtractDeploymentConfig(c.resources.Deployment)
-
-	return convertValuesConfigToMap(valuesConfig)
-}
-
 // convertValuesConfigToMap converts ValuesConfig struct to map[string]any.
 func convertValuesConfigToMap(vc extractor.ValuesConfig) map[string]any {
 	config := make(map[string]any)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -51,6 +51,11 @@ const (
 	testWebhookCertsVolume            = "webhook-certs"
 )
 
+func extractDeploymentConfig(deployment *unstructured.Unstructured) map[string]any {
+	de := extractor.DeploymentExtractor{}
+	return convertValuesConfigToMap(de.ExtractDeploymentConfig(deployment))
+}
+
 var _ = Describe("ChartConverter", func() {
 	var (
 		converter *ChartConverter
@@ -191,7 +196,7 @@ var _ = Describe("ChartConverter", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).NotTo(BeNil())
 			Expect(config).To(HaveKey("env"))
@@ -234,7 +239,7 @@ var _ = Describe("ChartConverter", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("metricsPort"))
 			Expect(config["metricsPort"]).To(Equal(8443))
@@ -264,7 +269,7 @@ var _ = Describe("ChartConverter", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("webhookPort"))
 			Expect(config["webhookPort"]).To(Equal(9443))
@@ -297,7 +302,7 @@ var _ = Describe("ChartConverter", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config["metricsPort"]).To(Equal(9090))
 			Expect(config["healthPort"]).To(BeNil())
@@ -332,13 +337,13 @@ var _ = Describe("ChartConverter", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 			Expect(config).To(HaveKey("imagePullSecrets"))
 			Expect(config["imagePullSecrets"]).To(Equal(imagePullSecrets))
 		})
 
 		It("should handle deployment without containers", func() {
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 			// Should still extract deployment-level fields (replicas, strategy) even without containers
 			Expect(config).To(HaveKey("replicas"))
 			Expect(config["replicas"]).To(Equal(1))
@@ -393,7 +398,7 @@ var _ = Describe("ChartConverter", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("extraVolumes"))
 			extraVols, ok := config["extraVolumes"].([]any)
@@ -448,7 +453,7 @@ var _ = Describe("ChartConverter", func() {
 			err = unstructured.SetNestedSlice(resources.Deployment.Object, containers, "spec", "template", "spec", "containers")
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			extraVols, ok := config["extraVolumes"].([]any)
 			Expect(ok).To(BeTrue())
@@ -462,7 +467,7 @@ var _ = Describe("ChartConverter", func() {
 
 		It("should extract deployment replicas", func() {
 			// replicas is set in BeforeEach to 1
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("replicas"))
 			Expect(config["replicas"]).To(Equal(1))
@@ -480,7 +485,7 @@ var _ = Describe("ChartConverter", func() {
 			err := unstructured.SetNestedField(resources.Deployment.Object, strategy, "spec", "strategy")
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("strategy"))
 			strategyConfig, ok := config["strategy"].(map[string]any)
@@ -499,7 +504,7 @@ var _ = Describe("ChartConverter", func() {
 				resources.Deployment.Object, "high-priority", "spec", "template", "spec", "priorityClassName")
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("priorityClassName"))
 			Expect(config["priorityClassName"]).To(Equal("high-priority"))
@@ -529,7 +534,7 @@ var _ = Describe("ChartConverter", func() {
 				"spec", "template", "spec", "topologySpreadConstraints")
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("topologySpreadConstraints"))
 			tsc, ok := config["topologySpreadConstraints"].([]any)
@@ -548,7 +553,7 @@ var _ = Describe("ChartConverter", func() {
 				resources.Deployment.Object, int64(30), "spec", "template", "spec", "terminationGracePeriodSeconds")
 			Expect(err).NotTo(HaveOccurred())
 
-			config := converter.ExtractDeploymentConfig()
+			config := extractDeploymentConfig(resources.Deployment)
 
 			Expect(config).To(HaveKey("terminationGracePeriodSeconds"))
 			Expect(config["terminationGracePeriodSeconds"]).To(Equal(30))

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -22,20 +22,20 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
 // GetDefaultContainerName extracts the container name from kubectl.kubernetes.io/default-container annotation.
 // This allows the Helm plugin to work with any container name, not just "manager".
 // If the annotation is not found, it falls back to "manager" for backward compatibility.
 func GetDefaultContainerName(yamlContent string) string {
-	// Look for kubectl.kubernetes.io/default-container annotation
-	pattern := regexp.MustCompile(`(?m)^\s*kubectl\.kubernetes\.io/default-container:\s+(\S+)`)
+	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(common.DefaultContainerAnnotation) + `:\s+(\S+)`)
 	matches := pattern.FindStringSubmatch(yamlContent)
 	if len(matches) > 1 {
 		return matches[1]
 	}
-	// Fallback to "manager" for backward compatibility with older scaffolds
-	return "manager"
+	return common.DefaultManagerContainerName
 }
 
 // LeadingWhitespace extracts the leading whitespace from a line.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -2855,10 +2855,39 @@ spec:
 		})
 
 		It("should append only extraVolumes from values and keep webhook/metrics conditional", func() {
-			deployment := &unstructured.Unstructured{}
-			deployment.SetAPIVersion("apps/v1")
-			deployment.SetKind("Deployment")
-			deployment.SetName("test-project-controller-manager")
+			deployment := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]any{
+						"name": "test-project-controller-manager", //nolint:goconst
+					},
+					"spec": map[string]any{
+						"template": map[string]any{
+							"spec": map[string]any{
+								"volumes": []any{
+									map[string]any{"name": "webhook-certs", "secret": map[string]any{"secretName": "webhook-server-cert"}},
+									map[string]any{"name": "metrics-certs", "secret": map[string]any{"secretName": "metrics-server-cert"}},
+								},
+								"containers": []any{
+									map[string]any{
+										"name":  "manager",
+										"image": "controller:latest",
+										"volumeMounts": []any{
+											map[string]any{
+												"name": "webhook-certs", "mountPath": "/tmp/k8s-webhook-server/serving-certs", "readOnly": true,
+											},
+											map[string]any{
+												"name": "metrics-certs", "mountPath": "/tmp/k8s-metrics-server/metrics-certs", "readOnly": true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
 			content := `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -2873,27 +2902,22 @@ spec:
       - name: metrics-certs
         secret:
           secretName: metrics-server-cert
-      - name: app-secret-1
-        secret:
-          secretName: app-secret-1
       containers:
       - name: manager
         image: controller:latest
         volumeMounts:
-        - name: webhook-certs
-          mountPath: /tmp/k8s-webhook-server/serving-certs
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
           readOnly: true
-        - name: metrics-certs
-          mountPath: /tmp/k8s-metrics-server/metrics-certs
-          readOnly: true
-        - name: app-secret-1
-          mountPath: /etc/secrets
+        - mountPath: /tmp/k8s-metrics-server/metrics-certs
+          name: metrics-certs
           readOnly: true
 `
 			result := templater.ApplyHelmSubstitutions(content, deployment)
 			Expect(result).To(ContainSubstring(".Values.certManager.enabled"))
 			Expect(result).To(ContainSubstring(".Values.manager.extraVolumes"))
-			Expect(result).To(ContainSubstring("app-secret-1"))
+			Expect(result).To(ContainSubstring("webhook-certs"))
+			Expect(result).To(ContainSubstring("metrics-certs"))
 		})
 
 		It("should fall back to 'manager' when default-container annotation is missing", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -393,6 +393,165 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		})
 	})
 
+	// Validates the full pipeline for deployments with custom volumes alongside system volumes.
+	// Custom volumes must appear only via extraVolumes template; system volumes remain literal.
+	Context("Custom volumes deduplication", func() {
+		It("should render custom volumes only through extraVolumes template, not as literal entries", func() {
+			kustomizeYAML := createKustomizeWithCustomVolumes("test-project")
+			err := setupKustomizeFile(manifestsFile, kustomizeYAML)
+			Expect(err).NotTo(HaveOccurred())
+
+			scaffolderBase = scaffolds.NewChartScaffolder(projectConfig, false, manifestsFile, outputDir)
+			scaffolderBase.InjectFS(fs)
+
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			chartPath := filepath.Join(tmpDir, outputDir, "chart")
+			managerTemplatePath := filepath.Join(chartPath, "templates", "manager", "manager.yaml")
+
+			By("reading the generated manager template")
+			managerBytes, err := os.ReadFile(managerTemplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			managerStr := string(managerBytes)
+
+			By("verifying extraVolumes appears via Helm template")
+			Expect(managerStr).To(ContainSubstring(".Values.manager.extraVolumes"),
+				"manager template must reference extraVolumes from values")
+
+			By("verifying extraVolumeMounts appears via Helm template")
+			Expect(managerStr).To(ContainSubstring(".Values.manager.extraVolumeMounts"),
+				"manager template must reference extraVolumeMounts from values")
+
+			By("verifying no literal custom volume entries remain in the template")
+			Expect(managerStr).NotTo(ContainSubstring("app-config"),
+				"custom volume name must not appear as literal entry in manager template")
+			Expect(managerStr).NotTo(ContainSubstring("app-secret"),
+				"custom volume name must not appear as literal entry in manager template")
+
+			By("verifying system volumes still appear in the template")
+			Expect(managerStr).To(ContainSubstring("webhook-certs"),
+				"system volume webhook-certs must remain in manager template")
+			Expect(managerStr).To(ContainSubstring("metrics-certs"),
+				"system volume metrics-certs must remain in manager template")
+
+			By("verifying custom volumes are extracted to values.yaml")
+			valuesPath := filepath.Join(chartPath, "values.yaml")
+			valuesBytes, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			valuesStr := string(valuesBytes)
+			Expect(valuesStr).To(ContainSubstring("extraVolumes:"),
+				"extraVolumes must be present in values.yaml")
+			Expect(valuesStr).To(ContainSubstring("extraVolumeMounts:"),
+				"extraVolumeMounts must be present in values.yaml")
+			Expect(valuesStr).To(ContainSubstring("app-config"),
+				"custom volume app-config must be in values.yaml")
+
+			By("verifying the chart loads cleanly")
+			chart, err := helmChartLoader.LoadDir(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chart.Validate()).To(Succeed())
+		})
+	})
+
+	// Validates the pipeline when only custom volumes exist (no system volumes like webhook-certs
+	// or metrics-certs). All volumes should be extracted to values and stripped from the template.
+	Context("Custom volumes without system volumes", func() {
+		It("should extract all volumes to values and leave none as literal entries", func() {
+			kustomizeYAML := createKustomizeWithCustomVolumesOnly("test-project")
+			err := setupKustomizeFile(manifestsFile, kustomizeYAML)
+			Expect(err).NotTo(HaveOccurred())
+
+			scaffolderBase = scaffolds.NewChartScaffolder(projectConfig, false, manifestsFile, outputDir)
+			scaffolderBase.InjectFS(fs)
+
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			chartPath := filepath.Join(tmpDir, outputDir, "chart")
+			managerTemplatePath := filepath.Join(chartPath, "templates", "manager", "manager.yaml")
+
+			By("reading the generated manager template")
+			managerBytes, err := os.ReadFile(managerTemplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			managerStr := string(managerBytes)
+
+			By("verifying extraVolumes appears via Helm template")
+			Expect(managerStr).To(ContainSubstring(".Values.manager.extraVolumes"),
+				"manager template must reference extraVolumes from values")
+
+			By("verifying extraVolumeMounts appears via Helm template")
+			Expect(managerStr).To(ContainSubstring(".Values.manager.extraVolumeMounts"),
+				"manager template must reference extraVolumeMounts from values")
+
+			By("verifying no literal custom volume entries remain in the template")
+			Expect(managerStr).NotTo(ContainSubstring("app-config"),
+				"custom volume name must not appear as literal entry in manager template")
+			Expect(managerStr).NotTo(ContainSubstring("app-secret"),
+				"custom volume name must not appear as literal entry in manager template")
+
+			By("verifying custom volumes are extracted to values.yaml")
+			valuesPath := filepath.Join(chartPath, "values.yaml")
+			valuesBytes, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			valuesStr := string(valuesBytes)
+			Expect(valuesStr).To(ContainSubstring("extraVolumes:"),
+				"extraVolumes must be present in values.yaml")
+			Expect(valuesStr).To(ContainSubstring("extraVolumeMounts:"),
+				"extraVolumeMounts must be present in values.yaml")
+
+			By("verifying the chart loads cleanly")
+			chart, err := helmChartLoader.LoadDir(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chart.Validate()).To(Succeed())
+		})
+	})
+
+	// Validates the pipeline when a sidecar container appears before the manager and the
+	// default-container annotation identifies which container is the manager.
+	Context("Sidecar before manager with default-container annotation", func() {
+		It("should extract and strip volumes from the correct container", func() {
+			kustomizeYAML := createKustomizeWithSidecarBeforeManager("test-project")
+			err := setupKustomizeFile(manifestsFile, kustomizeYAML)
+			Expect(err).NotTo(HaveOccurred())
+
+			scaffolderBase = scaffolds.NewChartScaffolder(projectConfig, false, manifestsFile, outputDir)
+			scaffolderBase.InjectFS(fs)
+
+			err = scaffolderBase.Scaffold()
+			Expect(err).NotTo(HaveOccurred())
+
+			chartPath := filepath.Join(tmpDir, outputDir, "chart")
+			managerTemplatePath := filepath.Join(chartPath, "templates", "manager", "manager.yaml")
+
+			By("reading the generated manager template")
+			managerBytes, err := os.ReadFile(managerTemplatePath)
+			Expect(err).NotTo(HaveOccurred())
+			managerStr := string(managerBytes)
+
+			By("verifying custom volumes only appear via Helm template")
+			Expect(managerStr).To(ContainSubstring(".Values.manager.extraVolumes"))
+			Expect(managerStr).NotTo(ContainSubstring("app-config"),
+				"custom volume must not appear as literal entry")
+
+			By("verifying system volumes remain in the template")
+			Expect(managerStr).To(ContainSubstring("webhook-certs"))
+
+			By("verifying values.yaml has the manager's extraVolumes")
+			valuesPath := filepath.Join(chartPath, "values.yaml")
+			valuesBytes, err := os.ReadFile(valuesPath)
+			Expect(err).NotTo(HaveOccurred())
+			valuesStr := string(valuesBytes)
+			Expect(valuesStr).To(ContainSubstring("extraVolumes:"))
+			Expect(valuesStr).To(ContainSubstring("app-config"))
+
+			By("verifying the chart loads cleanly")
+			chart, err := helmChartLoader.LoadDir(chartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chart.Validate()).To(Succeed())
+		})
+	})
+
 	// A project that already has hand-authored tolerations, nodeSelector, and affinity in
 	// its manager Deployment (typical of a project created before the Helm plugin was added)
 	// must produce a chart where each scheduling field appears exactly once in
@@ -789,6 +948,169 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      serviceAccountName: ` + projectName + `-controller-manager
+`
+}
+
+func createKustomizeWithCustomVolumes(projectName string) string {
+	return `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        - name: metrics-certs
+          mountPath: /tmp/k8s-metrics-server/metrics-certs
+          readOnly: true
+        - name: app-config
+          mountPath: /etc/config
+        - name: app-secret
+          mountPath: /etc/secret
+          readOnly: true
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      - name: metrics-certs
+        secret:
+          secretName: metrics-server-cert
+      - name: app-config
+        configMap:
+          name: my-config
+      - name: app-secret
+        secret:
+          secretName: my-secret
+      serviceAccountName: ` + projectName + `-controller-manager
+`
+}
+
+func createKustomizeWithSidecarBeforeManager(projectName string) string {
+	return `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: sidecar
+        image: sidecar:v1
+      - name: manager
+        image: controller:latest
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
+        - name: app-config
+          mountPath: /etc/config
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+      - name: app-config
+        configMap:
+          name: my-config
+      serviceAccountName: ` + projectName + `-controller-manager
+`
+}
+
+func createKustomizeWithCustomVolumesOnly(projectName string) string {
+	return `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        volumeMounts:
+        - name: app-config
+          mountPath: /etc/config
+        - name: app-secret
+          mountPath: /etc/secret
+          readOnly: true
+      volumes:
+      - name: app-config
+        configMap:
+          name: my-config
+      - name: app-secret
+        secret:
+          secretName: my-secret
       serviceAccountName: ` + projectName + `-controller-manager
 `
 }


### PR DESCRIPTION
Custom volumes (e.g. user-added configMaps, secrets) appeared both as
literal entries in the generated manager.yaml template AND via
{{ toYaml .Values.manager.extraVolumes }}, causing duplication at install time.

The fix is in the extractor: extractExtraVolumes and extractExtraVolumeMounts
now remove custom volumes from the resource object after extracting them for
values.yaml. Since yaml.Marshal runs on the cleaned object, custom volumes
never appear in the template — they only flow through values.yaml.

System volumes (webhook-certs, metrics-certs) are kept in the object so they
render as conditionals in the template.

Fixes #5718

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
