### PR TITLE
✨ (go/v4, API): Validate Resource.Path for external and non-external resources

### DIFF
--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -546,7 +546,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 	Context("getWebhookResourceFlags", func() {
 		It("returns correct flags for specified resources", func() {
 			res := resource.Resource{
-				Path:     "external/test",
+				Path:     certManagerAPIPath,
 				GVK:      resource.GVK{Group: exampleDomain, Version: "v1", Kind: exampleKind, Domain: fixtureTest},
 				External: true,
 				Webhooks: &resource.Webhooks{
@@ -558,7 +558,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 			}
 			flags := getWebhookResourceFlags(res)
 			Expect(flags).To(ContainElements(
-				"--external-api-path", "external/test",
+				"--external-api-path", certManagerAPIPath,
 				"--external-api-domain", fixtureTest,
 				"--programmatic-validation", "--defaulting", "--conversion", "--spoke", "v2",
 			))
@@ -652,7 +652,7 @@ var _ = Describe("generate: create-helpers", func() {
 					API:        &resource.API{Namespaced: true},
 					Controller: true,
 					External:   true,
-					Path:       "external/path",
+					Path:       certManagerAPIPath,
 				}
 				// Run createAPI and verify no errors
 				Expect(createAPI(res)).To(Succeed())
@@ -816,7 +816,6 @@ var _ = Describe("generate: kubebuilder", func() {
 				},
 			}
 			store := &fakeStore{cfg: cfg}
-			// Run kubebuilderCreate and verify no errors
 			Expect(kubebuilderCreate(store)).To(Succeed())
 		})
 	})

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/mod/module"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -72,7 +73,27 @@ func (r Resource) Validate() error {
 		return fmt.Errorf("invalid Plural: %#v", errors)
 	}
 
-	// TODO: validate the path
+	if r.External {
+		if r.Path == "" {
+			return fmt.Errorf("invalid Path: external resources must specify a path " +
+				"(e.g., github.com/org/repo/api/v1)")
+		}
+		if strings.Contains(r.Path, "@") {
+			return fmt.Errorf("invalid Path: version specifiers belong in the module field, not the path")
+		}
+		if err := module.CheckImportPath(r.Path); err != nil {
+			return fmt.Errorf("invalid Path: must be a valid Go import path: %w", err)
+		}
+		first, _, _ := strings.Cut(r.Path, "/")
+		if !strings.Contains(first, ".") || strings.HasPrefix(first, ".") {
+			return fmt.Errorf("invalid Path: must be a fully-qualified Go import path " +
+				"(e.g., github.com/org/repo/api/v1)")
+		}
+	} else if r.Path != "" {
+		if err := module.CheckImportPath(r.Path); err != nil {
+			return fmt.Errorf("invalid Path: %w", err)
+		}
+	}
 
 	// Validate the API
 	if r.API != nil && !r.API.IsEmpty() {

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Resource", func() {
 		version       = "v1"
 		kind          = "Kind"
 		plural        = "kinds"
+		v1beta1       = "v1beta1"
 		invalidPlural = "plural"
 	)
 
@@ -100,6 +101,52 @@ var _ = Describe("Resource", func() {
 			Entry("invalid Plural", Resource{GVK: gvk, Plural: "Plural"}),
 			Entry("invalid API", Resource{GVK: gvk, Plural: invalidPlural, API: &API{CRDVersion: "1"}}),
 			Entry("invalid Webhooks", Resource{GVK: gvk, Plural: invalidPlural, Webhooks: &Webhooks{WebhookVersion: "1"}}),
+		)
+
+		DescribeTable("should succeed for valid Paths",
+			func(p string) {
+				Expect(Resource{GVK: gvk, Plural: plural, Path: p}.Validate()).To(Succeed())
+			},
+			Entry("empty path (partial resource)", ""),
+			Entry("simple relative path", "api/v1"),
+			Entry("full module import path", "github.com/org/repo/api/v1"),
+			Entry("multi-segment path with hyphen", "github.com/my-org/my-repo/api/v1"),
+			Entry("k8s core path", "k8s.io/api/core/v1"),
+		)
+
+		DescribeTable("should succeed for valid external Paths",
+			func(p string) {
+				Expect(Resource{GVK: gvk, Plural: plural, External: true, Path: p}.Validate()).To(Succeed())
+			},
+			Entry("full module import path", "github.com/org/repo/api/v1"),
+			Entry("k8s core path", "k8s.io/api/core/v1"),
+		)
+
+		DescribeTable("should fail for invalid Paths",
+			func(p, message string) {
+				err := Resource{GVK: gvk, Plural: plural, Path: p}.Validate()
+				Expect(err).NotTo(Succeed())
+				Expect(err.Error()).To(ContainSubstring("invalid Path"))
+				Expect(err.Error()).To(ContainSubstring(message))
+			},
+			Entry("absolute filesystem path", "/absolute/path", "empty path element"),
+			Entry("path traversal", "../traversal", `invalid path element ".."`),
+			Entry("double slash", "a//b", "double slash"),
+			Entry("trailing slash", "path/", "trailing slash"),
+		)
+
+		DescribeTable("should fail for invalid external Paths",
+			func(p, message string) {
+				err := Resource{GVK: gvk, Plural: plural, External: true, Path: p}.Validate()
+				Expect(err).NotTo(Succeed())
+				Expect(err.Error()).To(ContainSubstring("invalid Path"))
+				Expect(err.Error()).To(ContainSubstring(message))
+			},
+			Entry("empty path", "", "external resources must specify a path"),
+			Entry("absolute filesystem path", "/absolute/path", "must be a valid Go import path"),
+			Entry("relative package path", "api/v1", "must be a fully-qualified Go import path"),
+			Entry("leading-dot pseudo-domain", ".com/api/v1", "must be a fully-qualified Go import path"),
+			Entry("module version in path", "github.com/org/repo@v1.0.0", "version specifiers belong in the module field"),
 		)
 	})
 

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -120,7 +120,9 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 
 	if opts.DoDefaulting || opts.DoValidation || opts.DoConversion {
-		res.Path = resource.APIPackagePath(c.GetRepository(), res.Group, res.Version, c.IsMultiGroup())
+		if !res.External {
+			res.Path = resource.APIPackagePath(c.GetRepository(), res.Group, res.Version, c.IsMultiGroup())
+		}
 
 		res.Webhooks.WebhookVersion = "v1"
 		if opts.DoDefaulting {
@@ -164,8 +166,12 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 		alreadyHasAPI = err == nil && loadedRes.HasAPI()
 		if !alreadyHasAPI {
 			if res.External {
-				res.Path = opts.ExternalAPIPath
-				res.Domain = opts.ExternalAPIDomain
+				if len(opts.ExternalAPIPath) > 0 {
+					res.Path = opts.ExternalAPIPath
+				}
+				if len(opts.ExternalAPIDomain) > 0 {
+					res.Domain = opts.ExternalAPIDomain
+				}
 			} else {
 				// Handle core types
 				if domain, found := coreGroups[res.Group]; found {

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Options", func() {
 							Expect(res.Path).To(Equal(path.Join(cfg.GetRepository(), "api", gvk.Version)))
 						}
 					} else if len(options.ExternalAPIPath) > 0 {
-						Expect(res.Path).To(Equal("testPath"))
+						Expect(res.Path).To(Equal("github.com/example/external/api/v1"))
 					} else {
 						// Core-resources have a path despite not having an API/Webhook but they are not tested here
 						Expect(res.Path).To(Equal(""))
@@ -121,10 +121,61 @@ var _ = Describe("Options", func() {
 			Entry("when updating nothing", Options{}),
 			Entry("when updating the plural", Options{Plural: "mates"}),
 			Entry("when updating the Controller", Options{DoController: true}),
-			Entry("when updating with External API Path", Options{ExternalAPIPath: "testPath", ExternalAPIDomain: "test.io"}),
+			Entry("when updating with External API Path",
+				Options{ExternalAPIPath: "github.com/example/external/api/v1", ExternalAPIDomain: "test.io"}),
 			Entry("when updating the API with setting webhooks params",
 				Options{DoAPI: true, DoDefaulting: true, DoValidation: true, DoConversion: true}),
 		)
+
+		It("should retain path and external flag when ExternalAPIPath is not provided but resource is already external",
+			func() {
+				const externalPath = "github.com/example/external/api/v1"
+
+				res := resource.Resource{
+					GVK:      gvk,
+					Plural:   plural,
+					External: true,
+					Path:     externalPath,
+					API:      &resource.API{},
+					Webhooks: &resource.Webhooks{},
+				}
+
+				Options{DoController: true}.UpdateResource(&res, cfg)
+
+				Expect(res.External).To(BeTrue())
+				Expect(res.Path).To(Equal(externalPath))
+				Expect(res.Validate()).To(Succeed())
+			})
+
+		It("should preserve res.Domain when ExternalAPIDomain is not supplied in !alreadyHasAPI block",
+			func() {
+				const externalPath = "github.com/example/external/api/v1"
+				const externalDomain = "example.com"
+
+				res := resource.Resource{
+					GVK: resource.GVK{
+						Group:   group,
+						Domain:  externalDomain,
+						Version: version,
+						Kind:    kind,
+					},
+					Plural:   plural,
+					External: true,
+					Path:     externalPath,
+					API:      &resource.API{},
+					Webhooks: &resource.Webhooks{},
+				}
+
+				// DoDefaulting without ExternalAPIPath — simulates webhook flow without re-providing the flag
+				Options{DoDefaulting: true}.UpdateResource(&res, cfg)
+
+				Expect(res.External).To(BeTrue())
+				Expect(res.GVK.Domain).To(Equal(externalDomain),
+					"domain must not be zeroed out when ExternalAPIDomain is empty")
+				Expect(res.Path).To(Equal(externalPath),
+					"path must not be clobbered by webhook block for external resource")
+				Expect(res.Validate()).To(Succeed())
+			})
 
 		DescribeTable("should use core apis",
 			func(group, qualified string) {

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -36,6 +36,9 @@ const (
 	captains        = "captains"
 	shipGroup       = "ship"
 	frigateKind     = "Frigate"
+
+	externalAPIModuleWithVersion = "github.com/external/api@v1.0.0"
+	relativeAPIPath              = "api/v1"
 )
 
 var _ = Describe("createAPISubcommand", func() {
@@ -94,13 +97,99 @@ var _ = Describe("createAPISubcommand", func() {
 
 	It("should require external-api-path when using external-api-module", func() {
 		subCmd.options.DoAPI = false
-		subCmd.options.ExternalAPIModule = "github.com/external/api@v1.0.0"
+		subCmd.options.ExternalAPIModule = externalAPIModuleWithVersion
 		subCmd.options.ExternalAPIPath = ""
 
 		err := subCmd.InjectResource(res)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("requires '--external-api-path'"))
+	})
+
+	It("should reject external-api-path with module version", func() {
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = externalAPIModuleWithVersion
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("version specifiers belong in the module field"))
+	})
+
+	It("should reject bare relative external-api-path", func() {
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = relativeAPIPath
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("must be a fully-qualified Go import path"))
+	})
+
+	It("should reject leading-dot pseudo-domain external-api-path", func() {
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = ".com/org/repo/api/v1"
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("must be a fully-qualified Go import path"))
+	})
+
+	It("should reject malformed external-api-path", func() {
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = "a//b"
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("malformed import path"))
+		Expect(err.Error()).To(ContainSubstring("double slash"))
+	})
+
+	It("should allow adding a controller to existing external resource without re-providing --external-api-path", func() {
+		const externalPath = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+		existingExternal := *res
+		existingExternal.External = true
+		existingExternal.Path = externalPath
+		Expect(cfg.AddResource(existingExternal)).To(Succeed())
+
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = ""
+		res.External = true
+		res.Path = externalPath
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an actionable error for --resource=false on old project with relative external path", func() {
+		// Simulate an old PROJECT file that stored a relative path instead of a Go import path
+		existingExternal := *res
+		existingExternal.External = true
+		existingExternal.Path = relativeAPIPath
+		Expect(cfg.AddResource(existingExternal)).To(Succeed())
+
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = ""
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("must be a fully-qualified Go import path"))
+		Expect(err.Error()).To(ContainSubstring("github.com/org/repo/api/v1"))
 	})
 
 	It("should prevent duplicate API without force flag", func() {

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -96,23 +96,21 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 		"Resource irregular plural form (e.g., 'people' for 'Person'); auto-detected from resource kind if not provided")
 
 	fs.BoolVar(&p.options.DoDefaulting, "defaulting", false,
-		"If set, scaffold defaulting webhook")
+		"If set, scaffold the defaulting webhook")
 	fs.BoolVar(&p.options.DoValidation, "programmatic-validation", false,
-		"If set, scaffold validating webhook")
+		"If set, scaffold the validating webhook")
 	fs.BoolVar(&p.options.DoConversion, "conversion", false,
-		"If set, scaffold conversion webhook")
+		"If set, scaffold the conversion webhook")
 
 	fs.StringSliceVar(&p.options.Spoke, "spoke",
 		nil,
 		"Comma-separated list of spoke versions to be added to the conversion webhook (e.g., --spoke v1,v2)")
 
 	fs.StringVar(&p.options.DefaultingPath, "defaulting-path", "",
-		"[Optional] Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path). "+
-			"Only valid with --defaulting")
+		"Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path); only valid with --defaulting")
 
 	fs.StringVar(&p.options.ValidationPath, "validation-path", "",
-		"[Optional] Custom path for the validation webhook (e.g., /my-custom-validate-path). "+
-			"Only valid with --programmatic-validation")
+		"Custom path for the validation webhook (e.g., /my-custom-validate-path); only valid with --programmatic-validation")
 
 	// TODO: remove for go/v5
 	fs.BoolVar(&p.isLegacyPath, "legacy", false,
@@ -141,6 +139,17 @@ func (p *createWebhookSubcommand) InjectConfig(c config.Config) error {
 
 func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 	p.resource = res
+
+	// Copy essential fields from existing resource in PROJECT file (Path, Plural,
+	// External, Core, Module). API/Controllers/Webhooks are managed separately
+	// by UpdateResource.
+	if existingRes, err := p.config.GetResource(res.GVK); err == nil {
+		p.resource.Path = existingRes.Path
+		p.resource.Plural = existingRes.Plural
+		p.resource.External = existingRes.External
+		p.resource.Core = existingRes.Core
+		p.resource.Module = existingRes.Module
+	}
 
 	if len(p.options.ExternalAPIPath) != 0 && len(p.options.ExternalAPIDomain) != 0 && p.isLegacyPath {
 		return errors.New("you cannot scaffold webhooks for external types using the legacy path")

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -66,6 +66,7 @@ var _ = Describe("createWebhookSubcommand", func() {
 	})
 
 	It("should reject defaulting-path without --defaulting", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
 		subCmd.options.DefaultingPath = "/custom-path"
 		subCmd.options.DoDefaulting = false
 
@@ -76,6 +77,7 @@ var _ = Describe("createWebhookSubcommand", func() {
 	})
 
 	It("should reject validation-path without --programmatic-validation", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
 		subCmd.options.ValidationPath = "/custom-path"
 		subCmd.options.DoValidation = false
 
@@ -86,7 +88,8 @@ var _ = Describe("createWebhookSubcommand", func() {
 	})
 
 	It("should require external-api-path when using external-api-module", func() {
-		subCmd.options.ExternalAPIModule = "github.com/external/api@v1.0.0"
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.ExternalAPIModule = externalAPIModuleWithVersion
 		subCmd.options.ExternalAPIPath = ""
 		subCmd.options.DoDefaulting = true
 
@@ -94,6 +97,91 @@ var _ = Describe("createWebhookSubcommand", func() {
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("requires '--external-api-path'"))
+	})
+
+	It("should reject external-api-path with module version", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.ExternalAPIPath = externalAPIModuleWithVersion
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("version specifiers belong in the module field"))
+	})
+
+	It("should reject bare relative external-api-path", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.ExternalAPIPath = relativeAPIPath
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("must be a fully-qualified Go import path"))
+	})
+
+	It("should reject leading-dot pseudo-domain external-api-path", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.ExternalAPIPath = ".com/org/repo/api/v1"
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("must be a fully-qualified Go import path"))
+	})
+
+	It("should reject malformed external-api-path", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.ExternalAPIPath = "a//b"
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("malformed import path"))
+		Expect(err.Error()).To(ContainSubstring("double slash"))
+	})
+
+	It("should allow creating a webhook for an external resource with a valid path", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.ExternalAPIPath = "github.com/example/external/api/v1"
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.External).To(BeTrue())
+		Expect(res.Path).To(Equal("github.com/example/external/api/v1"))
+	})
+
+	It("should retain path for existing external resource without re-providing --external-api-path", func() {
+		const externalPath = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+
+		// Simulate an existing external resource stored in PROJECT.
+		// GVK domain stays as testIO because the lookup key is constructed from the CLI flags
+		// (--group, --version, --kind) with the project domain — not the external-api-domain.
+		storedRes := *res
+		storedRes.External = true
+		storedRes.Path = externalPath
+		Expect(cfg.AddResource(storedRes)).To(Succeed())
+
+		// User runs: kubebuilder create webhook --group crew --version v1 --kind Captain --defaulting
+		// without re-supplying --external-api-path
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.External).To(BeTrue())
+		Expect(res.Path).To(Equal(externalPath))
 	})
 
 	Context("isValidVersion", func() {


### PR DESCRIPTION
**Description:**
- Removes the `// TODO: validate the path placeholder` in Resource.Validate() and implements full path validation.
- External resources are validated via a new exported ValidateExternalAPIPath function, which checks that the path is non-empty, contains no @ (with a hint to use the module: field instead), is a valid Go import path per `golang.org/x/mod/module.CheckImportPath`, is domain-qualified (rejects bare relative paths and leading-dot pseudo-domains like .com/org/api), and includes a package sub-path (rejects bare domains like example.com).
 - Non-external resources with a non-empty path are validated structurally via `module.CheckImportPath`.
 - A new validateExternalAPIPathFlag wrapper in the v4 plugin validates --external-api-path at the CLI flag layer before the resource is mutated, providing actionable error messages that name the relevant flag and remediation steps.
- Test fixtures that used invalid paths (`external/test`, `external/path`, `testPath`) are updated to valid domain-qualified paths, and new table-driven tests cover the valid and invalid path cases.

**Motivation:**
The External resource feature requires a resolvable Go package import path because scaffolding imports external API types rather than generating them. Without validation, invalid paths — relative paths, @-containing module specs, bare domains - were silently written to the PROJECT file and only failed at go build time with cryptic errors unrelated to the original mistake.