### PR TITLE
🐛 (go/v4) Scaffolded test suites no longer wrap testEnv.Stop() in Eventually, which masked teardown failures by retrying after a SIGKILL. Teardown is now asserted once.

### DIFF
--- a/.github/workflows/cross-platform-tests.yml
+++ b/.github/workflows/cross-platform-tests.yml
@@ -38,6 +38,17 @@ jobs:
       - name: Remove pre-installed kustomize
         run: sudo rm -f /usr/local/bin/kustomize
 
+      # GitHub's macOS runners have hostnames longer than the 63-byte k8s label
+      # limit. kube-apiserver 1.35+ can never create its identity Lease on such
+      # hosts and then deadlocks on SIGTERM, so every envtest teardown times out.
+      # TODO: remove once https://github.com/kubernetes/kubernetes/issues/140242
+      # is fixed in the Kubernetes version used by envtest.
+      - name: Shorten hostname (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo scutil --set HostName kb-macos-runner
+          hostname
+
       - name: Unit Tests
         run: make test-unit
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/controller/suite_test.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -167,9 +166,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/getting-started/testdata/project/internal/controller/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,9 +88,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/controller/suite_test.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -167,9 +166,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -534,7 +534,7 @@ func (sp *Sample) updateSuiteTest() {
 	err = pluginutil.InsertCode(
 		filepath.Join(sp.ctx.Dir, "internal/controller/suite_test.go"),
 		`
-	"time"
+	"testing"
 `, `
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -597,9 +597,8 @@ var (
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 `, suiteTestCleanup)
 	hackutils.CheckError("updating suite_test.go to cleanup tests", err)

--- a/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
+++ b/hack/docs/internal/cronjob-tutorial/writing_tests_env.go
@@ -117,9 +117,8 @@ You won't need to touch these.
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 /*

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/controllers/controller_suitetest.go
@@ -138,7 +138,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -201,9 +200,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -253,9 +253,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/apps/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,9 +87,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/cert-manager/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -88,9 +87,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/crew/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,9 +88,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/example.com/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -93,9 +92,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/fiz/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,9 +88,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo.policy/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,9 +88,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/foo/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,9 +88,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/sea-creatures/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -97,9 +96,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
+++ b/testdata/project-v4-multigroup/internal/controller/ship/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -97,9 +96,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/webhook_suite_test.go
@@ -135,9 +135,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/webhook_suite_test.go
@@ -135,9 +135,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/webhook_suite_test.go
@@ -135,9 +135,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/controller/suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/controller/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -93,9 +92,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -136,9 +136,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/controller/suite_test.go
+++ b/testdata/project-v4/internal/controller/suite_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -94,9 +93,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.

--- a/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
+++ b/testdata/project-v4/internal/webhook/v1/webhook_suite_test.go
@@ -154,9 +154,8 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()
-	Eventually(func() error {
-		return testEnv.Stop()
-	}, time.Minute, time.Second).Should(Succeed())
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })
 
 // getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.


### PR DESCRIPTION
As part of the v4.11.0 release, we bumped `controller-runtime` from `v0.22.4` to `v0.23.0` to add support for Kubernetes v1.35 in https://github.com/kubernetes-sigs/kubebuilder/pull/5378.

After this upgrade, CI started failing with teardown timeouts on the macOS runners. At first, the failures appeared to be caused by the `controller-runtime` upgrade. After further investigation, we identified the root cause: a kube-apiserver 1.35+ bug where the process never shuts down on SIGTERM when its identity Lease cannot be created — which happens on GitHub's macOS runners because their hostnames exceed the 63-byte label limit.

The investigation also showed that wrapping teardown in `Eventually(testEnv.Stop())` should not be promoted. It does not make teardown more reliable; it masks the failure. The first `Stop()` call SIGKILLs the apiserver and returns an error, the retry returns nil because the process is already dead, and the suite reports green.

This PR:
- Fixes the scaffold to assert teardown once (`err := testEnv.Stop(); Expect(err).NotTo(HaveOccurred())`), the same convention controller-runtime uses in its own test suites.
- Adds a workaround in the GitHub Action: shorten the macOS runner hostname so the identity Lease can be created. It carries a TODO to remove it once the upstream issue is fixed.

For more details, see:
- Kubernetes issue: https://github.com/kubernetes/kubernetes/issues/140242
- Proposed upstream fix: https://github.com/kubernetes/kubernetes/pull/140241
- Investigation: https://github.com/kubernetes-sigs/kubebuilder/issues/5804#issuecomment-4887039560

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5804 https://github.com/kubernetes-sigs/kubebuilder/pull/5805