### PR TITLE
🌱 (go/v4): Add missing test coverage for the --ssa workflow

### DIFF
--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -540,6 +540,31 @@ var _ = Describe("generate: get-args-helpers", func() {
 				Expect(getAPIResourceFlags(res)).To(ContainElements("--resource", "--namespaced=false", "--controller=false"))
 			})
 		})
+
+		Context("for Server-Side Apply", func() {
+			It("includes --ssa only when SSA is enabled on the resource", func() {
+				res.API.CRDVersion = "v1"
+				res.API.Namespaced = true
+				res.API.SSA = true
+				Expect(getAPIResourceFlags(res)).To(ContainElements(
+					"--resource", "--namespaced", "--ssa", "--controller=false"))
+			})
+
+			It("omits --ssa when SSA is disabled on the resource", func() {
+				res.API.CRDVersion = "v1"
+				res.API.Namespaced = true
+				res.API.SSA = false
+				Expect(getAPIResourceFlags(res)).NotTo(ContainElement("--ssa"))
+			})
+
+			It("omits --ssa for resource-less entries (--resource=false)", func() {
+				// A nil API means --resource=false; --ssa must never be emitted.
+				res.API = nil
+				flags := getAPIResourceFlags(res)
+				Expect(flags).To(ContainElement("--resource=false"))
+				Expect(flags).NotTo(ContainElement("--ssa"))
+			})
+		})
 	})
 
 	// getWebhookResourceFlags

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -95,6 +95,27 @@ var _ = Describe("createAPISubcommand", func() {
 		Expect(err.Error()).To(ContainSubstring("cannot use '--external-api-path'"))
 	})
 
+	It("should reject --ssa when not creating an API resource (--resource=false)", func() {
+		subCmd.options.SSA = true
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(
+			"'--ssa' can only be used when creating an API resource ('--resource=true')"))
+	})
+
+	It("should allow --ssa when creating an API resource (--resource=true)", func() {
+		subCmd.options.SSA = true
+		subCmd.options.DoAPI = true
+		subCmd.options.DoController = true
+
+		Expect(subCmd.InjectResource(res)).To(Succeed())
+		Expect(res.API.SSA).To(BeTrue())
+	})
+
 	It("should require external-api-path when using external-api-module", func() {
 		subCmd.options.DoAPI = false
 		subCmd.options.ExternalAPIModule = externalAPIModuleWithVersion

--- a/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaffolds
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pluginutil "sigs.k8s.io/kubebuilder/v4/pkg/plugin/util"
+	"sigs.k8s.io/kubebuilder/v4/test/e2e/utils"
+)
+
+var _ = Describe("Server-Side Apply (--ssa) Scaffolding", func() {
+	var kbc *utils.TestContext
+
+	BeforeEach(func() {
+		var err error
+		kbc, err = utils.NewTestContext(pluginutil.KubebuilderBinName, "GO111MODULE=on")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kbc.Prepare()).To(Succeed())
+
+		By("initializing a project")
+		Expect(kbc.Init(
+			"--domain", "test.io",
+			"--repo", "test.io/ssatest",
+		)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("removing working directory")
+		kbc.Destroy()
+	})
+
+	It("should scaffold a webhook for an SSA resource and run 'make manifests' successfully", func() {
+		By("creating an API with Server-Side Apply enabled")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Captain",
+			"--resource", "--controller",
+			"--ssa",
+			"--make=false",
+		)).To(Succeed())
+
+		By("verifying the SSA applyconfiguration generator was wired into the Makefile")
+		makefile, err := os.ReadFile(filepath.Join(kbc.Dir, "Makefile"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(makefile)).To(ContainSubstring("applyconfiguration:headerFile"))
+
+		By("creating defaulting and validation webhooks for the SSA resource")
+		Expect(kbc.CreateWebhook(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Captain",
+			"--defaulting",
+			"--programmatic-validation",
+			"--make=false",
+		)).To(Succeed())
+
+		By("running 'make manifests'")
+		Expect(kbc.Make("manifests")).To(Succeed())
+
+		By("verifying webhook manifests were generated for the SSA resource")
+		webhookManifest, err := os.ReadFile(filepath.Join(kbc.Dir, "config", "webhook", "manifests.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(webhookManifest)).To(ContainSubstring("captains"))
+
+		By("verifying applyconfiguration code was generated for the SSA resource")
+		acFile := filepath.Join(kbc.Dir, "api", "v1", "applyconfiguration", "api", "v1", "captain.go")
+		_, err = os.Stat(acFile)
+		Expect(err).NotTo(HaveOccurred(), "applyconfiguration should be generated for the SSA resource")
+	})
+
+	It("should support splitting the SSA API and its controller across two commands", func() {
+		typesFile := filepath.Join(kbc.Dir, "api", "v1", "admiral_types.go")
+		controllerFile := filepath.Join(kbc.Dir, "internal", "controller", "admiral_controller.go")
+
+		By("creating the SSA API resource WITHOUT a controller")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Admiral",
+			"--resource=true",
+			"--controller=false",
+			"--ssa",
+			"--make=false",
+		)).To(Succeed())
+
+		By("verifying the SSA marker was scaffolded on the resource")
+		typesContent, err := os.ReadFile(typesFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(typesContent)).To(ContainSubstring("+genclient"))
+
+		By("verifying no controller was scaffolded yet")
+		_, err = os.Stat(controllerFile)
+		Expect(os.IsNotExist(err)).To(BeTrue(), "controller should not exist before it is requested")
+
+		By("adding the controller for the existing SSA resource WITHOUT recreating the API")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Admiral",
+			"--resource=false",
+			"--controller=true",
+			"--make=false",
+		)).To(Succeed())
+
+		By("verifying the controller was scaffolded and wired to the SSA resource")
+		controllerContent, err := os.ReadFile(controllerFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(controllerContent)).To(ContainSubstring("type AdmiralReconciler struct"))
+		Expect(string(controllerContent)).To(ContainSubstring("crewv1.Admiral"))
+
+		By("verifying the controller is registered with the manager in main.go")
+		mainContent, err := os.ReadFile(filepath.Join(kbc.Dir, "cmd", "main.go"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(mainContent)).To(ContainSubstring("AdmiralReconciler{"))
+
+		By("verifying the SSA marker on the resource was preserved after adding the controller")
+		typesContent, err = os.ReadFile(typesFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(typesContent)).To(ContainSubstring("+genclient"))
+
+		By("verifying the PROJECT file tracks both ssa and the controller for the resource")
+		projectContent, err := os.ReadFile(filepath.Join(kbc.Dir, "PROJECT"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(projectContent)).To(ContainSubstring("ssa: true"),
+			"adding the controller must not drop the ssa flag from the PROJECT file")
+		Expect(string(projectContent)).To(ContainSubstring("controller: true"))
+	})
+})

--- a/test/e2e/all/plugin_v4_test.go
+++ b/test/e2e/all/plugin_v4_test.go
@@ -142,5 +142,16 @@ var _ = Describe("kubebuilder", func() {
 				InstallMethod:      helpers.InstallMethodKustomize,
 			})
 		})
+
+		It("should generate a runnable project with cluster-scoped "+
+			"Server-Side Apply (--ssa --namespaced=false)", func() {
+			helpers.GenerateV4WithSSAClusterScoped(kbc)
+			helpers.Run(kbc, helpers.RunOptions{
+				HasWebhook:         false,
+				HasMetrics:         true,
+				HasNetworkPolicies: false,
+				InstallMethod:      helpers.InstallMethodKustomize,
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Description

Adds automated test coverage for the Server-Side Apply (`--ssa`) workflow in the
`go/v4` plugin, which previously had little or none:

- [x] **Unit** — the reconstructed command includes `--ssa` only for resources
  that enable it (`internal/cli/alpha/internal/generate_test.go`).
- [x] **Unit** — `create api --ssa --resource=false` fails with the expected
  error message (`pkg/plugins/golang/v4/api_test.go`).
- [x] **E2E** — added a spec for the existing `GenerateV4WithSSAClusterScoped`
  helper, which was defined but never used (`test/e2e/all/plugin_v4_test.go`).
- [x] **Integration** — `create webhook` works for an SSA resource and
  `make manifests` succeeds
  (`pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go`).
- [x] **Integration** — the split `create api --ssa --controller=false` then
  `create api --resource=false --controller=true` workflow wires the controller
  to the SSA resource (same file).

## Motivation

`--ssa` is an ALPHA feature whose behavior spans flag validation, command
reconstruction in `alpha generate`, marker/Makefile scaffolding, and the split
create-api / create-controller workflow. Almost none of these paths had
automated coverage, so a refactor could silently break the `--ssa` contract with
nothing to catch it. This PR locks in the current behavior.

## Changes

1. **Unit — `getAPIResourceFlags` re-emits `--ssa` only when enabled.**
   **File**: `internal/cli/alpha/internal/generate_test.go`.
   Drives the
   flag-reconstruction helper used by `alpha generate` with three resource
   shapes: SSA-enabled (`--ssa` present), SSA-disabled (absent), and
   resource-less / `--resource=false` (never present). Guards the "regenerate my
   project from PROJECT" round-trip.

2. **Unit — `--ssa` requires `--resource=true`.**
   **File**: `pkg/plugins/golang/v4/api_test.go`. 
   Calls `InjectResource` with
   `SSA=true, DoAPI=false` and asserts the exact error message, plus a happy-path
   case confirming `--ssa` with `--resource=true` succeeds and sets
   `res.API.SSA`. Pins the validation contract and its user-facing message.

3. **E2E — cluster-scoped SSA.**
   **File**: `test/e2e/all/plugin_v4_test.go`.
   The `GenerateV4WithSSAClusterScoped`
   helper existed but was dead code (never called). Wired it into a real spec
   (init → `create api --namespaced=false --ssa` → `helpers.Run`), which also
   exercises its assertion that cluster-scoped SSA emits
   `+genclient:nonNamespaced`. Kept-and-used rather than removed, since it adds
   genuine cluster-scoped coverage.

4. **Integration — webhook on an SSA resource + `make manifests`.**
   **File**: `pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go` (new).
   Scaffolds a real project: `create api --ssa`, then `create webhook
   --defaulting --programmatic-validation`, then `make manifests`. Asserts the
   flow succeeds and that the SSA-specific artifacts are produced — the
   `applyconfiguration` package and the webhook manifests. Proves webhooks and
   SSA compose and that the rewritten Makefile target really generates
   apply-configurations end to end.

5. **Integration — the split API/controller workflow.**
   **File**: `pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go` (same new
   file). 
   Runs `create api --ssa --controller=false`, then `create api
   --resource=false --controller=true`. Verifies the controller isn't scaffolded
   prematurely, then that it exists and is wired to the SSA resource
   (`AdmiralReconciler` referencing `crewv1.Admiral`, registered in `main.go`),
   and that SSA is preserved — both the `+genclient` marker and `ssa: true` in
   the `PROJECT` file. That last check guards the `SSA || other.SSA` merge so
   adding a controller can never silently downgrade the resource out of SSA.

## Testing

- [x] `go test ./internal/cli/alpha/internal/ ./pkg/plugins/golang/v4/ -count=1`
- [x] `go test -tags=integration ./pkg/plugins/golang/v4/scaffolds/ -count=1` (run `make install` first)
- [x] `golangci-lint run` — 0 issues in changed code
- [x] `git diff --check`
- [x] `make test-e2e-local` — cluster-scoped SSA spec (runs in CI)

Fixes #5821
