### PR TITLE
🐛 fix(helm/v2-alpha) points to an SA that does not exist when sa.enabled: false and no name is set and ensure properly coverage of SA variantes documented

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -51,13 +51,13 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
-Otherwise, use the standard resourceName helper with "controller-manager" suffix.
+When enabled, use the chart's ServiceAccount name.
+When disabled, serviceAccount.name must be set; use "default" to pick the namespace default ServiceAccount.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
-{{- else }}
+{{- if .Values.serviceAccount.enabled }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}
+{{- else }}
+{{- required "serviceAccount.name is required when serviceAccount.enabled=false (set name: default explicitly to use the namespace default ServiceAccount)" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- if .Values.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -126,7 +126,8 @@ serviceAccount:
   # Install default ServiceAccount provided
   enabled: true
 
-  ## Existing ServiceAccount name (only when enabled=false)
+  ## Existing ServiceAccount name (required when enabled=false)
+  ## Set to "default" to use the namespace default ServiceAccount
   ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/_helpers.tpl
@@ -51,13 +51,13 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
-Otherwise, use the standard resourceName helper with "controller-manager" suffix.
+When enabled, use the chart's ServiceAccount name.
+When disabled, serviceAccount.name must be set; use "default" to pick the namespace default ServiceAccount.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
-{{- else }}
+{{- if .Values.serviceAccount.enabled }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}
+{{- else }}
+{{- required "serviceAccount.name is required when serviceAccount.enabled=false (set name: default explicitly to use the namespace default ServiceAccount)" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- if .Values.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -126,7 +126,8 @@ serviceAccount:
   # Install default ServiceAccount provided
   enabled: true
 
-  ## Existing ServiceAccount name (only when enabled=false)
+  ## Existing ServiceAccount name (required when enabled=false)
+  ## Set to "default" to use the namespace default ServiceAccount
   ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/_helpers.tpl
@@ -51,13 +51,13 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
-Otherwise, use the standard resourceName helper with "controller-manager" suffix.
+When enabled, use the chart's ServiceAccount name.
+When disabled, serviceAccount.name must be set; use "default" to pick the namespace default ServiceAccount.
 */}}
 {{- define "project.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
-{{- else }}
+{{- if .Values.serviceAccount.enabled }}
 {{- include "project.resourceName" (dict "suffix" "controller-manager" "context" .) }}
+{{- else }}
+{{- required "serviceAccount.name is required when serviceAccount.enabled=false (set name: default explicitly to use the namespace default ServiceAccount)" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- if .Values.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -126,7 +126,8 @@ serviceAccount:
   # Install default ServiceAccount provided
   enabled: true
 
-  ## Existing ServiceAccount name (only when enabled=false)
+  ## Existing ServiceAccount name (required when enabled=false)
+  ## Set to "default" to use the namespace default ServiceAccount
   ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -247,7 +247,42 @@ Add custom labels and annotations using `manager.labels`, `manager.annotations`,
 
 ### ServiceAccount configuration
 
-Set `serviceAccount.enabled: true` (default) to create a ServiceAccount. Set `serviceAccount.enabled: false` to use an existing one.
+Set `serviceAccount.enabled: true` (default) to create a ServiceAccount. Set `serviceAccount.enabled: false` to use an existing one:
+
+```yaml
+serviceAccount:
+  enabled: false
+  name: my-existing-sa
+```
+
+The chart ships with the toggle enabled:
+
+```yaml
+serviceAccount:
+  enabled: true
+```
+
+Helm merges this default into any values file that omits the section, so omitting it keeps creating the account.
+
+When `serviceAccount.enabled: false`, `serviceAccount.name` is required and the chart fails to render without it. Set `name: default` explicitly to use the namespace default ServiceAccount.
+
+The resolved name is used consistently in the Deployment and in all RBAC bindings, for both cluster-scoped and namespaced RBAC modes:
+
+| `serviceAccount.enabled` | `serviceAccount.name` | ServiceAccount created | Name used (Deployment + RBAC bindings) |
+|--------------------------|-----------------------|------------------------|----------------------------------------|
+| `true` (default) | any | Yes | Generated (`<fullname>-controller-manager`, name is ignored) |
+| `false` | set | No | The provided name |
+| `false` | `default` | No | Namespace default ServiceAccount |
+| `false` | unset | No | Render fails with a clear error |
+
+The generated name is built from the chart fullname, typically `<release>-<chart>`, plus the `-controller-manager` suffix, truncated to the 63-character Kubernetes limit. It respects `nameOverride` and `fullnameOverride`.
+
+<aside class="note warning" role="note">
+<p class="note-title">Why an explicit name is required</p>
+
+Falling back to the namespace default ServiceAccount silently would bind the operator RBAC permissions to a shared identity. Requiring `serviceAccount.name` makes that choice explicit and catches misconfiguration at render time.
+
+</aside>
 
 Add annotations for cloud provider integrations:
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/rbac.go
@@ -128,10 +128,9 @@ func WrapServiceAccountWithEnabledConditional(yamlContent string) string {
 	if !strings.HasSuffix(yamlContent, "\n") {
 		yamlContent += "\n"
 	}
-	// Default to enabled, but allow an explicit false to disable ServiceAccount creation.
-	// Compare via toString so the guard matches the serviceAccountName helper exactly and never
-	// pipes the boolean through default (which would swallow an explicit false).
-	return "{{- if ne (.Values.serviceAccount.enabled | toString) \"false\" }}\n" + yamlContent + "{{- end }}\n"
+	// Create the ServiceAccount unless serviceAccount.enabled is false. Plain truthiness matches the
+	// serviceAccountName helper and every other section toggle in the chart.
+	return "{{- if .Values.serviceAccount.enabled }}\n" + yamlContent + "{{- end }}\n"
 }
 
 // AddServiceAccountLabelsAndAnnotations adds custom labels/annotations with omit() filtering.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -4172,7 +4172,7 @@ metadata:
 
 				result := saTemplater.ApplyHelmSubstitutions(content, serviceAccount)
 
-				Expect(result).To(ContainSubstring(`{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}`))
+				Expect(result).To(ContainSubstring(`{{- if .Values.serviceAccount.enabled }}`))
 				Expect(result).To(ContainSubstring("{{- end }}"))
 			})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl.go
@@ -122,15 +122,16 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{` + "`" + `{{/*
 ServiceAccount name to use.
-If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
-Otherwise, use the standard resourceName helper with "controller-manager" suffix.
+When enabled, use the chart's ServiceAccount name.
+When disabled, serviceAccount.name must be set; use "default" to pick the namespace default ServiceAccount.
 */}}` + "`" + `}}
 {{` + "`" + `{{- define "%s.serviceAccountName" -}}` + "`" + `}}
-{{` + "`" + `{{- if and (eq (.Values.serviceAccount.enabled | toString) "false")` +
-	` .Values.serviceAccount.name }}` + "`" + `}}
-{{` + "`" + `{{- .Values.serviceAccount.name }}` + "`" + `}}
-{{` + "`" + `{{- else }}` + "`" + `}}
+{{` + "`" + `{{- if .Values.serviceAccount.enabled }}` + "`" + `}}
 {{` + "`" + `{{- include "%s.resourceName" (dict "suffix" "controller-manager" "context" .) }}` + "`" + `}}
+{{` + "`" + `{{- else }}` + "`" + `}}
+{{` + "`" + `{{- required "serviceAccount.name is required when serviceAccount.enabled=false ` +
+	`(set name: default explicitly to use the namespace default ServiceAccount)" .Values.serviceAccount.name }}` +
+	"`" + `}}
 {{` + "`" + `{{- end }}` + "`" + `}}
 {{` + "`" + `{{- end }}` + "`" + `}}
 `

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/helpers_tpl_test.go
@@ -37,10 +37,13 @@ var _ = Describe("HelmHelpers", func() {
 
 			Expect(templateBody).To(ContainSubstring(`{{- define "test-project.serviceAccountName" -}}`))
 			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}`))
-			Expect(templateBody).To(ContainSubstring(`{{- .Values.serviceAccount.name }}`))
+				`{{- if .Values.serviceAccount.enabled }}`))
 			Expect(templateBody).To(ContainSubstring(
 				`{{- include "test-project.resourceName" (dict "suffix" "controller-manager" "context" .) }}`))
+			Expect(templateBody).To(ContainSubstring(
+				`{{- required "serviceAccount.name is required when serviceAccount.enabled=false ` +
+					`(set name: default explicitly to use the namespace default ServiceAccount)" ` +
+					`.Values.serviceAccount.name }}`))
 		})
 
 		It("generates resourceName helper with 63-character limit truncation logic", func() {
@@ -59,7 +62,7 @@ var _ = Describe("HelmHelpers", func() {
 			Expect(templateBody).To(ContainSubstring(`| trunc 63 | trimSuffix "-"`))
 		})
 
-		It("allows external ServiceAccount name to bypass nameOverride/fullnameOverride", func() {
+		It("requires an explicit ServiceAccount name when disabled", func() {
 			helpers := &HelmHelpers{
 				ProjectNameMixin: machinery.ProjectNameMixin{ProjectName: "test-project"},
 			}
@@ -69,10 +72,9 @@ var _ = Describe("HelmHelpers", func() {
 
 			templateBody := helpers.TemplateBody
 
-			Expect(templateBody).To(ContainSubstring(
-				`{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}`))
-			Expect(templateBody).To(ContainSubstring(
-				`{{- .Values.serviceAccount.name }}`))
+			Expect(templateBody).To(ContainSubstring(`{{- else }}`))
+			Expect(templateBody).To(ContainSubstring(`{{- required "serviceAccount.name is required`))
+			Expect(templateBody).NotTo(ContainSubstring(`| default "default"`))
 		})
 	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -537,7 +537,8 @@ serviceAccount:
   # Install default ServiceAccount provided
   enabled: true
 
-  ## Existing ServiceAccount name (only when enabled=false)
+  ## Existing ServiceAccount name (required when enabled=false)
+  ## Set to "default" to use the namespace default ServiceAccount
   ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -351,7 +352,9 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 	})
 
 	Context("ServiceAccount name resolution (rendered)", func() {
-		renderChart := func(setArgs ...string) string {
+		const generatedName = "my-release-test-project-controller-manager"
+
+		runHelmTemplate := func(setArgs ...string) (string, error) {
 			if _, err := exec.LookPath("helm"); err != nil {
 				Skip("helm binary not found on PATH; skipping render-based test")
 			}
@@ -366,36 +369,150 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			chartPath := filepath.Join(tmpDir, outputDir, "chart")
 			args := append([]string{"template", "my-release", chartPath, "--namespace", "my-namespace"}, setArgs...)
 			out, err := exec.Command("helm", args...).CombinedOutput()
-			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", string(out))
-			return string(out)
+			return string(out), err
 		}
 
-		It("uses the external ServiceAccount name when enabled=false and name is set", func() {
+		renderChart := func(setArgs ...string) string {
+			out, err := runHelmTemplate(setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		renderChartExpectFailure := func(setArgs ...string) string {
+			out, err := runHelmTemplate(setArgs...)
+			Expect(err).To(HaveOccurred(), "helm template should have failed, got: %s", out)
+			return out
+		}
+
+		// Anchor on the line start so a binding subject ("- kind: ServiceAccount") is not
+		// counted as a created ServiceAccount resource.
+		hasServiceAccountManifest := func(rendered string) bool {
+			return strings.HasPrefix(rendered, "kind: ServiceAccount\n") ||
+				strings.Contains(rendered, "\nkind: ServiceAccount\n")
+		}
+
+		saSubjectNames := func(rendered string) []string {
+			re := regexp.MustCompile(`- kind: ServiceAccount\s+name:\s+(\S+)`)
+			var names []string
+			for _, m := range re.FindAllStringSubmatch(rendered, -1) {
+				names = append(names, m[1])
+			}
+			return names
+		}
+
+		// Match "kind:" at the line start so a query for RoleBinding never matches ClusterRoleBinding.
+		countKind := func(rendered, kind string) int {
+			return strings.Count(rendered, "\nkind: "+kind+"\n")
+		}
+
+		DescribeTable("resolves serviceAccountName across every enabled/name combination",
+			func(setArgs []string, wantName string, wantManifest bool) {
+				rendered := renderChart(setArgs...)
+
+				By("the Deployment references the expected ServiceAccount")
+				Expect(rendered).To(ContainSubstring("serviceAccountName: " + wantName))
+
+				By("every RBAC binding subject resolves to that same ServiceAccount")
+				subjects := saSubjectNames(rendered)
+				Expect(subjects).NotTo(BeEmpty())
+				Expect(subjects).To(HaveEach(wantName))
+
+				By("the ServiceAccount manifest is created only when the chart owns the SA")
+				Expect(hasServiceAccountManifest(rendered)).To(Equal(wantManifest))
+			},
+			Entry("defaults (enabled=true, no name): chart creates and uses the generated SA",
+				[]string{}, generatedName, true),
+			Entry("enabled=true with a custom name: name ignored, chart owns the SA",
+				[]string{"--set", "serviceAccount.enabled=true", "--set", "serviceAccount.name=custom-sa"},
+				generatedName, true),
+			Entry("enabled=false with a name: uses the external SA, creates none",
+				[]string{"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa"},
+				"external-sa", false),
+			Entry("enabled=false with name=default: opts into the namespace default SA, creates none",
+				[]string{"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=default"},
+				"default", false),
+			Entry("enabled null with a name: behaves as disabled, uses that name, creates none",
+				[]string{"--set", "serviceAccount.enabled=null", "--set", "serviceAccount.name=external-sa"},
+				"external-sa", false),
+		)
+
+		// Failing at render time prevents silently binding operator RBAC to the shared default SA.
+		DescribeTable("fails to render when enabled=false and no ServiceAccount name is set",
+			func(setArgs []string) {
+				out := renderChartExpectFailure(setArgs...)
+				Expect(out).To(ContainSubstring(
+					"serviceAccount.name is required when serviceAccount.enabled=false"))
+				Expect(out).To(ContainSubstring(
+					"set name: default explicitly to use the namespace default ServiceAccount"))
+			},
+			Entry("name unset", []string{"--set", "serviceAccount.enabled=false"}),
+			Entry("name empty", []string{"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name="}),
+			Entry("name null", []string{"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=null"}),
+			Entry("toggle null, no name: behaves as disabled", []string{"--set", "serviceAccount.enabled=null"}),
+		)
+
+		DescribeTable("keeps every binding subject consistent with the Deployment across RBAC scope modes",
+			func(setArgs []string, wantName string) {
+				rendered := renderChart(setArgs...)
+
+				Expect(rendered).To(ContainSubstring("serviceAccountName: " + wantName))
+				subjects := saSubjectNames(rendered)
+				Expect(subjects).NotTo(BeEmpty())
+				Expect(subjects).To(HaveEach(wantName))
+			},
+			Entry("cluster-scoped, default SA", []string{}, generatedName),
+			Entry("namespaced, default SA",
+				[]string{"--set", "rbac.namespaced=true"}, generatedName),
+			Entry("cluster-scoped, external SA",
+				[]string{"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa"},
+				"external-sa"),
+			Entry("namespaced, external SA",
+				[]string{
+					"--set", "rbac.namespaced=true",
+					"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa",
+				},
+				"external-sa"),
+			Entry("cluster-scoped, explicit name=default",
+				[]string{"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=default"}, "default"),
+			Entry("namespaced, explicit name=default",
+				[]string{
+					"--set", "rbac.namespaced=true",
+					"--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=default",
+				},
+				"default"),
+		)
+
+		// Scope rules from helm-v2-alpha.md: manager bindings switch with rbac.namespaced,
+		// leader-election is always a RoleBinding, metrics-auth is always a ClusterRoleBinding.
+		DescribeTable("applies the documented RBAC scope rules for SA-bearing bindings",
+			func(setArgs []string, wantClusterRoleBindings, wantRoleBindings int) {
+				rendered := renderChart(setArgs...)
+
+				By("binding kinds follow the documented cluster/namespaced rules")
+				Expect(countKind(rendered, "ClusterRoleBinding")).To(Equal(wantClusterRoleBindings))
+				Expect(countKind(rendered, "RoleBinding")).To(Equal(wantRoleBindings))
+
+				By("whatever bindings render, their SA subjects stay consistent")
+				Expect(saSubjectNames(rendered)).To(HaveEach(generatedName))
+			},
+			Entry("cluster-scoped, metrics off: manager CRB + leader-election RB",
+				[]string{}, 1, 1),
+			Entry("namespaced, metrics off: manager switches to RB, leader-election RB, no CRB",
+				[]string{"--set", "rbac.namespaced=true"}, 0, 2),
+			Entry("cluster-scoped, metrics on: manager CRB + metrics-auth CRB",
+				[]string{"--set", "metrics.enabled=true", "--set", "metrics.secure=true"}, 2, 1),
+			Entry("namespaced, metrics on: metrics-auth stays CRB, manager+leader-election RB",
+				[]string{"--set", "rbac.namespaced=true", "--set", "metrics.enabled=true", "--set", "metrics.secure=true"},
+				1, 2),
+		)
+
+		It("never leaks the generated name when an external SA is selected", func() {
 			rendered := renderChart("--set", "serviceAccount.enabled=false", "--set", "serviceAccount.name=external-sa")
-
-			By("the Deployment references the external ServiceAccount, not the generated name")
-			Expect(rendered).To(ContainSubstring("serviceAccountName: external-sa"))
-			Expect(rendered).NotTo(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
-
-			By("no ServiceAccount manifest is created since enabled=false")
-			Expect(rendered).NotTo(ContainSubstring("kind: ServiceAccount"))
+			Expect(rendered).NotTo(ContainSubstring("serviceAccountName: " + generatedName))
 		})
 
-		It("falls back to the generated name when serviceAccount config is left at defaults", func() {
-			rendered := renderChart()
-
-			By("the Deployment uses the generated controller-manager name")
-			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
-
-			By("the default ServiceAccount manifest is created")
-			Expect(rendered).To(ContainSubstring("kind: ServiceAccount"))
-		})
-
-		It("uses the generated name when enabled=true even if serviceAccount.name is set", func() {
+		It("never leaks a stale custom name while the chart manages its own SA", func() {
 			rendered := renderChart("--set", "serviceAccount.enabled=true", "--set", "serviceAccount.name=custom-sa")
-
-			By("the external name is ignored while the chart manages its own ServiceAccount")
-			Expect(rendered).To(ContainSubstring("serviceAccountName: my-release-test-project-controller-manager"))
 			Expect(rendered).NotTo(ContainSubstring("serviceAccountName: custom-sa"))
 		})
 	})
@@ -943,13 +1060,15 @@ spec:
 }
 
 // createKustomizeForServiceAccountRender extends createBasicKustomizeOutput (Namespace +
-// ServiceAccount + Deployment) with the only two pieces the serviceAccountName render tests need:
-//   - a pod-template annotations block, so the chart renders cleanly under `helm template` instead
-//     of nil-pointering on .Values.manager.pod.annotations (the generator emits an unguarded
-//     reference when the source pod template has no annotations); and
-//   - an explicit serviceAccountName on the pod spec, which is what the helper rewrites.
+// ServiceAccount + Deployment) for the serviceAccountName render tests. It adds:
+//   - a pod-template annotations block, otherwise the chart nil-pointers on
+//     .Values.manager.pod.annotations under `helm template`;
+//   - an explicit serviceAccountName on the pod spec, which the helper rewrites;
+//   - the three bindings that carry the manager ServiceAccount as a subject, so tests can check every
+//     subject stays consistent: manager (switches with rbac.namespaced), leader-election (always a
+//     RoleBinding), and metrics-auth (always a ClusterRoleBinding, only when metrics is secure).
 func createKustomizeForServiceAccountRender(projectName string) string {
-	return strings.Replace(
+	withPod := strings.Replace(
 		createBasicKustomizeOutput(projectName),
 		`    metadata:
       labels:
@@ -966,6 +1085,94 @@ func createKustomizeForServiceAccountRender(projectName string) string {
       containers:`,
 		1,
 	)
+
+	return withPod + `---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-manager-role
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ` + projectName + `-manager-role
+subjects:
+- kind: ServiceAccount
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-leader-election-role
+  namespace: ` + projectName + `-system
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-leader-election-rolebinding
+  namespace: ` + projectName + `-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ` + projectName + `-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-metrics-auth-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ` + projectName + `-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+`
 }
 
 func setupKustomizeFile(filePath, content string) error {

--- a/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/_helpers.tpl
@@ -51,13 +51,13 @@ Dynamically calculates safe truncation to ensure total name length <= 63 chars.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enabled is false and serviceAccount.name is set, use that name.
-Otherwise, use the standard resourceName helper with "controller-manager" suffix.
+When enabled, use the chart's ServiceAccount name.
+When disabled, serviceAccount.name must be set; use "default" to pick the namespace default ServiceAccount.
 */}}
 {{- define "project-v4-with-plugins.serviceAccountName" -}}
-{{- if and (eq (.Values.serviceAccount.enabled | toString) "false") .Values.serviceAccount.name }}
-{{- .Values.serviceAccount.name }}
-{{- else }}
+{{- if .Values.serviceAccount.enabled }}
 {{- include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager" "context" .) }}
+{{- else }}
+{{- required "serviceAccount.name is required when serviceAccount.enabled=false (set name: default explicitly to use the namespace default ServiceAccount)" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne (.Values.serviceAccount.enabled | toString) "false" }}
+{{- if .Values.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -143,7 +143,8 @@ serviceAccount:
   # Install default ServiceAccount provided
   enabled: true
 
-  ## Existing ServiceAccount name (only when enabled=false)
+  ## Existing ServiceAccount name (required when enabled=false)
+  ## Set to "default" to use the namespace default ServiceAccount
   ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""


### PR DESCRIPTION
On `master`, when `serviceAccount.enabled: false` is set but `serviceAccount.name` is not provided, the chart still configures the Deployment and all RBAC bindings to use the generated ServiceAccount name, `<fullname>-controller-manager`, where `<fullname>` is typically `<release>-<chart>`.

However, because the chart does not create a ServiceAccount when `serviceAccount.enabled` is `false`, the Deployment ends up referencing a ServiceAccount that does not exist.

This PR fixes that behavior by requiring `serviceAccount.name` to be explicitly set whenever `serviceAccount.enabled: false`. If it is not set, template rendering now fails with a clear error message:

```text
serviceAccount.name is required when serviceAccount.enabled=false (set name: default explicitly to use the namespace default ServiceAccount)
```

Failing during template rendering is safer than silently falling back to the namespace `default` ServiceAccount, which could unintentionally grant the controller the permissions of a shared identity.

Users who intentionally want to use the namespace default ServiceAccount can explicitly opt in by setting:

```yaml
serviceAccount:
  enabled: false
  name: default
```

The configured ServiceAccount name is now used consistently by the Deployment and all RBAC bindings for both cluster-scoped and namespaced installations.

The generated ServiceAccount name continues to be based on `<fullname>-controller-manager`, where `<fullname>` respects `fullnameOverride` and `nameOverride`, is truncated to Kubernetes' 63-character name limit, and has any trailing `-` removed.

## ServiceAccount behavior

| `serviceAccount.enabled` | `serviceAccount.name` | ServiceAccount created | Name used (Deployment & RBAC) |
|--------------------------|-----------------------|------------------------|-------------------------------|
| `true` (default) | unset | ✅ Yes | Generated (`<fullname>-controller-manager`) |
| `true` | set | ✅ Yes | Generated (`serviceAccount.name` is ignored) |
| key omitted | unset | ✅ Yes | Generated (`<fullname>-controller-manager`) |
| key omitted | set | ✅ Yes | Generated (`serviceAccount.name` is ignored) |
| `false` | set | ❌ No | User-provided name |
| `false` | `default` | ❌ No | Namespace `default` ServiceAccount (explicit opt-in) |
| `false` | unset, empty, or `null` | ❌ No | Template rendering fails |

## Documentation

The scaffolded `values.yaml` comments and the `helm/v2-alpha` documentation have been updated to document the new requirement and the expected configuration behavior.

## Tests

Added rendered integration tests covering all combinations of:

- `serviceAccount.enabled` (`true`, `false`, omitted)
- `serviceAccount.name` (set, `default`, unset, empty, and `null`)
- `rbac.namespaced` (`true`, `false`)
- `metrics.enabled` (`true`, `false`)

The tests verify that:

- The generated manifests consistently reference the expected ServiceAccount across all supported configurations.
- Rendering fails with the expected error message when `serviceAccount.enabled=false` and `serviceAccount.name` is not provided.

(Follow-up of #5757)