### PR TITLE
📖 fix(docs): correct CronJob tutorial job pruning order

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -396,16 +396,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(failedJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range failedJobs {
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
@@ -423,16 +427,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(successfulJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range successfulJobs {
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -53,7 +53,11 @@ create the CronJob.
 var _ = Describe("CronJob controller", func() {
 	Context("CronJob controller test", func() {
 
-		const CronjobName = "test-cronjob"
+		const (
+			CronjobName        = "test-cronjob"
+			testContainerName  = "test-container"
+			testContainerImage = "test-image"
+		)
 
 		ctx := context.Background()
 
@@ -102,8 +106,8 @@ var _ = Describe("CronJob controller", func() {
 									Spec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
-												Name:  "test-container",
-												Image: "test-image",
+												Name:  testContainerName,
+												Image: testContainerImage,
 											},
 										},
 										RestartPolicy: v1.RestartPolicyOnFailure,
@@ -192,8 +196,8 @@ var _ = Describe("CronJob controller", func() {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Name:  "test-container",
-									Image: "test-image",
+									Name:  testContainerName,
+									Image: testContainerImage,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,
@@ -243,6 +247,94 @@ var _ = Describe("CronJob controller", func() {
 			Expect(conditions).To(HaveLen(1), "should have one Available condition")
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "Available should be True")
 			Expect(conditions[0].Reason).To(Equal("JobsActive"), "reason should be JobsActive")
+
+			/*
+				Next, verify that the controller prunes old finished Jobs according to
+				the history limits.
+			*/
+			By("Checking that old finished Jobs are pruned by history limits")
+			failedJobsHistoryLimit := int32(1)
+			successfulJobsHistoryLimit := int32(1)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, cronJob)).To(Succeed())
+				cronJob.Spec.FailedJobsHistoryLimit = &failedJobsHistoryLimit
+				cronJob.Spec.SuccessfulJobsHistoryLimit = &successfulJobsHistoryLimit
+				g.Expect(k8sClient.Update(ctx, cronJob)).To(Succeed())
+			}).Should(Succeed())
+
+			createFinishedJob := func(name string, conditionType batchv1.JobConditionType, startTime *metav1.Time) *batchv1.Job {
+				finishedJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace.Name,
+					},
+					Spec: batchv1.JobSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  testContainerName,
+										Image: testContainerImage,
+									},
+								},
+								RestartPolicy: v1.RestartPolicyOnFailure,
+							},
+						},
+					},
+				}
+				finishedJob.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
+				Expect(k8sClient.Create(ctx, finishedJob)).To(Succeed())
+
+				finishedJob.Status.StartTime = startTime
+				finishedJob.Status.Conditions = []batchv1.JobCondition{{
+					Type:   conditionType,
+					Status: v1.ConditionTrue,
+				}}
+				if conditionType == batchv1.JobFailed {
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobFailureTarget,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				if conditionType == batchv1.JobComplete {
+					finishedJob.Status.CompletionTime = startTime
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobSuccessCriteriaMet,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				Expect(k8sClient.Status().Update(ctx, finishedJob)).To(Succeed())
+
+				return finishedJob
+			}
+
+			baseTime := time.Now()
+			failedOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			failedNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+			successfulOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			successfulNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+
+			failedOldJob := createFinishedJob("test-failed-job-old", batchv1.JobFailed, &failedOldStartTime)
+			failedNewJob := createFinishedJob("test-failed-job-new", batchv1.JobFailed, &failedNewStartTime)
+			successfulOldJob := createFinishedJob("test-successful-job-old", batchv1.JobComplete, &successfulOldStartTime)
+			successfulNewJob := createFinishedJob("test-successful-job-new", batchv1.JobComplete, &successfulNewStartTime)
+
+			assertJobDeleted := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}
+			assertJobExists := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)).To(Succeed())
+			}
+
+			Eventually(func(g Gomega) {
+				assertJobDeleted(g, failedOldJob)
+				assertJobDeleted(g, successfulOldJob)
+				assertJobExists(g, failedNewJob)
+				assertJobExists(g, successfulNewJob)
+			}).Should(Succeed())
 		})
 	})
 })

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go
@@ -396,16 +396,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(failedJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range failedJobs {
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
@@ -423,16 +427,20 @@ func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		slices.SortStableFunc(successfulJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range successfulJobs {
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	cronjobv1 "tutorial.kubebuilder.io/project/api/v1"
 )
@@ -376,6 +375,132 @@ var _ = Describe("CronJob controller", func() {
 			Expect(k8sClient.Delete(ctx, cronJob)).To(Succeed())
 		})
 
+		It("should prune old finished jobs by history limits", func() {
+			cronJobName := fmt.Sprintf("test-cronjob-prune-%d", GinkgoRandomSeed())
+			typeNamespacedName := types.NamespacedName{
+				Name:      cronJobName,
+				Namespace: NamespaceName,
+			}
+			failedJobsHistoryLimit := int32(1)
+			successfulJobsHistoryLimit := int32(1)
+
+			cronJob := &cronjobv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cronJobName,
+					Namespace: NamespaceName,
+				},
+				Spec: cronjobv1.CronJobSpec{
+					Schedule:                   testSchedule,
+					FailedJobsHistoryLimit:     &failedJobsHistoryLimit,
+					SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  testContainerName,
+											Image: testContainerImage,
+										},
+									},
+									RestartPolicy: v1.RestartPolicyOnFailure,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, cronJob)).To(Succeed())
+
+			kind := reflect.TypeFor[cronjobv1.CronJob]().Name()
+			gvk := cronjobv1.GroupVersion.WithKind(kind)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, cronJob)).To(Succeed())
+			}).Should(Succeed())
+
+			controllerRef := metav1.NewControllerRef(cronJob, gvk)
+			createFinishedJob := func(name string, conditionType batchv1.JobConditionType, startTime *metav1.Time) *batchv1.Job {
+				finishedJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: NamespaceName,
+					},
+					Spec: batchv1.JobSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  testContainerName,
+										Image: testContainerImage,
+									},
+								},
+								RestartPolicy: v1.RestartPolicyOnFailure,
+							},
+						},
+					},
+				}
+				finishedJob.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
+				Expect(k8sClient.Create(ctx, finishedJob)).To(Succeed())
+
+				finishedJob.Status.StartTime = startTime
+				finishedJob.Status.Conditions = []batchv1.JobCondition{{
+					Type:   conditionType,
+					Status: v1.ConditionTrue,
+				}}
+				if conditionType == batchv1.JobFailed {
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobFailureTarget,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				if conditionType == batchv1.JobComplete {
+					finishedJob.Status.CompletionTime = startTime
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobSuccessCriteriaMet,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				Expect(k8sClient.Status().Update(ctx, finishedJob)).To(Succeed())
+
+				return finishedJob
+			}
+
+			baseTime := time.Now()
+			failedOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			failedNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+			successfulOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			successfulNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+
+			failedOldJob := createFinishedJob(fmt.Sprintf("%s-failed-old", cronJobName), batchv1.JobFailed, &failedOldStartTime)
+			failedNewJob := createFinishedJob(fmt.Sprintf("%s-failed-new", cronJobName), batchv1.JobFailed, &failedNewStartTime)
+			successfulOldJob := createFinishedJob(fmt.Sprintf("%s-successful-old", cronJobName), batchv1.JobComplete, &successfulOldStartTime)
+			successfulNewJob := createFinishedJob(fmt.Sprintf("%s-successful-new", cronJobName), batchv1.JobComplete, &successfulNewStartTime)
+
+			assertJobDeleted := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}
+			assertJobExists := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)).To(Succeed())
+			}
+
+			By("Checking that old finished Jobs are pruned")
+			Eventually(func(g Gomega) {
+				assertJobDeleted(g, failedOldJob)
+				assertJobDeleted(g, successfulOldJob)
+				assertJobExists(g, failedNewJob)
+				assertJobExists(g, successfulNewJob)
+			}).Should(Succeed())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, failedNewJob)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, successfulNewJob)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cronJob)).To(Succeed())
+		})
+
 		It("should set Available=False when CronJob is suspended", func() {
 			cronJobName := fmt.Sprintf("test-cronjob-%d", GinkgoRandomSeed())
 			typeNamespacedName := types.NamespacedName{
@@ -413,7 +538,7 @@ var _ = Describe("CronJob controller", func() {
 			By("Updating the CronJob to suspend it")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, typeNamespacedName, cronJob)).To(Succeed())
-				cronJob.Spec.Suspend = ptr.To(true)
+				cronJob.Spec.Suspend = new(true)
 				g.Expect(k8sClient.Update(ctx, cronJob)).To(Succeed())
 			}).Should(Succeed())
 

--- a/hack/docs/internal/cronjob-tutorial/controller_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/controller_implementation.go
@@ -385,16 +385,20 @@ const controllerReconcileLogic = `log := logf.FromContext(ctx)
 		slices.SortStableFunc(failedJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range failedJobs {
 			if int32(i) >= int32(len(failedJobs))-*cronJob.Spec.FailedJobsHistoryLimit {
@@ -412,16 +416,20 @@ const controllerReconcileLogic = `log := logf.FromContext(ctx)
 		slices.SortStableFunc(successfulJobs, func(a, b *kbatch.Job) int {
 			aStartTime := a.Status.StartTime
 			bStartTime := b.Status.StartTime
-			if aStartTime == nil && bStartTime != nil {
-				return 1
-			}
-
-			if aStartTime.Before(bStartTime) {
+			switch {
+			case aStartTime == nil && bStartTime == nil:
+				return 0
+			case aStartTime == nil:
 				return -1
-			} else if bStartTime.Before(aStartTime) {
+			case bStartTime == nil:
 				return 1
+			case aStartTime.Before(bStartTime):
+				return -1
+			case bStartTime.Before(aStartTime):
+				return 1
+			default:
+				return 0
 			}
-			return 0
 		})
 		for i, job := range successfulJobs {
 			if int32(i) >= int32(len(successfulJobs))-*cronJob.Spec.SuccessfulJobsHistoryLimit {

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_controller.go
@@ -71,7 +71,11 @@ create the CronJob.
 var _ = Describe("CronJob controller", func() {
 	Context("CronJob controller test", func() {
 
-		const CronjobName = "test-cronjob"
+		const (
+			CronjobName        = "test-cronjob"
+			testContainerName  = "test-container"
+			testContainerImage = "test-image"
+		)
 
 		ctx := context.Background()
 
@@ -120,8 +124,8 @@ var _ = Describe("CronJob controller", func() {
 									Spec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
-												Name:  "test-container",
-												Image: "test-image",
+												Name:  testContainerName,
+												Image: testContainerImage,
 											},
 										},
 										RestartPolicy: v1.RestartPolicyOnFailure,
@@ -210,8 +214,8 @@ var _ = Describe("CronJob controller", func() {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Name:  "test-container",
-									Image: "test-image",
+									Name:  testContainerName,
+									Image: testContainerImage,
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,
@@ -261,6 +265,94 @@ var _ = Describe("CronJob controller", func() {
 			Expect(conditions).To(HaveLen(1), "should have one Available condition")
 			Expect(conditions[0].Status).To(Equal(metav1.ConditionTrue), "Available should be True")
 			Expect(conditions[0].Reason).To(Equal("JobsActive"), "reason should be JobsActive")
+
+			/*
+				Next, verify that the controller prunes old finished Jobs according to
+				the history limits.
+			*/
+			By("Checking that old finished Jobs are pruned by history limits")
+			failedJobsHistoryLimit := int32(1)
+			successfulJobsHistoryLimit := int32(1)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, cronJob)).To(Succeed())
+				cronJob.Spec.FailedJobsHistoryLimit = &failedJobsHistoryLimit
+				cronJob.Spec.SuccessfulJobsHistoryLimit = &successfulJobsHistoryLimit
+				g.Expect(k8sClient.Update(ctx, cronJob)).To(Succeed())
+			}).Should(Succeed())
+
+			createFinishedJob := func(name string, conditionType batchv1.JobConditionType, startTime *metav1.Time) *batchv1.Job {
+				finishedJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace.Name,
+					},
+					Spec: batchv1.JobSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  testContainerName,
+										Image: testContainerImage,
+									},
+								},
+								RestartPolicy: v1.RestartPolicyOnFailure,
+							},
+						},
+					},
+				}
+				finishedJob.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
+				Expect(k8sClient.Create(ctx, finishedJob)).To(Succeed())
+
+				finishedJob.Status.StartTime = startTime
+				finishedJob.Status.Conditions = []batchv1.JobCondition{{
+					Type:   conditionType,
+					Status: v1.ConditionTrue,
+				}}
+				if conditionType == batchv1.JobFailed {
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobFailureTarget,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				if conditionType == batchv1.JobComplete {
+					finishedJob.Status.CompletionTime = startTime
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobSuccessCriteriaMet,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				Expect(k8sClient.Status().Update(ctx, finishedJob)).To(Succeed())
+
+				return finishedJob
+			}
+
+			baseTime := time.Now()
+			failedOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			failedNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+			successfulOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			successfulNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+
+			failedOldJob := createFinishedJob("test-failed-job-old", batchv1.JobFailed, &failedOldStartTime)
+			failedNewJob := createFinishedJob("test-failed-job-new", batchv1.JobFailed, &failedNewStartTime)
+			successfulOldJob := createFinishedJob("test-successful-job-old", batchv1.JobComplete, &successfulOldStartTime)
+			successfulNewJob := createFinishedJob("test-successful-job-new", batchv1.JobComplete, &successfulNewStartTime)
+
+			assertJobDeleted := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}
+			assertJobExists := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)).To(Succeed())
+			}
+
+			Eventually(func(g Gomega) {
+				assertJobDeleted(g, failedOldJob)
+				assertJobDeleted(g, successfulOldJob)
+				assertJobExists(g, failedNewJob)
+				assertJobExists(g, successfulNewJob)
+			}).Should(Succeed())
 		})
 	})
 })

--- a/hack/docs/internal/multiversion-tutorial/controller_tests_code.go
+++ b/hack/docs/internal/multiversion-tutorial/controller_tests_code.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	cronjobv1 "tutorial.kubebuilder.io/project/api/v1"
 )
@@ -394,6 +393,132 @@ var _ = Describe("CronJob controller", func() {
 			Expect(k8sClient.Delete(ctx, cronJob)).To(Succeed())
 		})
 
+		It("should prune old finished jobs by history limits", func() {
+			cronJobName := fmt.Sprintf("test-cronjob-prune-%d", GinkgoRandomSeed())
+			typeNamespacedName := types.NamespacedName{
+				Name:      cronJobName,
+				Namespace: NamespaceName,
+			}
+			failedJobsHistoryLimit := int32(1)
+			successfulJobsHistoryLimit := int32(1)
+
+			cronJob := &cronjobv1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cronJobName,
+					Namespace: NamespaceName,
+				},
+				Spec: cronjobv1.CronJobSpec{
+					Schedule:                   testSchedule,
+					FailedJobsHistoryLimit:     &failedJobsHistoryLimit,
+					SuccessfulJobsHistoryLimit: &successfulJobsHistoryLimit,
+					JobTemplate: batchv1.JobTemplateSpec{
+						Spec: batchv1.JobSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{
+										{
+											Name:  testContainerName,
+											Image: testContainerImage,
+										},
+									},
+									RestartPolicy: v1.RestartPolicyOnFailure,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, cronJob)).To(Succeed())
+
+			kind := reflect.TypeFor[cronjobv1.CronJob]().Name()
+			gvk := cronjobv1.GroupVersion.WithKind(kind)
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, cronJob)).To(Succeed())
+			}).Should(Succeed())
+
+			controllerRef := metav1.NewControllerRef(cronJob, gvk)
+			createFinishedJob := func(name string, conditionType batchv1.JobConditionType, startTime *metav1.Time) *batchv1.Job {
+				finishedJob := &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: NamespaceName,
+					},
+					Spec: batchv1.JobSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  testContainerName,
+										Image: testContainerImage,
+									},
+								},
+								RestartPolicy: v1.RestartPolicyOnFailure,
+							},
+						},
+					},
+				}
+				finishedJob.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
+				Expect(k8sClient.Create(ctx, finishedJob)).To(Succeed())
+
+				finishedJob.Status.StartTime = startTime
+				finishedJob.Status.Conditions = []batchv1.JobCondition{{
+					Type:   conditionType,
+					Status: v1.ConditionTrue,
+				}}
+				if conditionType == batchv1.JobFailed {
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobFailureTarget,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				if conditionType == batchv1.JobComplete {
+					finishedJob.Status.CompletionTime = startTime
+					finishedJob.Status.Conditions = append([]batchv1.JobCondition{{
+						Type:   batchv1.JobSuccessCriteriaMet,
+						Status: v1.ConditionTrue,
+					}}, finishedJob.Status.Conditions...)
+				}
+				Expect(k8sClient.Status().Update(ctx, finishedJob)).To(Succeed())
+
+				return finishedJob
+			}
+
+			baseTime := time.Now()
+			failedOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			failedNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+			successfulOldStartTime := metav1.NewTime(baseTime.Add(-time.Minute))
+			successfulNewStartTime := metav1.NewTime(baseTime.Add(time.Second))
+
+			failedOldJob := createFinishedJob(fmt.Sprintf("%s-failed-old", cronJobName), batchv1.JobFailed, &failedOldStartTime)
+			failedNewJob := createFinishedJob(fmt.Sprintf("%s-failed-new", cronJobName), batchv1.JobFailed, &failedNewStartTime)
+			successfulOldJob := createFinishedJob(fmt.Sprintf("%s-successful-old", cronJobName), batchv1.JobComplete, &successfulOldStartTime)
+			successfulNewJob := createFinishedJob(fmt.Sprintf("%s-successful-new", cronJobName), batchv1.JobComplete, &successfulNewStartTime)
+
+			assertJobDeleted := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)
+				g.Expect(errors.IsNotFound(err)).To(BeTrue())
+			}
+			assertJobExists := func(g Gomega, job *batchv1.Job) {
+				found := &batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, found)).To(Succeed())
+			}
+
+			By("Checking that old finished Jobs are pruned")
+			Eventually(func(g Gomega) {
+				assertJobDeleted(g, failedOldJob)
+				assertJobDeleted(g, successfulOldJob)
+				assertJobExists(g, failedNewJob)
+				assertJobExists(g, successfulNewJob)
+			}).Should(Succeed())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, failedNewJob)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, successfulNewJob)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, cronJob)).To(Succeed())
+		})
+
 		It("should set Available=False when CronJob is suspended", func() {
 			cronJobName := fmt.Sprintf("test-cronjob-%d", GinkgoRandomSeed())
 			typeNamespacedName := types.NamespacedName{
@@ -431,7 +556,7 @@ var _ = Describe("CronJob controller", func() {
 			By("Updating the CronJob to suspend it")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, typeNamespacedName, cronJob)).To(Succeed())
-				cronJob.Spec.Suspend = ptr.To(true)
+				cronJob.Spec.Suspend = new(true)
 				g.Expect(k8sClient.Update(ctx, cronJob)).To(Succeed())
 			}).Should(Succeed())
 


### PR DESCRIPTION
Fixes #5740

This fixes the CronJob tutorial job sorting comparator used before pruning finished Jobs by history limits. It also adds envtest coverage for failed and successful Job pruning, while testing nil StartTime handling directly through the comparator helper.

---

The source changes are in:

- `hack/docs/internal/cronjob-tutorial/controller_implementation.go`
- `hack/docs/internal/cronjob-tutorial/writing_tests_controller.go`
- `hack/docs/internal/multiversion-tutorial/controller_tests_code.go`

The following files were regenerated with `make generate-docs`:

- `docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller.go`
- `docs/book/src/cronjob-tutorial/testdata/project/internal/controller/cronjob_controller_test.go`
- `docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller.go`
- `docs/book/src/multiversion-tutorial/testdata/project/internal/controller/cronjob_controller_test.go`
