### PR TITLE
🐛 (helm/v2-alpha): Handle nil serviceAccount values

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -55,8 +55,9 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}
+{{- $sa.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}
 {{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,5 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if ne ($sa.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,12 +8,12 @@ metadata:
     app.kubernetes.io/name: {{ include "project.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- with .Values.serviceAccount.labels }}
+    {{- with $sa.labels }}
     {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with $sa.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
@@ -55,8 +55,9 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}
+{{- $sa.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}
 {{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,5 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if ne ($sa.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,12 +8,12 @@ metadata:
     app.kubernetes.io/name: {{ include "project.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- with .Values.serviceAccount.labels }}
+    {{- with $sa.labels }}
     {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with $sa.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -55,8 +55,9 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}
+{{- $sa.name }}
 {{- else }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}
 {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,5 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if ne ($sa.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,12 +8,12 @@ metadata:
     app.kubernetes.io/name: {{ include "project.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- with .Values.serviceAccount.labels }}
+    {{- with $sa.labels }}
     {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with $sa.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
@@ -131,7 +131,8 @@ func WrapServiceAccountWithEnabledConditional(yamlContent string) string {
 	// Default to enabled, but allow an explicit false to disable ServiceAccount creation.
 	// Compare via toString so the guard matches the serviceAccountName helper exactly and never
 	// pipes the boolean through default (which would swallow an explicit false).
-	return "{{- if ne (.Values.serviceAccount.enabled | toString) \"false\" }}\n" + yamlContent + "{{- end }}\n"
+	return "{{- $sa := .Values.serviceAccount | default dict -}}\n" +
+		"{{- if ne ($sa.enabled | toString) \"false\" }}\n" + yamlContent + "{{- end }}\n"
 }
 
 // AddServiceAccountLabelsAndAnnotations adds custom labels/annotations with omit() filtering.
@@ -170,7 +171,7 @@ func AddServiceAccountLabelsAndAnnotations(yamlContent string) string {
 			childIndent := strings.Repeat(" ", currentIndent+2)
 
 			// Add custom labels
-			result = appendHelmMapBlock(result, childIndent, ".Values.serviceAccount.labels", existingKeys)
+			result = appendHelmMapBlock(result, childIndent, "$sa.labels", existingKeys)
 
 			// Merge into an existing annotations block when present; otherwise add one.
 			indent := strings.Repeat(" ", currentIndent)
@@ -197,10 +198,10 @@ func AddServiceAccountLabelsAndAnnotations(yamlContent string) string {
 					}
 
 					existingAnnotationKeys := extractKeysFromLines(result[annotationsStart:])
-					result = appendHelmMapBlock(result, childIndent, ".Values.serviceAccount.annotations", existingAnnotationKeys)
+					result = appendHelmMapBlock(result, childIndent, "$sa.annotations", existingAnnotationKeys)
 				} else {
 					result = append(result,
-						indent+"{{- with .Values.serviceAccount.annotations }}",
+						indent+"{{- with $sa.annotations }}",
 						indent+"annotations:",
 						childIndent+"{{- toYaml . | nindent "+strconv.Itoa(currentIndent+2)+" }}",
 						indent+"{{- end }}",
@@ -208,7 +209,7 @@ func AddServiceAccountLabelsAndAnnotations(yamlContent string) string {
 				}
 			} else {
 				result = append(result,
-					indent+"{{- with .Values.serviceAccount.annotations }}",
+					indent+"{{- with $sa.annotations }}",
 					indent+"annotations:",
 					childIndent+"{{- toYaml . | nindent "+strconv.Itoa(currentIndent+2)+" }}",
 					indent+"{{- end }}",

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -4172,7 +4172,8 @@ metadata:
 
 				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
-				Expect(result).To(ContainSubstring(`{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}`))
+				Expect(result).To(ContainSubstring(`{{- $sa := .Values.serviceAccount | default dict -}}`))
+				Expect(result).To(ContainSubstring(`{{- if ne ($sa.enabled | toString) "false" }}`))
 				Expect(result).To(ContainSubstring("{{- end }}"))
 			})
 
@@ -4193,7 +4194,7 @@ metadata:
 
 				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
-				Expect(result).To(ContainSubstring("{{- with .Values.serviceAccount.annotations }}"))
+				Expect(result).To(ContainSubstring("{{- with $sa.annotations }}"))
 				Expect(result).To(ContainSubstring("annotations:"))
 				Expect(result).To(ContainSubstring("{{- toYaml . | nindent 4 }}"))
 			})
@@ -4216,7 +4217,7 @@ metadata:
 
 				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
-				Expect(result).To(ContainSubstring("{{- with .Values.serviceAccount.labels }}"))
+				Expect(result).To(ContainSubstring("{{- with $sa.labels }}"))
 				Expect(result).To(ContainSubstring(`{{- with omit .`))
 				Expect(result).To(ContainSubstring(`"app.kubernetes.io/name"`))
 				Expect(result).To(ContainSubstring(`"app.kubernetes.io/managed-by"`))
@@ -4249,7 +4250,7 @@ metadata:
 				Expect(result).To(ContainSubstring("existing.annotation/key"))
 
 				// Should add template for custom annotations with duplicate filtering
-				Expect(result).To(ContainSubstring("{{- with .Values.serviceAccount.annotations }}"))
+				Expect(result).To(ContainSubstring("{{- with $sa.annotations }}"))
 				Expect(result).To(ContainSubstring(`{{- with omit .`))
 				Expect(result).To(ContainSubstring(`"existing.annotation/key"`))
 			})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -126,9 +126,9 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}` + "`" + `}}
 {{` + "`" + `{{- define "%s.serviceAccountName" -}}` + "`" + `}}
-{{` + "`" + `{{- if and (eq (.Values.serviceAccount.enabled | toString) "false")` +
-	` .Values.serviceAccount.name }}` + "`" + `}}
-{{` + "`" + `{{- .Values.serviceAccount.name }}` + "`" + `}}
+{{` + "`" + `{{- $sa := .Values.serviceAccount | default dict -}}` + "`" + `}}
+{{` + "`" + `{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}` + "`" + `}}
+{{` + "`" + `{{- $sa.name }}` + "`" + `}}
 {{` + "`" + `{{- else }}` + "`" + `}}
 {{` + "`" + `{{- include "%s.resourceName" (dict "suffix" "controller-manager" "context" .) }}` + "`" + `}}
 {{` + "`" + `{{- end }}` + "`" + `}}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
@@ -37,8 +37,10 @@ var _ = Describe("HelmHelpers", func() {
 
 			Expect(templateBody).To(ContainSubstring(`{{- define "test-project.serviceAccountName" -}}`))
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}`))
-			Expect(templateBody).To(ContainSubstring(`{{- .Values.serviceAccount.name }}`))
+				`{{- $sa := .Values.serviceAccount | default dict -}}`))
+			Expect(templateBody).To(ContainSubstring(
+				`{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}`))
+			Expect(templateBody).To(ContainSubstring(`{{- $sa.name }}`))
 			Expect(templateBody).To(ContainSubstring(
 				`{{- include "test-project.resourceName" (dict "suffix" "controller-manager" "context" .) }}`))
 		})
@@ -70,9 +72,9 @@ var _ = Describe("HelmHelpers", func() {
 			templateBody := helpers.TemplateBody
 
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}`))
+				`{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}`))
 			Expect(templateBody).To(ContainSubstring(
-				`{{- .Values.serviceAccount.name }}`))
+				`{{- $sa.name }}`))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 	})
 
 	Context("ServiceAccount name resolution (rendered)", func() {
-		renderChart := func(setArgs ...string) string {
+		renderChart := func(lintValues map[string]interface{}, setArgs ...string) string {
 			if _, err := exec.LookPath("helm"); err != nil {
 				Skip("helm binary not found on PATH; skipping render-based test")
 			}
@@ -364,6 +364,11 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			Expect(scaffolderBase.Scaffold()).To(Succeed())
 
 			chartPath := filepath.Join(tmpDir, outputDir, "chart")
+
+			By("linting the generated chart with the ServiceAccount values")
+			lintResult := action.NewLint().Run([]string{chartPath}, lintValues)
+			Expect(lintResult.Errors).To(BeEmpty(), "helm lint failed: %v", lintResult.Errors)
+
 			args := append([]string{"template", "my-release", chartPath, "--namespace", "my-namespace"}, setArgs...)
 			out, err := exec.Command("helm", args...).CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", string(out))
@@ -371,7 +376,10 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		}
 
 		It("uses the external ServiceAccount name when enabled=false and name is set", func() {
-			rendered := renderChart("--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa")
+			rendered := renderChart(
+				map[string]interface{}{"serviceAccount": map[string]interface{}{"enabled": false, "name": "external-sa"}},
+				"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa",
+			)
 
 			By("the Deployment references the external ServiceAccount, not the generated name")
 			Expect(rendered).To(ContainSubstring("serviceAccountName: external-sa"))
@@ -382,7 +390,7 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		})
 
 		It("falls back to the generated name when serviceAccount config is left at defaults", func() {
-			rendered := renderChart()
+			rendered := renderChart(nil)
 
 			By("the Deployment uses the generated controller-manager name")
 			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
@@ -391,8 +399,41 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			Expect(rendered).To(ContainSubstring("kind: ServiceAccount"))
 		})
 
+		It("falls back to the generated ServiceAccount when serviceAccount is null", func() {
+			rendered := renderChart(map[string]interface{}{"serviceAccount": nil}, "--set", "serviceAccount=null")
+
+			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
+			Expect(rendered).To(ContainSubstring("kind: ServiceAccount"))
+		})
+
+		It("falls back to the generated ServiceAccount when serviceAccount is empty", func() {
+			rendered := renderChart(map[string]interface{}{"serviceAccount": map[string]interface{}{}}, "--set-json", "serviceAccount={}")
+
+			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
+			Expect(rendered).To(ContainSubstring("kind: ServiceAccount"))
+		})
+
+		It("renders custom labels and annotations on the generated ServiceAccount", func() {
+			rendered := renderChart(
+				map[string]interface{}{
+					"serviceAccount": map[string]interface{}{
+						"labels":      map[string]interface{}{"team": "platform"},
+						"annotations": map[string]interface{}{"owner": "platform"},
+					},
+				},
+				"--set", "serviceAccount.labels.team=platform",
+				"--set", "serviceAccount.annotations.owner=platform",
+			)
+
+			Expect(rendered).To(ContainSubstring("team: platform"))
+			Expect(rendered).To(ContainSubstring("owner: platform"))
+		})
+
 		It("uses the generated name when enabled=true even if serviceAccount.name is set", func() {
-			rendered := renderChart("--set", "serviceAccount.enabled=true", "--set", "serviceAccount.name=custom-sa")
+			rendered := renderChart(
+				map[string]interface{}{"serviceAccount": map[string]interface{}{"enabled": true, "name": "custom-sa"}},
+				"--set", "serviceAccount.enabled=true", "--set", "serviceAccount.name=custom-sa",
+			)
 
 			By("the external name is ignored while the chart manages its own ServiceAccount")
 			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -55,8 +55,9 @@ If serviceAccount.enabled is false and serviceAccount.name is set, use that name
 Otherwise, use the standard resourceName helper with "controller-manager" suffix.
 */}}
 {{- define "project-v4-with-plugins.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if and (eq ($sa.enabled | toString) "false") $sa.name }}
+{{- $sa.name }}
 {{- else }}
 {{- include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" .) }}
 {{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,5 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- $sa := .Values.serviceAccount | default dict -}}
+{{- if ne ($sa.enabled | toString) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,12 +8,12 @@ metadata:
     app.kubernetes.io/name: {{ include "project-v4-with-plugins.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- with .Values.serviceAccount.labels }}
+    {{- with $sa.labels }}
     {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- end }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with $sa.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
## Summary
- Default the Helm `serviceAccount` values map before reading `enabled`, `name`, labels, or annotations.
- Add render coverage for `serviceAccount=null`, an empty serviceAccount map, and custom ServiceAccount metadata.

## Testing
- [x] `go test ./pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates ./pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater -count=1`
- [x] `go test -tags=integration ./pkg/plugins/optional/helm/v2alpha/scaffolds/test -count=1`
- [x] `make lint-fix`
- [x] `make test-unit`
- [x] `git diff --check`

Fixes #5826
