### PR TITLE
🌱 Configure Dependabot to monitor scaffolded GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,40 @@ updates:
       prefix: ":book:"
     labels:
       - "ok-to-test"
+
+  # Maintain dependencies for scaffolded GitHub Actions in the projects
+  - package-ecosystem: "github-actions"
+    directory: "/testdata/project-v4"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 0
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+
+  - package-ecosystem: "github-actions"
+    directory: "/testdata/project-v4-multigroup"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 0
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"
+
+  - package-ecosystem: "github-actions"
+    directory: "/testdata/project-v4-with-plugins"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 0
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
**Description**
This PR resolves the remaining tasks in #5825 by adding a notification mechanism for outdated GitHub Actions in our scaffolded templates. 

It configures Dependabot to monitor the `github-actions` ecosystem across the `testdata/project-v4`, `testdata/project-v4-multigroup`, and `testdata/project-v4-with-plugins` directories. This mirrors our existing strategy for `gomod` updates: when a new action release is available, Dependabot will open a PR against the `testdata` samples, thereby notifying maintainers that the underlying Go templates in `pkg/plugins/` should be refreshed.

Closes #5825
