### PR TITLE
📖 (building-cronjob): uncomment make command

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/emptycontroller.go
@@ -59,7 +59,7 @@ needed to run.  As we add more functionality, we'll need to revisit these.
 The `ClusterRole` manifest at `config/rbac/role.yaml` is generated from the above markers via controller-gen with the following command:
 */
 
-// make manifests
+make manifests
 
 /*
 NOTE: If you receive an error, please run the specified command in the error and re-run `make manifests`.


### PR DESCRIPTION
## What

Remove the `//` from the `make manifests` command.

| Before | After |
|--------|------|
|  <img width="786" height="125" alt="before" src="https://github.com/user-attachments/assets/1c8d5f3b-6cf7-4f80-b717-2db590dae97c" />           |     <img width="779" height="121" alt="after" src="https://github.com/user-attachments/assets/293f357b-3582-4a4b-9570-f495a0e40439" />     |

## Why

It's a command and not a Go comment.

## Testing

```
cd docs/book/
./install-and-build.sh
/tmp/mdbook serve

http://localhost:3000/cronjob-tutorial/controller-overview.html
```
