### PR TITLE
🐛 (go/v4): Resolve envtest teardown timeout in scaffold generator

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -95,9 +95,8 @@ var _ = BeforeSuite(func() {
 	*/
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -168,8 +167,13 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 /*

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -95,8 +95,9 @@ var _ = BeforeSuite(func() {
 	*/
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -167,9 +168,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -57,12 +57,11 @@ Now, let's go through the code generated.
 */
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	testEnv        *envtest.Environment
-	cfg            *rest.Config
-	k8sClient      client.Client // You'll be using this client in your tests.
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client // You'll be using this client in your tests.
 )
 
 func TestControllers(t *testing.T) {
@@ -96,8 +95,9 @@ var _ = BeforeSuite(func() {
 	*/
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -153,11 +153,8 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
@@ -171,16 +168,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -57,11 +57,12 @@ Now, let's go through the code generated.
 */
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	testEnv   *envtest.Environment
-	cfg       *rest.Config
-	k8sClient client.Client // You'll be using this client in your tests.
+	ctx            context.Context
+	cancel         context.CancelFunc
+	testEnv        *envtest.Environment
+	cfg            *rest.Config
+	k8sClient      client.Client // You'll be using this client in your tests.
+	managerStopped chan struct{}
 )
 
 func TestControllers(t *testing.T) {
@@ -152,8 +153,11 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopCh)
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
@@ -167,10 +171,13 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	<-managerStopped
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = batchv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = batchv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = batchv1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -67,9 +67,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -90,8 +89,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,9 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,15 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -89,10 +89,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -95,9 +95,8 @@ var _ = BeforeSuite(func() {
 	*/
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -168,8 +167,13 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 /*

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -95,8 +95,9 @@ var _ = BeforeSuite(func() {
 	*/
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -167,9 +168,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -57,12 +57,11 @@ Now, let's go through the code generated.
 */
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	testEnv        *envtest.Environment
-	cfg            *rest.Config
-	k8sClient      client.Client // You'll be using this client in your tests.
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	testEnv   *envtest.Environment
+	cfg       *rest.Config
+	k8sClient client.Client // You'll be using this client in your tests.
 )
 
 func TestControllers(t *testing.T) {
@@ -96,8 +95,9 @@ var _ = BeforeSuite(func() {
 	*/
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -153,11 +153,8 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
@@ -171,16 +168,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -57,11 +57,12 @@ Now, let's go through the code generated.
 */
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	testEnv   *envtest.Environment
-	cfg       *rest.Config
-	k8sClient client.Client // You'll be using this client in your tests.
+	ctx            context.Context
+	cancel         context.CancelFunc
+	testEnv        *envtest.Environment
+	cfg            *rest.Config
+	k8sClient      client.Client // You'll be using this client in your tests.
+	managerStopped chan struct{}
 )
 
 func TestControllers(t *testing.T) {
@@ -152,8 +153,11 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopCh)
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
@@ -167,10 +171,13 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	<-managerStopped
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = batchv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = batchv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = batchv1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = batchv2.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = batchv2.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = batchv2.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -597,9 +597,8 @@ var (
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 `, suiteTestCleanup)
 	hackutils.CheckError("updating suite_test.go to cleanup tests", err)

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -597,8 +597,13 @@ var (
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 `, suiteTestCleanup)
 	hackutils.CheckError("updating suite_test.go to cleanup tests", err)

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -597,15 +597,8 @@ var (
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 `, suiteTestCleanup)
 	hackutils.CheckError("updating suite_test.go to cleanup tests", err)

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -597,10 +597,12 @@ var (
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -117,8 +117,13 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 /*

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -117,9 +117,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -40,7 +40,6 @@ var (
 	testEnv   *envtest.Environment
 	cfg       *rest.Config
 	k8sClient client.Client // You'll be using this client in your tests.
-	managerStopped chan struct{}
 )
 `
 
@@ -102,11 +101,8 @@ const suiteTestDescription = `
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
@@ -121,16 +117,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -40,6 +40,7 @@ var (
 	testEnv   *envtest.Environment
 	cfg       *rest.Config
 	k8sClient client.Client // You'll be using this client in your tests.
+	managerStopped chan struct{}
 )
 `
 
@@ -101,8 +102,11 @@ const suiteTestDescription = `
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopCh)
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
@@ -117,10 +121,13 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	<-managerStopped
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -181,7 +181,6 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join({{ .CRDDirectoryRelativePath }}, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:   {{ .Resource.HasAPI }},
-		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -202,8 +201,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -179,8 +179,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join({{ .CRDDirectoryRelativePath }}, "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: {{ .Resource.HasAPI }},
+		CRDDirectoryPaths:       []string{filepath.Join({{ .CRDDirectoryRelativePath }}, "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   {{ .Resource.HasAPI }},
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -201,9 +202,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -201,10 +201,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -181,6 +181,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join({{ .CRDDirectoryRelativePath }}, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:   {{ .Resource.HasAPI }},
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -201,15 +202,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -239,7 +239,6 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:   {{ .WireResource }},
-		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "webhook")},
@@ -301,8 +300,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
@@ -385,7 +389,6 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:   {{ .WireResource }},
-		ControlPlaneStopTimeout: time.Minute,
 
 		// The BinaryAssetsDirectory is only required if you want to run the tests directly
 		// without call the makefile target test. If not informed it will look for the
@@ -460,7 +463,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -214,6 +214,7 @@ var (
 	k8sClient client.Client
 	cfg *rest.Config
 	testEnv *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -226,6 +227,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = %s.AddToScheme(scheme.Scheme)
@@ -235,8 +237,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: {{ .WireResource }},
+		CRDDirectoryPaths:       []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   {{ .WireResource }},
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "webhook")},
@@ -276,6 +279,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -296,9 +300,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
@@ -362,6 +366,7 @@ var (
 	ctx context.Context
 	k8sClient client.Client
 	testEnv *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -374,11 +379,13 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: {{ .WireResource }},
+		CRDDirectoryPaths:       []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   {{ .WireResource }},
+		ControlPlaneStopTimeout: time.Minute,
 
 		// The BinaryAssetsDirectory is only required if you want to run the tests directly
 		// without call the makefile target test. If not informed it will look for the
@@ -431,6 +438,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -451,8 +459,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -214,7 +214,6 @@ var (
 	k8sClient client.Client
 	cfg *rest.Config
 	testEnv *envtest.Environment
-	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -227,10 +226,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = %s.AddToScheme(scheme.Scheme)
@@ -242,6 +237,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:   {{ .WireResource }},
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "webhook")},
@@ -279,12 +275,8 @@ var _ = BeforeSuite(func() {
 
 	%s
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -305,16 +297,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
@@ -378,7 +362,6 @@ var (
 	ctx context.Context
 	k8sClient client.Client
 	testEnv *envtest.Environment
-	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -391,15 +374,12 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:       []string{filepath.Join({{ .BaseDirectoryRelativePath }}, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:   {{ .WireResource }},
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		// The BinaryAssetsDirectory is only required if you want to run the tests directly
 		// without call the makefile target test. If not informed it will look for the
@@ -450,12 +430,8 @@ var _ = BeforeSuite(func() {
 
 	%s
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -476,15 +452,7 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -227,7 +227,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = %s.AddToScheme(scheme.Scheme)
@@ -276,9 +279,12 @@ var _ = BeforeSuite(func() {
 
 	%s
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -300,10 +306,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())
@@ -383,7 +391,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -439,9 +450,12 @@ var _ = BeforeSuite(func() {
 
 	%s
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -463,10 +477,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -66,9 +66,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,8 +88,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -66,8 +66,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -88,9 +89,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -88,10 +88,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -66,8 +66,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -88,15 +89,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
@@ -66,9 +66,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,8 +88,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
@@ -66,8 +66,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -88,9 +89,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
@@ -88,10 +88,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
@@ -66,8 +66,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -88,15 +89,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,9 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -67,9 +67,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -90,8 +89,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,15 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -89,10 +89,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
@@ -71,9 +71,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -94,8 +93,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
@@ -71,8 +71,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -93,9 +94,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
@@ -93,10 +93,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
@@ -71,8 +71,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -93,15 +94,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,9 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -67,9 +67,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -90,8 +89,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,15 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -89,10 +89,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,9 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -67,9 +67,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -90,8 +89,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,15 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -89,10 +89,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,9 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -67,9 +67,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -90,8 +89,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -67,8 +67,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -89,15 +90,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -89,10 +89,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -75,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -97,9 +98,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -98,8 +97,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -75,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -97,15 +98,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -97,10 +97,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -75,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -97,9 +98,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -98,8 +97,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -75,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -97,15 +98,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -97,10 +97,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
@@ -74,9 +74,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -140,8 +139,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
@@ -46,11 +46,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -63,6 +64,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = appsv1.AddToScheme(scheme.Scheme)
@@ -72,8 +74,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -115,6 +118,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -135,9 +139,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
@@ -46,12 +46,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,10 +63,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = appsv1.AddToScheme(scheme.Scheme)
@@ -77,8 +72,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -118,12 +114,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -144,16 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
@@ -64,7 +64,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = appsv1.AddToScheme(scheme.Scheme)
@@ -115,9 +118,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -139,10 +145,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
@@ -46,11 +46,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -63,6 +64,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = certmanagerv1.AddToScheme(scheme.Scheme)
@@ -72,8 +74,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -115,6 +118,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -135,9 +139,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
@@ -74,9 +74,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -140,8 +139,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
@@ -46,12 +46,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,10 +63,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = certmanagerv1.AddToScheme(scheme.Scheme)
@@ -77,8 +72,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -118,12 +114,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -144,16 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
@@ -64,7 +64,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = certmanagerv1.AddToScheme(scheme.Scheme)
@@ -115,9 +118,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -139,10 +145,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
@@ -74,9 +74,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -140,8 +139,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
@@ -46,11 +46,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -63,6 +64,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = corev1.AddToScheme(scheme.Scheme)
@@ -72,8 +74,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -115,6 +118,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -135,9 +139,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
@@ -46,12 +46,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,10 +63,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = corev1.AddToScheme(scheme.Scheme)
@@ -77,8 +72,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -118,12 +114,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -144,16 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
@@ -64,7 +64,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = corev1.AddToScheme(scheme.Scheme)
@@ -115,9 +118,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -139,10 +145,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = crewv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = crewv1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = crewv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = examplecomv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = examplecomv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = examplecomv1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = shipv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = shipv1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = shipv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = shipv2alpha1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-with-plugins/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/suite_test.go
@@ -71,9 +71,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -94,8 +93,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/suite_test.go
@@ -71,8 +71,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -93,9 +94,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/suite_test.go
@@ -93,10 +93,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-with-plugins/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/suite_test.go
@@ -71,8 +71,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -93,15 +94,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = examplecomv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = examplecomv1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = examplecomv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -141,8 +140,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -116,6 +119,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -136,9 +140,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
@@ -116,9 +119,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -140,10 +146,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = examplecomv1alpha1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -119,12 +115,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -145,16 +137,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -72,9 +72,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   true,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -95,8 +94,13 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -72,8 +72,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: time.Minute,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -94,9 +95,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -94,10 +94,12 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -72,8 +72,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   true,
+		ControlPlaneStopTimeout: 60 * time.Second,
 	}
 
 	// Retrieve the first found binary directory to allow running tests from IDEs
@@ -94,15 +95,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
@@ -47,11 +47,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx       context.Context
-	cancel    context.CancelFunc
-	k8sClient client.Client
-	cfg       *rest.Config
-	testEnv   *envtest.Environment
+	ctx            context.Context
+	cancel         context.CancelFunc
+	k8sClient      client.Client
+	cfg            *rest.Config
+	testEnv        *envtest.Environment
+	managerStopped chan struct{}
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	managerStopped = make(chan struct{})
 
 	var err error
 	err = crewv1.AddToScheme(scheme.Scheme)
@@ -73,8 +75,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: time.Minute,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -134,6 +137,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(managerStopped)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -154,9 +158,9 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	<-managerStopped
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
@@ -75,9 +75,8 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing:   false,
-		ControlPlaneStopTimeout: time.Minute,
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -159,8 +158,13 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	// Wait for the control plane to shut down gracefully.
+	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
+	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
+	// and return nil, allowing the test suite to pass.
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, time.Minute, time.Second).Should(Succeed())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
@@ -47,12 +47,11 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	ctx            context.Context
-	cancel         context.CancelFunc
-	k8sClient      client.Client
-	cfg            *rest.Config
-	testEnv        *envtest.Environment
-	managerStopped chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
 )
 
 func TestAPIs(t *testing.T) {
@@ -65,10 +64,6 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
-	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
-	// if the BeforeSuite panics before the manager is started.
-	managerStopped = make(chan struct{})
-	close(managerStopped)
 
 	var err error
 	err = crewv1.AddToScheme(scheme.Scheme)
@@ -78,8 +73,9 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: false,
+		CRDDirectoryPaths:       []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing:   false,
+		ControlPlaneStopTimeout: 60 * time.Second,
 
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
@@ -137,12 +133,8 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
-	// Re-initialize managerStopped to an open channel before starting the manager
-	managerStopped = make(chan struct{})
-	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -163,16 +155,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	<-managerStopped
-	// Wait for the control plane to stop gracefully.
-	//
-	// If the control plane does not stop within the default 20-second timeout,
-	// testEnv.Stop() forcefully terminates the process and returns an error.
-	// A later retry detects that the process has already stopped and returns
-	// nil, allowing the test suite to continue.
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
@@ -65,7 +65,10 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	ctx, cancel = context.WithCancel(context.TODO())
+	// Initialize managerStopped as closed to avoid a deadlock in AfterSuite
+	// if the BeforeSuite panics before the manager is started.
 	managerStopped = make(chan struct{})
+	close(managerStopped)
 
 	var err error
 	err = crewv1.AddToScheme(scheme.Scheme)
@@ -134,9 +137,12 @@ var _ = BeforeSuite(func() {
 
 	// +kubebuilder:scaffold:webhook
 
+	// Re-initialize managerStopped to an open channel before starting the manager
+	managerStopped = make(chan struct{})
+	managerStopCh := managerStopped
 	go func() {
 		defer GinkgoRecover()
-		defer close(managerStopped)
+		defer close(managerStopCh)
 		err = mgr.Start(ctx)
 		Expect(err).NotTo(HaveOccurred())
 	}()
@@ -158,10 +164,12 @@ var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
 	<-managerStopped
-	// Wait for the control plane to shut down gracefully.
-	// If it fails to gracefully shut down within the default timeout (20s) and SIGKILLs the process,
-	// testEnv.Stop() will return an error. Eventually will retry, see that the process is already dead,
-	// and return nil, allowing the test suite to pass.
+	// Wait for the control plane to stop gracefully.
+	//
+	// If the control plane does not stop within the default 20-second timeout,
+	// testEnv.Stop() forcefully terminates the process and returns an error.
+	// A later retry detects that the process has already stopped and returns
+	// nil, allowing the test suite to continue.
 	Eventually(func() error {
 		return testEnv.Stop()
 	}, time.Minute, time.Second).Should(Succeed())


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

### Description
This PR replaces the `Eventually` polling wrapper around `testEnv.Stop()` with proper graceful teardown logic in the `go/v4` scaffold templates. 
- **Webhook Suite:** Introduces a `managerStopped` synchronization channel. The `AfterSuite` now blocks until `mgr.Start()` returns, ensuring all caches, watches, and webhook servers are closed *before* `testEnv.Stop()` is invoked.
- **Controller Suite:** Removes the `Eventually` wrapper in favor of a direct, single `testEnv.Stop()` call.
- **Envtest Config:** Increases `ControlPlaneStopTimeout` to `time.Minute` to allow the kube-apiserver sufficient time to exit under heavy, parallel CI loads.

### Motivation
Previously, using `Eventually(testEnv.Stop())` merely masked teardown race conditions. It would trigger a `SIGKILL` timeout on the first attempt, and then report a false "success" on the second poll because the process was already dead. This defeated the purpose of a graceful shutdown and led to flaky CI test timeouts, especially in projects utilizing multigroup parallelism. By explicitly waiting for the manager's routines to exit, we eliminate the race condition and allow the control plane to shut down cleanly.

Fixes #5804

