### PR TITLE
✨ (CLI): Hide For plugin prefix in CLI help unless explicitly needed

### DIFF
--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -147,22 +147,7 @@ func (c *CLI) applySubcommandHooks(
 		}
 	}
 
-	showPluginPrefix := false
-	for _, arg := range os.Args {
-		if isPluginsFlag(arg) {
-			showPluginPrefix = true
-			break
-		}
-	}
-	if !showPluginPrefix {
-		for _, p := range c.resolvedPlugins {
-			if _, isExternal := p.(external.Plugin); isExternal {
-				showPluginPrefix = true
-				break
-			}
-		}
-	}
-
+	showPluginPrefix := c.shouldShowPluginPrefix(os.Args)
 	result, err := initializationHooks(cmd, subcommands, c.metadata(), showPluginPrefix)
 	if err != nil {
 		cmdErr(cmd, err)
@@ -189,6 +174,23 @@ func (c *CLI) applySubcommandHooks(
 func (c *CLI) appendPluginTable(cmd *cobra.Command, filter func(plugin.Plugin) bool, title string) {
 	pluginTable := c.getPluginTableFilteredForSubcommand(filter)
 	cmd.Long = fmt.Sprintf("%s\n%s:\n\n%s\n", cmd.Long, title, pluginTable)
+}
+
+// shouldShowPluginPrefix returns true if the plugin prefix should be shown in help output.
+// The prefix is shown if the user explicitly requested it via the --plugins flag, or if
+// any of the resolved plugins is an external plugin.
+func (c *CLI) shouldShowPluginPrefix(args []string) bool {
+	for _, arg := range args {
+		if isPluginsFlag(arg) {
+			return true
+		}
+	}
+	for _, p := range c.resolvedPlugins {
+		if _, isExternal := p.(external.Plugin); isExternal {
+			return true
+		}
+	}
+	return false
 }
 
 // initHooksResult holds the result of initializationHooks: resource options and
@@ -244,7 +246,9 @@ func mergeFlagSetInto(
 			// This is the first time we realize the flag is duplicated. We must rewrite the
 			// first plugin's usage to include its prefix for disambiguation.
 			firstKey := firstPluginByFlag[flag.Name]
-			existing.Usage = "For plugin (" + firstKey + "): " + existing.Usage
+			if firstKey != "" {
+				existing.Usage = "For plugin (" + firstKey + "): " + existing.Usage
+			}
 		}
 
 		existing.Usage += " AND for plugin (" + pluginKey + "): " + strings.TrimSpace(flag.Usage)

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -190,6 +190,7 @@ func mergeFlagSetInto(
 	duplicateValues map[string][]pflag.Value,
 	pluginKey string,
 	firstPluginByFlag map[string]string,
+	showPluginPrefix bool,
 ) error {
 	destNames := make(map[string]struct{})
 	dest.VisitAll(func(f *pflag.Flag) {
@@ -205,7 +206,11 @@ func mergeFlagSetInto(
 		existing := dest.Lookup(flag.Name)
 		if _, wasInDest := destNames[flag.Name]; !wasInDest {
 			firstPluginByFlag[flag.Name] = pluginKey
-			existing.Usage = "For plugin (" + pluginKey + "): " + strings.TrimSpace(flag.Usage)
+			if showPluginPrefix {
+				existing.Usage = "For plugin (" + pluginKey + "): " + strings.TrimSpace(flag.Usage)
+			} else {
+				existing.Usage = strings.TrimSpace(flag.Usage)
+			}
 			return
 		}
 		if existing.Value.Type() != flag.Value.Type() {
@@ -217,6 +222,14 @@ func mergeFlagSetInto(
 			return
 		}
 		duplicateValues[flag.Name] = append(duplicateValues[flag.Name], flag.Value)
+		
+		if !showPluginPrefix && len(duplicateValues[flag.Name]) == 1 {
+			// This is the first time we realize the flag is duplicated. We must rewrite the 
+			// first plugin's usage to include its prefix for disambiguation.
+			firstKey := firstPluginByFlag[flag.Name]
+			existing.Usage = "For plugin (" + firstKey + "): " + existing.Usage
+		}
+
 		existing.Usage += " AND for plugin (" + pluginKey + "): " + strings.TrimSpace(flag.Usage)
 	})
 	return err
@@ -280,13 +293,34 @@ func initializationHooks(
 	// duplicate names do not panic; values are synced after parse and help text is aggregated.
 	duplicateValues := make(map[string][]pflag.Value)
 	firstPluginByFlag := make(map[string]string)
+
+	type pluginFlagSet struct {
+		key   string
+		flags *pflag.FlagSet
+	}
+	var flagSets []pluginFlagSet
+
 	for _, tuple := range subcommands {
 		if subcommand, hasFlags := tuple.subcommand.(plugin.HasFlags); hasFlags {
 			tmpSet := pflag.NewFlagSet(cmd.Name(), pflag.ExitOnError)
 			subcommand.BindFlags(tmpSet)
-			if err := mergeFlagSetInto(cmd.Flags(), tmpSet, duplicateValues, tuple.key, firstPluginByFlag); err != nil {
-				return nil, err
+			if tmpSet.HasFlags() {
+				flagSets = append(flagSets, pluginFlagSet{key: tuple.key, flags: tmpSet})
 			}
+		}
+	}
+
+	showPluginPrefix := false
+	for _, arg := range os.Args {
+		if arg == "--plugins" || strings.HasPrefix(arg, "--plugins=") {
+			showPluginPrefix = true
+			break
+		}
+	}
+
+	for _, pfs := range flagSets {
+		if err := mergeFlagSetInto(cmd.Flags(), pfs.flags, duplicateValues, pfs.key, firstPluginByFlag, showPluginPrefix); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/external"
 )
 
 // noResolvedPluginError is returned by subcommands that require a plugin when none was resolved.
@@ -146,7 +147,23 @@ func (c *CLI) applySubcommandHooks(
 		}
 	}
 
-	result, err := initializationHooks(cmd, subcommands, c.metadata())
+	showPluginPrefix := false
+	for _, arg := range os.Args {
+		if isPluginsFlag(arg) {
+			showPluginPrefix = true
+			break
+		}
+	}
+	if !showPluginPrefix {
+		for _, p := range c.resolvedPlugins {
+			if _, isExternal := p.(external.Plugin); isExternal {
+				showPluginPrefix = true
+				break
+			}
+		}
+	}
+
+	result, err := initializationHooks(cmd, subcommands, c.metadata(), showPluginPrefix)
 	if err != nil {
 		cmdErr(cmd, err)
 		return
@@ -222,9 +239,9 @@ func mergeFlagSetInto(
 			return
 		}
 		duplicateValues[flag.Name] = append(duplicateValues[flag.Name], flag.Value)
-		
+
 		if !showPluginPrefix && len(duplicateValues[flag.Name]) == 1 {
-			// This is the first time we realize the flag is duplicated. We must rewrite the 
+			// This is the first time we realize the flag is duplicated. We must rewrite the
 			// first plugin's usage to include its prefix for disambiguation.
 			firstKey := firstPluginByFlag[flag.Name]
 			existing.Usage = "For plugin (" + firstKey + "): " + existing.Usage
@@ -257,6 +274,7 @@ func initializationHooks(
 	cmd *cobra.Command,
 	subcommands []keySubcommandTuple,
 	meta plugin.CLIMetadata,
+	showPluginPrefix bool,
 ) (*initHooksResult, error) {
 	// Update metadata hook.
 	subcmdMeta := plugin.SubcommandMetadata{
@@ -307,14 +325,6 @@ func initializationHooks(
 			if tmpSet.HasFlags() {
 				flagSets = append(flagSets, pluginFlagSet{key: tuple.key, flags: tmpSet})
 			}
-		}
-	}
-
-	showPluginPrefix := false
-	for _, arg := range os.Args {
-		if arg == "--plugins" || strings.HasPrefix(arg, "--plugins=") {
-			showPluginPrefix = true
-			break
 		}
 	}
 

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -180,17 +181,13 @@ func (c *CLI) appendPluginTable(cmd *cobra.Command, filter func(plugin.Plugin) b
 // The prefix is shown if the user explicitly requested it via the --plugins flag, or if
 // any of the resolved plugins is an external plugin.
 func (c *CLI) shouldShowPluginPrefix(args []string) bool {
-	for _, arg := range args {
-		if isPluginsFlag(arg) {
-			return true
-		}
+	if slices.ContainsFunc(args, isPluginsFlag) {
+		return true
 	}
-	for _, p := range c.resolvedPlugins {
-		if _, isExternal := p.(external.Plugin); isExternal {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(c.resolvedPlugins, func(p plugin.Plugin) bool {
+		_, isExternal := p.(external.Plugin)
+		return isExternal
+	})
 }
 
 // initHooksResult holds the result of initializationHooks: resource options and
@@ -333,7 +330,8 @@ func initializationHooks(
 	}
 
 	for _, pfs := range flagSets {
-		if err := mergeFlagSetInto(cmd.Flags(), pfs.flags, duplicateValues, pfs.key, firstPluginByFlag, showPluginPrefix); err != nil {
+		err := mergeFlagSetInto(cmd.Flags(), pfs.flags, duplicateValues, pfs.key, firstPluginByFlag, showPluginPrefix)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -349,7 +349,7 @@ var _ = Describe("cmd_helpers", func() {
 			Expect(flag.Usage).To(Equal(expectedUsage))
 		})
 
-		It("should not show For plugin prefix when showPluginPrefix is false", func() {
+		It("should not show For plugin prefix when showPluginPrefix is false for a single flag", func() {
 			dest := pflag.NewFlagSet("dest", pflag.ExitOnError)
 			goPlugin := pflag.NewFlagSet("go", pflag.ExitOnError)
 			duplicateValues := make(map[string][]pflag.Value)
@@ -364,6 +364,30 @@ var _ = Describe("cmd_helpers", func() {
 			flag := dest.Lookup("force")
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Usage).To(Equal("overwrite scaffolded files to apply changes"))
+		})
+
+		It("should rewrite with For plugin prefixes when flags collide and showPluginPrefix is false", func() {
+			dest := pflag.NewFlagSet("dest", pflag.ExitOnError)
+			goPlugin := pflag.NewFlagSet("go", pflag.ExitOnError)
+			helmPlugin := pflag.NewFlagSet("helm", pflag.ExitOnError)
+			duplicateValues := make(map[string][]pflag.Value)
+			firstPluginByFlag := make(map[string]string)
+
+			var a, b bool
+			goPlugin.BoolVar(&a, "force", false, "overwrite scaffolded files to apply changes (manual edits may be lost)")
+			helmPlugin.BoolVar(&b, "force", false, "if true, regenerates all the files")
+
+			Expect(mergeFlagSetInto(dest, goPlugin, duplicateValues, "base.go.kubebuilder.io/v4", firstPluginByFlag, false)).
+				NotTo(HaveOccurred())
+
+			Expect(mergeFlagSetInto(dest, helmPlugin, duplicateValues, "helm.kubebuilder.io/v2-alpha", firstPluginByFlag, false)).
+				NotTo(HaveOccurred())
+
+			flag := dest.Lookup("force")
+			Expect(flag).NotTo(BeNil())
+			expectedUsage := "For plugin (base.go.kubebuilder.io/v4): overwrite scaffolded files to apply changes " +
+				"(manual edits may be lost) AND for plugin (helm.kubebuilder.io/v2-alpha): if true, regenerates all the files"
+			Expect(flag.Usage).To(Equal(expectedUsage))
 		})
 
 		It("should return error when same flag name is bound with different value types", func() {
@@ -451,7 +475,7 @@ var _ = Describe("cmd_helpers", func() {
 			}
 			meta := plugin.CLIMetadata{}
 
-			result, err := initializationHooks(cmd, tuples, meta)
+			result, err := initializationHooks(cmd, tuples, meta, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.duplicateFlagValues["force"]).To(HaveLen(1), "second plugin's Value recorded as duplicate")
 

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -123,18 +123,18 @@ var _ = Describe("cmd_helpers", func() {
 	Context("shouldShowPluginPrefix", func() {
 		It("should return true if --plugins flag is used", func() {
 			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
-			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init", "--plugins"})).To(BeTrue())
-			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init", "--plugins=go/v4"})).To(BeTrue())
+			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit, "--plugins"})).To(BeTrue())
+			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit, "--plugins=go/v4"})).To(BeTrue())
 		})
 
 		It("should return true if an external plugin is present", func() {
 			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}, external.Plugin{}}}
-			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init"})).To(BeTrue())
+			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit})).To(BeTrue())
 		})
 
 		It("should return false if neither --plugins flag nor external plugin is used", func() {
 			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
-			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init", "--domain", "example.com"})).To(BeFalse())
+			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit, "--domain", "my-test.example.com"})).To(BeFalse())
 		})
 	})
 
@@ -399,8 +399,8 @@ var _ = Describe("cmd_helpers", func() {
 			Expect(mergeFlagSetInto(dest, goPlugin, duplicateValues, "base.go.kubebuilder.io/v4", firstPluginByFlag, false)).
 				NotTo(HaveOccurred())
 
-			Expect(mergeFlagSetInto(dest, helmPlugin, duplicateValues, "helm.kubebuilder.io/v2-alpha", firstPluginByFlag, false)).
-				NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(dest, helmPlugin, duplicateValues,
+				"helm.kubebuilder.io/v2-alpha", firstPluginByFlag, false)).NotTo(HaveOccurred())
 
 			flag := dest.Lookup("force")
 			Expect(flag).NotTo(BeNil())
@@ -460,8 +460,10 @@ var _ = Describe("cmd_helpers", func() {
 
 			duplicateValues := make(map[string][]pflag.Value)
 			firstPluginByFlag := make(map[string]string)
-			Expect(mergeFlagSetInto(cmdFlags, pluginA, duplicateValues, "pluginA/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
-			Expect(mergeFlagSetInto(cmdFlags, pluginB, duplicateValues, "pluginB/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(cmdFlags, pluginA, duplicateValues,
+				"pluginA/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(cmdFlags, pluginB, duplicateValues,
+				"pluginB/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
 
 			Expect(cmdFlags.Parse([]string{flagForce, flagValueTrue})).NotTo(HaveOccurred())
 			syncDuplicateFlags(cmdFlags, duplicateValues)

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/external"
 )
 
 var _ = Describe("cmd_helpers", func() {
@@ -116,6 +117,24 @@ var _ = Describe("cmd_helpers", func() {
 			chain := []string{flagKey1, flagKey2, flagKey2}
 			result := moveKeyToFront(chain, flagKey2)
 			Expect(result).To(Equal([]string{flagKey2, flagKey1}))
+		})
+	})
+
+	Context("shouldShowPluginPrefix", func() {
+		It("should return true if --plugins flag is used", func() {
+			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
+			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init", "--plugins"})).To(BeTrue())
+			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init", "--plugins=go/v4"})).To(BeTrue())
+		})
+
+		It("should return true if an external plugin is present", func() {
+			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}, external.Plugin{}}}
+			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init"})).To(BeTrue())
+		})
+
+		It("should return false if neither --plugins flag nor external plugin is used", func() {
+			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
+			Expect(c.shouldShowPluginPrefix([]string{"kubebuilder", "init", "--domain", "example.com"})).To(BeFalse())
 		})
 	})
 

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -280,7 +280,7 @@ var _ = Describe("cmd_helpers", func() {
 			dest.BoolVar(&destBool, "force", false, "overwrite files (plugin A)")
 			src.BoolVar(&srcBool, "force", false, "regenerate all files (plugin B)")
 
-			err := mergeFlagSetInto(dest, src, duplicateValues, "pluginB/v1", firstPluginByFlag)
+			err := mergeFlagSetInto(dest, src, duplicateValues, "pluginB/v1", firstPluginByFlag, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(dest.Lookup("force")).NotTo(BeNil())
 			Expect(duplicateValues["force"]).To(HaveLen(1))
@@ -296,7 +296,7 @@ var _ = Describe("cmd_helpers", func() {
 			dest.BoolVar(&a, "force", false, "overwrite files (plugin A)")
 			src.BoolVar(&b, "force", false, "regenerate all files (plugin B)")
 
-			err := mergeFlagSetInto(dest, src, duplicateValues, "pluginB/v1", firstPluginByFlag)
+			err := mergeFlagSetInto(dest, src, duplicateValues, "pluginB/v1", firstPluginByFlag, true)
 			Expect(err).NotTo(HaveOccurred())
 
 			flag := dest.Lookup("force")
@@ -317,8 +317,8 @@ var _ = Describe("cmd_helpers", func() {
 			pluginA.BoolVar(&a, "force", false, "overwrite files (plugin A)")
 			pluginB.BoolVar(&b, "force", false, "regenerate all files (plugin B)")
 
-			Expect(mergeFlagSetInto(dest, pluginA, duplicateValues, "pluginA/v1", firstPluginByFlag)).NotTo(HaveOccurred())
-			Expect(mergeFlagSetInto(dest, pluginB, duplicateValues, "pluginB/v1", firstPluginByFlag)).NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(dest, pluginA, duplicateValues, "pluginA/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(dest, pluginB, duplicateValues, "pluginB/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
 
 			flag := dest.Lookup("force")
 			Expect(flag).NotTo(BeNil())
@@ -337,9 +337,9 @@ var _ = Describe("cmd_helpers", func() {
 			goPlugin.BoolVar(&a, "force", false, "overwrite scaffolded files to apply changes (manual edits may be lost)")
 			helmPlugin.BoolVar(&b, "force", false, "if true, regenerates all the files")
 
-			Expect(mergeFlagSetInto(dest, goPlugin, duplicateValues, "base.go.kubebuilder.io/v4", firstPluginByFlag)).
+			Expect(mergeFlagSetInto(dest, goPlugin, duplicateValues, "base.go.kubebuilder.io/v4", firstPluginByFlag, true)).
 				NotTo(HaveOccurred())
-			Expect(mergeFlagSetInto(dest, helmPlugin, duplicateValues, "helm.kubebuilder.io/v2-alpha", firstPluginByFlag)).
+			Expect(mergeFlagSetInto(dest, helmPlugin, duplicateValues, "helm.kubebuilder.io/v2-alpha", firstPluginByFlag, true)).
 				NotTo(HaveOccurred())
 
 			flag := dest.Lookup("force")
@@ -347,6 +347,23 @@ var _ = Describe("cmd_helpers", func() {
 			expectedUsage := "For plugin (base.go.kubebuilder.io/v4): overwrite scaffolded files to apply changes " +
 				"(manual edits may be lost) AND for plugin (helm.kubebuilder.io/v2-alpha): if true, regenerates all the files"
 			Expect(flag.Usage).To(Equal(expectedUsage))
+		})
+
+		It("should not show For plugin prefix when showPluginPrefix is false", func() {
+			dest := pflag.NewFlagSet("dest", pflag.ExitOnError)
+			goPlugin := pflag.NewFlagSet("go", pflag.ExitOnError)
+			duplicateValues := make(map[string][]pflag.Value)
+			firstPluginByFlag := make(map[string]string)
+
+			var a bool
+			goPlugin.BoolVar(&a, "force", false, "overwrite scaffolded files to apply changes")
+
+			Expect(mergeFlagSetInto(dest, goPlugin, duplicateValues, "base.go.kubebuilder.io/v4", firstPluginByFlag, false)).
+				NotTo(HaveOccurred())
+
+			flag := dest.Lookup("force")
+			Expect(flag).NotTo(BeNil())
+			Expect(flag.Usage).To(Equal("overwrite scaffolded files to apply changes"))
 		})
 
 		It("should return error when same flag name is bound with different value types", func() {
@@ -361,7 +378,7 @@ var _ = Describe("cmd_helpers", func() {
 			dest.BoolVar(&a, "flag", false, "bool usage (plugin A)")
 			src.StringVar(&b, "flag", "", "string usage (plugin B)")
 
-			err := mergeFlagSetInto(dest, src, duplicateValues, "pluginB/v1", firstPluginByFlag)
+			err := mergeFlagSetInto(dest, src, duplicateValues, "pluginB/v1", firstPluginByFlag, true)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("same flag name"))
 			Expect(err.Error()).To(ContainSubstring("different value types"))
@@ -400,8 +417,8 @@ var _ = Describe("cmd_helpers", func() {
 
 			duplicateValues := make(map[string][]pflag.Value)
 			firstPluginByFlag := make(map[string]string)
-			Expect(mergeFlagSetInto(cmdFlags, pluginA, duplicateValues, "pluginA/v1", firstPluginByFlag)).NotTo(HaveOccurred())
-			Expect(mergeFlagSetInto(cmdFlags, pluginB, duplicateValues, "pluginB/v1", firstPluginByFlag)).NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(cmdFlags, pluginA, duplicateValues, "pluginA/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
+			Expect(mergeFlagSetInto(cmdFlags, pluginB, duplicateValues, "pluginB/v1", firstPluginByFlag, true)).NotTo(HaveOccurred())
 
 			Expect(cmdFlags.Parse([]string{flagForce, flagValueTrue})).NotTo(HaveOccurred())
 			syncDuplicateFlags(cmdFlags, duplicateValues)

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -123,8 +123,12 @@ var _ = Describe("cmd_helpers", func() {
 	Context("shouldShowPluginPrefix", func() {
 		It("should return true if --plugins flag is used", func() {
 			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
-			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit, "--plugins"})).To(BeTrue())
-			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit, "--plugins=go/v4"})).To(BeTrue())
+			Expect(c.shouldShowPluginPrefix([]string{
+				kubebuilderCommandName, kubebuilderSubcommandInit, "--plugins",
+			})).To(BeTrue())
+			Expect(c.shouldShowPluginPrefix([]string{
+				kubebuilderCommandName, kubebuilderSubcommandInit, "--plugins=go/v4",
+			})).To(BeTrue())
 		})
 
 		It("should return true if an external plugin is present", func() {
@@ -134,7 +138,9 @@ var _ = Describe("cmd_helpers", func() {
 
 		It("should return false if neither --plugins flag nor external plugin is used", func() {
 			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
-			Expect(c.shouldShowPluginPrefix([]string{kubebuilderCommandName, kubebuilderSubcommandInit, "--domain", "my-test.example.com"})).To(BeFalse())
+			Expect(c.shouldShowPluginPrefix([]string{
+				kubebuilderCommandName, kubebuilderSubcommandInit, "--domain", "my-test.example.com",
+			})).To(BeFalse())
 		})
 	})
 

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -80,7 +80,7 @@ var _ = Describe("init", func() {
 	Context("flag descriptions", func() {
 		It("should use the same project version description for root and init", func() {
 			cli := CLI{
-				commandName:           "kubebuilder",
+				commandName:           kubebuilderCommandName,
 				defaultProjectVersion: config.Version{Number: 3},
 				plugins:               map[string]plugin.Plugin{},
 			}

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -35,7 +35,10 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 )
 
-const domainFlagArg = "--domain"
+const (
+	domainFlagArg = "--domain"
+	exampleDomain = "example.com"
+)
 
 var _ = Describe("Discover external plugins", func() {
 	Context("with valid plugins root path", func() {
@@ -474,7 +477,7 @@ var _ = Describe("Discover external plugins", func() {
 				pluginsFlagArg,
 				"myexternalplugin/v1",
 				domainFlagArg,
-				"example.com",
+				exampleDomain,
 				"--binary-flag",
 				"--license",
 				"apache2",
@@ -484,7 +487,7 @@ var _ = Describe("Discover external plugins", func() {
 			args := parseExternalPluginArgs()
 			Expect(args).Should(ContainElements(
 				domainFlagArg,
-				"example.com",
+				exampleDomain,
 				"--binary-flag",
 				"--license",
 				"apache2",
@@ -530,13 +533,13 @@ var _ = Describe("Discover external plugins", func() {
 				kubebuilderSubcommandInit,
 				"--plugins=myexternalplugin/v1",
 				domainFlagArg,
-				"example.com",
+				exampleDomain,
 			}
 
 			args := parseExternalPluginArgs()
 			Expect(args).Should(ContainElements(
 				domainFlagArg,
-				"example.com",
+				exampleDomain,
 			))
 			Expect(args).ShouldNot(ContainElement("--plugins=myexternalplugin/v1"))
 		})


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
**Description**
This PR resolves #5835 by removing the verbose plugin ownership prefixes from the CLI help output during standard usage.

The `For plugin (<plugin-key>):` prefix is now only displayed when:
1. The user explicitly passes the `--plugins` flag via the CLI.
2. Two or more plugins contribute the exact same flag (e.g., `--force`), where the prefix is dynamically added back to safely disambiguate ownership.

This makes the default CLI `help` and error outputs significantly cleaner and easier to read.

**Testing**
- Added tests in `cmd_helpers_test.go` to verify the prefix is hidden by default and correctly reapplied during collisions.
- Verified manually by running `make build && ./bin/kubebuilder create webhook --help`.

Closes #5835
