### PR TITLE
🐛 (go/v4,CLI): Restrict YEAR placeholder substitution

### DIFF
--- a/pkg/machinery/scaffold.go
+++ b/pkg/machinery/scaffold.go
@@ -24,6 +24,7 @@ import (
 	log "log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -550,8 +551,12 @@ func (s Scaffold) writeFile(f *File) error {
 	return nil
 }
 
-// SubstituteYear replaces every occurrence of "YEAR" in the boilerplate string
-// with the current UTC year.
+var yearPlaceholder = regexp.MustCompile(`\bYEAR\b`)
+
+var nowFunc = time.Now
+
+// SubstituteYear replaces standalone "YEAR" placeholders in the boilerplate string
+// with the current local year.
 func SubstituteYear(boilerplate string) string {
-	return strings.ReplaceAll(boilerplate, "YEAR", strconv.Itoa(time.Now().UTC().Year()))
+	return yearPlaceholder.ReplaceAllString(boilerplate, strconv.Itoa(nowFunc().Year()))
 }

--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -17,7 +17,6 @@ package machinery
 import (
 	"errors"
 	"os"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -109,16 +108,47 @@ var _ = Describe("Scaffold", func() {
 	})
 
 	Describe("SubstituteYear", func() {
-		It("should replace YEAR with the current UTC year", func() {
-			currentYear := strconv.Itoa(time.Now().UTC().Year())
+		BeforeEach(func() {
+			nowFunc = func() time.Time {
+				return time.Date(2025, time.January, 1, 0, 30, 0, 0, time.FixedZone("UTC+1", 60*60))
+			}
+		})
+
+		AfterEach(func() {
+			nowFunc = time.Now
+		})
+
+		It("should replace YEAR with the current local year", func() {
 			Expect(SubstituteYear("Copyright YEAR The Authors.")).
-				To(Equal("Copyright " + currentYear + " The Authors."))
+				To(Equal("Copyright 2025 The Authors."))
 		})
 
 		It("should leave strings without YEAR unchanged", func() {
 			Expect(SubstituteYear("Copyright 2024 The Authors.")).
 				To(Equal("Copyright 2024 The Authors."))
 		})
+
+		DescribeTable("should replace only standalone YEAR placeholders",
+			func(input, expected string) {
+				Expect(SubstituteYear(input)).To(Equal(expected))
+			},
+			Entry("replaces multiple standalone placeholders",
+				"Copyright YEAR-YEAR The Authors.",
+				"Copyright 2025-2025 The Authors.",
+			),
+			Entry("replaces standalone placeholders next to punctuation",
+				"Copyright (YEAR), The Authors.",
+				"Copyright (2025), The Authors.",
+			),
+			Entry("does not replace YEAR inside another word",
+				"Copyright YEAR GOODYEAR PREYEAR YEARLY Authors.",
+				"Copyright 2025 GOODYEAR PREYEAR YEARLY Authors.",
+			),
+			Entry("does not replace YEAR next to digits or underscores",
+				"Copyright YEAR YEAR2024 2024YEAR YEAR_2024 Authors.",
+				"Copyright 2025 YEAR2024 2024YEAR YEAR_2024 Authors.",
+			),
+		)
 	})
 
 	Describe("Scaffold.Execute", func() {


### PR DESCRIPTION
## Summary
- Restricts `SubstituteYear` to standalone `YEAR` placeholders so owner names such as `GOODYEAR` stay unchanged.
- Uses the local year for boilerplate substitution.
- Adds regression coverage for the placeholder boundary case.

## Testing
- [x] `go test ./pkg/machinery -count=1`
- [x] `make lint-fix`
- [x] `make test-unit`
- [x] `make build`
- [x] `git diff --check`

Closes #5807
