### PR TITLE
⚠️ (autoupdate/v1-alpha): Remove GitHub Models integration from Kubebuilder and its auto-update tooling, as the service is no longer available to new users

### DIFF
--- a/docs/book/src/getting-started/testdata/project/.github/workflows/auto_update.yml
+++ b/docs/book/src/getting-started/testdata/project/.github/workflows/auto_update.yml
@@ -3,7 +3,7 @@ name: Auto Update
 # The 'kubebuilder alpha update' command requires write access to the repository to create a branch
 # with the update files and allow you to open a pull request using the link provided in the issue.
 # The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
-# To protect your codebase, please ensure that you have branch protection rules configured for your 
+# To protect your codebase, please ensure that you have branch protection rules configured for your
 # main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
 permissions: {}
 
@@ -58,11 +58,6 @@ jobs:
       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
-      #
-      # WARNING: This workflow does not use GitHub Models AI summary by default.
-      # To enable AI-generated summaries in GitHub issues, you need permissions to use GitHub Models.
-      # If you have the required permissions, re-run:
-      #   kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
       run: |
         kubebuilder alpha update \
           --force \

--- a/docs/book/src/plugins/available/autoupdate-v1-alpha.md
+++ b/docs/book/src/plugins/available/autoupdate-v1-alpha.md
@@ -1,6 +1,6 @@
 # AutoUpdate (`autoupdate/v1-alpha`)
 
-Keeping your Kubebuilder project up to date with the latest improvements shouldn’t be a chore.
+Keeping your Kubebuilder project up to date with the latest improvements shouldn't be a chore.
 With a small amount of setup, you can receive **automatic Pull Request** suggestions whenever a new
 Kubebuilder release is available — keeping your project **maintained, secure, and aligned with ecosystem changes**.
 
@@ -22,7 +22,6 @@ changes are not pushed or merged without proper review.
 
 
 - When you want to reduce the burden of keeping the project updated and well-maintained.
-- When you want guidance and help from AI to know what changes are needed to keep your project up to date and to solve conflicts (requires `--use-gh-models` flag and GitHub Models permissions).
 
 ## How to use it
 
@@ -31,34 +30,6 @@ changes are not pushed or merged without proper review.
 ```shell
 kubebuilder edit --plugins="autoupdate/v1-alpha"
 ```
-
-### Optional: GitHub Models AI summary
-
-By default, the workflow works without GitHub Models to avoid permission errors.
-If you want AI-generated summaries in your update issues:
-
-```shell
-kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
-```
-
-<aside class="note" role="note">
-<p class="note-title">Permissions required to use GitHub Models in GitHub Actions</p>
-
-To use GitHub Models in your workflows, organization and repository administrators must grant this permission.
-
-**If you have admin access:**
-
-1. Go to **Settings → Code and automation → Models**
-2. Enable GitHub Models for your repository
-
-**Don't see the Models option?**
-
-Your organization or enterprise may have disabled it. Contact your administrator:
-
-- Organization admins: [Managing Models in your organization][manage-org-models]
-- Enterprise admins: [Managing Models at enterprise scale][manage-models-at-scale]
-
-</aside>
 
 ## How it works
 
@@ -70,10 +41,6 @@ The plugin scaffolds a GitHub Actions workflow that checks for new Kubebuilder r
 **Example Issue:**
 
 <img width="638" height="482" alt="Example Issue" src="https://github.com/user-attachments/assets/589fd16b-7709-4cd5-b169-fd53d69790d4" />
-
-**With GitHub Models enabled** (optional), you also get AI-generated summaries:
-
-<img width="582" height="646" alt="AI Summary" src="https://github.com/user-attachments/assets/d460a5af-5ca4-4dd5-afb8-7330dd6de148" />
 
 **Conflict help** (when needed):
 
@@ -88,7 +55,6 @@ The generated workflow uses the `kubebuilder alpha update` command with default 
 - `--push` - Automatically push the output branch to remote
 - `--restore-path .github/workflows` - Preserve CI workflows from base branch
 - `--open-gh-issue` - Create a GitHub Issue with PR compare link
-- `--use-gh-models` - (optional) Add AI summary to the issue
 
 **Additional available flags:**
 - `--merge-message` - Custom commit message for clean merges
@@ -117,95 +83,8 @@ Edit `.github/workflows/auto_update.yml`:
       --conflict-message "chore: update with conflicts - review needed"
 ```
 
-## Troubleshooting
-
-#### If you get the 403 Forbidden Error
-
-**Error message:**
-```text
-ERROR Update failed error=failed to open GitHub issue: gh models run failed: exit status 1
-Error: unexpected response from the server: 403 Forbidden
-```
-
-**Quick fix:** Disable GitHub Models (works for everyone)
-
-```shell
-kubebuilder edit --plugins="autoupdate/v1-alpha"
-```
-
-This regenerates the workflow without GitHub Models:
-
-```yaml
-permissions:
-  contents: write
-  issues: write
-  # No models: read permission
-
-steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
-    # ... other setup steps
-
-  - name: Run kubebuilder alpha update
-    # WARNING: This workflow does not use GitHub Models AI summary by default.
-    # To enable AI-generated summaries, you need permissions to use GitHub Models.
-    # If you have the required permissions, re-run:
-    #   kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
-    run: |
-      kubebuilder alpha update \
-        --force \
-        --push \
-        --restore-path .github/workflows \
-        --open-gh-issue
-```
-
-The workflow continues to work—just without AI summaries.
-
-**To enable GitHub Models instead:**
-
-1. Ask your GitHub administrator to enable Models (see links below)
-2. Enable it in **Settings → Code and automation → Models**
-3. Re-run with:
-
-```shell
-kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
-```
-
-This regenerates the workflow WITH GitHub Models:
-
-```yaml
-permissions:
-  contents: write
-  issues: write
-  models: read  # Added for GitHub Models
-
-steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
-    # ... other setup steps
-
-  - name: Install gh-models extension
-    run: |
-      gh extension install github/gh-models --force
-      gh models --help >/dev/null
-
-  - name: Run kubebuilder alpha update
-    # --use-gh-models: Adds an AI-generated comment to the Issue with
-    #   a summary of scaffold changes and conflict-resolution guidance (if any).
-    run: |
-      kubebuilder alpha update \
-        --force \
-        --push \
-        --restore-path .github/workflows \
-        --open-gh-issue \
-        --use-gh-models
-```
-
 ## Demonstration
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/dHNKx5jPSqc?si=wYwZZ0QLwFij10Sb" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 [alpha-update-command]: ./../../reference/commands/alpha_update.md
-[ai-models]: https://docs.github.com/en/github-models/about-github-models
-[manage-models-at-scale]: https://docs.github.com/en/github-models/github-models-at-scale/manage-models-at-scale
-[manage-org-models]: https://docs.github.com/en/organizations/managing-organization-settings/managing-or-restricting-github-models-for-your-organization

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -319,4 +319,3 @@ kubebuilder edit --plugins="autoupdate/v1-alpha"
 [markers]: reference/markers.md
 [controller-gen]: https://sigs.k8s.io/controller-tools/cmd/controller-gen
 [scaffolding-markers]: reference/markers/scaffold.md
-[ai-gh-models]: https://docs.github.com/en/github-models/about-github-models

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -17,9 +17,6 @@ You can reduce the burden of keeping your project up to date by using the
 automates the process of running `kubebuilder alpha update` on a schedule
 workflow when new Kubebuilder releases are available.
 
-Moreover, you is able to get help from [AI models][ai-gh-models] to understand what changes are needed to keep your project up to date
-and how to solve conflicts if any are faced.
-
 </aside>
 
 ## When to use it
@@ -69,7 +66,6 @@ The command creates three temporary branches:
     - `--push`: push the result to `origin` automatically.
     - `--git-config`: sets git configurations.
     - `--open-gh-issue`: create a GitHub issue with a checklist and compare link (requires `gh`).
-    - `--use-gh-models`: add an AI overview **comment** to that issue using `gh models`
 
 ### Step 5: Cleanup
 - Once the output branch is ready, all the temporary working branches are deleted.
@@ -157,12 +153,10 @@ make manifests generate fmt vet lint-fix
 make all
 ```
 
-## Using with GitHub Issues (`--open-gh-issue`) and AI (`--use-gh-models`) assistance
+## Using with GitHub Issues (`--open-gh-issue`)
 
 Pass `--open-gh-issue` to have the command create a GitHub **Issue** in your repository
-to assist with the update. Also, if you also pass `--use-gh-models`, the tool posts a follow-up comment
-on that Issue with an AI-generated overview of the most important changes plus brief conflict-resolution
-guidance.
+to assist with the update.
 
 ### Examples
 
@@ -171,23 +165,11 @@ Create an Issue with a compare link:
 kubebuilder alpha update --open-gh-issue
 ```
 
-Create an Issue **and** add an AI summary:
-```shell
-kubebuilder alpha update --open-gh-issue --use-gh-models
-```
-
 ### What you’ll see
 
 The command opens an Issue that links to the diff so you can create the PR and review it, for example:
 
 <img width="638" height="482" alt="Example Issue" src="https://github.com/user-attachments/assets/589fd16b-7709-4cd5-b169-fd53d69790d4" />
-
-With `--use-gh-models`, an AI comment highlights key changes and suggests how to resolve any conflicts:
-
-<img width="740" height="425" alt="Comment" src="https://github.com/user-attachments/assets/fb5f214e-be0e-43b8-a3fb-b5744ac8f66e" />
-
-Moreover, AI models are used to help you understand what changes are needed to keep your project up to date,
-and to suggest resolutions if conflicts are encountered, as in the following example:
 
 ### Automation
 
@@ -247,7 +229,6 @@ The command uses that value to pick the correct CLI for re-scaffolding.
 | `--restore-path`   | Repeatable. Paths to preserve from the base branch when squashing (e.g., `.github/workflows`). **Not supported** with `--show-commits`.                                                                                                 |
 | `--show-commits`   | Keep full history (do not squash). **Not compatible** with `--restore-path`.                                                                                                                                                            |
 | `--to-version`     | Kubebuilder release to update **to** (e.g., `v4.7.0`). If unset, defaults to the latest available release.                                                                                                                              |
-| `--use-gh-models`  | Post an AI overview as an issue comment using `gh models`. Requires `gh` + `gh-models` extension. Effective only when `--open-gh-issue` is also set.                                                                                    |
 | `-h, --help`       | Show help for this command.                                                                                                                                                                                                             |
 
 ## Demonstration
@@ -272,4 +253,3 @@ so the current behavior may differ slightly from what is shown in the demo.
 [project-config]: ../../reference/project-config.md
 [autoupdate-plugin]: ./../../plugins/available/autoupdate-v1-alpha.md
 [design-proposal]: ./../../../../../designs/update_action.md
-[ai-gh-models]: https://docs.github.com/en/github-models/about-github-models

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -382,9 +382,6 @@ func migrateAutoUpdatePlugin(s store.Store) error {
 	}
 
 	args := []string{kubebuilderSubcommandEdit, flagPlugins, plugin.KeyFor(autoupdatev1alpha.Plugin{})}
-	if autoUpdatePlugin.UseGHModels {
-		args = append(args, "--use-gh-models")
-	}
 	if err = util.RunCmd("kubebuilder edit", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run edit subcommand for Auto plugin: %w", err)
 	}

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -1022,20 +1022,10 @@ var _ = Describe("generate: migrate-plugins", func() {
 			Expect(migrateAutoUpdatePlugin(store)).NotTo(Succeed())
 		})
 
-		It("migrates Auto Update plugin successfully without UseGHModels", func() {
+		It("migrates Auto Update plugin successfully", func() {
 			cfg := &fakeConfig{
 				plugins: map[string]any{
-					autoupdatePluginKey: autoupdatev1alpha.PluginConfig{UseGHModels: false},
-				},
-			}
-			store := &fakeStore{cfg: cfg}
-			Expect(migrateAutoUpdatePlugin(store)).To(Succeed())
-		})
-
-		It("migrates Auto Update plugin successfully with UseGHModels enabled", func() {
-			cfg := &fakeConfig{
-				plugins: map[string]any{
-					autoupdatePluginKey: autoupdatev1alpha.PluginConfig{UseGHModels: true},
+					autoupdatePluginKey: autoupdatev1alpha.PluginConfig{},
 				},
 			}
 			store := &fakeStore{cfg: cfg}

--- a/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
+++ b/internal/cli/alpha/internal/update/helpers/open_gh_issue.go
@@ -17,20 +17,7 @@ limitations under the License.
 package helpers
 
 import (
-	"bufio"
-	"bytes"
-	"fmt"
-	"os/exec"
-	"regexp"
-	"slices"
 	"strings"
-)
-
-// Curated-diff budgets (fixed; no env vars)
-const (
-	selectedDiffTotalCap     = 96 << 10 // 96 KiB total across all files
-	selectedDiffLinesPerFile = 120      // default +/- lines per file
-	selectedDiffLinesGoMod   = 240      // allow more for go.mod
 )
 
 // IssueTitleTmpl is the title template for the GitHub issue.
@@ -41,7 +28,7 @@ const IssueTitleTmpl = "[Action Required] Upgrade the Scaffold: %[2]s -> %[1]s"
 //nolint:lll
 const IssueBodyTmpl = `## Description
 
-Upgrade your project to use the latest scaffold changes introduced in Kubebuilder [%[1]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[1]s).  
+Upgrade your project to use the latest scaffold changes introduced in Kubebuilder [%[1]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[1]s).
 
 See the release notes from [%[3]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[3]s) to [%[1]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[1]s) for details about the changes included in this upgrade.
 
@@ -50,13 +37,13 @@ See the release notes from [%[3]s](https://github.com/kubernetes-sigs/kubebuilde
 A scheduled workflow already attempted this upgrade and created the branch %[4]s to help you in this process.
 
 Create a Pull Request using the URL below to review the changes:
-%[2]s  
+%[2]s
 
 ## Next steps
 
 **Verify the changes**
-- Build the project  
-- Run tests  
+- Build the project
+- Run tests
 - Confirm everything still works
 
 :book: **More info:** https://kubebuilder.io/reference/commands/alpha_update
@@ -67,7 +54,7 @@ Create a Pull Request using the URL below to review the changes:
 //nolint:lll
 const IssueBodyTmplWithConflicts = `## Description
 
-Upgrade your project to use the latest scaffold changes introduced in Kubebuilder [%[1]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[1]s).  
+Upgrade your project to use the latest scaffold changes introduced in Kubebuilder [%[1]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[1]s).
 
 See the release notes from [%[3]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[3]s) to [%[1]s](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%[1]s) for details about the changes included in this upgrade.
 
@@ -78,7 +65,7 @@ A scheduled workflow already attempted this upgrade and created the branch (%[4]
 :warning: **Conflicts were detected during the merge.**
 
 Create a Pull Request using the URL below to review the changes and resolve conflicts manually:
-%[2]s  
+%[2]s
 
 ## Next steps
 
@@ -94,98 +81,16 @@ To apply the update in a clean branch, run:
 kubebuilder alpha update --output-branch my-fix-branch
 ~~~
 
-This will create a new branch (my-fix-branch) with the update applied.  
+This will create a new branch (my-fix-branch) with the update applied.
 Resolve conflicts there, complete the merge locally, and push the branch.
 
 ### 3. Verify the changes
-- Build the project  
-- Run tests  
+- Build the project
+- Run tests
 - Confirm everything still works
 
 :book: **More info:** https://kubebuilder.io/reference/commands/alpha_update
 `
-
-// AiPRPrompt is the prompt to `gh models run`.
-//
-//nolint:lll
-const AiPRPrompt = `You are a senior Go/K8s engineer. Produce a concise, reviewer-friendly **Pull Request summary** for a Kubebuilder project upgrade.
-Style rules:
-- Use **simple, plain English** (like Kubebuilder docs).
-- Avoid jargon or long sentences.
-- Focus on clarity and readability for new contributors.
-
-Rules (follow strictly):
-- Do NOT output angle-bracket placeholders like <OUTPUT_BRANCH>; use the real value from the context.
-- Do NOT guess versions. Only mention an exact version (e.g., controller-runtime v0.21.0)
-  if that exact version string appears in the provided diffs/context (e.g., go.mod).
-- When talking about dependencies:
-  - **Only** name modules that changed on **non-indirect** ` + "`require`" + ` lines in **go.mod** (i.e., lines **without** "// indirect").
-  - You may also name explicit tool versions found in **Makefile** or **Dockerfile** (e.g., controller-tools, golangci-lint, Go toolchain).
-  - **Never** name modules that appear only with "// indirect" or only in **go.sum** or generated files.
-  - If you cannot name any direct modules safely, write simply: "dependencies updated" (no module names).
-- Output exactly one overview and one reviewed-changes table. No duplicates.
-- Valid Markdown only. No ">>>", no meta commentary.
-- Start with this exact sentence, substituting real values:
-  "This is a Kubebuilder scaffold update from %s to %s on branch %s."
-  If a Compare PR URL is provided in the context header, append it **in parentheses** at the end of that sentence as a Markdown link, e.g., " (see [compare PR](URL))".
-- A "conflict" means the file currently contains Git merge markers (<<<<<<<, =======, >>>>>>>) and requires manual resolution. If no conflicts are provided in the context, omit the conflicts section entirely.
-- Conflicts section: ONLY add if there are conflicts. Do NOT invent conflicts.
-- Do NOT invent changes; use only what is in the context.
-
-Required sections (Markdown, EXACT wording/case):
-
-## ( :robot: AI generate ) Scaffold Changes Overview
-Start with one short sentence: "This is a Kubebuilder scaffold update from <FROM> to <TO> on branch <OUTPUT_BRANCH>." (with the optional compare link in parentheses at the end).
-Then list 4–6 concise bullet highlights (e.g., Go/tooling bumps, controller-runtime/k8s.io deps, security hardening like readOnlyRootFilesystem, error handling improvements).
-Then list **only the most important 6–10 bullet points** (never more than 10 items total in this section).
-If there are many changes, summarize and cluster them (e.g., "several small Go tooling bumps") instead of listing everything.
-
-### ( :robot: AI generate ) Reviewed Changes
-Add a collapsible block:
-<details>
-<summary>Show a summary per file</summary>
-
-| File | Description |
-| ---- | ----------- |
-| … | … |
-
-</details>
-
-Build the table using ONLY the "Changed files" lists provided in the context. Do not invent files.
-It is OK if some files also appear in the Conflicts section.
-If there are many GENERATED files, you may **group them** using a glob with a count (e.g., ` + "`config/crd/bases/*.yaml (12 files)`" + `) instead of listing each one.
-
-**ONLY** if the context includes conflict files; add ANOTHER collapsible block titled **Conflicts Summary**:
-
-<details>
-<summary>Conflicts Summary</summary>
-
-| File | Description |
-| ---- | ----------- |
-| … | … |
-
-</details>
-
-A "conflict" means the file currently contains Git merge markers (<<<<<<<, =======, >>>>>>>) and requires manual resolution. If no conflicts are provided in the context, omit this section.
-
-List each conflicted file with a brief suggestion. For GENERATED files:
-- api/**/zz_generated.*.go: "Do not edit by hand; run: make generate"
-- config/crd/bases/*.yaml: "Fix types in api/*_types.go; then run: make manifests"
-- config/rbac/*.yaml: "Fix markers in controllers/webhooks; then run: make manifests"
-- dist/install.yaml: "Fix conflicts; then run: make build-installer"`
-
-// listConflictFiles uses the unified conflict detection from conflict.go
-func listConflictFiles() (src []string, gen []string) {
-	conflicts := FindConflictFiles()
-	return conflicts.SourceFiles, conflicts.GeneratedFiles
-}
-
-func bulletList(items []string) string {
-	if len(items) == 0 {
-		return "<none>"
-	}
-	return "- " + strings.Join(items, "\n- ")
-}
 
 // FirstURL is a helper to grab the first URL-looking token from gh stdout
 func FirstURL(s string) string {
@@ -205,345 +110,4 @@ func IssueNumberFromURL(u string) string {
 		return u[i+1:]
 	}
 	return ""
-}
-
-// listChangedFiles returns files changed between base..head, split into SOURCE and GENERATED.
-func listChangedFiles(base, head string) (src []string, gen []string) {
-	cmd := exec.Command("git", "diff", "--name-only", "-M", "--diff-filter=ACMRTD", base+".."+head)
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, nil // best-effort
-	}
-	for p := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		if isGeneratedKB(p) {
-			gen = append(gen, p)
-		} else {
-			src = append(src, p)
-		}
-	}
-	slices.Sort(src)
-	slices.Sort(gen)
-	return src, gen
-}
-
-// BuildFullPrompet builds the AI context and writes it to a temp file.
-// It returns the absolute filepath to pass via --input-file/--file.
-func BuildFullPrompet(
-	fromVersion, toVersion, baseBranch, outBranch, compareURL, releaseURL string,
-) string {
-	changedSrc, changedGen := listChangedFiles(baseBranch, outBranch)
-	conflictSrc, conflictGen := listConflictFiles()
-
-	var ctx strings.Builder
-
-	fmt.Fprintf(&ctx, "Kubebuilder upgrade: %s -> %s\n", fromVersion, toVersion)
-	fmt.Fprintf(&ctx, "Compare PR URL: %s\n", compareURL)
-	fmt.Fprintf(&ctx, "Release notes: %s\n\n", releaseURL)
-	ctx.WriteString("\n")
-
-	// List changed files so the AI can build the Reviewed Changes table.
-	if len(changedSrc) > 0 {
-		fmt.Fprintf(&ctx, "\nChanged [SOURCE] files:\n%s\n", bulletList(changedSrc))
-	}
-	if len(changedGen) > 0 {
-		fmt.Fprintf(&ctx, "\nChanged [GENERATED] files:\n%s\n", bulletList(changedGen))
-	}
-	// List conflicts for extra context (will be empty if none)
-	if len(conflictSrc) > 0 {
-		fmt.Fprintf(&ctx, "\nConflicted [SOURCE] files:\n%s\n", bulletList(conflictSrc))
-	}
-	if len(conflictGen) > 0 {
-		fmt.Fprintf(&ctx, "\nConflicted [GENERATED] files:\n%s\n", bulletList(conflictGen))
-	}
-
-	// Concise, curated diffs for important SOURCE files only
-	if len(changedSrc) > 0 {
-		ctx.WriteString("## Selected diffs\n")
-		// Per-file cap is ignored for go.mod (it uses its own higher cap).
-		const perFileLineCap = selectedDiffLinesPerFile
-		// total cap is fixed inside concatSelectedDiffs (selectedDiffTotalCap).
-		ctx.WriteString(concatSelectedDiffs(strings.TrimSpace(baseBranch),
-			strings.TrimSpace(outBranch), changedSrc, perFileLineCap, selectedDiffTotalCap))
-		ctx.WriteString("\n")
-	}
-
-	return ctx.String()
-}
-
-// Never include these in curated diffs.
-func excludedFromDiff(p string) bool {
-	return isGeneratedKB(p) ||
-		strings.HasSuffix(p, ".md") ||
-		p == "PROJECT" ||
-		p == "go.sum" ||
-		strings.HasPrefix(p, "grafana/") ||
-		strings.HasPrefix(p, "config/crd/bases/") ||
-		strings.HasPrefix(p, "hack/") ||
-		strings.HasPrefix(p, "bin/") ||
-		strings.HasPrefix(p, "vendor/") ||
-		strings.HasSuffix(p, ".log")
-}
-
-// Only files that matter for KB review context (after exclusions).
-func importantFile(p string) bool {
-	if excludedFromDiff(p) {
-		return false
-	}
-
-	// Critical Kubebuilder files
-	//nolint:goconst
-	if p == "go.mod" || p == "Makefile" || p == "Dockerfile" {
-		return true
-	}
-
-	// Core source code
-	if strings.HasPrefix(p, "cmd/") ||
-		strings.HasPrefix(p, "controllers/") ||
-		strings.HasPrefix(p, "internal/controller/") ||
-		strings.HasPrefix(p, "internal/webhook/") ||
-		(strings.HasPrefix(p, "api/") && strings.HasSuffix(p, "_types.go")) {
-		return true
-	}
-
-	// Test files (important for breaking changes)
-	if strings.HasPrefix(p, "test/") && (strings.HasSuffix(p, "_test.go") ||
-		strings.HasSuffix(p, ".go")) {
-		return true
-	}
-
-	// Important config files (not generated)
-	if strings.HasPrefix(p, "config/") {
-		// Include kustomization files and important config
-		if strings.HasSuffix(p, "kustomization.yaml") ||
-			strings.HasPrefix(p, "config/default/") ||
-			strings.HasPrefix(p, "config/manager/") ||
-			strings.HasPrefix(p, "config/webhook/") ||
-			strings.HasPrefix(p, "config/certmanager/") ||
-			strings.HasPrefix(p, "config/prometheus/") ||
-			strings.HasPrefix(p, "config/network-policy/") {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Priority: lower number = earlier.
-// 0: go.mod (dependencies)
-// 1: Makefile (build automation)
-// 2: Dockerfile (container images)
-// 3: Core code (cmd/, controllers/, api/*_types.go, internal/)
-// 4: Critical config (config/default, config/manager)
-// 5: Webhook & security config (config/webhook, config/certmanager)
-// 6: Other config (config/*)
-// 7: Tests
-// 9: fallback
-func filePriority(p string) int {
-	switch {
-	case p == "go.mod":
-		return 0
-	case p == "Makefile":
-		return 1
-	case p == "Dockerfile":
-		return 2
-	case strings.HasPrefix(p, "cmd/"),
-		strings.HasPrefix(p, "controllers/"),
-		strings.HasPrefix(p, "internal/controller/"),
-		strings.HasPrefix(p, "internal/webhook/"),
-		(strings.HasPrefix(p, "api/") && strings.HasSuffix(p, "_types.go")):
-		return 3
-	case strings.HasPrefix(p, "config/default/"),
-		strings.HasPrefix(p, "config/manager/"),
-		p == "config/default/kustomization.yaml",
-		p == "config/manager/kustomization.yaml":
-		return 4
-	case strings.HasPrefix(p, "config/webhook/"),
-		strings.HasPrefix(p, "config/certmanager/"),
-		strings.HasPrefix(p, "config/prometheus/"),
-		strings.HasPrefix(p, "config/network-policy/"):
-		return 5
-	case strings.HasPrefix(p, "config/"):
-		return 6
-	case strings.HasPrefix(p, "test/"):
-		return 7
-	default:
-		return 9
-	}
-}
-
-//nolint:lll
-var (
-	reFlags       = regexp.MustCompile(`(?i)--(leader-elect|metrics-bind-address|health-probe-bind-address|\bzap|secure-port|bind-address)`)
-	reGo          = regexp.MustCompile(`(?i)^(?:\+|\-)\s*(package|import|type|func|const|var|//\+kubebuilder:|//go:(?:build|generate)|return|if\s+err|log\.|fmt\.|errors?\.|client\.|ctrl\.|manager|scheme|requeue|context\.|SetupWithManager|Reconcile|reconcile\.Result)`)
-	reYAMLKey     = regexp.MustCompile(`(?i)(apiVersion:|kind:|metadata:|name:|namespace:|image:|command:|args:|env:|resources:|limits:|requests:|ports:|securityContext:|readOnlyRootFilesystem|runAsNonRoot|seccompProfile|allowPrivilegeEscalation|capabilities|livenessProbe|readinessProbe|namePrefix:|commonLabels:|bases:|patches:|replicas:)`)
-	reDocker      = regexp.MustCompile(`(?i)^(?:\+|\-)\s*(FROM|ARG|ENV|RUN|ENTRYPOINT|CMD|COPY|ADD|USER|WORKDIR)\b`)
-	reMakeLine    = regexp.MustCompile(`(?i)^(?:\+|\-)\s*([A-Z0-9_]+)\s*[:?+]?=\s*|^(?:\+|\-)\s*(manifests|generate|fmt|vet|lint-fix|docker-build|test|install|uninstall|deploy|undeploy|build-installer|controller-gen|kustomize)\b`)
-	reKubebuilder = regexp.MustCompile(`(?i)^(?:\+|\-)\s*(\/\/\+kubebuilder:|kubebuilder\s+(init|create|edit)|controller-runtime|sigs\.k8s\.io|k8s\.io\/api|k8s\.io\/apimachinery)`)
-)
-
-// keepGoModLine returns true for +/- go.mod lines we want to retain.
-// Keep: module/go/toolchain, replace, require lines without "// indirect", and block delimiters.
-func keepGoModLine(s string) bool {
-	if len(s) == 0 || (s[0] != '+' && s[0] != '-') {
-		return false
-	}
-	t := strings.TrimSpace(s[1:]) // strip +/- then trim
-	switch {
-	case strings.HasPrefix(t, "module "):
-		return true
-	case strings.HasPrefix(t, "go "):
-		return true
-	case strings.HasPrefix(t, "toolchain "):
-		return true
-	case strings.HasPrefix(t, "replace "):
-		return true
-	case strings.HasPrefix(t, "require ") && !strings.Contains(t, "// indirect"):
-		return true
-	case t == "require (" || t == ")": // keep block delimiters for readability
-		return true
-	default:
-		return false
-	}
-}
-
-// Decide if a +/- line is interesting based on the file path.
-func interestingLine(path, line string) bool {
-	if len(line) == 0 || (line[0] != '+' && line[0] != '-') {
-		return false
-	}
-	switch {
-	case strings.HasSuffix(path, ".go"):
-		return reGo.MatchString(line) || reKubebuilder.MatchString(line)
-	case strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml"):
-		return reYAMLKey.MatchString(line) || reFlags.MatchString(line) || reKubebuilder.MatchString(line)
-	case path == "Makefile":
-		return reMakeLine.MatchString(line) || reKubebuilder.MatchString(line)
-	case path == "Dockerfile":
-		return reDocker.MatchString(line)
-	case strings.HasSuffix(path, "kustomization.yaml"):
-		// Kustomization files are critical for Kubebuilder config
-		return true
-	default:
-		// Unknown text files: keep Kubebuilder-related lines and obvious flag changes
-		return reFlags.MatchString(line) || reKubebuilder.MatchString(line)
-	}
-}
-
-// Curated unified=0 diff: keep hunk headers + filtered +/- lines.
-// For go.mod keep only direct requires and key headers (still capped).
-func selectedDiff(base, head, path string, maxLines int) string {
-	cmd := exec.Command("git", "diff", "--no-color", "-w", "--unified=0", base+".."+head, "--", path)
-	out, _ := cmd.Output()
-	if len(out) == 0 {
-		return ""
-	}
-
-	sc := bufio.NewScanner(bytes.NewReader(out))
-	lines := 0
-	var b strings.Builder
-
-	if path == "go.mod" {
-		for sc.Scan() {
-			s := sc.Text()
-			if strings.HasPrefix(s, "@@") {
-				b.WriteString(s + "\n")
-				continue
-			}
-			if keepGoModLine(s) {
-				b.WriteString(s + "\n")
-				lines++
-				if lines >= maxLines {
-					break
-				}
-			}
-		}
-		return strings.TrimSpace(b.String())
-	}
-
-	for sc.Scan() {
-		s := sc.Text()
-		if strings.HasPrefix(s, "@@") {
-			b.WriteString(s + "\n")
-			continue
-		}
-		if len(s) == 0 || (s[0] != '+' && s[0] != '-') {
-			continue
-		}
-		if interestingLine(path, s) {
-			b.WriteString(s + "\n")
-			lines++
-			if lines >= maxLines {
-				break
-			}
-		}
-	}
-	return strings.TrimSpace(b.String())
-}
-
-func concatSelectedDiffs(base, head string, files []string, perFileLineCap, totalByteCap int) string {
-	var b strings.Builder
-
-	// Global budget: prefer the passed-in cap if >0, else default.
-	remaining := totalByteCap
-	if remaining <= 0 {
-		remaining = selectedDiffTotalCap
-	}
-
-	// Filter and prioritize candidates
-	candidates := make([]string, 0, len(files))
-	for _, p := range files {
-		if importantFile(p) {
-			candidates = append(candidates, p)
-		}
-	}
-	slices.SortStableFunc(candidates, func(a, b string) int {
-		pi, pj := filePriority(a), filePriority(b)
-		if pi != pj {
-			return pi - pj
-		}
-		return strings.Compare(a, b) // stable alphabetical within same priority
-	})
-
-	// Emit diffs until the global budget is hit
-	for _, p := range candidates {
-		// Per-file line budget: use param if >0, else default; ensure go.mod gets at least its larger cap.
-		perCap := perFileLineCap
-		if perCap <= 0 {
-			perCap = selectedDiffLinesPerFile
-		}
-		if p == "go.mod" && perCap < selectedDiffLinesGoMod {
-			perCap = selectedDiffLinesGoMod
-		}
-
-		diff := selectedDiff(base, head, p, perCap)
-		if diff == "" {
-			continue
-		}
-
-		section := "----- BEGIN SELECTED DIFF " + p + " -----\n" + diff + "\n----- END SELECTED DIFF " + p + " -----\n\n"
-		if len(section) > remaining {
-			if remaining <= 0 {
-				b.WriteString("\n... [global diff budget reached] ...\n")
-				break
-			}
-			// Trim last section to fit remaining budget
-			cut := min(remaining, len(section))
-			b.WriteString(section[:cut])
-			b.WriteString("\n... [global diff budget reached] ...\n")
-			break
-		}
-
-		b.WriteString(section)
-		remaining -= len(section)
-	}
-
-	out := strings.TrimSpace(b.String())
-	if out == "" {
-		return "<no selected diffs produced>"
-	}
-	return out
 }

--- a/internal/cli/alpha/internal/update/helpers/open_gh_issue_test.go
+++ b/internal/cli/alpha/internal/update/helpers/open_gh_issue_test.go
@@ -22,46 +22,6 @@ import (
 )
 
 var _ = Describe("Open GitHub Issue Helpers", func() {
-	Describe("excludedFromDiff", func() {
-		It("should exclude unimportant files", func() {
-			Expect(excludedFromDiff("PROJECT")).To(BeTrue())
-			Expect(excludedFromDiff("README.md")).To(BeTrue())
-			Expect(excludedFromDiff("hack/boilerplate.go.txt")).To(BeTrue())
-			Expect(excludedFromDiff("go.sum")).To(BeTrue())
-		})
-
-		It("should include important files", func() {
-			Expect(excludedFromDiff("go.mod")).To(BeFalse())
-			Expect(excludedFromDiff("Makefile")).To(BeFalse())
-			Expect(excludedFromDiff("Dockerfile")).To(BeFalse())
-		})
-	})
-
-	Describe("importantFile", func() {
-		It("should identify important core files", func() {
-			Expect(importantFile("go.mod")).To(BeTrue())
-			Expect(importantFile("Makefile")).To(BeTrue())
-			Expect(importantFile("cmd/main.go")).To(BeTrue())
-			Expect(importantFile("api/v1/captain_types.go")).To(BeTrue())
-		})
-
-		It("should exclude generated and unimportant files", func() {
-			Expect(importantFile("PROJECT")).To(BeFalse())
-			Expect(importantFile("hack/boilerplate.go.txt")).To(BeFalse())
-			Expect(importantFile("config/crd/bases/captain.yaml")).To(BeFalse())
-		})
-	})
-
-	Describe("filePriority", func() {
-		It("should prioritize files correctly", func() {
-			Expect(filePriority("go.mod")).To(Equal(0))
-			Expect(filePriority("Makefile")).To(Equal(1))
-			Expect(filePriority("Dockerfile")).To(Equal(2))
-			Expect(filePriority("cmd/main.go")).To(Equal(3))
-			Expect(filePriority("config/default/kustomization.yaml")).To(Equal(4))
-		})
-	})
-
 	Describe("FirstURL", func() {
 		It("should extract URLs from text", func() {
 			Expect(FirstURL("https://github.com/user/repo")).To(Equal("https://github.com/user/repo"))
@@ -74,43 +34,6 @@ var _ = Describe("Open GitHub Issue Helpers", func() {
 		It("should extract issue numbers", func() {
 			Expect(IssueNumberFromURL("https://github.com/user/repo/issues/123")).To(Equal("123"))
 			Expect(IssueNumberFromURL("https://github.com/user/repo/pull/456")).To(Equal("456"))
-		})
-	})
-
-	Describe("bulletList", func() {
-		It("should format bullet lists", func() {
-			Expect(bulletList([]string{})).To(Equal("<none>"))
-			Expect(bulletList([]string{"item1"})).To(Equal("- item1"))
-			Expect(bulletList([]string{"item1", "item2"})).To(Equal("- item1\n- item2"))
-		})
-	})
-
-	Describe("keepGoModLine", func() {
-		It("should keep important go.mod lines", func() {
-			Expect(keepGoModLine("+module github.com/user/repo")).To(BeTrue())
-			Expect(keepGoModLine("+go 1.21")).To(BeTrue())
-			Expect(keepGoModLine("+require example.com/pkg v1.0.0")).To(BeTrue())
-		})
-
-		It("should skip indirect dependencies", func() {
-			Expect(keepGoModLine("+require example.com/pkg v1.0.0 // indirect")).To(BeFalse())
-		})
-	})
-
-	Describe("interestingLine", func() {
-		It("should detect interesting Go lines", func() {
-			Expect(interestingLine("main.go", "+import \"context\"")).To(BeTrue())
-			Expect(interestingLine("controller.go", "+//+kubebuilder:rbac:groups=apps")).To(BeTrue())
-		})
-
-		It("should detect interesting YAML lines", func() {
-			Expect(interestingLine("manager.yaml", "+apiVersion: apps/v1")).To(BeTrue())
-			Expect(interestingLine("config.yaml", "+image: controller:latest")).To(BeTrue())
-		})
-
-		It("should skip uninteresting lines", func() {
-			Expect(interestingLine("main.go", "+x := 1")).To(BeFalse())
-			Expect(interestingLine("config.yaml", "+# comment")).To(BeFalse())
 		})
 	})
 })

--- a/internal/cli/alpha/internal/update/integration_test.go
+++ b/internal/cli/alpha/internal/update/integration_test.go
@@ -416,7 +416,7 @@ var _ = Describe("kubebuilder", func() {
 				To(Succeed(), "failed to set custom registry in dist/chart/values.yaml")
 
 			By("editing project with Auto Update plugin")
-			cmd = exec.Command(kb, "edit", "--plugins=autoupdate.kubebuilder.io/v1-alpha", "--use-gh-models")
+			cmd = exec.Command(kb, "edit", "--plugins=autoupdate.kubebuilder.io/v1-alpha")
 			cmd.Dir = dir
 			output, err = cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("edit autoupdate failed: %s", output))

--- a/internal/cli/alpha/internal/update/update.go
+++ b/internal/cli/alpha/internal/update/update.go
@@ -18,7 +18,6 @@ package update
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -92,8 +91,6 @@ type Update struct {
 	// CLI (`gh`) to be installed and authenticated in the local environment.
 	OpenGhIssue bool
 
-	UseGhModels bool
-
 	// GitConfig holds per-invocation Git settings applied to every `git` command via
 	// `git -c key=value`.
 	//
@@ -128,12 +125,6 @@ type Update struct {
 // Update a project using a default three-way Git merge.
 // This helps apply new scaffolding changes while preserving custom code.
 func (opts *Update) Update() error {
-	// Inform users about GitHub Models if they're opening an issue but not using AI summary
-	if opts.OpenGhIssue && !opts.UseGhModels {
-		log.Info("Consider enabling GitHub Models to get an AI summary to help with the update")
-		log.Info("Use the --use-gh-models flag if your project/organization has permission to use GitHub Models")
-	}
-
 	log.Info("Checking out base branch", "branch", opts.FromBranch)
 	checkoutCmd := helpers.GitCmd(opts.GitConfig, "checkout", opts.FromBranch)
 	if err := checkoutCmd.Run(); err != nil {
@@ -293,56 +284,6 @@ func (opts *Update) openGitHubIssue(hasConflicts bool) error {
 	}
 	log.Info("GitHub Issue created to track the update", "url", issueURL, "compare", createPRURL)
 
-	if opts.UseGhModels {
-		log.Info("Generating AI summary with gh models")
-
-		if issueURL == "" {
-			return fmt.Errorf("issue created but URL could not be determined")
-		}
-
-		releaseURL := fmt.Sprintf("https://github.com/kubernetes-sigs/kubebuilder/releases/tag/%s",
-			opts.ToVersion)
-
-		ctx := helpers.BuildFullPrompet(
-			opts.FromVersion, opts.ToVersion, opts.FromBranch, out,
-			createPRURL, releaseURL)
-
-		var outBuf, errBuf bytes.Buffer
-		cmd := exec.Command(
-			"gh", "models", "run", "openai/gpt-5",
-			"--system-prompt", helpers.AiPRPrompt,
-		)
-		cmd.Stdin = strings.NewReader(ctx)
-		cmd.Stdout = &outBuf
-		cmd.Stderr = &errBuf
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("gh models run failed: %w\nstderr:\n%s", err, errBuf.String())
-		}
-
-		summary := strings.TrimSpace(outBuf.String())
-		if summary != "" {
-			num := helpers.IssueNumberFromURL(issueURL)
-			target := issueURL
-			args := make([]string, 4, 7)
-			args[0] = "issue"
-			args[1] = "comment"
-			args[2] = "--repo"
-			args[3] = repo
-			if num != "" {
-				target = num
-			}
-			args = append(args, target, "--body", summary)
-			commentCmd := exec.Command("gh", args...)
-			commentCmd.Stdout = os.Stdout
-			commentCmd.Stderr = os.Stderr
-			if err := commentCmd.Run(); err != nil {
-				return fmt.Errorf("failed to add AI summary comment: %s", err)
-			}
-			log.Info("AI summary comment added to the issue")
-		} else {
-			log.Warn("AI summary was empty, no comment added")
-		}
-	}
 	return nil
 }
 

--- a/internal/cli/alpha/internal/update/validate.go
+++ b/internal/cli/alpha/internal/update/validate.go
@@ -57,21 +57,7 @@ func (opts *Update) Validate() error {
 		}
 	}
 
-	if opts.UseGhModels && !isGhModelsExtensionInstalled() {
-		return fmt.Errorf("gh-models extension is not installed. To install the extension, run: " +
-			"gh extension install https://github.com/github/gh-models")
-	}
-
 	return nil
-}
-
-// isGhModelsExtensionInstalled checks if the gh-models extension is installed
-func isGhModelsExtensionInstalled() bool {
-	cmd := exec.Command("gh", "extension", "list")
-	if _, err := cmd.Output(); err != nil {
-		return false
-	}
-	return true
 }
 
 // validateGitRepo verifies if the current directory is a valid Git repository and checks for uncommitted changes.

--- a/internal/cli/alpha/update.go
+++ b/internal/cli/alpha/update.go
@@ -89,8 +89,8 @@ Defaults:
     --merge-message "chore: upgrade kubebuilder scaffold" \
     --conflict-message "chore: upgrade with conflicts - manual review needed"
 
-  # Create an issue and add an AI overview comment
-  kubebuilder alpha update --open-gh-issue --use-gh-models
+  # Create an issue to track the update
+  kubebuilder alpha update --open-gh-issue
 
   # Add extra Git configs (no need to re-specify defaults)
   kubebuilder alpha update --git-config merge.conflictStyle=diff3 --git-config rerere.enabled=true
@@ -100,10 +100,6 @@ Defaults:
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if opts.ShowCommits && len(opts.RestorePath) > 0 {
 				return fmt.Errorf("the --restore-path flag is not supported with --show-commits")
-			}
-
-			if opts.UseGhModels && !opts.OpenGhIssue {
-				return fmt.Errorf("the --use-gh-models requires --open-gh-issue to be set")
 			}
 
 			// Defaults always on unless "disable" is present anywhere
@@ -174,12 +170,6 @@ Defaults:
 	updateCmd.Flags().BoolVar(&opts.OpenGhIssue, "open-gh-issue", false,
 		"If set, create a GitHub issue with a pre-filled checklist and compare link after the update "+
 			"completes (requires `gh`)")
-	updateCmd.Flags().BoolVar(
-		&opts.UseGhModels,
-		"use-gh-models",
-		false,
-		"If set, generate and post an AI summary comment to the GitHub Issue using `gh models run` "+
-			"(requires --open-gh-issue and GitHub CLI with the `gh-models` extension)")
 	updateCmd.Flags().StringArrayVar(
 		&gitCfg,
 		"git-config",

--- a/pkg/plugins/optional/autoupdate/v1alpha/edit.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/edit.go
@@ -18,7 +18,6 @@ package v1alpha
 
 import (
 	"fmt"
-	log "log/slog"
 
 	"github.com/spf13/pflag"
 
@@ -31,8 +30,7 @@ import (
 var _ plugin.EditSubcommand = &editSubcommand{}
 
 type editSubcommand struct {
-	config      config.Config
-	useGHModels bool
+	config config.Config
 }
 
 func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
@@ -40,16 +38,10 @@ func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *
 
 	subcmdMeta.Examples = fmt.Sprintf(`  # Edit a common project with this plugin
   %[1]s edit --plugins=%[2]s
-
-  # Edit a common project with GitHub Models enabled (requires repo permissions)
-  %[1]s edit --plugins=%[2]s --use-gh-models
 `, cliMeta.CommandName, plugin.KeyFor(Plugin{}))
 }
 
-func (p *editSubcommand) BindFlags(fs *pflag.FlagSet) {
-	fs.BoolVar(&p.useGHModels, "use-gh-models", false,
-		"If set, enable GitHub Models AI summary in the scaffolded workflow (requires GitHub Models permissions)")
-}
+func (p *editSubcommand) BindFlags(_ *pflag.FlagSet) {}
 
 func (p *editSubcommand) InjectConfig(c config.Config) error {
 	p.config = c
@@ -68,24 +60,15 @@ func (p *editSubcommand) PreScaffold(machinery.Filesystem) error {
 }
 
 func (p *editSubcommand) Scaffold(fs machinery.Filesystem) error {
-	if err := insertPluginMetaToConfig(p.config, PluginConfig{UseGHModels: p.useGHModels}); err != nil {
+	if err := insertPluginMetaToConfig(p.config, PluginConfig{}); err != nil {
 		return fmt.Errorf("error inserting project plugin meta to configuration: %w", err)
 	}
 
-	scaffolder := scaffolds.NewInitScaffolder(p.useGHModels)
+	scaffolder := scaffolds.NewInitScaffolder()
 	scaffolder.InjectFS(fs)
 	if err := scaffolder.Scaffold(); err != nil {
 		return fmt.Errorf("error scaffolding edit subcommand: %w", err)
 	}
 
-	return nil
-}
-
-func (p *editSubcommand) PostScaffold() error {
-	// Inform users about GitHub Models if they didn't enable it
-	if !p.useGHModels {
-		log.Info("Consider enabling GitHub Models to get an AI summary to help with the update")
-		log.Info("Use the --use-gh-models flag if your project/organization has permission to use GitHub Models")
-	}
 	return nil
 }

--- a/pkg/plugins/optional/autoupdate/v1alpha/plugin.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/plugin.go
@@ -39,16 +39,7 @@ Under the hood, the workflow runs 'kubebuilder alpha update' using a **3-way mer
 3) **Permissions required** (via the built-in 'GITHUB_TOKEN'):
    - **contents: write** — needed to create and push the update branch.
    - **issues: write** — needed to create the tracking Issue with the PR link.
-   - **models: read** (optional) — only required if using --use-gh-models flag for AI-generated summaries.
-4) **Protect your branches**: Enable **branch protection rules** so automated changes **cannot** be pushed directly. All updates must go through a Pull Request for review.
-
-### Optional: GitHub Models AI Summary
-
-By default, the workflow does NOT use GitHub Models. To enable AI-generated summaries in GitHub issues:
-  - Ensure your repository/organization has permissions to use GitHub Models.
-  - Re-run: kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models
-
-Without this flag, the workflow will still work but won't include AI summaries (avoiding 403 Forbidden errors).`
+4) **Protect your branches**: Enable **branch protection rules** so automated changes **cannot** be pushed directly. All updates must go through a Pull Request for review.`
 
 const pluginName = "autoupdate." + plugins.DefaultNameQualifier
 
@@ -65,9 +56,7 @@ type Plugin struct {
 var _ plugin.Edit = Plugin{}
 
 // PluginConfig defines the structure that will be used to track the data
-type PluginConfig struct {
-	UseGHModels bool `json:"useGHModels,omitempty"`
-}
+type PluginConfig struct{}
 
 // Name returns the name of the plugin
 func (Plugin) Name() string { return pluginName }

--- a/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/edit.go
@@ -33,16 +33,11 @@ type editScaffolder struct {
 
 	// fs is the filesystem that will be used by the scaffolder
 	fs machinery.Filesystem
-
-	// useGHModels determines if GitHub Models AI summary should be enabled
-	useGHModels bool
 }
 
 // NewInitScaffolder returns a new Scaffolder for project initialization operations
-func NewInitScaffolder(useGHModels bool) plugins.Scaffolder {
-	return &editScaffolder{
-		useGHModels: useGHModels,
-	}
+func NewInitScaffolder() plugins.Scaffolder {
+	return &editScaffolder{}
 }
 
 // InjectFS implements cmdutil.Scaffolder
@@ -59,7 +54,7 @@ func (s *editScaffolder) Scaffold() error {
 	)
 
 	err := scaffold.Execute(
-		&github.AutoUpdate{UseGHModels: s.useGHModels},
+		&github.AutoUpdate{},
 	)
 	if err != nil {
 		return fmt.Errorf("failed to execute init scaffold: %w", err)

--- a/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github/auto_update.go
+++ b/pkg/plugins/optional/autoupdate/v1alpha/scaffolds/internal/github/auto_update.go
@@ -28,9 +28,6 @@ var _ machinery.Template = &AutoUpdate{}
 type AutoUpdate struct {
 	machinery.TemplateMixin
 	machinery.BoilerplateMixin
-
-	// UseGHModels indicates whether to enable GitHub Models AI summary
-	UseGHModels bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -50,7 +47,7 @@ const autoUpdateTemplate = `name: Auto Update
 # The 'kubebuilder alpha update' command requires write access to the repository to create a branch
 # with the update files and allow you to open a pull request using the link provided in the issue.
 # The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
-# To protect your codebase, please ensure that you have branch protection rules configured for your 
+# To protect your codebase, please ensure that you have branch protection rules configured for your
 # main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
 permissions: {}
 
@@ -63,8 +60,7 @@ jobs:
   auto-update:
     permissions:
       contents: write  # Create and push the update branch
-      issues: write    # Create GitHub Issue with PR link{{ if .UseGHModels }}
-      models: read     # Use GitHub Models for AI summaries{{ end }}
+      issues: write    # Create GitHub Issue with PR link
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
@@ -97,13 +93,7 @@ jobs:
         chmod +x kubebuilder
         sudo mv kubebuilder /usr/local/bin/
         kubebuilder version
-{{ if .UseGHModels }}
-    # Install Models extension for GitHub CLI.
-    - name: Install gh-models extension
-      run: |
-        gh extension install github/gh-models --force
-        gh models --help >/dev/null
-{{ end }}
+
     # Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
@@ -111,19 +101,11 @@ jobs:
       # --force: Completes the merge even if conflicts occur, leaving conflict markers.
       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
-      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.{{ if .UseGHModels }}
-      # --use-gh-models: Adds an AI-generated comment to the created Issue with
-      #   a short overview of the scaffold changes and conflict-resolution guidance (if any).{{ else }}
-      #
-      # WARNING: This workflow does not use GitHub Models AI summary by default.
-      # To enable AI-generated summaries in GitHub issues, you need permissions to use GitHub Models.
-      # If you have the required permissions, re-run:
-      #   kubebuilder edit --plugins="autoupdate/v1-alpha" --use-gh-models{{ end }}
+      # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
       run: |
         kubebuilder alpha update \
           --force \
           --push \
           --restore-path .github/workflows \
-          --open-gh-issue{{ if .UseGHModels }} \
-          --use-gh-models{{ end }}
+          --open-gh-issue
 `

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -134,7 +134,7 @@ function scaffold_test_project {
     $kb edit --plugins=helm.kubebuilder.io/v2-alpha
 
     header_text 'Editing project with Auto Update plugin ...'
-    $kb edit --plugins=autoupdate.kubebuilder.io/v1-alpha --use-gh-models
+    $kb edit --plugins=autoupdate.kubebuilder.io/v1-alpha
   fi
 
   # To avoid conflicts

--- a/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/auto_update.yml
@@ -3,7 +3,7 @@ name: Auto Update
 # The 'kubebuilder alpha update' command requires write access to the repository to create a branch
 # with the update files and allow you to open a pull request using the link provided in the issue.
 # The branch created will be named in the format kubebuilder-update-from-<from-version>-to-<to-version> by default.
-# To protect your codebase, please ensure that you have branch protection rules configured for your 
+# To protect your codebase, please ensure that you have branch protection rules configured for your
 # main branches. This will guarantee that no one can bypass a review and push directly to a branch like 'main'.
 permissions: {}
 
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: write  # Create and push the update branch
       issues: write    # Create GitHub Issue with PR link
-      models: read     # Use GitHub Models for AI summaries
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,12 +50,6 @@ jobs:
         sudo mv kubebuilder /usr/local/bin/
         kubebuilder version
 
-    # Install Models extension for GitHub CLI.
-    - name: Install gh-models extension
-      run: |
-        gh extension install github/gh-models --force
-        gh models --help >/dev/null
-
     # Run the Kubebuilder alpha update command.
     # More info: https://kubebuilder.io/reference/commands/alpha_update
     - name: Run kubebuilder alpha update
@@ -65,12 +58,9 @@ jobs:
       # --push: Automatically pushes the resulting output branch to the 'origin' remote.
       # --restore-path: Preserves specified paths (e.g., CI workflow files) when squashing.
       # --open-gh-issue: Creates a GitHub Issue with a link for opening a PR for review.
-      # --use-gh-models: Adds an AI-generated comment to the created Issue with
-      #   a short overview of the scaffold changes and conflict-resolution guidance (if any).
       run: |
         kubebuilder alpha update \
           --force \
           --push \
           --restore-path .github/workflows \
-          --open-gh-issue \
-          --use-gh-models
+          --open-gh-issue

--- a/testdata/project-v4-with-plugins/PROJECT
+++ b/testdata/project-v4-with-plugins/PROJECT
@@ -8,8 +8,7 @@ layout:
 - go.kubebuilder.io/v4
 namespaced: true
 plugins:
-  autoupdate.kubebuilder.io/v1-alpha:
-    useGHModels: true
+  autoupdate.kubebuilder.io/v1-alpha: {}
   deploy-image.go.kubebuilder.io/v1-alpha:
     resources:
     - domain: testproject.org


### PR DESCRIPTION
## Summary

Remove GitHub Models integration from Kubebuilder and its auto-update tooling, as the service is no longer available to new customers: https://github.blog/changelog/2026-06-16-github-models-is-no-longer-available-to-new-customers/

### Breaking Change

Users of the auto-update plugin should re-run updates with `--force`

```
kubebuilder edit --plugins="autoupdate/v1-alpha" --force
```

Closes #5776