### PR TITLE
✨ (go/v4) Follow-up on #5458 (unreleased): Always emit resource:path for cluster-scoped SSA resources

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/api_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_test.go
@@ -171,6 +171,7 @@ var _ = Describe("API scaffolding with Server-Side Apply", func() {
 			content := scaffoldTypes(res, false)
 
 			Expect(content).To(ContainSubstring("// +genclient\n// +genclient:nonNamespaced"))
+			Expect(content).To(ContainSubstring("// +kubebuilder:resource:path=admirals,scope=Cluster"))
 		})
 
 		It("should scaffold the opt-out marker when another kind in the package has SSA enabled", func() {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -124,7 +124,7 @@ type {{ .Resource.Kind }}Status struct {
 {{- end }}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-{{- if and (not .Resource.API.Namespaced) (not .Resource.IsRegularPlural) }}
+{{- if and (not .Resource.API.Namespaced) (or (not .Resource.IsRegularPlural) .Resource.API.SSA) }}
 // +kubebuilder:resource:path={{ .Resource.Plural }},scope=Cluster
 {{- else if not .Resource.API.Namespaced }}
 // +kubebuilder:resource:scope=Cluster


### PR DESCRIPTION
Cluster-scoped SSA kinds with a regular plural were generating
`+kubebuilder:resource:scope=Cluster` without an explicit `path=`.
The template now emits `path=<plural>,scope=Cluster` whenever SSA is
enabled on a cluster-scoped resource.
Fixes #5819
This PR was written in part with the assistance of generative AI; I reviewed and verified the changes.


Follow up of [#5458](https://github.com/kubernetes-sigs/kubebuilder/pull/5458)