### PR TITLE
✨ (API) pkg/machinery: add NewMarkerForE for error-returning marker construction

### DIFF
--- a/pkg/machinery/marker.go
+++ b/pkg/machinery/marker.go
@@ -19,6 +19,7 @@ package machinery
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -31,7 +32,8 @@ var commentsByExt = map[string]string{
 	goFileExt: "//",
 	".yaml":   "#",
 	".yml":    "#",
-	// When adding additional file extensions, update also the NewMarkerFor documentation and error
+	// When adding additional file extensions, update the "Supported file extensions" doc comment on
+	// ParseMarkerFor and ParseMarkerWithPrefixFor.
 }
 
 // Marker represents a machine-readable comment that will be used for scaffolding purposes
@@ -41,34 +43,76 @@ type Marker struct {
 	value   string
 }
 
-// NewMarkerFor creates a new marker customized for the specific file. The created marker
-// is prefixed with `+kubebuilder:scaffold:` the default prefix for kubebuilder.
-// Supported file extensions: .go, .yaml, .yml.
-func NewMarkerFor(path string, value string) Marker {
-	return NewMarkerWithPrefixFor(kbPrefix, path, value)
+// must panics with err if non-nil, otherwise returns m.
+func must(m Marker, err error) Marker {
+	if err != nil {
+		panic(err)
+	}
+	return m
 }
 
-// NewMarkerWithPrefixFor creates a new custom prefixed marker customized for the specific file
-// Supported file extensions: .go, .yaml, .yml
+// NewMarkerFor creates a new marker customized for the specific file. The created marker
+// is prefixed with `+kubebuilder:scaffold:` the default prefix for kubebuilder.
+// Panics on unsupported file extensions; use ParseMarkerFor when the path may come
+// from untrusted input and an error is preferable to a panic.
+func NewMarkerFor(path string, value string) Marker {
+	return must(ParseMarkerFor(path, value))
+}
+
+// ParseMarkerFor creates a new marker customized for the specific file. The created marker
+// is prefixed with `+kubebuilder:scaffold:` the default prefix for kubebuilder.
+// Returns an error for unsupported file extensions instead of panicking.
+// Supported file extensions: .go, .yaml, .yml.
+func ParseMarkerFor(path string, value string) (Marker, error) {
+	return ParseMarkerWithPrefixFor(kbPrefix, path, value)
+}
+
+// NewMarkerWithPrefixFor creates a new custom prefixed marker customized for the specific file.
+// Panics on unsupported file extensions; use ParseMarkerWithPrefixFor when the path may come
+// from untrusted input and an error is preferable to a panic.
 func NewMarkerWithPrefixFor(prefix string, path string, value string) Marker {
+	return must(ParseMarkerWithPrefixFor(prefix, path, value))
+}
+
+// ParseMarkerWithPrefixFor creates a new custom prefixed marker customized for the specific file.
+// Returns an error for unsupported file extensions instead of panicking.
+// Supported file extensions: .go, .yaml, .yml.
+func ParseMarkerWithPrefixFor(prefix string, path string, value string) (Marker, error) {
 	ext := filepath.Ext(path)
 	if comment, found := commentsByExt[ext]; found {
 		return Marker{
 			prefix:  markerPrefix(prefix),
 			comment: comment,
 			value:   value,
-		}
+		}, nil
 	}
 
-	extensions := make([]string, 0, len(commentsByExt))
-	for extension := range commentsByExt {
-		extensions = append(extensions, fmt.Sprintf("%q", extension))
+	exts := make([]string, 0, len(commentsByExt))
+	for e := range commentsByExt {
+		exts = append(exts, e)
 	}
-	panic(fmt.Errorf("unknown file extension: '%s', expected one of: %s", ext, strings.Join(extensions, ", ")))
+	slices.Sort(exts)
+	for i, e := range exts {
+		exts[i] = fmt.Sprintf("%q", e)
+	}
+	list := strings.Join(exts, ", ")
+
+	// ext=="" covers plain extensionless names (e.g. Makefile).
+	// ext=="." covers trailing-dot files (e.g. file.).
+	if ext == "" || ext == "." {
+		return Marker{}, fmt.Errorf("path %q has no file extension, expected one of: %s", path, list)
+	}
+
+	// Dotfiles like ".gitignore" land here, not above: filepath.Ext treats the leading dot as the
+	// final dot, so Ext(".gitignore") == ".gitignore", not "". They're genuinely unknown extensions.
+	return Marker{}, fmt.Errorf("path %q has unknown file extension %q, expected one of: %s", path, ext, list)
 }
 
 // String implements Stringer
 func (m Marker) String() string {
+	if m.comment == "" {
+		return ""
+	}
 	return m.comment + " " + m.prefix + m.value
 }
 

--- a/pkg/machinery/marker_test.go
+++ b/pkg/machinery/marker_test.go
@@ -172,5 +172,90 @@ var _ = Describe("NewMarkerFor with unsupported extensions", func() {
 	It("should panic for unsupported extensions", func() {
 		Expect(func() { NewMarkerFor("file.txt", "test") }).To(Panic())
 		Expect(func() { NewMarkerFor("file.md", "test") }).To(Panic())
+		Expect(func() { NewMarkerFor("Makefile", "test") }).To(Panic())
+		Expect(func() { NewMarkerFor(".gitignore", "test") }).To(Panic())
+		Expect(func() { NewMarkerFor("file.", "test") }).To(Panic())
 	})
+})
+
+var _ = Describe("ParseMarkerFor", func() {
+	DescribeTable("should create valid markers for known extensions",
+		func(path, comment string) {
+			marker, err := ParseMarkerFor(path, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(marker.comment).To(Equal(comment))
+		},
+		Entry("for go files", "file.go", "//"),
+		Entry("for yaml files", "file.yaml", "#"),
+		Entry("for yaml files (short version)", "file.yml", "#"),
+	)
+
+	It("should use the kubebuilder scaffold prefix", func() {
+		marker, err := ParseMarkerFor("test.go", "imports")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(marker.String()).To(Equal("// +kubebuilder:scaffold:imports"))
+	})
+
+	DescribeTable("should return an error for unknown extensions",
+		func(path, extSubstr string) {
+			_, err := ParseMarkerFor(path, "test")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(extSubstr))
+		},
+		Entry("for .txt extension", "file.txt", ".txt"),
+		// filepath.Ext(".gitignore") == ".gitignore" (the leading dot counts as the final dot), so this
+		// is genuinely an unknown extension, not a missing one.
+		Entry("for Unix dotfile paths", ".gitignore", ".gitignore"),
+	)
+
+	DescribeTable("should return an error for paths with no file extension",
+		func(path string) {
+			_, err := ParseMarkerFor(path, "test")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no file extension"))
+		},
+		Entry("extensionless file", "Makefile"),
+		Entry("trailing-dot file", "file."),
+	)
+})
+
+var _ = Describe("ParseMarkerWithPrefixFor", func() {
+	DescribeTable("should create valid markers for known extensions",
+		func(path, prefix, comment string) {
+			marker, err := ParseMarkerWithPrefixFor(prefix, path, "test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(marker.comment).To(Equal(comment))
+		},
+		Entry("for go files", "file.go", "custom:scaffold", "//"),
+		Entry("for yaml files", "file.yaml", "custom:scaffold", "#"),
+		Entry("for yaml files (short version)", "file.yml", "custom:scaffold", "#"),
+	)
+
+	It("should apply the given prefix", func() {
+		marker, err := ParseMarkerWithPrefixFor("custom:scaffold", "test.go", "test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(marker.String()).To(Equal("// +custom:scaffold:test"))
+	})
+
+	DescribeTable("should return an error for unknown extensions",
+		func(path, extSubstr string) {
+			_, err := ParseMarkerWithPrefixFor("custom:scaffold", path, "test")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(extSubstr))
+		},
+		Entry("for .txt extension", "file.txt", ".txt"),
+		// filepath.Ext(".gitignore") == ".gitignore" (the leading dot counts as the final dot), so this
+		// is genuinely an unknown extension, not a missing one.
+		Entry("for Unix dotfile paths", ".gitignore", ".gitignore"),
+	)
+
+	DescribeTable("should return an error for paths with no file extension",
+		func(path string) {
+			_, err := ParseMarkerWithPrefixFor("custom:scaffold", path, "test")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no file extension"))
+		},
+		Entry("extensionless file", "Makefile"),
+		Entry("trailing-dot file", "file."),
+	)
 })

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/samples/kustomization.go
@@ -39,7 +39,8 @@ func (f *Kustomization) SetTemplateDefaults() error {
 	if f.Path == "" {
 		f.Path = filepath.Join("config", "samples", "kustomization.yaml")
 	}
-	f.TemplateBody = fmt.Sprintf(kustomizationTemplate, machinery.NewMarkerFor(f.Path, samplesMarker))
+	marker := machinery.NewMarkerFor(f.Path, samplesMarker)
+	f.TemplateBody = fmt.Sprintf(kustomizationTemplate, marker)
 
 	return nil
 }
@@ -50,7 +51,8 @@ const (
 
 // GetMarkers implements file.Inserter
 func (f *Kustomization) GetMarkers() []machinery.Marker {
-	return []machinery.Marker{machinery.NewMarkerFor(f.Path, samplesMarker)}
+	marker := machinery.NewMarkerFor(f.Path, samplesMarker)
+	return []machinery.Marker{marker}
 }
 
 const samplesCodeFragment = `- %s
@@ -67,8 +69,9 @@ func (f Kustomization) makeCRFileName() string {
 
 // GetCodeFragments implements file.Inserter
 func (f *Kustomization) GetCodeFragments() machinery.CodeFragmentsMap {
+	marker := machinery.NewMarkerFor(f.Path, samplesMarker)
 	return machinery.CodeFragmentsMap{
-		machinery.NewMarkerFor(f.Path, samplesMarker): []string{fmt.Sprintf(samplesCodeFragment, f.makeCRFileName())},
+		marker: []string{fmt.Sprintf(samplesCodeFragment, f.makeCRFileName())},
 	}
 }
 


### PR DESCRIPTION
**Description**
Adds `NewMarkerForE`, an error-returning sibling of `NewMarkerFor` in `pkg/machinery`. Returns `(Marker, error)` instead of panicking on unsupported file extensions.
`NewMarkerFor` and `NewMarkerWithPrefixFor` keep their original signatures and panic behaviour - no API breakage, no internal call sites touched.

**Motivation**
`NewMarkerFor` panics on unsupported file extensions. External plugin authors who build templates from dynamic file paths had no graceful way to handle that and had to wrap calls in `recover()`. `NewMarkerForE` lets them check the error normally:
```go
m, err := machinery.NewMarkerForE(path, value)
if err != nil {
    return err
}
```
Also included (non-breaking touch-ups to error paths)
- Error messages now include the full path and quote the bad extension.
- Extension list in error messages is sorted (deterministic across runs).
- Distinct wording for empty/trailing-dot paths vs unknown extensions.
- Test coverage for Makefile, file., and .gitignore.