### PR TITLE
🐛 fix(helm/v2-alpha):  now properly identify controller-manager Deployment with a manager container

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
@@ -37,9 +37,8 @@ type ChartScaffolderConfig struct {
 	Force         bool
 }
 
-// ChartScaffolder orchestrates the conversion of kustomize output to Helm charts.
-// It parses kustomize YAML, analyzes resources, categorizes by function, applies Helm templating,
-// and generates machinery.Builders. File writing is handled by machinery.Scaffold.Execute().
+// ChartScaffolder converts kustomize output to a Helm chart.
+// File writing is deferred to machinery.Scaffold.Execute(), not this type.
 type ChartScaffolder struct {
 	config ChartScaffolderConfig
 }
@@ -49,9 +48,8 @@ func NewChartScaffolder(config ChartScaffolderConfig) *ChartScaffolder {
 	return &ChartScaffolder{config: config}
 }
 
-// PrepareTemplates executes the conversion pipeline and returns Machinery builders ready for execution.
-// Parses kustomize YAML, analyzes resources to extract metadata and features, converts resources to
-// Helm templates, and prepares Machinery builders with the analyzed data.
+// PrepareTemplates parses kustomize YAML, converts resources to Helm templates, and returns
+// the resulting machinery.Builders ready for file generation.
 func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.Builder, error) {
 	parser := kustomize.NewParser(s.config.ManifestsFile)
 
@@ -60,6 +58,17 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 	resources, err := parser.Parse()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse kustomize output from %s: %w", s.config.ManifestsFile, err)
+	}
+
+	if resources.Deployment == nil {
+		if len(resources.ExtraDeployments) > 0 {
+			return nil, fmt.Errorf(
+				"unable to generate the chart: found %d Deployments but could not identify the controller-manager; "+
+					"add the label \"control-plane: controller-manager\" to the manager Deployment",
+				len(resources.ExtraDeployments),
+			)
+		}
+		return nil, fmt.Errorf("unable to generate the chart: no Deployment found in the kustomize output")
 	}
 
 	if len(resources.CustomResources) > 0 {
@@ -79,7 +88,7 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 	}
 
 	resourceExtractor := extractor.NewExtractor()
-	extraction := resourceExtractor.Extract(&extractor.ResourceSet{
+	extraction, err := resourceExtractor.Extract(&extractor.ResourceSet{
 		Namespace:                 resources.Namespace,
 		Deployment:                resources.Deployment,
 		Services:                  resources.Services,
@@ -96,6 +105,9 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 		NetworkPolicies:           resources.NetworkPolicies,
 		Other:                     resources.Other,
 	}, s.config.ProjectName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate the chart: %w", err)
+	}
 
 	chartConverter := kustomize.NewChartConverter(
 		resources,

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
@@ -28,6 +28,11 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
+const (
+	testProjectName = "test-project"
+	testOutputDir   = "dist"
+)
+
 var _ = Describe("ChartScaffolder", func() {
 	Describe("PrepareTemplates", func() {
 		It("should add the generic metrics NetworkPolicy when it is missing", func() {
@@ -198,6 +203,52 @@ var _ = Describe("ChartScaffolder", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: false"))
 		})
+
+		It("should error when no Deployment is found in the kustomize output", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(manifestsPath, []byte(manifestsWithNoDeployment), 0o600)).To(Succeed())
+
+			scaffolder := NewChartScaffolder(ChartScaffolderConfig{
+				ProjectName:   testProjectName,
+				ManifestsFile: manifestsPath,
+				OutputDir:     testOutputDir,
+			})
+			_, err := scaffolder.PrepareTemplates(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to generate the chart"))
+			Expect(err.Error()).To(ContainSubstring("no Deployment found"))
+		})
+
+		It("should error when the Deployment has no containers", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(manifestsPath, []byte(manifestsWithDeploymentNoContainers), 0o600)).To(Succeed())
+
+			scaffolder := NewChartScaffolder(ChartScaffolderConfig{
+				ProjectName:   testProjectName,
+				ManifestsFile: manifestsPath,
+				OutputDir:     testOutputDir,
+			})
+			_, err := scaffolder.PrepareTemplates(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to generate the chart"))
+			Expect(err.Error()).To(ContainSubstring("no manager container found"))
+		})
+
+		It("should error when multiple Deployments are present but none can be identified as the manager", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(manifestsPath, []byte(manifestsWithAmbiguousDeployments), 0o600)).To(Succeed())
+
+			scaffolder := NewChartScaffolder(ChartScaffolderConfig{
+				ProjectName:   testProjectName,
+				ManifestsFile: manifestsPath,
+				OutputDir:     testOutputDir,
+			})
+			_, err := scaffolder.PrepareTemplates(machinery.Filesystem{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to generate the chart"))
+			Expect(err.Error()).To(ContainSubstring("could not identify the controller-manager"))
+			Expect(err.Error()).To(ContainSubstring("control-plane: controller-manager"))
+		})
 	})
 })
 
@@ -207,15 +258,15 @@ func executeChartScaffolder(manifestsPath string) afero.Fs {
 
 func executeChartScaffolderWithFS(manifestsPath string, fs afero.Fs) afero.Fs {
 	scaffolder := NewChartScaffolder(ChartScaffolderConfig{
-		ProjectName:   "test-project",
+		ProjectName:   testProjectName,
 		ManifestsFile: manifestsPath,
-		OutputDir:     "dist",
+		OutputDir:     testOutputDir,
 	})
 	builders, err := scaffolder.PrepareTemplates(machinery.Filesystem{})
 	Expect(err).NotTo(HaveOccurred())
 
 	cfg := cfgv3.New()
-	Expect(cfg.SetProjectName("test-project")).To(Succeed())
+	Expect(cfg.SetProjectName(testProjectName)).To(Succeed())
 
 	scaffold := machinery.NewScaffold(machinery.Filesystem{FS: fs}, machinery.WithConfig(cfg))
 	Expect(scaffold.Execute(builders...)).To(Succeed())
@@ -364,4 +415,57 @@ spec:
       ports:
         - port: 443
           protocol: TCP
+`
+
+const manifestsWithDeploymentNoContainers = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-system
+spec:
+  template:
+    spec:
+      containers: []
+`
+
+const manifestsWithNoDeployment = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-project-controller-manager
+  namespace: test-system
+`
+
+const manifestsWithAmbiguousDeployments = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpha-operator
+  namespace: test-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: worker
+        image: worker:latest
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: beta-operator
+  namespace: test-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: worker
+        image: worker:latest
 `

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
@@ -17,6 +17,7 @@ limitations under the License.
 package extractor
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -64,119 +65,121 @@ type ImageConfig struct {
 }
 
 // ExtractDeploymentConfig extracts configuration values from the deployment for values.yaml.
-func (d *DeploymentExtractor) ExtractDeploymentConfig(deployment *unstructured.Unstructured) ValuesConfig {
+func (d *DeploymentExtractor) ExtractDeploymentConfig(deployment *unstructured.Unstructured) (ValuesConfig, error) {
 	config := ValuesConfig{
 		Manager: ManagerConfig{},
 	}
 
 	if deployment == nil {
-		return config
+		return config, nil
 	}
 
-	configMap := make(map[string]any)
+	extracted := make(map[string]any)
 
-	extractDeploymentReplicas(deployment, configMap)
-	extractDeploymentStrategy(deployment, configMap)
+	extractDeploymentReplicas(deployment, extracted)
+	extractDeploymentStrategy(deployment, extracted)
 
 	specMap := extractDeploymentSpec(deployment)
 	if specMap != nil {
-		extractPodSecurityContext(specMap, configMap)
-		extractImagePullSecrets(specMap, configMap)
-		extractPodNodeSelector(specMap, configMap)
-		extractPodTolerations(specMap, configMap)
-		extractPodAffinity(specMap, configMap)
-		extractPriorityClassName(specMap, configMap)
-		extractTopologySpreadConstraints(specMap, configMap)
-		extractTerminationGracePeriodSeconds(specMap, configMap)
+		extractPodSecurityContext(specMap, extracted)
+		extractImagePullSecrets(specMap, extracted)
+		extractPodNodeSelector(specMap, extracted)
+		extractPodTolerations(specMap, extracted)
+		extractPodAffinity(specMap, extracted)
+		extractPriorityClassName(specMap, extracted)
+		extractTopologySpreadConstraints(specMap, extracted)
+		extractTerminationGracePeriodSeconds(specMap, extracted)
 
-		container := findManagerContainer(specMap, managerContainerName(deployment))
-		if container != nil {
-			extractContainerEnv(container, configMap)
-			extractContainerImage(container, configMap)
-			extractContainerArgs(container, configMap)
-			extractContainerPorts(container, configMap)
-			extractContainerResources(container, configMap)
-			extractContainerSecurityContext(container, configMap)
-
-			extractExtraVolumes(specMap, configMap)
-			extractExtraVolumeMounts(container, configMap)
+		container := findManagerContainer(deployment, specMap)
+		if container == nil {
+			return config, fmt.Errorf("no manager container found in Deployment %q", deployment.GetName())
 		}
+
+		extractContainerEnv(container, extracted)
+		extractContainerImage(container, extracted)
+		extractContainerArgs(container, extracted)
+		extractContainerPorts(container, extracted)
+		extractContainerResources(container, extracted)
+		extractContainerSecurityContext(container, extracted)
+
+		extractExtraVolumes(specMap, extracted)
+		extractExtraVolumeMounts(container, extracted)
 	}
 
-	config.Manager = convertToManagerConfig(configMap)
+	config.Manager = convertToManagerConfig(extracted)
 
-	if webhookPort, ok := configMap["webhookPort"].(int); ok {
+	if webhookPort, ok := extracted["webhookPort"].(int); ok {
 		config.WebhookPort = webhookPort
 	}
-	if metricsPort, ok := configMap["metricsPort"].(int); ok {
+	if metricsPort, ok := extracted["metricsPort"].(int); ok {
 		config.MetricsPort = metricsPort
 	}
 
-	return config
+	return config, nil
 }
 
 func convertToManagerConfig(configMap map[string]any) ManagerConfig {
-	mc := ManagerConfig{}
+	cfg := ManagerConfig{}
 
 	if replicas, ok := configMap["replicas"].(int); ok {
 		r := replicas
-		mc.Replicas = &r
+		cfg.Replicas = &r
 	}
 	if image, ok := configMap["image"].(map[string]any); ok {
-		mc.Image = ImageConfig{
+		cfg.Image = ImageConfig{
 			Repository: getStringValue(image, "repository"),
 			Tag:        getStringValue(image, "tag"),
 			PullPolicy: getStringValue(image, "pullPolicy"),
 		}
 	}
 	if resources, ok := configMap["resources"].(map[string]any); ok {
-		mc.Resources = resources
+		cfg.Resources = resources
 	}
 	if nodeSelector, ok := configMap["podNodeSelector"].(map[string]any); ok {
-		mc.NodeSelector = nodeSelector
+		cfg.NodeSelector = nodeSelector
 	}
 	if tolerations, ok := configMap["podTolerations"].([]any); ok {
-		mc.Tolerations = tolerations
+		cfg.Tolerations = tolerations
 	}
 	if affinity, ok := configMap["podAffinity"].(map[string]any); ok {
-		mc.Affinity = affinity
+		cfg.Affinity = affinity
 	}
 	if args, ok := configMap["args"].([]any); ok {
-		mc.Args = args
+		cfg.Args = args
 	}
 	if env, ok := configMap["env"].([]any); ok {
-		mc.Env = env
+		cfg.Env = env
 	}
 	if securityContext, ok := configMap["securityContext"].(map[string]any); ok {
-		mc.SecurityContext = securityContext
+		cfg.SecurityContext = securityContext
 	}
 	if podSecurityContext, ok := configMap["podSecurityContext"].(map[string]any); ok {
-		mc.PodSecurityContext = podSecurityContext
+		cfg.PodSecurityContext = podSecurityContext
 	}
 	if imagePullSecrets, ok := configMap["imagePullSecrets"].([]any); ok {
-		mc.ImagePullSecrets = imagePullSecrets
+		cfg.ImagePullSecrets = imagePullSecrets
 	}
 	if priorityClassName, ok := configMap["priorityClassName"].(string); ok {
-		mc.PriorityClassName = priorityClassName
+		cfg.PriorityClassName = priorityClassName
 	}
 	if topologySpreadConstraints, ok := configMap["topologySpreadConstraints"].([]any); ok {
-		mc.TopologySpreadConstraints = topologySpreadConstraints
+		cfg.TopologySpreadConstraints = topologySpreadConstraints
 	}
 	if terminationGracePeriodSeconds, ok := configMap["terminationGracePeriodSeconds"].(int); ok {
-		tgps := terminationGracePeriodSeconds
-		mc.TerminationGracePeriodSeconds = &tgps
+		gracePeriod := terminationGracePeriodSeconds
+		cfg.TerminationGracePeriodSeconds = &gracePeriod
 	}
 	if strategy, ok := configMap["strategy"].(map[string]any); ok {
-		mc.Strategy = strategy
+		cfg.Strategy = strategy
 	}
 	if extraVolumes, ok := configMap["extraVolumes"].([]any); ok {
-		mc.ExtraVolumes = extraVolumes
+		cfg.ExtraVolumes = extraVolumes
 	}
 	if extraVolumeMounts, ok := configMap["extraVolumeMounts"].([]any); ok {
-		mc.ExtraVolumeMounts = extraVolumeMounts
+		cfg.ExtraVolumeMounts = extraVolumeMounts
 	}
 
-	return mc
+	return cfg
 }
 
 func getStringValue(m map[string]any, key string) string {
@@ -270,16 +273,23 @@ func extractPodAffinity(specMap map[string]any, config map[string]any) {
 	config["podAffinity"] = result
 }
 
+// managerContainerName reads the default-container annotation; falls back to "manager".
 func managerContainerName(deployment *unstructured.Unstructured) string {
-	ann, _, _ := unstructured.NestedStringMap(deployment.Object,
-		"spec", "template", "metadata", "annotations")
-	if name := ann[common.DefaultContainerAnnotation]; name != "" {
-		return name
+	if deployment == nil {
+		return common.DefaultManagerContainerName
+	}
+	annotations, found, err := unstructured.NestedStringMap(
+		deployment.Object, "spec", "template", "metadata", "annotations")
+	if found && err == nil {
+		if name, ok := annotations[common.DefaultContainerAnnotation]; ok && name != "" {
+			return name
+		}
 	}
 	return common.DefaultManagerContainerName
 }
 
-func findManagerContainer(specMap map[string]any, targetName string) map[string]any {
+// findManagerContainer returns the named manager container; falls back to the first container.
+func findManagerContainer(deployment *unstructured.Unstructured, specMap map[string]any) map[string]any {
 	containers, found, err := unstructured.NestedFieldNoCopy(specMap, "containers")
 	if !found || err != nil {
 		return nil
@@ -290,20 +300,67 @@ func findManagerContainer(specMap map[string]any, targetName string) map[string]
 		return nil
 	}
 
+	targetName := managerContainerName(deployment)
 	for _, c := range containersList {
-		container, ok := c.(map[string]any)
-		if !ok {
+		container, containerOK := c.(map[string]any)
+		if !containerOK {
 			continue
 		}
-		if name, _ := container["name"].(string); name == targetName {
+		if name, nameOK := container["name"].(string); nameOK && name == targetName {
 			return container
 		}
 	}
 
-	if first, ok := containersList[0].(map[string]any); ok {
-		return first
+	firstContainer, firstOK := containersList[0].(map[string]any)
+	if !firstOK {
+		return nil
 	}
-	return nil
+	return firstContainer
+}
+
+// RemoveExtractedVolumes removes custom volumes and mounts from the deployment manifest.
+// Must be called after ExtractDeploymentConfig: extraction captures them in values.yaml first,
+// then this removes them from the manifest so they are injected only via Helm values at install time.
+func (d *DeploymentExtractor) RemoveExtractedVolumes(deployment *unstructured.Unstructured) {
+	if deployment == nil {
+		return
+	}
+	specMap := extractDeploymentSpec(deployment)
+	if specMap == nil {
+		return
+	}
+
+	if volumes, found, err := unstructured.NestedFieldNoCopy(specMap, "volumes"); found && err == nil {
+		if volumesList, ok := volumes.([]any); ok {
+			specMap["volumes"] = retainSystemEntries(volumesList)
+		}
+	}
+
+	container := findManagerContainer(deployment, specMap)
+	if container == nil {
+		return
+	}
+	if mounts, found, err := unstructured.NestedFieldNoCopy(container, "volumeMounts"); found && err == nil {
+		if mountsList, ok := mounts.([]any); ok {
+			container["volumeMounts"] = retainSystemEntries(mountsList)
+		}
+	}
+}
+
+// retainSystemEntries keeps only webhook-certs and metrics-certs entries from a volume or volumeMount slice.
+func retainSystemEntries(entries []any) []any {
+	result := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := entryMap["name"].(string)
+		if _, isSystem := defaultWebhookMetricsVolumeNames[name]; isSystem {
+			result = append(result, entry)
+		}
+	}
+	return result
 }
 
 func extractContainerEnv(container map[string]any, config map[string]any) {
@@ -329,8 +386,7 @@ func extractContainerImage(container map[string]any, config map[string]any) {
 	repository := imageValue
 	tag := ""
 
-	// For digest-pinned images (repo@sha256:...), keep the full reference in repository.
-	// For tag-based images (repo:tag), split into repository and tag.
+	// Digest-pinned images stay whole in repository; tag-based images are split.
 	if !strings.Contains(imageValue, "@") {
 		tag = "latest"
 		lastColon := strings.LastIndex(imageValue, ":")
@@ -482,98 +538,43 @@ var defaultWebhookMetricsVolumeNames = map[string]struct{}{
 	"metrics-certs": {},
 }
 
-// extractExtraVolumes extracts volumes, excluding webhook-certs and metrics-certs.
-func extractExtraVolumes(specMap map[string]any, config map[string]any) {
-	volumes, found, err := unstructured.NestedFieldNoCopy(specMap, "volumes")
+// extractExtraEntries filters a slice of named entries (volumes or volumeMounts),
+// dropping any whose "name" field is in defaultWebhookMetricsVolumeNames, and stores
+// the result under configKey in config.
+func extractExtraEntries(source map[string]any, fieldKey, configKey string, config map[string]any) {
+	raw, found, err := unstructured.NestedFieldNoCopy(source, fieldKey)
 	if !found || err != nil {
 		return
 	}
-	volumesList, ok := volumes.([]any)
-	if !ok || len(volumesList) == 0 {
+	entries, ok := raw.([]any)
+	if !ok || len(entries) == 0 {
 		return
 	}
-	extra := make([]any, 0, len(volumesList))
-	for _, v := range volumesList {
-		vm, ok := v.(map[string]any)
-		if !ok {
-			continue
-		}
-		name, _ := vm["name"].(string)
-		if _, isDefault := defaultWebhookMetricsVolumeNames[name]; isDefault {
-			continue
-		}
-		extra = append(extra, v)
-	}
-	if len(extra) > 0 {
-		config["extraVolumes"] = extra
-	}
-}
-
-// extractExtraVolumeMounts extracts volume mounts, excluding webhook-certs and metrics-certs.
-func extractExtraVolumeMounts(container map[string]any, config map[string]any) {
-	mounts, found, err := unstructured.NestedFieldNoCopy(container, "volumeMounts")
-	if !found || err != nil {
-		return
-	}
-	mountsList, ok := mounts.([]any)
-	if !ok || len(mountsList) == 0 {
-		return
-	}
-	extra := make([]any, 0, len(mountsList))
-	for _, m := range mountsList {
-		mm, ok := m.(map[string]any)
-		if !ok {
-			continue
-		}
-		name, _ := mm["name"].(string)
-		if _, isDefault := defaultWebhookMetricsVolumeNames[name]; isDefault {
-			continue
-		}
-		extra = append(extra, m)
-	}
-	if len(extra) > 0 {
-		config["extraVolumeMounts"] = extra
-	}
-}
-
-// StripCustomVolumes removes custom (non-system) volumes and volume mounts from the deployment
-// so they only appear via Helm values templates. Call this after ExtractDeploymentConfig.
-func (d *DeploymentExtractor) StripCustomVolumes(deployment *unstructured.Unstructured) {
-	if deployment == nil {
-		return
-	}
-	specMap := extractDeploymentSpec(deployment)
-	if specMap == nil {
-		return
-	}
-	retainSystemEntries(specMap, "volumes")
-	container := findManagerContainer(specMap, managerContainerName(deployment))
-	if container != nil {
-		retainSystemEntries(container, "volumeMounts")
-	}
-}
-
-func retainSystemEntries(m map[string]any, key string) {
-	items, found, err := unstructured.NestedFieldNoCopy(m, key)
-	if !found || err != nil {
-		return
-	}
-	itemsList, ok := items.([]any)
-	if !ok || len(itemsList) == 0 {
-		return
-	}
-	system := make([]any, 0, len(itemsList))
-	for _, item := range itemsList {
-		entry, ok := item.(map[string]any)
+	extra := make([]any, 0, len(entries))
+	for _, e := range entries {
+		entry, ok := e.(map[string]any)
 		if !ok {
 			continue
 		}
 		name, _ := entry["name"].(string)
 		if _, isDefault := defaultWebhookMetricsVolumeNames[name]; isDefault {
-			system = append(system, item)
+			continue
 		}
+		extra = append(extra, e)
 	}
-	m[key] = system
+	if len(extra) > 0 {
+		config[configKey] = extra
+	}
+}
+
+// extractExtraVolumes extracts volumes, excluding webhook-certs and metrics-certs.
+func extractExtraVolumes(specMap map[string]any, config map[string]any) {
+	extractExtraEntries(specMap, "volumes", "extraVolumes", config)
+}
+
+// extractExtraVolumeMounts extracts volume mounts, excluding webhook-certs and metrics-certs.
+func extractExtraVolumeMounts(container map[string]any, config map[string]any) {
+	extractExtraEntries(container, "volumeMounts", "extraVolumeMounts", config)
 }
 
 // extractDeploymentReplicas extracts the replicas count from the deployment spec.
@@ -638,10 +639,71 @@ func extractTerminationGracePeriodSeconds(specMap map[string]any, config map[str
 	}
 }
 
-// isWebhookPortName returns true if the port name is webhook-related.
+// isWebhookPortName reports whether name identifies a webhook port.
 func isWebhookPortName(name string) bool {
 	name = strings.ToLower(name)
 	return name == "webhook-server" || name == "webhook"
+}
+
+// FindManagerDeployment returns the controller-manager Deployment from the slice.
+// With exactly one deployment, it is returned directly — no heuristics needed.
+// With multiple deployments, the following signals are tried in order:
+//  1. deployment label control-plane=controller-manager
+//  2. pod-template annotation kubectl.kubernetes.io/default-container is non-empty
+//  3. a container whose name is exactly "manager"
+//  4. deployment name contains "controller-manager"
+//
+// Returns nil when the slice is empty or when multiple deployments are present
+// but none matches any signal. Callers must treat nil as a hard error.
+func FindManagerDeployment(deployments []*unstructured.Unstructured) *unstructured.Unstructured {
+	if len(deployments) == 0 {
+		return nil
+	}
+	if len(deployments) == 1 {
+		return deployments[0]
+	}
+
+	for _, d := range deployments {
+		if d.GetLabels()["control-plane"] == "controller-manager" {
+			return d
+		}
+	}
+	for _, d := range deployments {
+		annotations, _, _ := unstructured.NestedStringMap(d.Object, "spec", "template", "metadata", "annotations")
+		if annotations[common.DefaultContainerAnnotation] != "" {
+			return d
+		}
+	}
+	for _, d := range deployments {
+		specMap := extractDeploymentSpec(d)
+		if specMap != nil && hasContainerNamed(specMap, common.DefaultManagerContainerName) {
+			return d
+		}
+	}
+	for _, d := range deployments {
+		if strings.Contains(d.GetName(), "controller-manager") {
+			return d
+		}
+	}
+	return nil
+}
+
+func hasContainerNamed(specMap map[string]any, name string) bool {
+	containers, _, _ := unstructured.NestedFieldNoCopy(specMap, "containers")
+	containersList, ok := containers.([]any)
+	if !ok {
+		return false
+	}
+	for _, c := range containersList {
+		container, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if container["name"] == name {
+			return true
+		}
+	}
+	return false
 }
 
 // toInt converts numeric types (int, int32, int64, float64) to int.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -32,22 +32,26 @@ const (
 	keyVolumeMounts = "volumeMounts"
 	keyMountPath    = "mountPath"
 
-	valAppsV1          = "apps/v1"
-	valDeployment      = "Deployment"
-	valTestDeploy      = "test-deployment"
-	valManager         = "manager"
-	valControllerImage = "controller:latest"
-	valAppConfig       = "app-config"
-	valAppSecret       = "app-secret"
-	valMyConfig        = "my-config"
-	valMySecret        = "my-secret"
-	valWebhookCert     = "webhook-certs"
-	valMetricsCert     = "metrics-certs"
-	valWebhookSecret   = "webhook-server-cert"
-	valSidecar         = "sidecar"
-	valMountConfig     = "/etc/config"
-	valMountCerts      = "/certs"
-	valMountMetrics    = "/metrics"
+	valAppsV1            = "apps/v1"
+	valDeployment        = "Deployment"
+	valTestDeploy        = "test-deployment"
+	valManager           = "manager"
+	valControllerImage   = "controller:latest"
+	valMgrImage          = "mgr:v1"
+	valSidecarImage      = "side:latest"
+	valCustomConfig      = "custom-config"
+	valMountConfigDir    = "/config"
+	valAppConfig         = "app-config"
+	valAppSecret         = "app-secret"
+	valMyConfig          = "my-config"
+	valMySecret          = "my-secret"
+	valWebhookCert       = "webhook-certs"
+	valMetricsCert       = "metrics-certs"
+	valWebhookSecretName = "webhook-server-cert"
+	valSidecar           = "sidecar"
+	valMountConfig       = "/etc/config"
+	valMountCerts        = "/certs"
+	valMountMetrics      = "/metrics"
 
 	annotationDefaultContainer = "kubectl.kubernetes.io/default-container"
 )
@@ -72,9 +76,11 @@ func makeDeployment(opts deploymentOpts) *unstructured.Unstructured {
 	}
 	template := map[string]any{"spec": podSpec}
 	if opts.annotations != nil {
-		template["metadata"] = map[string]any{
-			"annotations": opts.annotations,
+		annotations := make(map[string]any, len(opts.annotations))
+		for k, v := range opts.annotations {
+			annotations[k] = v
 		}
+		template["metadata"] = map[string]any{"annotations": annotations}
 	}
 	return &unstructured.Unstructured{
 		Object: map[string]any{
@@ -89,7 +95,9 @@ func makeDeployment(opts deploymentOpts) *unstructured.Unstructured {
 }
 
 func podSpec(d *unstructured.Unstructured) map[string]any {
-	return d.Object["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)
+	spec, _, _ := unstructured.NestedFieldNoCopy(d.Object, "spec", "template", "spec")
+	m, _ := spec.(map[string]any)
+	return m
 }
 
 var _ = Describe("DeploymentExtractor", func() {
@@ -109,22 +117,275 @@ var _ = Describe("DeploymentExtractor", func() {
 		})
 
 		It("should return nil when replicas is not set", func() {
-			result := extractor.ExtractDeploymentConfig(deployment)
+			result, err := extractor.ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).To(BeNil())
 		})
 
 		It("should preserve scale-to-zero", func() {
 			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(0)
-			result := extractor.ExtractDeploymentConfig(deployment)
+			result, err := extractor.ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).NotTo(BeNil())
 			Expect(*result.Manager.Replicas).To(Equal(0))
 		})
 
 		It("should extract replicas value", func() {
 			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(3)
-			result := extractor.ExtractDeploymentConfig(deployment)
+			result, err := extractor.ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).NotTo(BeNil())
 			Expect(*result.Manager.Replicas).To(Equal(3))
+		})
+	})
+
+	Describe("findManagerContainer", func() {
+		It("should return the container named 'manager' when it is first", func() {
+			d := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{keyName: valManager, keyImage: valMgrImage},
+				},
+			})
+			spec := podSpec(d)
+			c := findManagerContainer(d, spec)
+			Expect(c).NotTo(BeNil())
+			Expect(c[keyName]).To(Equal(valManager))
+		})
+
+		It("should return the manager container even when a sidecar comes first", func() {
+			d := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{keyName: valSidecar, keyImage: valSidecarImage},
+					{keyName: valManager, keyImage: valMgrImage},
+				},
+			})
+			spec := podSpec(d)
+			c := findManagerContainer(d, spec)
+			Expect(c).NotTo(BeNil())
+			Expect(c[keyName]).To(Equal(valManager))
+		})
+
+		It("should respect the default-container annotation", func() {
+			d := makeDeployment(deploymentOpts{
+				annotations: map[string]string{
+					annotationDefaultContainer: "custom-manager",
+				},
+				containers: []map[string]any{
+					{keyName: valSidecar, keyImage: valSidecarImage},
+					{keyName: "custom-manager", keyImage: valMgrImage},
+				},
+			})
+			spec := podSpec(d)
+			c := findManagerContainer(d, spec)
+			Expect(c).NotTo(BeNil())
+			Expect(c[keyName]).To(Equal("custom-manager"))
+		})
+
+		It("should fall back to the first container when no name matches", func() {
+			d := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{keyName: valSidecar, keyImage: valSidecarImage},
+					{keyName: "other", keyImage: "other:v1"},
+				},
+			})
+			spec := podSpec(d)
+			c := findManagerContainer(d, spec)
+			Expect(c).NotTo(BeNil())
+			Expect(c[keyName]).To(Equal(valSidecar))
+		})
+	})
+
+	Describe("RemoveExtractedVolumes", func() {
+		var ext *DeploymentExtractor
+
+		BeforeEach(func() {
+			ext = &DeploymentExtractor{}
+		})
+
+		It("should remove all custom volumes and leave an empty slice", func() {
+			d := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valCustomConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valCustomConfig, keyMountPath: valMountConfigDir},
+					},
+				}},
+			})
+
+			ext.RemoveExtractedVolumes(d)
+
+			spec := podSpec(d)
+			volumes, _, _ := unstructured.NestedFieldNoCopy(spec, "volumes")
+			Expect(volumes.([]any)).To(BeEmpty())
+			containers, _, _ := unstructured.NestedFieldNoCopy(spec, "containers")
+			manager := containers.([]any)[0].(map[string]any)
+			mounts, _, _ := unstructured.NestedFieldNoCopy(manager, keyVolumeMounts)
+			Expect(mounts.([]any)).To(BeEmpty())
+		})
+
+		It("should remove custom volumes while keeping system volumes", func() {
+			d := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecretName}},
+					map[string]any{keyName: valCustomConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
+				},
+				containers: []map[string]any{{
+					keyName:  valManager,
+					keyImage: valMgrImage,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valWebhookCert, keyMountPath: "/tmp/certs"},
+						map[string]any{keyName: valCustomConfig, keyMountPath: valMountConfigDir},
+					},
+				}},
+			})
+
+			ext.RemoveExtractedVolumes(d)
+
+			spec := podSpec(d)
+			volumes, _, _ := unstructured.NestedFieldNoCopy(spec, "volumes")
+			volumeList, ok := volumes.([]any)
+			Expect(ok).To(BeTrue())
+			Expect(volumeList).To(HaveLen(1))
+			Expect(volumeList[0].(map[string]any)[keyName]).To(Equal(valWebhookCert))
+
+			containers, _, _ := unstructured.NestedFieldNoCopy(spec, "containers")
+			managerContainer := containers.([]any)[0].(map[string]any)
+			mounts, _, _ := unstructured.NestedFieldNoCopy(managerContainer, keyVolumeMounts)
+			mountList, ok := mounts.([]any)
+			Expect(ok).To(BeTrue())
+			Expect(mountList).To(HaveLen(1))
+			Expect(mountList[0].(map[string]any)[keyName]).To(Equal(valWebhookCert))
+		})
+
+		It("should keep both metrics-certs and webhook-certs volumes", func() {
+			d := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert},
+					map[string]any{keyName: valMetricsCert},
+				},
+				containers: []map[string]any{{
+					keyName: valManager,
+					keyVolumeMounts: []any{
+						map[string]any{keyName: valWebhookCert, keyMountPath: valMountCerts},
+						map[string]any{keyName: valMetricsCert, keyMountPath: valMountMetrics},
+					},
+				}},
+			})
+
+			ext.RemoveExtractedVolumes(d)
+
+			spec := podSpec(d)
+			volumes, _, _ := unstructured.NestedFieldNoCopy(spec, "volumes")
+			Expect(volumes.([]any)).To(HaveLen(2))
+		})
+
+		It("should only strip volume mounts from the manager container, not sidecars", func() {
+			d := makeDeployment(deploymentOpts{
+				volumes: []any{
+					map[string]any{keyName: valWebhookCert},
+					map[string]any{keyName: valCustomConfig},
+				},
+				containers: []map[string]any{
+					{
+						keyName: valSidecar,
+						keyVolumeMounts: []any{
+							map[string]any{keyName: valCustomConfig, keyMountPath: valMountConfigDir},
+						},
+					},
+					{
+						keyName: valManager,
+						keyVolumeMounts: []any{
+							map[string]any{keyName: valWebhookCert, keyMountPath: "/tmp/certs"},
+							map[string]any{keyName: valCustomConfig, keyMountPath: valMountConfigDir},
+						},
+					},
+				},
+			})
+
+			ext.RemoveExtractedVolumes(d)
+
+			spec := podSpec(d)
+			containers, _, _ := unstructured.NestedFieldNoCopy(spec, "containers")
+			containerList := containers.([]any)
+
+			sidecar := containerList[0].(map[string]any)
+			sidecarMounts, _, _ := unstructured.NestedFieldNoCopy(sidecar, keyVolumeMounts)
+			Expect(sidecarMounts.([]any)).To(HaveLen(1), "sidecar mounts must not be touched")
+
+			manager := containerList[1].(map[string]any)
+			managerMounts, _, _ := unstructured.NestedFieldNoCopy(manager, keyVolumeMounts)
+			Expect(managerMounts.([]any)).To(HaveLen(1))
+			Expect(managerMounts.([]any)[0].(map[string]any)[keyName]).To(Equal(valWebhookCert))
+		})
+
+		It("should be a no-op on nil deployment", func() {
+			Expect(func() { ext.RemoveExtractedVolumes(nil) }).NotTo(Panic())
+		})
+	})
+
+	Describe("FindManagerDeployment", func() {
+		It("should return nil for an empty or nil slice", func() {
+			Expect(FindManagerDeployment(nil)).To(BeNil())
+			Expect(FindManagerDeployment([]*unstructured.Unstructured{})).To(BeNil())
+		})
+
+		It("should return the only deployment with no heuristics applied", func() {
+			d := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valSidecar}}})
+			Expect(FindManagerDeployment([]*unstructured.Unstructured{d})).To(Equal(d))
+		})
+
+		Context("with multiple deployments", func() {
+			It("should select by label control-plane=controller-manager first", func() {
+				other := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valManager}}})
+				winner := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: "other"}}})
+				winner.SetName("winner")
+				winner.SetLabels(map[string]string{"control-plane": "controller-manager"})
+
+				result := FindManagerDeployment([]*unstructured.Unstructured{other, winner})
+				Expect(result).To(Equal(winner))
+			})
+
+			It("should select by pod-template annotation when no label matches", func() {
+				other := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valManager}}})
+				winner := makeDeployment(deploymentOpts{
+					annotations: map[string]string{annotationDefaultContainer: valSidecar},
+					containers:  []map[string]any{{keyName: valSidecar}},
+				})
+				winner.SetName("winner")
+
+				result := FindManagerDeployment([]*unstructured.Unstructured{other, winner})
+				Expect(result).To(Equal(winner))
+			})
+
+			It("should select by container named manager when no label or annotation matches", func() {
+				other := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valSidecar}}})
+				winner := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valManager}}})
+				winner.SetName("winner")
+
+				result := FindManagerDeployment([]*unstructured.Unstructured{other, winner})
+				Expect(result).To(Equal(winner))
+			})
+
+			It("should select by name containing controller-manager when no other signal matches", func() {
+				other := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valSidecar}}})
+				other.SetName("other")
+				winner := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valSidecar}}})
+				winner.SetName("my-controller-manager")
+
+				result := FindManagerDeployment([]*unstructured.Unstructured{other, winner})
+				Expect(result).To(Equal(winner))
+			})
+
+			It("should return nil when multiple deployments have no identifying signals", func() {
+				first := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valSidecar}}})
+				second := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valSidecar}}})
+
+				result := FindManagerDeployment([]*unstructured.Unstructured{first, second})
+				Expect(result).To(BeNil())
+			})
 		})
 	})
 
@@ -171,16 +432,17 @@ var _ = Describe("DeploymentExtractor", func() {
 				}},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.ExtraVolumes).To(HaveLen(2))
 			Expect(config.Manager.ExtraVolumeMounts).To(HaveLen(2))
-			Expect(podSpec(deployment)["volumes"].([]any)).To(HaveLen(2), "extraction should not mutate")
+			Expect(podSpec(deployment)["volumes"].([]any)).To(HaveLen(2), "extraction must not mutate the deployment")
 		})
 
 		It("should separate system and custom volumes", func() {
 			deployment := makeDeployment(deploymentOpts{
 				volumes: []any{
-					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecret}},
+					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecretName}},
 					map[string]any{keyName: valMetricsCert, keySecret: map[string]any{keySecretName: "metrics-server-cert"}},
 					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
 				},
@@ -194,7 +456,8 @@ var _ = Describe("DeploymentExtractor", func() {
 				}},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.ExtraVolumes).To(HaveLen(1))
 			Expect(config.Manager.ExtraVolumeMounts).To(HaveLen(1))
 		})
@@ -214,58 +477,10 @@ var _ = Describe("DeploymentExtractor", func() {
 				}},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.ExtraVolumes).To(BeNil())
 			Expect(config.Manager.ExtraVolumeMounts).To(BeNil())
-		})
-	})
-
-	Describe("StripCustomVolumes", func() {
-		It("should remove all custom volumes and leave empty slice", func() {
-			deployment := makeDeployment(deploymentOpts{
-				volumes: []any{
-					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
-				},
-				containers: []map[string]any{{
-					keyName: valManager,
-					keyVolumeMounts: []any{
-						map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
-					},
-				}},
-			})
-
-			(&DeploymentExtractor{}).StripCustomVolumes(deployment)
-
-			spec := podSpec(deployment)
-			Expect(spec["volumes"].([]any)).To(BeEmpty())
-			container := spec["containers"].([]any)[0].(map[string]any)
-			Expect(container["volumeMounts"].([]any)).To(BeEmpty())
-		})
-
-		It("should keep system volumes and strip custom ones", func() {
-			deployment := makeDeployment(deploymentOpts{
-				volumes: []any{
-					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecret}},
-					map[string]any{keyName: valMetricsCert, keySecret: map[string]any{keySecretName: "metrics-server-cert"}},
-					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
-				},
-				containers: []map[string]any{{
-					keyName: valManager,
-					keyVolumeMounts: []any{
-						map[string]any{keyName: valWebhookCert, keyMountPath: valMountCerts},
-						map[string]any{keyName: valMetricsCert, keyMountPath: valMountMetrics},
-						map[string]any{keyName: valAppConfig, keyMountPath: valMountConfig},
-					},
-				}},
-			})
-
-			(&DeploymentExtractor{}).StripCustomVolumes(deployment)
-
-			spec := podSpec(deployment)
-			volumes := spec["volumes"].([]any)
-			Expect(volumes).To(HaveLen(2))
-			Expect(volumes[0].(map[string]any)["name"]).To(Equal(valWebhookCert))
-			Expect(volumes[1].(map[string]any)["name"]).To(Equal(valMetricsCert))
 		})
 	})
 
@@ -280,7 +495,8 @@ var _ = Describe("DeploymentExtractor", func() {
 				},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.Image.Repository).To(Equal("controller"))
 			Expect(config.Manager.Image.Tag).To(Equal("latest"))
 		})
@@ -296,7 +512,8 @@ var _ = Describe("DeploymentExtractor", func() {
 				},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.Image.Repository).To(Equal("controller"))
 		})
 
@@ -308,7 +525,8 @@ var _ = Describe("DeploymentExtractor", func() {
 				},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.Image.Repository).To(Equal("controller"))
 		})
 
@@ -319,17 +537,26 @@ var _ = Describe("DeploymentExtractor", func() {
 				},
 			})
 
-			config := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Manager.Image.Repository).To(Equal("controller"))
 		})
 
-		It("should strip volumes from the correct container with sidecar before manager", func() {
+		It("should error when the deployment has no containers", func() {
+			deployment := makeDeployment(deploymentOpts{})
+
+			_, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no manager container found"))
+		})
+
+		It("should strip volumes only from the manager container when a sidecar comes first", func() {
 			deployment := makeDeployment(deploymentOpts{
 				annotations: map[string]string{
 					annotationDefaultContainer: valManager,
 				},
 				volumes: []any{
-					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecret}},
+					map[string]any{keyName: valWebhookCert, keySecret: map[string]any{keySecretName: valWebhookSecretName}},
 					map[string]any{keyName: valAppConfig, keyConfigMap: map[string]any{keyName: valMyConfig}},
 				},
 				containers: []map[string]any{
@@ -349,20 +576,20 @@ var _ = Describe("DeploymentExtractor", func() {
 				},
 			})
 
-			(&DeploymentExtractor{}).StripCustomVolumes(deployment)
+			(&DeploymentExtractor{}).RemoveExtractedVolumes(deployment)
 
 			spec := podSpec(deployment)
 			volumes := spec["volumes"].([]any)
 			Expect(volumes).To(HaveLen(1))
-			Expect(volumes[0].(map[string]any)["name"]).To(Equal(valWebhookCert))
+			Expect(volumes[0].(map[string]any)[keyName]).To(Equal(valWebhookCert))
 
 			sidecar := spec["containers"].([]any)[0].(map[string]any)
-			Expect(sidecar["volumeMounts"].([]any)).To(HaveLen(1), "sidecar mounts should be untouched")
+			Expect(sidecar[keyVolumeMounts].([]any)).To(HaveLen(1), "sidecar mounts must not be touched")
 
 			manager := spec["containers"].([]any)[1].(map[string]any)
-			managerMounts := manager["volumeMounts"].([]any)
+			managerMounts := manager[keyVolumeMounts].([]any)
 			Expect(managerMounts).To(HaveLen(1))
-			Expect(managerMounts[0].(map[string]any)["name"]).To(Equal(valWebhookCert))
+			Expect(managerMounts[0].(map[string]any)[keyName]).To(Equal(valWebhookCert))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/extractor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/extractor.go
@@ -77,18 +77,21 @@ type ResourceSet struct {
 // Extract performs complete extraction of parsed resources.
 // It extracts metadata first, then detects features, and finally extracts deployment configuration.
 // projectName is the configured project name which becomes the chart name.
-func (e *Extractor) Extract(resources *ResourceSet, projectName string) *Extraction {
+func (e *Extractor) Extract(resources *ResourceSet, projectName string) (*Extraction, error) {
 	metadata := e.metadataExtractor.ExtractMetadata(resources, projectName)
 	features := e.featuresExtractor.DetectFeatures(resources, metadata.DetectedPrefix, metadata.ManagerNamespace)
-	values := e.deploymentExtractor.ExtractDeploymentConfig(resources.Deployment)
+	values, err := e.deploymentExtractor.ExtractDeploymentConfig(resources.Deployment)
+	if err != nil {
+		return nil, err
+	}
 
-	// Strip custom volumes from deployment after extraction so they only
-	// appear via Helm values templates, not as literal entries in the manifest.
-	e.deploymentExtractor.StripCustomVolumes(resources.Deployment)
+	if resources.Deployment != nil {
+		e.deploymentExtractor.RemoveExtractedVolumes(resources.Deployment)
+	}
 
 	return &Extraction{
 		Metadata: metadata,
 		Features: features,
 		Values:   values,
-	}
+	}, nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -57,12 +57,7 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 	features.HasCRDs = len(resources.CustomResourceDefinitions) > 0
 	features.HasWebhooks = len(resources.WebhookConfigurations) > 0
 
-	if resources.Issuer != nil {
-		features.HasCertManager = true
-	}
-	if len(resources.Certificates) > 0 {
-		features.HasCertManager = true
-	}
+	features.HasCertManager = resources.Issuer != nil || len(resources.Certificates) > 0
 
 	features.HasPrometheus = len(resources.ServiceMonitors) > 0
 	features.HasNetworkPolicy = len(resources.NetworkPolicies) > 0
@@ -162,34 +157,22 @@ func extractPortFromService(svc *unstructured.Unstructured) int {
 		return 0
 	}
 
-	if port, ok := firstPort["port"].(int64); ok {
-		return int(port)
-	}
-	if port, ok := firstPort["port"].(int); ok {
-		return port
-	}
-
-	return 0
+	port, _ := toInt(firstPort["port"])
+	return port
 }
 
 // extractWebhookPortFromDeployment extracts the webhook port from deployment container ports.
 func extractWebhookPortFromDeployment(deployment *unstructured.Unstructured) int {
-	containers, found, err := unstructured.NestedFieldNoCopy(deployment.Object, "spec", "template", "spec", "containers")
-	if !found || err != nil {
+	specMap := extractDeploymentSpec(deployment)
+	if specMap == nil {
+		return 0
+	}
+	container := findManagerContainer(deployment, specMap)
+	if container == nil {
 		return 0
 	}
 
-	containersList, ok := containers.([]any)
-	if !ok || len(containersList) == 0 {
-		return 0
-	}
-
-	firstContainer, ok := containersList[0].(map[string]any)
-	if !ok {
-		return 0
-	}
-
-	portsField, found, err := unstructured.NestedFieldNoCopy(firstContainer, "ports")
+	portsField, found, err := unstructured.NestedFieldNoCopy(container, "ports")
 	if !found || err != nil {
 		return 0
 	}
@@ -206,12 +189,8 @@ func extractWebhookPortFromDeployment(deployment *unstructured.Unstructured) int
 		}
 
 		name, _ := portMap["name"].(string)
-		name = strings.ToLower(name)
-		if name == "webhook-server" || name == "webhook" {
-			if cp, ok := portMap["containerPort"].(int64); ok {
-				return int(cp)
-			}
-			if cp, ok := portMap["containerPort"].(int); ok {
+		if isWebhookPortName(name) {
+			if cp, ok := toInt(portMap["containerPort"]); ok {
 				return cp
 			}
 		}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/metadata.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/metadata.go
@@ -146,23 +146,16 @@ func extractDeployManagerVersion(deployment *unstructured.Unstructured) string {
 		return ""
 	}
 
-	// Extract containers using NestedFieldNoCopy to avoid deep copy issues with integer fields
-	containers, found, err := unstructured.NestedFieldNoCopy(deployment.Object, "spec", "template", "spec", "containers")
-	if !found || err != nil {
+	specMap := extractDeploymentSpec(deployment)
+	if specMap == nil {
+		return ""
+	}
+	container := findManagerContainer(deployment, specMap)
+	if container == nil {
 		return ""
 	}
 
-	containersList, ok := containers.([]any)
-	if !ok || len(containersList) == 0 {
-		return ""
-	}
-
-	firstContainer, ok := containersList[0].(map[string]any)
-	if !ok {
-		return ""
-	}
-
-	image, found, err := unstructured.NestedString(firstContainer, "image")
+	image, found, err := unstructured.NestedString(container, "image")
 	if !found || err != nil || image == "" {
 		return ""
 	}
@@ -170,7 +163,7 @@ func extractDeployManagerVersion(deployment *unstructured.Unstructured) string {
 	// Strip digest suffix if present (e.g., repository:tag@sha256:... or repository@sha256:...)
 	// appVersion must be a semantic version, not a digest
 	imageWithoutDigest := image
-	if before, _, ok0 := strings.Cut(image, "@"); ok0 {
+	if before, _, hasDigest := strings.Cut(image, "@"); hasDigest {
 		imageWithoutDigest = before
 	}
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/categorizer.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/categorizer.go
@@ -146,9 +146,7 @@ func (c *ResourceCategorizer) collectMetricsResources() []*unstructured.Unstruct
 
 // collectPrometheusResources gathers prometheus related resources.
 func (c *ResourceCategorizer) collectPrometheusResources() []*unstructured.Unstructured {
-	prometheusResources := make([]*unstructured.Unstructured, 0, len(c.resources.ServiceMonitors))
-	prometheusResources = append(prometheusResources, c.resources.ServiceMonitors...)
-	return prometheusResources
+	return c.resources.ServiceMonitors
 }
 
 // collectNetworkPolicyResources gathers network policy related resources.
@@ -181,6 +179,8 @@ func (c *ResourceCategorizer) isMetricsService(service *unstructured.Unstructure
 // collectExtrasResources gathers uncategorized resources that don't fit standard categories.
 func (c *ResourceCategorizer) collectExtrasResources() []*unstructured.Unstructured {
 	var extrasResources []*unstructured.Unstructured
+
+	extrasResources = append(extrasResources, c.resources.ExtraDeployments...)
 
 	for _, service := range c.resources.Services {
 		if !c.isWebhookService(service) && !c.isMetricsService(service) {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/categorizer_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/categorizer_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kustomize
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	labelControlPlaneKey   = "control-plane"
+	labelControlPlaneValue = "controller-manager"
+)
+
+func makeDeployment(name string, labels map[string]string) *unstructured.Unstructured {
+	d := &unstructured.Unstructured{}
+	d.SetAPIVersion("apps/v1")
+	d.SetKind("Deployment")
+	d.SetName(name)
+	if labels != nil {
+		d.SetLabels(labels)
+	}
+	return d
+}
+
+var _ = Describe("ResourceCategorizer", func() {
+	Describe("CategorizeByFunction", func() {
+		It("should place the manager deployment in the manager group", func() {
+			resources := &ParsedResources{
+				Deployment: makeDeployment("project-v4-controller-manager", map[string]string{
+					labelControlPlaneKey: labelControlPlaneValue,
+				}),
+			}
+			groups := NewResourceCategorizer(resources).CategorizeByFunction()
+			Expect(groups["manager"]).To(HaveLen(1))
+			Expect(groups["manager"][0].GetName()).To(Equal("project-v4-controller-manager"))
+			Expect(groups["extras"]).To(BeNil())
+		})
+
+		It("should place extra deployments in the extras group, not the manager group", func() {
+			resources := &ParsedResources{
+				Deployment: makeDeployment("project-v4-controller-manager", map[string]string{
+					labelControlPlaneKey: labelControlPlaneValue,
+				}),
+				ExtraDeployments: []*unstructured.Unstructured{
+					makeDeployment("project-v4-some-operator", nil),
+				},
+			}
+			groups := NewResourceCategorizer(resources).CategorizeByFunction()
+
+			Expect(groups["manager"]).To(HaveLen(1))
+			Expect(groups["manager"][0].GetName()).To(Equal("project-v4-controller-manager"))
+
+			Expect(groups["extras"]).To(HaveLen(1))
+			Expect(groups["extras"][0].GetName()).To(Equal("project-v4-some-operator"))
+		})
+
+		It("should place multiple extra deployments in the extras group", func() {
+			resources := &ParsedResources{
+				Deployment: makeDeployment("controller-manager", map[string]string{
+					labelControlPlaneKey: labelControlPlaneValue,
+				}),
+				ExtraDeployments: []*unstructured.Unstructured{
+					makeDeployment("operator-a", nil),
+					makeDeployment("operator-b", nil),
+				},
+			}
+			groups := NewResourceCategorizer(resources).CategorizeByFunction()
+
+			Expect(groups["manager"]).To(HaveLen(1))
+			Expect(groups["extras"]).To(HaveLen(2))
+			extraNames := []string{
+				groups["extras"][0].GetName(),
+				groups["extras"][1].GetName(),
+			}
+			Expect(extraNames).To(ConsistOf("operator-a", "operator-b"))
+		})
+
+		It("should produce no manager or extras group when resources are empty", func() {
+			resources := &ParsedResources{}
+			groups := NewResourceCategorizer(resources).CategorizeByFunction()
+			Expect(groups["manager"]).To(BeNil())
+			Expect(groups["extras"]).To(BeNil())
+		})
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -53,7 +53,9 @@ const (
 
 func extractDeploymentConfig(deployment *unstructured.Unstructured) map[string]any {
 	de := extractor.DeploymentExtractor{}
-	return convertValuesConfigToMap(de.ExtractDeploymentConfig(deployment))
+	cfg, err := de.ExtractDeploymentConfig(deployment)
+	Expect(err).NotTo(HaveOccurred())
+	return convertValuesConfigToMap(cfg)
 }
 
 var _ = Describe("ChartConverter", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser.go
@@ -25,14 +25,17 @@ import (
 
 	"go.yaml.in/yaml/v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor"
 )
 
 // ParsedResources holds Kubernetes resources organized by type for Helm chart generation.
 type ParsedResources struct {
 	// Core Kubernetes resources
-	Namespace  *unstructured.Unstructured
-	Deployment *unstructured.Unstructured
-	Services   []*unstructured.Unstructured
+	Namespace        *unstructured.Unstructured
+	Deployment       *unstructured.Unstructured
+	ExtraDeployments []*unstructured.Unstructured
+	Services         []*unstructured.Unstructured
 
 	// RBAC resources
 	ServiceAccount      *unstructured.Unstructured
@@ -88,6 +91,7 @@ func (p *Parser) Parse() (*ParsedResources, error) {
 // ParseFromReader parses multi-document YAML from a reader and categorizes resources by type.
 func (p *Parser) ParseFromReader(reader io.Reader) (*ParsedResources, error) {
 	decoder := yaml.NewDecoder(reader)
+	var deployments []*unstructured.Unstructured
 	resources := &ParsedResources{
 		CustomResourceDefinitions: make([]*unstructured.Unstructured, 0),
 		Roles:                     make([]*unstructured.Unstructured, 0),
@@ -113,17 +117,26 @@ func (p *Parser) ParseFromReader(reader io.Reader) (*ParsedResources, error) {
 			return nil, fmt.Errorf("failed to decode YAML document: %w", err)
 		}
 
-		// Skip empty documents
 		if doc == nil {
 			continue
 		}
 
 		obj := &unstructured.Unstructured{Object: doc}
-		p.categorizeResource(obj, resources)
+		if obj.GetKind() == "Deployment" {
+			deployments = append(deployments, obj)
+		} else {
+			p.categorizeResource(obj, resources)
+		}
 	}
 
-	// After parsing all resources, identify Custom Resources by matching against CRD API groups
 	p.identifyCustomResources(resources)
+
+	resources.Deployment = extractor.FindManagerDeployment(deployments)
+	for _, d := range deployments {
+		if d != resources.Deployment {
+			resources.ExtraDeployments = append(resources.ExtraDeployments, d)
+		}
+	}
 
 	return resources, nil
 }
@@ -150,8 +163,6 @@ func (p *Parser) categorizeResource(obj *unstructured.Unstructured, resources *P
 		resources.ClusterRoleBindings = append(resources.ClusterRoleBindings, obj)
 	case kind == "Service":
 		resources.Services = append(resources.Services, obj)
-	case kind == "Deployment":
-		resources.Deployment = obj
 	case kind == "Certificate" && apiVersion == "cert-manager.io/v1":
 		resources.Certificates = append(resources.Certificates, obj)
 	case kind == "Issuer" && apiVersion == "cert-manager.io/v1":
@@ -182,18 +193,12 @@ func (p *Parser) identifyCustomResources(resources *ParsedResources) {
 		return
 	}
 
-	// Separate Custom Resources from Other resources
 	var remainingOther []*unstructured.Unstructured
 	for _, resource := range resources.Other {
 		if resource == nil {
 			continue
 		}
-
-		// Extract API group from the resource's apiVersion (format: group/version or just version)
-		apiVersion := resource.GetAPIVersion()
-		apiGroup := extractAPIGroup(apiVersion)
-
-		// If this resource's API group matches one of our CRDs, it's a Custom Resource
+		apiGroup := extractAPIGroup(resource.GetAPIVersion())
 		if crdAPIGroups[apiGroup] {
 			resources.CustomResources = append(resources.CustomResources, resource)
 		} else {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/parser_deployment_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kustomize
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Parser deployment selection (integration)", func() {
+	var parser *Parser
+
+	BeforeEach(func() {
+		parser = NewParser("")
+	})
+
+	It("selects the single deployment and leaves ExtraDeployments empty", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: only-deployment
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).NotTo(BeNil())
+		Expect(result.Deployment.GetName()).To(Equal("only-deployment"))
+		Expect(result.ExtraDeployments).To(BeEmpty())
+	})
+
+	It("selects the deployment with label control-plane: controller-manager", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: other-deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager-deployment
+  labels:
+    control-plane: controller-manager
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).NotTo(BeNil())
+		Expect(result.Deployment.GetName()).To(Equal("manager-deployment"))
+	})
+
+	It("selects the deployment with pod-template annotation when no label matches", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: other-deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: annotated-deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).NotTo(BeNil())
+		Expect(result.Deployment.GetName()).To(Equal("annotated-deployment"))
+	})
+
+	It("selects the deployment with a container named manager when no label or annotation matches", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: other-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: sidecar
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: named-container-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).NotTo(BeNil())
+		Expect(result.Deployment.GetName()).To(Equal("named-container-deployment"))
+	})
+
+	It("leaves Deployment nil and all in ExtraDeployments when multiple deployments have no signals", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: first-deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second-deployment
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).To(BeNil())
+		Expect(result.ExtraDeployments).To(HaveLen(2))
+	})
+
+	// The label control-plane: controller-manager is preserved across kustomize namePrefix transforms.
+	It("identifies the manager when kustomize namePrefix has been applied", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: project-v4-controller-manager
+  namespace: project-v4-system
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: project-v4
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).NotTo(BeNil())
+		Expect(result.Deployment.GetName()).To(Equal("project-v4-controller-manager"))
+		Expect(result.ExtraDeployments).To(BeEmpty())
+	})
+
+	It("places non-manager deployments in ExtraDeployments", func() {
+		yaml := `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: project-v4-controller-manager
+  labels:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: project-v4-some-operator
+`
+		result, err := parser.ParseFromReader(strings.NewReader(yaml))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Deployment).NotTo(BeNil())
+		Expect(result.Deployment.GetName()).To(Equal("project-v4-controller-manager"))
+		Expect(result.ExtraDeployments).To(HaveLen(1))
+		Expect(result.ExtraDeployments[0].GetName()).To(Equal("project-v4-some-operator"))
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -131,16 +131,8 @@ func HandleRBACConditionalWrappers(yamlContent, kind, name string) string {
 	if isHelper {
 		return fmt.Sprintf("{{- if .Values.rbac.helpers.enabled }}\n%s{{- end }}\n", yamlContent)
 	}
-	if isMetricsAuthRole {
-		// Only needed when secure metrics enabled (authn via TokenReview/SubjectAccessReview)
-		return fmt.Sprintf("{{- if and .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
-	}
-	if isMetricsReader {
-		// Only needed when secure metrics enabled (uses nonResourceURLs for /metrics access)
-		return fmt.Sprintf("{{- if and .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
-	}
-	if isMetricsAuthBinding {
-		// Binding for metrics-auth-role, only needed when secure metrics enabled
+	// metrics-auth-role, metrics-reader, and metrics-auth-rolebinding all require secure metrics
+	if isMetricsAuthRole || isMetricsReader || isMetricsAuthBinding {
 		return fmt.Sprintf("{{- if and .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n", yamlContent)
 	}
 	// Essential RBAC (manager, leader-election) - always created
@@ -256,24 +248,22 @@ func InjectCRDResourcePolicyAnnotation(yamlContent string) string {
 // MakeWebhookAnnotationsConditional makes cert-manager annotations conditional on .Values.certManager.enabled.
 func MakeWebhookAnnotationsConditional(yamlContent string) string {
 	// Find cert-manager.io/inject-ca-from annotation and make it conditional
-	if strings.Contains(yamlContent, "cert-manager.io/inject-ca-from") {
-		// Replace the cert-manager annotation with conditional wrapper
-		certManagerPattern := regexp.MustCompile(`(\s+)cert-manager\.io/inject-ca-from:\s*[^\n]+`)
-		yamlContent = certManagerPattern.ReplaceAllStringFunc(yamlContent, func(match string) string {
-			// Extract the indentation
-			indentMatch := regexp.MustCompile(`^(\s+)`).FindStringSubmatch(match)
-			indent := ""
-			if len(indentMatch) > 1 {
-				indent = indentMatch[1]
-			}
-
-			// Extract the annotation line with proper indentation
-			annotationLine := strings.TrimSpace(match)
-
-			return fmt.Sprintf("%s{{- if .Values.certManager.enabled }}\n%s%s\n%s{{- end }}",
-				indent, indent, annotationLine, indent)
-		})
+	if !strings.Contains(yamlContent, "cert-manager.io/inject-ca-from") {
+		return yamlContent
 	}
-
+	certManagerPattern := regexp.MustCompile(`(\s+)cert-manager\.io/inject-ca-from:\s*[^\n]+`)
+	// Replace the cert-manager annotation with conditional wrapper
+	yamlContent = certManagerPattern.ReplaceAllStringFunc(yamlContent, func(match string) string {
+		// Extract the indentation
+		indentMatch := regexp.MustCompile(`^(\s+)`).FindStringSubmatch(match)
+		indent := ""
+		if len(indentMatch) > 1 {
+			indent = indentMatch[1]
+		}
+		// Extract the annotation line with proper indentation
+		annotationLine := strings.TrimSpace(match)
+		return fmt.Sprintf("%s{{- if .Values.certManager.enabled }}\n%s%s\n%s{{- end }}",
+			indent, indent, annotationLine, indent)
+	})
 	return yamlContent
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -26,12 +26,15 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
+var defaultContainerPattern = regexp.MustCompile(
+	`(?m)^\s*` + regexp.QuoteMeta(common.DefaultContainerAnnotation) + `:\s+(\S+)`,
+)
+
 // GetDefaultContainerName extracts the container name from kubectl.kubernetes.io/default-container annotation.
 // This allows the Helm plugin to work with any container name, not just "manager".
 // If the annotation is not found, it falls back to "manager" for backward compatibility.
 func GetDefaultContainerName(yamlContent string) string {
-	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(common.DefaultContainerAnnotation) + `:\s+(\S+)`)
-	matches := pattern.FindStringSubmatch(yamlContent)
+	matches := defaultContainerPattern.FindStringSubmatch(yamlContent)
 	if len(matches) > 1 {
 		return matches[1]
 	}
@@ -46,47 +49,38 @@ func LeadingWhitespace(line string) (string, int) {
 	return line[:indentLen], indentLen
 }
 
-// IsManagerDeployment checks if a Deployment is the controller manager.
-// It returns true if either the deployment name contains "controller-manager"
-// OR the deployment has the label "control-plane: controller-manager".
+// IsManagerDeployment reports whether resource is the controller-manager Deployment.
+// Annotation is not checked — any extra Deployment may carry it, causing false positives.
 func IsManagerDeployment(resource *unstructured.Unstructured) bool {
-	name := resource.GetName()
-	labels := resource.GetLabels()
-	return strings.Contains(name, "controller-manager") ||
-		(labels != nil && labels["control-plane"] == "controller-manager")
+	if resource.GetLabels()["control-plane"] == "controller-manager" {
+		return true
+	}
+	if names := ExtractContainerNames(resource); names["manager"] {
+		return true
+	}
+	return strings.Contains(resource.GetName(), "controller-manager")
 }
 
-// MakeYamlContent wraps YAML content with conditional cert-manager wrappers.
-// This function is used as a callback for regexp.ReplaceAllStringFunc.
-// It shifts the block by 2 additional spaces so that items align with the
-// child indent used by appendToListFromValues for extraVolumes/extraVolumeMounts.
+// MakeYamlContent wraps a YAML block with a cert-manager conditional.
+// Shifts by 2 spaces to align with the child indent used by appendToListFromValues.
 func MakeYamlContent(match string) string {
+	return wrapBlock(match, "{{- if .Values.certManager.enabled }}")
+}
+
+// wrapBlock wraps a YAML block match with the given Helm conditional string.
+func wrapBlock(match, condition string) string {
 	lines := strings.Split(match, "\n")
-	if len(lines) > 0 {
-		var indent strings.Builder
-		if len(lines[0]) > 0 && lines[0][0] == ' ' {
-			// Count leading spaces
-			for _, char := range lines[0] {
-				if char == ' ' {
-					indent.WriteString(" ")
-				} else {
-					break
-				}
-			}
-		}
-
-		childIndent := indent.String() + "  "
-
-		// Reconstruct the block with conditional wrapper at child indent
-		var result strings.Builder
-		fmt.Fprintf(&result, "%s{{- if .Values.certManager.enabled }}\n", childIndent)
-		for _, line := range lines {
-			result.WriteString("  " + line + "\n")
-		}
-		fmt.Fprintf(&result, "%s{{- end }}", childIndent)
-		return result.String()
+	indent, _ := LeadingWhitespace(lines[0])
+	childIndent := indent + "  "
+	var result strings.Builder
+	fmt.Fprintf(&result, "%s%s\n", childIndent, condition)
+	for _, line := range lines {
+		result.WriteString("  ")
+		result.WriteString(line)
+		result.WriteByte('\n')
 	}
-	return match
+	fmt.Fprintf(&result, "%s{{- end }}", childIndent)
+	return result.String()
 }
 
 const (
@@ -103,8 +97,47 @@ var (
 	}
 )
 
-// ExtractContainerNames returns the set of container and initContainer names declared in a
-// Deployment (or any Pod-template-bearing resource).
+// FindManagerContainerRange returns the 0-based inclusive line range of the manager container in yamlContent.
+// Returns (-1, -1) when not found; callers use this to restrict substitutions to the manager only.
+func FindManagerContainerRange(yamlContent string) (int, int) {
+	containerName := GetDefaultContainerName(yamlContent)
+	lines := strings.Split(yamlContent, "\n")
+
+	start := -1
+	containerIndentLen := -1
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "- name: "+containerName {
+			continue
+		}
+		_, indentLen := LeadingWhitespace(line)
+		start = i
+		containerIndentLen = indentLen
+		break
+	}
+
+	if start == -1 {
+		return -1, -1
+	}
+
+	end := len(lines) - 1
+	for i := start + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		_, indentLen := LeadingWhitespace(lines[i])
+		if indentLen <= containerIndentLen && strings.HasPrefix(trimmed, "- ") {
+			end = i - 1
+			break
+		}
+	}
+
+	return start, end
+}
+
+// ExtractContainerNames returns all container and initContainer names from a Deployment.
 func ExtractContainerNames(resource *unstructured.Unstructured) map[string]bool {
 	names := map[string]bool{}
 	for _, fieldPath := range [][]string{

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
-// metadataPosition represents the current position in the deployment manifest.
 type metadataPosition int
 
 const (
@@ -36,7 +35,6 @@ const (
 	positionPodMetadata
 )
 
-// blockType represents which specific YAML block we're currently inside.
 type blockType int
 
 const (
@@ -47,21 +45,16 @@ const (
 	blockPodAnnotations
 )
 
-// customFieldsState tracks parsing state for injecting custom labels and annotations.
 type customFieldsState struct {
-	// Current position in the manifest structure
 	position                metadataPosition
 	deploymentMetadataDepth int
 
-	// Flags to track if we've already injected templates (prevent duplicates)
 	addedLabelsToDeployment      bool
 	addedPodLabels               bool
 	addedAnnotationsToDeployment bool
 	addedPodAnnotations          bool
-	// Whether Deployment has an annotations field in the kustomize output
-	hasDeploymentAnnotations bool
+	hasDeploymentAnnotations     bool
 
-	// Current block being parsed and its indentation
 	currentBlock       blockType
 	currentBlockIndent int
 }
@@ -99,9 +92,7 @@ func TemplateDeploymentFields(detectedPrefix, chartName, yamlContent string) str
 		".Values.manager.tolerations",
 	)
 
-	// Optional Kubernetes features: deployment strategy and pod scheduling
-	// Template conditionals are always created (even if field doesn't exist in kustomize)
-	// so users can uncomment them in values.yaml without regenerating the chart
+	// Always emit these conditionals so users can enable them in values.yaml without regenerating.
 	yamlContent = templateBasicWithStatement(
 		yamlContent,
 		"strategy",
@@ -120,17 +111,23 @@ func TemplateDeploymentFields(detectedPrefix, chartName, yamlContent string) str
 	return yamlContent
 }
 
+// isManagerContainerPresent reports whether yamlContent contains the manager container by literal or templated name.
+func isManagerContainerPresent(yamlContent string) bool {
+	containerName := GetDefaultContainerName(yamlContent)
+	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
+	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
+	return hasLiteralName || hasTemplatedName
+}
+
 func templateReplicas(yamlContent string) string {
 	if strings.Contains(yamlContent, ".Values.manager.replicas") {
 		return yamlContent
 	}
-	// Replace spec.replicas with values.yaml reference, preserving indentation
 	replicasPattern := regexp.MustCompile(`(?m)^(\s*)replicas:\s*\d+\s*$`)
 	return replicasPattern.ReplaceAllString(yamlContent, "${1}replicas: {{ .Values.manager.replicas }}")
 }
 
 func AddCustomLabelsAndAnnotations(yamlContent string) string {
-	// Check which blocks are present to avoid duplicates when re-running
 	hasDeploymentLabels := strings.Contains(yamlContent, "{{- if .Values.manager.labels }}") ||
 		strings.Contains(yamlContent, "{{- with .Values.manager.labels }}")
 	hasDeploymentAnnotations := strings.Contains(yamlContent, "{{- if .Values.manager.annotations }}") ||
@@ -183,16 +180,17 @@ func AddCustomLabelsAndAnnotations(yamlContent string) string {
 }
 
 func templateEnvironmentVariables(yamlContent string) string {
-	containerName := GetDefaultContainerName(yamlContent)
-	// Check for both literal container name and templated container name
-	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
-	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
-	if !hasLiteralName && !hasTemplatedName {
+	if !isManagerContainerPresent(yamlContent) {
 		return yamlContent
 	}
 
+	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
+
 	lines := strings.Split(yamlContent, "\n")
 	for i := range lines {
+		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+			continue
+		}
 		if strings.TrimSpace(lines[i]) != "env:" {
 			continue
 		}
@@ -253,18 +251,18 @@ func templateEnvironmentVariables(yamlContent string) string {
 	return yamlContent
 }
 
-// templateResources converts resource sections to Helm templates
 func templateResources(yamlContent string) string {
-	containerName := GetDefaultContainerName(yamlContent)
-	// Check for both literal container name and templated container name
-	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
-	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
-	if (!hasLiteralName && !hasTemplatedName) || !strings.Contains(yamlContent, "resources:") {
+	if !isManagerContainerPresent(yamlContent) || !strings.Contains(yamlContent, "resources:") {
 		return yamlContent
 	}
 
+	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
+
 	lines := strings.Split(yamlContent, "\n")
 	for i := range lines {
+		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+			continue
+		}
 		if strings.TrimSpace(lines[i]) != "resources:" {
 			continue
 		}
@@ -280,7 +278,6 @@ func templateResources(yamlContent string) string {
 			if lineIndent < indentLen {
 				break
 			}
-			// stop at same-level keys that are not part of the resources mapping
 			if lineIndent == indentLen && !strings.Contains(trimmed, ":") {
 				break
 			}
@@ -315,7 +312,6 @@ func templateResources(yamlContent string) string {
 }
 
 func templateSecurityContexts(yamlContent string) string {
-	// Security contexts are preserved from kustomize output as-is
 	return yamlContent
 }
 
@@ -327,8 +323,8 @@ func templateVolumes(yamlContent string) string {
 	return appendToListFromValues(yamlContent, "volumes:", ".Values.manager.extraVolumes")
 }
 
-// appendToListFromValues appends a values path to a YAML list field.
-// For "key: []", replaces with conditional template. For "key:" with items, appends to the end.
+// appendToListFromValues injects a values reference into a YAML list field.
+// Replaces "key: []" with a conditional template; appends to "key:" with existing items.
 func appendToListFromValues(yamlContent string, keyColon string, valuesPath string) string {
 	if !strings.Contains(yamlContent, keyColon) {
 		return yamlContent
@@ -390,30 +386,22 @@ func appendToListFromValues(yamlContent string, keyColon string, valuesPath stri
 	return yamlContent
 }
 
-// templateImagePullSecrets exposes imagePullSecrets via values.yaml.
-// This is an optional Kubernetes deployment field that affects registry authentication but not operator logic.
-// Always injects a conditional template (even when field is missing from kustomize) so users can
-// uncomment it in values.yaml without regenerating the chart.
-// Handles list format with special logic to include all list items.
+// templateImagePullSecrets injects imagePullSecrets; always emits the block so users can enable it in values.yaml.
 func templateImagePullSecrets(yamlContent string) string {
 	lines := strings.Split(yamlContent, "\n")
 
-	// Check if field already exists
 	if strings.Contains(yamlContent, "imagePullSecrets:") {
 		for i := range lines {
-			// Use prefix to allow `imagePullSecrets: []` to be preserved
 			if !strings.HasPrefix(strings.TrimSpace(lines[i]), "imagePullSecrets:") {
 				continue
 			}
 
-			// Avoid duplicate templating
 			if i+1 < len(lines) && strings.Contains(lines[i+1], ".Values.manager.imagePullSecrets") {
 				return yamlContent
 			}
 
 			indentStr, indentLen := LeadingWhitespace(lines[i])
 			end := i + 1
-			// Find end of imagePullSecrets block
 			for ; end < len(lines); end++ {
 				trimmed := strings.TrimSpace(lines[end])
 				if trimmed == "" {
@@ -445,7 +433,6 @@ func templateImagePullSecrets(yamlContent string) string {
 		}
 	}
 
-	// Field doesn't exist - inject into pod spec (spec.template.spec)
 	var insertAt int
 	foundTemplate := false
 	for i := range lines {
@@ -482,7 +469,6 @@ func templateImagePullSecrets(yamlContent string) string {
 	return strings.Join(newLines, "\n")
 }
 
-// templatePodSecurityContext exposes podSecurityContext via values.yaml
 func templatePodSecurityContext(yamlContent string) string {
 	if !strings.Contains(yamlContent, "securityContext:") {
 		return yamlContent
@@ -540,18 +526,18 @@ func templatePodSecurityContext(yamlContent string) string {
 	return yamlContent
 }
 
-// templateContainerSecurityContext exposes container securityContext via values.yaml
 func templateContainerSecurityContext(yamlContent string) string {
-	containerName := GetDefaultContainerName(yamlContent)
-	// Check for both literal container name and templated container name
-	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
-	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
-	if (!hasLiteralName && !hasTemplatedName) || !strings.Contains(yamlContent, "securityContext:") {
+	if !isManagerContainerPresent(yamlContent) || !strings.Contains(yamlContent, "securityContext:") {
 		return yamlContent
 	}
 
+	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
+
 	lines := strings.Split(yamlContent, "\n")
 	for i := range lines {
+		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+			continue
+		}
 		if strings.TrimSpace(lines[i]) != "securityContext:" {
 			continue
 		}
@@ -604,24 +590,24 @@ func templateContainerSecurityContext(yamlContent string) string {
 	return yamlContent
 }
 
-// isManagerDeployment checks if a Deployment is the controller manager.
-// It returns true if either the deployment name contains "controller-manager"
-// OR the deployment has the label "control-plane: controller-manager".
-
-// templateControllerManagerArgs exposes controller manager args via values.yaml while keeping core defaults
 func templateControllerManagerArgs(yamlContent string) string {
-	containerName := GetDefaultContainerName(yamlContent)
-	// Check for both literal container name and templated container name
-	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
-	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
-	if !hasLiteralName && !hasTemplatedName {
+	if !isManagerContainerPresent(yamlContent) {
 		return yamlContent
 	}
+
+	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
 
 	argsPattern := regexp.MustCompile(`(?m)([ \t]+)args:\n((?:[ \t]+-.*\n)+)`)
 	loc := argsPattern.FindStringSubmatchIndex(yamlContent)
 	if loc == nil {
 		return yamlContent
+	}
+
+	if rangeStart >= 0 {
+		matchLine := strings.Count(yamlContent[:loc[0]], "\n")
+		if matchLine < rangeStart || matchLine > rangeEnd {
+			return yamlContent
+		}
 	}
 
 	match := yamlContent[loc[0]:loc[1]]
@@ -719,19 +705,18 @@ func templateControllerManagerArgs(yamlContent string) string {
 	return yamlContent[:loc[0]] + newBlock + yamlContent[loc[1]:]
 }
 
-// templateImageReference converts hardcoded image references to Helm templates
 func templateImageReference(yamlContent string) string {
-	containerName := GetDefaultContainerName(yamlContent)
-	// Check for both literal container name and templated container name (which may have been
-	// converted by substituteResourceNamesWithPrefix before this function runs)
-	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
-	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
-	if !hasLiteralName && !hasTemplatedName {
+	if !isManagerContainerPresent(yamlContent) {
 		return yamlContent
 	}
 
+	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
+
 	lines := strings.Split(yamlContent, "\n")
 	for i := 0; i < len(lines); i++ {
+		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+			continue
+		}
 		trimmed := strings.TrimSpace(lines[i])
 		if !strings.HasPrefix(trimmed, "image:") {
 			continue
@@ -753,7 +738,6 @@ func templateImageReference(yamlContent string) string {
 			if lineIndent <= indentLen {
 				break
 			}
-			// Stop when we reach a sibling key like env:, args:, etc.
 			if lineIndent == indentLen+2 && strings.HasSuffix(nextTrimmed, ":") {
 				if strings.Contains(nextTrimmed, "imagePullPolicy") {
 					continue
@@ -762,7 +746,6 @@ func templateImageReference(yamlContent string) string {
 			}
 		}
 
-		// Remove any existing imagePullPolicy line inside the block
 		blockLines := lines[i+1 : end]
 		filtered := make([]string, 0, len(blockLines))
 		for _, line := range blockLines {
@@ -811,7 +794,6 @@ func templateBasicWithStatement(
 	var start, end int
 	var indentLen int
 	if !strings.Contains(yamlContent, yamlKey) {
-		// Find parent block start if the key is missing
 		pKeyParts := strings.Split(parentKey, ".")
 		pKeyIdx := 0
 		pKeyInit := false
@@ -825,7 +807,6 @@ func templateBasicWithStatement(
 				continue
 			}
 
-			// Parent key part found
 			pKeyIdx++
 			pKeyInit = true
 			if pKeyIdx >= len(pKeyParts) {
@@ -836,7 +817,6 @@ func templateBasicWithStatement(
 		}
 		_, indentLen = LeadingWhitespace(lines[start])
 	} else {
-		// Find the existing block - stop at the first match.
 		for i := range len(lines) {
 			if !strings.HasPrefix(strings.TrimSpace(lines[i]), yamlKey) {
 				continue
@@ -860,7 +840,7 @@ func templateBasicWithStatement(
 					}
 				}
 			}
-			break // use the first match only
+			break
 		}
 		_, indentLen = LeadingWhitespace(lines[start])
 	}
@@ -889,16 +869,13 @@ func templateBasicWithStatement(
 }
 
 func templatePriorityClassName(yamlContent string) string {
-	// Avoid duplicate templating
 	if strings.Contains(yamlContent, ".Values.manager.priorityClassName") {
 		return yamlContent
 	}
 
 	lines := strings.Split(yamlContent, "\n")
 
-	// Check if field already exists
 	if strings.Contains(yamlContent, "priorityClassName:") {
-		// Replace existing field with template (quote filter ensures proper YAML quoting)
 		pattern := regexp.MustCompile(`(?m)^(\s*)priorityClassName:\s*"?([^"\n]*)"?\s*$`)
 		yamlContent = pattern.ReplaceAllString(yamlContent,
 			"${1}{{- with .Values.manager.priorityClassName }}\n"+
@@ -907,8 +884,6 @@ func templatePriorityClassName(yamlContent string) string {
 		return yamlContent
 	}
 
-	// Field doesn't exist - inject it after finding parent block (spec.template.spec)
-	// Look for "spec:" (pod spec) under template
 	var insertAt int
 	foundTemplate := false
 	for i := range lines {
@@ -918,49 +893,39 @@ func templatePriorityClassName(yamlContent string) string {
 			continue
 		}
 		if foundTemplate && trimmed == common.YamlKeySpec {
-			// Found pod spec, inject at next line
 			insertAt = i + 1
 			break
 		}
 	}
 
 	if insertAt == 0 || insertAt >= len(lines) {
-		// Couldn't find injection point
 		return yamlContent
 	}
 
-	// Get indentation from the line after spec:
 	_, indentLen := LeadingWhitespace(lines[insertAt])
 	indentStr := strings.Repeat(" ", indentLen)
 
-	// Create conditional block (quote filter ensures proper YAML quoting)
 	block := []string{
 		indentStr + "{{- with .Values.manager.priorityClassName }}",
 		indentStr + "priorityClassName: {{ . | quote }}",
 		indentStr + "{{- end }}",
 	}
 
-	// Insert block
 	newLines := append([]string{}, lines[:insertAt]...)
 	newLines = append(newLines, block...)
 	newLines = append(newLines, lines[insertAt:]...)
 	return strings.Join(newLines, "\n")
 }
 
-// templateTerminationGracePeriodSeconds templates terminationGracePeriodSeconds.
-// Always injects this field (even when not in kustomize output) so users can configure
-// pod shutdown timeout in values.yaml. Uses hasKey to allow 0 seconds (immediate shutdown).
+// templateTerminationGracePeriodSeconds injects terminationGracePeriodSeconds; uses hasKey to allow 0 values.
 func templateTerminationGracePeriodSeconds(yamlContent string) string {
-	// Avoid duplicate templating
 	if strings.Contains(yamlContent, ".Values.manager.terminationGracePeriodSeconds") {
 		return yamlContent
 	}
 
 	lines := strings.Split(yamlContent, "\n")
 
-	// Check if field already exists
 	if strings.Contains(yamlContent, "terminationGracePeriodSeconds:") {
-		// Replace existing field with template (hasKey + ne nil supports 0 values while preventing <no value>)
 		pattern := regexp.MustCompile(`(?m)^(\s*)terminationGracePeriodSeconds:\s*\d+\s*$`)
 		yamlContent = pattern.ReplaceAllString(yamlContent,
 			"${1}{{- if and (hasKey .Values.manager \"terminationGracePeriodSeconds\") "+
@@ -970,28 +935,22 @@ func templateTerminationGracePeriodSeconds(yamlContent string) string {
 		return yamlContent
 	}
 
-	// Field doesn't exist - inject it after finding serviceAccountName (typical location)
-	// Look for "serviceAccountName:" in pod spec
 	var insertAt int
 	for i := range lines {
 		trimmed := strings.TrimSpace(lines[i])
 		if strings.HasPrefix(trimmed, "serviceAccountName:") {
-			// Inject after serviceAccountName
 			insertAt = i + 1
 			break
 		}
 	}
 
 	if insertAt == 0 || insertAt >= len(lines) {
-		// Couldn't find injection point
 		return yamlContent
 	}
 
-	// Get indentation from serviceAccountName line
 	_, indentLen := LeadingWhitespace(lines[insertAt-1])
 	indentStr := strings.Repeat(" ", indentLen)
 
-	// Create conditional block (hasKey + ne nil supports 0 values while preventing <no value>)
 	block := []string{
 		indentStr + "{{- if and (hasKey .Values.manager \"terminationGracePeriodSeconds\") " +
 			"(ne .Values.manager.terminationGracePeriodSeconds nil) }}",
@@ -999,7 +958,6 @@ func templateTerminationGracePeriodSeconds(yamlContent string) string {
 		indentStr + "{{- end }}",
 	}
 
-	// Insert block
 	newLines := append([]string{}, lines[:insertAt]...)
 	newLines = append(newLines, block...)
 	newLines = append(newLines, lines[insertAt:]...)
@@ -1026,8 +984,6 @@ func handleDeploymentAnnotations(
 		childIndent := detectChildIndent(result, parentIndent)
 
 		if len(existingKeys) == 0 {
-			// Empty annotations block (e.g., from "annotations: {}") - wrap header in conditional
-			// to avoid rendering "annotations: null" when values not set
 			result = result[:len(result)-1]
 			childIndentWidth := strconv.Itoa(len(childIndent))
 			result = append(result,
@@ -1037,7 +993,6 @@ func handleDeploymentAnnotations(
 				parentIndent+"{{- end }}",
 			)
 		} else {
-			// Has existing annotations - inject additional ones with omit() filtering
 			result = injectDeploymentAnnotations(result, childIndent)
 		}
 
@@ -1049,7 +1004,6 @@ func handleDeploymentAnnotations(
 	return result
 }
 
-// handlePodAnnotations handles injection of custom Pod template annotations.
 func handlePodAnnotations(
 	state *customFieldsState, result []string, line, trimmed, indent string, indentLen int,
 ) []string {
@@ -1069,8 +1023,6 @@ func handlePodAnnotations(
 		childIndent := detectChildIndent(result, parentIndent)
 
 		if len(existingKeys) == 0 {
-			// Empty annotations block (e.g., from "annotations: {}") - wrap header in conditional
-			// to avoid rendering "annotations: null" when values not set
 			result = result[:len(result)-1]
 			childIndentWidth := strconv.Itoa(len(childIndent))
 			result = append(result,
@@ -1082,7 +1034,6 @@ func handlePodAnnotations(
 				parentIndent+"{{- end }}",
 			)
 		} else {
-			// Has existing annotations - inject additional ones with omit() filtering
 			result = addPodAnnotations(result, childIndent)
 		}
 
@@ -1104,7 +1055,6 @@ func handlePodAnnotations(
 	return result
 }
 
-// shouldInjectDeploymentAnnotations checks if we should inject Deployment annotations.
 func shouldInjectDeploymentAnnotations(
 	state *customFieldsState, trimmed string, indentLen int,
 ) bool {
@@ -1117,7 +1067,6 @@ func shouldInjectDeploymentAnnotations(
 		!strings.HasPrefix(trimmed, common.YamlKeyAnnotations+" {")
 }
 
-// shouldInjectPodAnnotations checks if we should inject Pod annotations.
 func shouldInjectPodAnnotations(state *customFieldsState, trimmed string, indentLen int) bool {
 	return (state.position == positionPodMetadata || state.position == positionAfterDeploymentMetadata) &&
 		state.currentBlock == blockPodAnnotations &&
@@ -1128,7 +1077,6 @@ func shouldInjectPodAnnotations(state *customFieldsState, trimmed string, indent
 		!strings.HasPrefix(trimmed, common.YamlKeyAnnotations+" {")
 }
 
-// handleDeploymentLabels handles injection of custom Deployment labels.
 func handleDeploymentLabels(
 	state *customFieldsState, result []string, line, trimmed string, indentLen int,
 ) []string {
@@ -1435,82 +1383,29 @@ func MakeWebhookVolumeMountsConditional(yamlContent string) string {
 
 // MakeMetricsVolumesConditional wraps metrics volumes with the metrics TLS conditional.
 func MakeMetricsVolumesConditional(yamlContent string) string {
-	// Make metrics volumes conditional on certManager.enabled AND metrics.enabled AND metrics.secure
 	if strings.Contains(yamlContent, "metrics-certs") && strings.Contains(yamlContent, "secretName: metrics-server-cert") {
-		// Match only spaces/tabs for indent to avoid consuming the newline
-		volumePattern := regexp.MustCompile(`([ \t]+)-\s*name:\s*metrics-certs[\s\S]*?secretName:\s*metrics-server-cert`)
-		yamlContent = volumePattern.ReplaceAllStringFunc(yamlContent, func(match string) string {
-			lines := strings.Split(match, "\n")
-			if len(lines) > 0 {
-				var indent strings.Builder
-				if len(lines[0]) > 0 && lines[0][0] == ' ' {
-					// Count leading spaces
-					for _, char := range lines[0] {
-						if char == ' ' {
-							indent.WriteString(" ")
-						} else {
-							break
-						}
-					}
-				}
-
-				childIndent := indent.String() + "  "
-
-				// Reconstruct the block with conditional wrapper at child indent
-				var result strings.Builder
-				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enabled"+
-					" .Values.metrics.enabled .Values.metrics.secure }}\n", childIndent)
-				for _, line := range lines {
-					result.WriteString("  " + line + "\n")
-				}
-				fmt.Fprintf(&result, "%s{{- end }}", childIndent)
-				return result.String()
-			}
-			return match
-		})
+		// [ \t]+ matches only spaces/tabs so the newline is not consumed by the regexp.
+		pattern := regexp.MustCompile(`([ \t]+)-\s*name:\s*metrics-certs[\s\S]*?secretName:\s*metrics-server-cert`)
+		yamlContent = wrapWithMetricsTLSConditional(pattern, yamlContent)
 	}
-
 	return yamlContent
 }
 
 // MakeMetricsVolumeMountsConditional wraps metrics volumeMounts with the metrics TLS conditional.
 func MakeMetricsVolumeMountsConditional(yamlContent string) string {
-	// Make metrics volumeMounts conditional on certManager.enabled AND metrics.enabled AND metrics.secure
 	metricsCertsPath := "/tmp/k8s-metrics-server/metrics-certs"
 	if strings.Contains(yamlContent, "metrics-certs") && strings.Contains(yamlContent, metricsCertsPath) {
-		// Match only spaces/tabs for indent to avoid consuming the newline
-		mountPattern := regexp.MustCompile(
+		// [ \t]+ matches only spaces/tabs so the newline is not consumed by the regexp.
+		pattern := regexp.MustCompile(
 			`([ \t]+)-\s*mountPath:\s*/tmp/k8s-metrics-server/metrics-certs[\s\S]*?readOnly:\s*true`)
-		yamlContent = mountPattern.ReplaceAllStringFunc(yamlContent, func(match string) string {
-			lines := strings.Split(match, "\n")
-			if len(lines) > 0 {
-				var indent strings.Builder
-				if len(lines[0]) > 0 && lines[0][0] == ' ' {
-					// Count leading spaces
-					for _, char := range lines[0] {
-						if char == ' ' {
-							indent.WriteString(" ")
-						} else {
-							break
-						}
-					}
-				}
-
-				childIndent := indent.String() + "  "
-
-				// Reconstruct the block with conditional wrapper at child indent
-				var result strings.Builder
-				fmt.Fprintf(&result, "%s{{- if and .Values.certManager.enabled"+
-					" .Values.metrics.enabled .Values.metrics.secure }}\n", childIndent)
-				for _, line := range lines {
-					result.WriteString("  " + line + "\n")
-				}
-				fmt.Fprintf(&result, "%s{{- end }}", childIndent)
-				return result.String()
-			}
-			return match
-		})
+		yamlContent = wrapWithMetricsTLSConditional(pattern, yamlContent)
 	}
-
 	return yamlContent
+}
+
+func wrapWithMetricsTLSConditional(pattern *regexp.Regexp, yamlContent string) string {
+	const metricsCondition = "{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}"
+	return pattern.ReplaceAllStringFunc(yamlContent, func(match string) string {
+		return wrapBlock(match, metricsCondition)
+	})
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -37,6 +37,8 @@ const (
 
 	// Test expectation constants for test-project.resourceName templates
 	expectedIssuerName = `name: {{ include "test-project.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}`
+
+	k8sSpecField = "spec"
 )
 
 var _ = Describe("Templater", func() {
@@ -2862,9 +2864,9 @@ spec:
 					"metadata": map[string]any{
 						"name": "test-project-controller-manager", //nolint:goconst
 					},
-					"spec": map[string]any{
+					k8sSpecField: map[string]any{
 						"template": map[string]any{
-							"spec": map[string]any{
+							k8sSpecField: map[string]any{
 								"volumes": []any{
 									map[string]any{"name": "webhook-certs", "secret": map[string]any{"secretName": "webhook-server-cert"}},
 									map[string]any{"name": "metrics-certs", "secret": map[string]any{"secretName": "metrics-server-cert"}},
@@ -4152,7 +4154,7 @@ rules: []`
 	Context("ServiceAccount configuration", func() {
 		Context("when managing ServiceAccount creation via values.yaml", func() {
 			It("allows toggling ServiceAccount installation with serviceAccount.enabled flag", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
+				saTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4168,14 +4170,14 @@ metadata:
   name: controller-manager
   namespace: system`
 
-				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
+				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
 				Expect(result).To(ContainSubstring("{{- if ne .Values.serviceAccount.enabled false }}"))
 				Expect(result).To(ContainSubstring("{{- end }}"))
 			})
 
 			It("supports custom annotations for cloud provider integrations", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
+				saTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4189,7 +4191,7 @@ metadata:
     app.kubernetes.io/name: test-project
   name: controller-manager`
 
-				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
+				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
 				Expect(result).To(ContainSubstring("{{- with .Values.serviceAccount.annotations }}"))
 				Expect(result).To(ContainSubstring("annotations:"))
@@ -4197,7 +4199,7 @@ metadata:
 			})
 
 			It("supports custom labels without duplicating existing standard labels", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
+				saTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4212,7 +4214,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager`
 
-				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
+				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
 				Expect(result).To(ContainSubstring("{{- with .Values.serviceAccount.labels }}"))
 				Expect(result).To(ContainSubstring(`{{- with omit .`))
@@ -4221,7 +4223,7 @@ metadata:
 			})
 
 			It("merges custom annotations with existing annotations without duplication", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
+				saTemplater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
 
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
@@ -4237,7 +4239,7 @@ metadata:
     existing.annotation/key: "existing-value"
   name: controller-manager`
 
-				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
+				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
 				// Should NOT have duplicate annotations: keys
 				annotationsCount := strings.Count(result, "annotations:")
@@ -4255,8 +4257,6 @@ metadata:
 
 		Context("when using default ServiceAccount with nameOverride/fullnameOverride", func() {
 			It("respects nameOverride and fullnameOverride for default ServiceAccount name", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
 				serviceAccount.SetKind("ServiceAccount")
@@ -4273,8 +4273,6 @@ metadata:
 			})
 
 			It("ensures ServiceAccount name matches across all resource references", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				deployment := &unstructured.Unstructured{}
 				deployment.SetAPIVersion("apps/v1")
 				deployment.SetKind("Deployment")
@@ -4296,8 +4294,6 @@ spec:
 
 		Context("when binding RBAC permissions to ServiceAccount", func() {
 			It("references ServiceAccount consistently in RoleBinding subjects", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				roleBinding := &unstructured.Unstructured{}
 				roleBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")
 				roleBinding.SetKind("RoleBinding")
@@ -4323,8 +4319,6 @@ subjects:
 			})
 
 			It("references ServiceAccount consistently in ClusterRoleBinding subjects", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				clusterRoleBinding := &unstructured.Unstructured{}
 				clusterRoleBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")
 				clusterRoleBinding.SetKind("ClusterRoleBinding")
@@ -4352,8 +4346,6 @@ subjects:
 
 		Context("when handling project names with prefixes", func() {
 			It("templates ServiceAccount name correctly with project prefix", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				serviceAccount := &unstructured.Unstructured{}
 				serviceAccount.SetAPIVersion("v1")
 				serviceAccount.SetKind("ServiceAccount")
@@ -4370,8 +4362,6 @@ metadata:
 			})
 
 			It("templates Deployment serviceAccountName field correctly with project prefix", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				deployment := &unstructured.Unstructured{}
 				deployment.SetAPIVersion("apps/v1")
 				deployment.SetKind("Deployment")
@@ -4391,8 +4381,6 @@ spec:
 			})
 
 			It("templates RoleBinding subjects correctly with project prefix", func() {
-				templater := NewTemplater(testProjectName, testProjectName, testProjectSystemNamespace, nil)
-
 				roleBinding := &unstructured.Unstructured{}
 				roleBinding.SetAPIVersion("rbac.authorization.k8s.io/v1")
 				roleBinding.SetKind("RoleBinding")
@@ -4413,7 +4401,7 @@ subjects:
 
 		Context("when ensuring Kubernetes resource name limits", func() {
 			It("delegates truncation to resourceName helper for 63-character limit compliance", func() {
-				templater := NewTemplater("very-long-project-name-that-needs-truncation",
+				longNameTemplater := NewTemplater("very-long-project-name-that-needs-truncation",
 					"very-long-project-name-that-needs-truncation",
 					"very-long-project-name-that-needs-truncation-system", nil)
 
@@ -4427,10 +4415,80 @@ kind: ServiceAccount
 metadata:
   name: controller-manager`
 
-				result := templater.ApplyHelmSubstitutions(content, serviceAccount)
+				result := longNameTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
 				Expect(result).To(ContainSubstring(
 					`name: {{ include "very-long-project-name-that-needs-truncation.serviceAccountName" . }}`))
+			})
+		})
+
+		Context("when a non-manager deployment is present alongside the manager", func() {
+			It("does not apply manager templates to an extra deployment with only the default-container annotation", func() {
+				// The annotation alone must not identify the manager — extra deployments with multiple containers carry it too.
+				extraDeployment := &unstructured.Unstructured{}
+				extraDeployment.SetAPIVersion("apps/v1")
+				extraDeployment.SetKind("Deployment")
+				extraDeployment.SetName("test-project-some-operator")
+
+				content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-some-operator
+  namespace: test-project-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: worker
+    spec:
+      containers:
+      - name: worker
+        image: worker:latest
+`
+				result := templater.ApplyHelmSubstitutions(content, extraDeployment)
+
+				Expect(result).NotTo(ContainSubstring("{{ .Values.manager.replicas }}"),
+					"manager replicas template must not appear in a non-manager deployment")
+				Expect(result).NotTo(ContainSubstring("{{ .Values.manager.image.repository }}"),
+					"manager image template must not appear in a non-manager deployment")
+				Expect(result).NotTo(ContainSubstring("{{ .Values.manager."),
+					"no manager values must be injected into a non-manager deployment")
+			})
+
+			It("applies manager-specific templates to a deployment identified only by container name", func() {
+				// Manager identified by container name when the control-plane label is absent.
+				managerDeployment := &unstructured.Unstructured{}
+				managerDeployment.SetAPIVersion("apps/v1")
+				managerDeployment.SetKind("Deployment")
+				managerDeployment.SetName("test-project-controller-manager")
+				managerDeployment.Object[k8sSpecField] = map[string]any{
+					"template": map[string]any{
+						k8sSpecField: map[string]any{
+							"containers": []any{
+								map[string]any{"name": "manager", "image": "controller:latest"},
+							},
+						},
+					},
+				}
+
+				content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+`
+				result := templater.ApplyHelmSubstitutions(content, managerDeployment)
+
+				Expect(result).To(ContainSubstring("{{ .Values.manager.replicas }}"),
+					"manager replicas template must appear for a deployment with a container named manager")
 			})
 		})
 	})


### PR DESCRIPTION
Fix the helm/v2alpha plugin manager Deployment identification when multiple Deployments are present, adds clear errors when no Deployment or manager container is found, and removes duplicated conditional-wrapping and volume-filtering logic.

## What are use cases which are fixed now

**- Fixed Helm chart generation when multiple Deployments are present.**

  The plugin now reliably identifies the controller-manager Deployment. If no match is found, it returns:

  `could not identify the controller-manager`

  Additional Deployments are added to the extras chart.

**- Fixed Helm chart generation when the manager Deployment has no containers.**

  The plugin now returns:

  `no manager container found in Deployment "<name>"`

## Code cleanup

- Replaced duplicated conditional wrapping logic with a shared `wrapBlock` helper.
- Replaced duplicated volume and volume-mount filtering logic with a shared `extractExtraEntries` helper.

## Test coverage

Added tests for:

- `RemoveExtractedVolumes` with only custom volumes.
- `ExtractDeploymentConfig` with no containers.
- Chart scaffolder error paths:
  - no Deployment
  - ambiguous Deployments
  - empty container list

Note: Motivated-by/Follow up: https://github.com/kubernetes-sigs/kubebuilder/pull/5764

