### PR TITLE
✨ Follow-up on #5458 (unreleased): `create api --ssa` warns and continues when markers cannot be injected, with more robust file updates and better test coverage.

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -22,6 +22,7 @@ import (
 	log "log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -113,9 +114,7 @@ func (s *apiScaffolder) Scaffold() error {
 		// If SSA is enabled and groupversion_info.go already exists, we need to inject the marker
 		// (the template only runs when creating a new version package)
 		if ssaEnabled {
-			if err := s.updateGroupVersionInfo(); err != nil {
-				return fmt.Errorf("error adding ac:generate marker: %w", err)
-			}
+			s.updateGroupVersionInfo()
 			// The ac:generate package marker enables generation for every kind in the
 			// group/version, so kinds scaffolded without SSA must opt out explicitly
 			if resources, err := s.config.GetResources(); err == nil {
@@ -184,44 +183,65 @@ func (s *apiScaffolder) apiPackageDir() string {
 	return filepath.Join("api", s.resource.Version)
 }
 
+// acGenerateMarkerHint tells users how to apply the marker manually when
+// scaffolding could not do it for them.
+const acGenerateMarkerHint = "Add '// +kubebuilder:ac:generate=true' to the package comment in " +
+	"groupversion_info.go, alongside the other Kubebuilder markers (for example right after " +
+	"'// +kubebuilder:object:generate=true'), to enable ApplyConfiguration generation for this group/version"
+
 // updateGroupVersionInfo adds the applyconfiguration generation marker
-// when groupversion_info.go already exists (e.g., adding a second API to an existing version)
-func (s *apiScaffolder) updateGroupVersionInfo() error {
+// when groupversion_info.go already exists (e.g., adding a second API to an existing version).
+// On failure, logs a warning and does not stop scaffolding.
+func (s *apiScaffolder) updateGroupVersionInfo() {
 	groupVersionPath := filepath.Join(s.apiPackageDir(), "groupversion_info.go")
 
 	// Check if marker already exists to avoid duplicates when using --force or multiple kinds
 	hasMarker, err := util.HasFileContentWith(groupVersionPath, "+kubebuilder:ac:generate=true")
 	if err != nil {
-		return fmt.Errorf("error checking for existing ac:generate marker: %w", err)
+		log.Warn("unable to check the '+kubebuilder:ac:generate=true' marker. "+acGenerateMarkerHint,
+			"path", groupVersionPath, "error", err)
+		return
 	}
 	if hasMarker {
-		return nil
+		return
 	}
 
-	// Add the marker after the object:generate marker
+	// Add the marker after the object:generate marker. The anchor is checked
+	// first because the InsertCode error would echo the whole file.
 	marker := `// +kubebuilder:object:generate=true`
+	hasAnchor, err := util.HasFileContentWith(groupVersionPath, marker)
+	if err != nil {
+		log.Warn("unable to check the '+kubebuilder:object:generate=true' marker. "+acGenerateMarkerHint,
+			"path", groupVersionPath, "error", err)
+		return
+	}
+	if !hasAnchor {
+		log.Warn("the '+kubebuilder:object:generate=true' marker was not found. "+acGenerateMarkerHint,
+			"path", groupVersionPath)
+		return
+	}
+
 	insert := "\n// +kubebuilder:ac:generate=true"
 	if err := util.InsertCode(groupVersionPath, marker, insert); err != nil {
-		return fmt.Errorf("error adding ac:generate marker: %w", err)
+		log.Warn("unable to add the '+kubebuilder:ac:generate=true' marker. "+acGenerateMarkerHint,
+			"path", groupVersionPath, "error", err)
 	}
-
-	return nil
 }
 
 // Makefile injection constants
 const (
 	makefileApplyConfigurationMarker = "applyconfiguration"
 
-	// The manifests target has a single consistent format — no boilerplate variants.
-	//nolint:lll
-	makefileOldManifestsLine = "\"$(CONTROLLER_GEN)\" rbac:roleName=manager-role crd webhook paths=\"./...\" output:crd:artifacts:config=config/crd/bases"
-	//nolint:lll
-	makefileNewManifestsLine = "\"$(CONTROLLER_GEN)\" rbac:roleName=manager-role crd webhook applyconfiguration:headerFile=\"hack/boilerplate.go.txt\" paths=\"./...\" output:crd:artifacts:config=config/crd/bases"
+	// The generators of the manifests target. Only this fragment is matched,
+	// so customized flags elsewhere in the line do not block the update.
+	makefileManifestsGeneratorsWithoutSSA = "rbac:roleName=manager-role crd webhook"
+	makefileManifestsGeneratorsWithSSA    = makefileManifestsGeneratorsWithoutSSA +
+		` applyconfiguration:headerFile="hack/boilerplate.go.txt"`
 
-	//nolint:lll
-	makefileOldManifestsHelp = "manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects."
-	//nolint:lll
-	makefileNewManifestsHelp = "manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects and ApplyConfiguration types."
+	makefileManifestsHelpWithoutSSA = "## Generate WebhookConfiguration, ClusterRole and " +
+		"CustomResourceDefinition objects."
+	makefileManifestsHelpWithSSA = "## Generate WebhookConfiguration, ClusterRole and " +
+		"CustomResourceDefinition objects and ApplyConfiguration types."
 )
 
 // isFirstSSAAPI checks if this is the first API with SSA enabled in the project.
@@ -350,30 +370,24 @@ func (s *apiScaffolder) updateMakefile() {
 // addApplyConfigGenToMakefile adds applyconfiguration generation to the manifests target.
 // Returns false when the Makefile already runs applyconfiguration generation.
 func addApplyConfigGenToMakefile(makefilePath string) (bool, error) {
-	info, err := os.Stat(makefilePath)
+	hasApplyConfig, err := util.HasFileContentWith(makefilePath, makefileApplyConfigurationMarker)
 	if err != nil {
-		return false, fmt.Errorf("failed to stat file %q: %w", makefilePath, err)
+		return false, fmt.Errorf("checking for applyconfiguration generation: %w", err)
 	}
-	//nolint:gosec // false positive
-	content, err := os.ReadFile(makefilePath)
-	if err != nil {
-		return false, fmt.Errorf("failed to read file %q: %w", makefilePath, err)
-	}
-
-	text := string(content)
-	if strings.Contains(text, makefileApplyConfigurationMarker) {
+	if hasApplyConfig {
 		return false, nil
 	}
 
-	if !strings.Contains(text, makefileOldManifestsLine) {
-		return false, fmt.Errorf("manifests controller-gen line not found in %q", makefilePath)
-	}
-
-	text = strings.Replace(text, makefileOldManifestsLine, makefileNewManifestsLine, 1)
-	// Best effort: keep the manifests target help accurate when it was not customized
-	text = strings.Replace(text, makefileOldManifestsHelp, makefileNewManifestsHelp, 1)
-	if err := os.WriteFile(makefilePath, []byte(text), info.Mode()); err != nil {
-		return false, fmt.Errorf("failed to write file %q: %w", makefilePath, err)
+	// One replacement updates the help comment and the recipe together, so a
+	// customized Makefile fails with no partial edits. The pattern is anchored
+	// on the manifests target, so another target running the same generators
+	// is not the one updated.
+	pattern := "(?m)^(manifests: controller-gen )" +
+		regexp.QuoteMeta(makefileManifestsHelpWithoutSSA) +
+		"\n(\t.*?)" + regexp.QuoteMeta(makefileManifestsGeneratorsWithoutSSA)
+	replacement := "${1}" + makefileManifestsHelpWithSSA + "\n${2}" + makefileManifestsGeneratorsWithSSA
+	if err := util.ReplaceRegexInFile(makefilePath, pattern, replacement); err != nil {
+		return false, fmt.Errorf("failed to update the manifests target in %q: %w", makefilePath, err)
 	}
 	return true, nil
 }

--- a/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
@@ -147,4 +147,69 @@ var _ = Describe("Server-Side Apply (--ssa) Scaffolding", func() {
 			"adding the controller must not drop the ssa flag from the PROJECT file")
 		Expect(string(projectContent)).To(ContainSubstring("controller: true"))
 	})
+
+	It("should complete 'create api --ssa' when groupversion_info.go was customized", func() {
+		By("creating a first SSA API to scaffold the group/version package")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Captain",
+			"--resource", "--controller",
+			"--ssa",
+			"--make=false",
+		)).To(Succeed())
+
+		By("removing the generate markers from groupversion_info.go, as a user customization")
+		gvPath := filepath.Join(kbc.Dir, "api", "v1", "groupversion_info.go")
+		customized := `// Package v1 contains API Schema definitions for the crew v1 API group.
+// +groupName=crew.test.io
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	// SchemeGroupVersion is group version used to register these objects.
+	// This name is used by applyconfiguration generators (e.g. controller-gen).
+	SchemeGroupVersion = schema.GroupVersion{Group: "crew.test.io", Version: "v1"}
+
+	// GroupVersion is an alias for SchemeGroupVersion, for backward compatibility.
+	GroupVersion = SchemeGroupVersion
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {
+		metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+		return nil
+	})
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+`
+		Expect(os.WriteFile(gvPath, []byte(customized), 0o644)).To(Succeed())
+
+		By("creating a second SSA API in the same group/version")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "FirstMate",
+			"--resource", "--controller",
+			"--ssa",
+			"--make=false",
+		)).To(Succeed(), "scaffolding must warn and continue when the marker cannot be injected")
+
+		By("verifying the customized file was left untouched")
+		content, err := os.ReadFile(gvPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal(customized))
+
+		By("verifying the new API was fully scaffolded")
+		_, err = os.Stat(filepath.Join(kbc.Dir, "api", "v1", "firstmate_types.go"))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = os.Stat(filepath.Join(kbc.Dir, "internal", "controller", "firstmate_controller.go"))
+		Expect(err).NotTo(HaveOccurred())
+	})
 })

--- a/pkg/plugins/golang/v4/scaffolds/api_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package scaffolds
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,6 +173,23 @@ var _ = Describe("API scaffolding with Server-Side Apply", func() {
 			content := scaffoldTypes(res, false)
 
 			Expect(content).To(ContainSubstring("// +genclient\n// +genclient:nonNamespaced"))
+		})
+
+		It("should keep the custom plural in the resource path when SSA is enabled", func() {
+			res := ssaTestResource("Admiral", true)
+			res.Plural = "admirales"
+			content := scaffoldTypes(res, false)
+
+			Expect(content).To(ContainSubstring("// +kubebuilder:resource:path=admirales"))
+		})
+
+		It("should keep the custom plural and scope in the resource path for a cluster-scoped kind with SSA enabled", func() {
+			res := ssaTestResource("Admiral", true)
+			res.Plural = "admirales"
+			res.API.Namespaced = false
+			content := scaffoldTypes(res, false)
+
+			Expect(content).To(ContainSubstring("// +kubebuilder:resource:path=admirales,scope=Cluster"))
 		})
 
 		It("should scaffold the opt-out marker when another kind in the package has SSA enabled", func() {
@@ -329,7 +348,7 @@ package v1
 			navigator := ssaTestResource("Navigator", true)
 			s := &apiScaffolder{config: newSSATestConfig(navigator), resource: navigator}
 
-			Expect(s.updateGroupVersionInfo()).To(Succeed())
+			s.updateGroupVersionInfo()
 
 			content, err := os.ReadFile(gvPath)
 			Expect(err).NotTo(HaveOccurred())
@@ -343,8 +362,8 @@ package v1
 			navigator := ssaTestResource("Navigator", true)
 			s := &apiScaffolder{config: newSSATestConfig(navigator), resource: navigator}
 
-			Expect(s.updateGroupVersionInfo()).To(Succeed())
-			Expect(s.updateGroupVersionInfo()).To(Succeed())
+			s.updateGroupVersionInfo()
+			s.updateGroupVersionInfo()
 
 			content, err := os.ReadFile(gvPath)
 			Expect(err).NotTo(HaveOccurred())
@@ -359,15 +378,65 @@ package v1
 			Expect(cfg.SetMultiGroup()).To(Succeed())
 			s := &apiScaffolder{config: cfg, resource: navigator}
 
-			Expect(s.updateGroupVersionInfo()).To(Succeed())
+			s.updateGroupVersionInfo()
 
 			content, err := os.ReadFile(gvPath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring("+kubebuilder:ac:generate=true"))
 		})
+
+		It("should warn and continue when the insertion anchor is missing", func() {
+			customized := `// Package v1 was customized and no longer has the generate marker.
+// +groupName=crew.test.io
+package v1
+`
+			gvPath := filepath.Join("api", "v1", "groupversion_info.go")
+			Expect(os.MkdirAll(filepath.Dir(gvPath), 0o755)).To(Succeed())
+			Expect(os.WriteFile(gvPath, []byte(customized), 0o644)).To(Succeed())
+
+			var logOutput bytes.Buffer
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+			DeferCleanup(func() { slog.SetDefault(previous) })
+
+			navigator := ssaTestResource("Navigator", true)
+			s := &apiScaffolder{config: newSSATestConfig(navigator), resource: navigator}
+
+			s.updateGroupVersionInfo()
+
+			Expect(logOutput.String()).To(ContainSubstring("marker was not found"))
+			Expect(logOutput.String()).To(ContainSubstring("+kubebuilder:ac:generate=true"))
+			Expect(logOutput.String()).To(ContainSubstring("+kubebuilder:object:generate=true"))
+			// The warning must not echo the file contents.
+			Expect(logOutput.String()).NotTo(ContainSubstring("Package v1 was customized"))
+
+			content, err := os.ReadFile(gvPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(customized))
+		})
+
+		It("should warn and continue when groupversion_info.go does not exist", func() {
+			var logOutput bytes.Buffer
+			previous := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+			DeferCleanup(func() { slog.SetDefault(previous) })
+
+			navigator := ssaTestResource("Navigator", true)
+			s := &apiScaffolder{config: newSSATestConfig(navigator), resource: navigator}
+
+			s.updateGroupVersionInfo()
+
+			Expect(logOutput.String()).To(ContainSubstring("unable to check"))
+			Expect(logOutput.String()).To(ContainSubstring("+kubebuilder:ac:generate=true"))
+		})
 	})
 
 	Describe("addApplyConfigGenToMakefile", func() {
+		//nolint:lll
+		const manifestsLine = `"$(CONTROLLER_GEN)" rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases`
+		//nolint:lll
+		const manifestsHelp = "manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects."
+
 		var makefilePath string
 
 		BeforeEach(func() {
@@ -379,8 +448,8 @@ package v1
 			makefilePath = filepath.Join(tmpDir, "Makefile")
 		})
 
-		It("should add applyconfiguration to the manifests target", func() {
-			content := "manifests: controller-gen\n\t" + makefileOldManifestsLine + "\n"
+		It("should add applyconfiguration to the manifests target and its help text", func() {
+			content := manifestsHelp + "\n\t" + manifestsLine + "\n"
 			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
 
 			updated, err := addApplyConfigGenToMakefile(makefilePath)
@@ -389,11 +458,12 @@ package v1
 
 			result, err := os.ReadFile(makefilePath)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(result)).To(ContainSubstring(makefileNewManifestsLine))
+			Expect(string(result)).To(ContainSubstring(makefileManifestsGeneratorsWithSSA + ` paths="./..."`))
+			Expect(string(result)).To(ContainSubstring(makefileManifestsHelpWithSSA))
 		})
 
-		It("should update the manifests target help text when it was not customized", func() {
-			content := makefileOldManifestsHelp + "\n\t" + makefileOldManifestsLine + "\n"
+		It("should update a manifests target with an unquoted CONTROLLER_GEN", func() {
+			content := manifestsHelp + "\n\t$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths=\"./...\"\n"
 			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
 
 			updated, err := addApplyConfigGenToMakefile(makefilePath)
@@ -402,11 +472,11 @@ package v1
 
 			result, err := os.ReadFile(makefilePath)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(result)).To(ContainSubstring(makefileNewManifestsHelp))
+			Expect(string(result)).To(ContainSubstring(makefileManifestsGeneratorsWithSSA))
 		})
 
 		It("should skip a Makefile that already runs applyconfiguration generation", func() {
-			content := "manifests: controller-gen\n\t" + makefileNewManifestsLine + "\n"
+			content := manifestsHelp + "\n\t" + `"$(CONTROLLER_GEN)" ` + makefileManifestsGeneratorsWithSSA + "\n"
 			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
 
 			updated, err := addApplyConfigGenToMakefile(makefilePath)
@@ -414,12 +484,65 @@ package v1
 			Expect(updated).To(BeFalse())
 		})
 
-		It("should return an error when the manifests line is not found", func() {
-			content := "manifests: controller-gen\n\tcustom-generator paths=\"./...\"\n"
+		It("should not duplicate anything when run more than once", func() {
+			content := manifestsHelp + "\n\t" + manifestsLine + "\n"
+			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
+
+			updated, err := addApplyConfigGenToMakefile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeTrue())
+
+			afterFirstRun, err := os.ReadFile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err = addApplyConfigGenToMakefile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeFalse())
+
+			afterSecondRun, err := os.ReadFile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(afterSecondRun)).To(Equal(string(afterFirstRun)))
+			Expect(strings.Count(string(afterSecondRun), "applyconfiguration:headerFile")).To(Equal(1))
+			Expect(strings.Count(string(afterSecondRun), "and ApplyConfiguration types")).To(Equal(1))
+		})
+
+		It("should update only the manifests target when another target runs the same generators", func() {
+			content := "manifests-fast: controller-gen\n\t" + manifestsLine + "\n" +
+				manifestsHelp + "\n\t" + manifestsLine + "\n"
+			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
+
+			updated, err := addApplyConfigGenToMakefile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeTrue())
+
+			result, err := os.ReadFile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Count(string(result), "applyconfiguration:headerFile")).To(Equal(1))
+			Expect(string(result)).To(ContainSubstring("manifests-fast: controller-gen\n\t" + manifestsLine))
+		})
+
+		It("should return an error and change nothing when the help comment was customized", func() {
+			content := "manifests: controller-gen ## My custom help\n\t" + manifestsLine + "\n"
 			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
 
 			_, err := addApplyConfigGenToMakefile(makefilePath)
 			Expect(err).To(HaveOccurred())
+
+			result, err := os.ReadFile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(result)).To(Equal(content))
+		})
+
+		It("should return an error and change nothing when the manifests generators are not found", func() {
+			content := manifestsHelp + "\n\tcustom-generator paths=\"./...\"\n"
+			Expect(os.WriteFile(makefilePath, []byte(content), 0o644)).To(Succeed())
+
+			_, err := addApplyConfigGenToMakefile(makefilePath)
+			Expect(err).To(HaveOccurred())
+
+			result, err := os.ReadFile(makefilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(result)).To(Equal(content))
 		})
 
 		It("should return an error when the Makefile does not exist", func() {


### PR DESCRIPTION
Follow-up on #5458 (unreleased).

  - `create api --ssa` now warns and continues when the marker cannot be injected into a customized `groupversion_info.go`, instead of stopping half scaffolded. The warning tells the user what to add manually.
  - The Makefile update uses the plugin util helpers and fails cleanly without partial edits when the manifests target was customized.
  - Simplified the injection: the applyconfiguration generator is added after `rbac:roleName=manager-role crd webhook` instead of matching the whole line, so customized flags no longer block the update. New `util.ReplaceOnceInFile` replaces only the first occurrence.
  - Increased coverage: warn paths, idempotency, duplicated lines, customized help comment, and an integration test for the full `create api --ssa` flow with a customized `groupversion_info.go`.
  
Note: scaffolding must not stop when an injection into a user-owned file fails; we warn with the manual action and continue. That covers scenario where the project has customizations and we are unable to do the injections. 
  
Closes: #5818, #5822