### PR TITLE
🌱 Rewrite boilerplate YEAR test in Ginkgo and extend SubstituteYear coverage

### DIFF
--- a/pkg/machinery/scaffold_test.go
+++ b/pkg/machinery/scaffold_test.go
@@ -128,6 +128,16 @@ var _ = Describe("Scaffold", func() {
 				To(Equal("Copyright 2024 The Authors."))
 		})
 
+		It("should return an empty string unchanged", func() {
+			Expect(SubstituteYear("")).To(Equal(""))
+		})
+
+		It("should substitute YEAR when boilerplate is provided via WithBoilerplate", func() {
+			s := NewScaffold(Filesystem{FS: afero.NewMemMapFs()},
+				WithBoilerplate("Copyright YEAR The Authors."))
+			Expect(s.injector.boilerplate).To(Equal("Copyright 2025 The Authors."))
+		})
+
 		DescribeTable("should replace only standalone YEAR placeholders",
 			func(input, expected string) {
 				Expect(SubstituteYear(input)).To(Equal(expected))

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/hack/boilerplate_test.go
@@ -17,22 +17,27 @@ limitations under the License.
 package hack_test
 
 import (
-	"strings"
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/hack"
 )
 
-func TestBoilerplateTemplateContainsYEAR(t *testing.T) {
-	bp := &hack.Boilerplate{
-		Owner:   "The Kubernetes Authors",
-		License: "apache2",
-	}
-	if err := bp.SetTemplateDefaults(); err != nil {
-		t.Fatalf("SetTemplateDefaults() error: %v", err)
-	}
-	body := bp.GetBody()
-	if !strings.Contains(body, "YEAR") {
-		t.Errorf("boilerplate template body must contain literal YEAR token; got:\n%s", body)
-	}
+func TestBoilerplate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Boilerplate Template Suite")
 }
+
+var _ = Describe("Boilerplate", func() {
+	It("should keep the literal YEAR placeholder instead of a hardcoded year", func() {
+		bp := &hack.Boilerplate{
+			Owner:   "The Kubernetes Authors",
+			License: "apache2",
+		}
+		Expect(bp.SetTemplateDefaults()).To(Succeed())
+		Expect(bp.GetBody()).To(ContainSubstring("YEAR"))
+		Expect(bp.GetBody()).NotTo(MatchRegexp(`Copyright \d{4}`))
+	})
+})


### PR DESCRIPTION
Part of the checklist in the issue is already covered by the SubstituteYear specs in `pkg/machinery/scaffold_test.go` (multiple placeholders, strings without YEAR). This covers the remaining items:

- `hack/boilerplate_test.go` rewritten from plain `testing` style to Ginkgo/Gomega, keeping the assertion that the template retains the literal `YEAR` placeholder instead of a hardcoded year
- added an empty input spec for `SubstituteYear`
- added a spec verifying YEAR substitution through `WithBoilerplate`

`go test ./pkg/machinery/... ./pkg/plugins/golang/v4/scaffolds/internal/templates/hack/...` passes.

Fixes #5808

This PR was written in part with the assistance of generative AI; I reviewed and verified the changes.
