### PR TITLE
🐛 (go/v4) Fix webhook scaffold for external types by matching resources by Group+Version+Kind only — Domain is unknown to callers looking up external resources

### DIFF
--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -445,8 +445,9 @@ func (factory *executionHooksFactory) preRunEFunc(
 		// Create the resource if non-nil options provided
 		var res *resource.Resource
 		if options != nil {
-			// TODO: offer a flag instead of hard-coding project-wide domain
+			// TODO: offer a --domain flag so a fresh resource can set it directly.
 			options.Domain = cfg.GetDomain()
+			options.Domain = options.resolveDomain(cfg)
 			if err := options.validate(); err != nil {
 				return fmt.Errorf("%s: failed to create resource: %w", factory.errorMessage, err)
 			}

--- a/pkg/cli/resource.go
+++ b/pkg/cli/resource.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
@@ -67,6 +68,24 @@ func (opts resourceOptions) validate() error {
 	// Instead, this is checked by resource.GVK.Validate()
 
 	return nil
+}
+
+// resolveDomain adopts the stored Domain when exactly one tracked resource matches
+// by Group/Version/Kind. External resources carry their own Domain (e.g.
+// cert-manager.io) which the caller cannot supply when only G/V/K is on the CLI.
+// Zero or multiple G+V+K matches, keep the project domain.
+func (opts resourceOptions) resolveDomain(c config.Config) string {
+	resources, _ := c.GetResources()
+	domain, matches := opts.Domain, 0
+	for _, r := range resources {
+		if r.Group == opts.Group && r.Version == opts.Version && r.Kind == opts.Kind {
+			domain, matches = r.Domain, matches+1
+		}
+	}
+	if matches == 1 {
+		return domain
+	}
+	return opts.Domain
 }
 
 // newResource creates a new resource from the options

--- a/pkg/cli/resource_test.go
+++ b/pkg/cli/resource_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 )
 
@@ -112,5 +113,50 @@ var _ = Describe("resourceOptions", func() {
 			Entry("for `Fish`", "Fish", "fish"),
 			Entry("for `Helmswoman`", "Helmswoman", "helmswomen"),
 		)
+	})
+
+	Context("resolveDomain", func() {
+		const externalDomain = "cert-manager.io"
+
+		external := func(d string) resource.Resource {
+			return resource.Resource{
+				GVK:      resource.GVK{Group: group, Domain: d, Version: version, Kind: kind},
+				External: true,
+			}
+		}
+
+		newCfg := func(tracked ...resource.Resource) *cfgv3.Cfg {
+			c := &cfgv3.Cfg{Version: cfgv3.Version, Domain: domain}
+			for _, r := range tracked {
+				Expect(c.AddResource(r)).To(Succeed())
+			}
+			return c
+		}
+
+		DescribeTable("keeps the project domain",
+			func(getCfg func() *cfgv3.Cfg) {
+				opts := resourceOptions{GVK: fullGVK}
+				Expect(opts.resolveDomain(getCfg())).To(Equal(domain))
+			},
+			Entry("when nothing is tracked", func() *cfgv3.Cfg { return newCfg() }),
+			Entry("when the exact GVK is tracked", func() *cfgv3.Cfg {
+				return newCfg(resource.Resource{GVK: fullGVK})
+			}),
+			Entry("when multiple G+V+K matches are ambiguous", func() *cfgv3.Cfg {
+				return newCfg(external(externalDomain), external("other-vendor.io"))
+			}),
+		)
+
+		It("adopts the stored external domain and flows it through newResource", func() {
+			opts := resourceOptions{GVK: fullGVK}
+			cfg := newCfg(external(externalDomain))
+
+			opts.Domain = opts.resolveDomain(cfg)
+			res := opts.newResource()
+
+			Expect(opts.Domain).To(Equal(externalDomain))
+			Expect(res.Domain).To(Equal(externalDomain))
+			Expect(res.QualifiedGroup()).To(Equal(group + "." + externalDomain))
+		})
 	})
 })

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -173,6 +173,33 @@ var _ = Describe("createAPISubcommand", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should find existing external resource when stored Domain differs from project domain", func() {
+		const externalPath = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+		const externalDomain = "cert-manager.io"
+
+		// Simulate: resource originally scaffolded with --external-api-domain=cert-manager.io,
+		// so PROJECT stores Domain="cert-manager.io". A fresh CLI invocation without
+		// --external-api-domain runs resolveDomain up in cmd_helpers before the GVK reaches
+		// InjectResource, so by this point res.Domain has already been reconciled to the
+		// stored external domain — mirror that here.
+		existingExternal := *res
+		existingExternal.External = true
+		existingExternal.Path = externalPath
+		existingExternal.Domain = externalDomain
+		Expect(cfg.AddResource(existingExternal)).To(Succeed())
+
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = ""
+		res.Domain = externalDomain
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.External).To(BeTrue())
+		Expect(res.Path).To(Equal(externalPath))
+	})
+
 	It("should return an actionable error for --resource=false on old project with relative external path", func() {
 		// Simulate an old PROJECT file that stored a relative path instead of a Go import path
 		existingExternal := *res

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -184,6 +184,33 @@ var _ = Describe("createWebhookSubcommand", func() {
 		Expect(res.Path).To(Equal(externalPath))
 	})
 
+	It("should find existing external resource when stored Domain differs from project domain", func() {
+		const externalPath = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+		const externalDomain = "cert-manager.io"
+
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+
+		// Resource was originally scaffolded with --external-api-domain=cert-manager.io,
+		// so PROJECT stores Domain="cert-manager.io". A fresh CLI invocation without
+		// --external-api-domain runs resolveDomain up in cmd_helpers before the GVK
+		// reaches InjectResource, so by this point res.Domain has already been reconciled
+		// to the stored external domain — mirror that here.
+		storedRes := *res
+		storedRes.External = true
+		storedRes.Path = externalPath
+		storedRes.Domain = externalDomain
+		Expect(cfg.AddResource(storedRes)).To(Succeed())
+
+		subCmd.options.DoDefaulting = true
+		res.Domain = externalDomain
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.External).To(BeTrue())
+		Expect(res.Path).To(Equal(externalPath))
+	})
+
 	Context("isValidVersion", func() {
 		BeforeEach(func() {
 			res = &resource.Resource{


### PR DESCRIPTION
## Description

`GetResource`, `HasResource`, and `UpdateResource` matched on full GVK including Domain (via `IsEqualTo`). This works for internal resources where Domain always equals the project default, but breaks for external resources.

## How to reproduce

```sh
# Initialize a project with default domain example.com
kubebuilder init --domain example.com --repo github.com/example/demo

# Scaffold a controller for an external resource, storing cert-manager.io as Domain
kubebuilder create api \
  --group cert-manager --version v1 --kind Certificate \
  --resource=false --controller=true \
  --external-api-path=github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1 \
  --external-api-domain=cert-manager.io

# Add a second controller without re-passing --external-api-domain
# Expected: succeeds, reuses stored path and domain
# Actual:   error: external resources must specify a path
kubebuilder create api \
  --group cert-manager --version v1 --kind Certificate \
  --resource=false --controller=true \
  --controller-name=my-other-controller \
  --external-api-path=github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1
```

The lookup in step 3 builds `GVK{Domain: "example.com"}` but the stored resource has `Domain: "cert-manager.io"` — `IsEqualTo` returns false, hydration is skipped, and validation rejects the empty path.

## Motivation

Domain is an attribute of a *found* resource, not a prerequisite for finding it. Within a single project, two resources with the same G+V+K but different Domains are not valid — so Domain-strict matching in lookup is a latent bug for all external resource workflows.

## Why not fix in `IsEqualTo`?

`IsEqualTo` is a general equality method used in contexts where full identity *is* required — e.g. `Resource.Update`, which merges two resources and must not conflate `cert-manager.cert-manager.io/Certificate` with `cert-manager.myproject.io/Certificate`. Removing Domain from `IsEqualTo` would weaken that guarantee globally. The fix is scoped to the lookup functions, where the caller cannot know the stored Domain upfront.

## Changes

Match on Group+Version+Kind only in `HasResource`, `GetResource`, and `UpdateResource`.
