### PR TITLE
🐛 (CLI) Ignore invalid PROJECT paths for version and help

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	log "log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -41,11 +42,16 @@ const (
 	pluginsFlag        = "plugins"
 	pluginsFlagArg     = "--plugins"
 	projectVersionFlag = "project-version"
+	helpFlagArg        = "--help"
+	shellZsh           = "zsh"
 
-	kubebuilderCommandName    = "kubebuilder"
-	kubebuilderSubcommandInit = "init"
-	pluginGoKubebuilderV4     = "go.kubebuilder.io/v4"
-	pluginGoKubebuilderV2     = "go.kubebuilder.io/v2"
+	kubebuilderCommandName          = "kubebuilder"
+	kubebuilderSubcommandHelp       = "help"
+	kubebuilderSubcommandInit       = "init"
+	kubebuilderSubcommandVersion    = "version"
+	kubebuilderSubcommandCompletion = "completion"
+	pluginGoKubebuilderV4           = "go.kubebuilder.io/v4"
+	pluginGoKubebuilderV2           = "go.kubebuilder.io/v2"
 
 	pluginsFlagDescription = "Comma-separated list of plugin keys to use. " +
 		"If unset, Kubebuilder uses the plugin chain from PROJECT or the CLI default"
@@ -182,7 +188,9 @@ func (c *CLI) buildCmd() error {
 
 	// Resolve plugins for project version and plugin keys.
 	if err := c.resolvePlugins(); err != nil {
-		return err
+		if !shouldIgnoreConfigLoadError(os.Args[1:]) {
+			return err
+		}
 	}
 
 	// Add the subcommands
@@ -200,7 +208,11 @@ func (c *CLI) getInfo() error {
 	if err := c.getInfoFromConfigFile(); errors.Is(err, os.ErrNotExist) {
 		hasConfigFile = false
 	} else if err != nil {
-		return err
+		if shouldIgnoreConfigLoadError(os.Args[1:]) {
+			hasConfigFile = false
+		} else {
+			return err
+		}
 	}
 
 	// We can't early return here in case a project configuration file was found because
@@ -245,33 +257,55 @@ func (c *CLI) getInfoFromConfigFile() error {
 	return c.getInfoFromConfig(cfg.Config())
 }
 
+// positionalArgs returns arguments that are not flags or flag values.
+func positionalArgs(args []string) []string {
+	positional := []string{}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "-") {
+			positional = append(positional, arg)
+			continue
+		}
+
+		// A flag in --flag=value form consumes no additional argument.
+		if strings.Contains(arg, "=") {
+			continue
+		}
+
+		// A flag consumes the following argument only when it is not another flag.
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			i++
+		}
+	}
+
+	return positional
+}
+
+// hasOnlyRootFlags returns true when args consists solely of root flags and their values.
+func hasOnlyRootFlags(args []string) bool {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case pluginsFlagArg, "--" + projectVersionFlag:
+			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
+		default:
+			if strings.HasPrefix(args[i], pluginsFlagArg+"=") ||
+				strings.HasPrefix(args[i], "--"+projectVersionFlag+"=") {
+				continue
+			}
+			return false
+		}
+	}
+
+	return true
+}
+
 // isAlphaGenerateCommand checks if the command invocation is `kubebuilder alpha generate`
 // by scanning os.Args (excluding global flags). It returns true if "alpha" is followed by "generate".
 func isAlphaGenerateCommand(args []string) bool {
-	positional := []string{}
-	skip := false
-
-	for i := range args {
-		arg := args[i]
-
-		// Skip flags and their values
-		if strings.HasPrefix(arg, "-") {
-			// If the flag is in --flag=value format, skip only this one
-			if strings.Contains(arg, "=") {
-				continue
-			}
-			// If it's --flag value format, skip next one too
-			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				skip = true
-			}
-			continue
-		}
-		if skip {
-			skip = false
-			continue
-		}
-		positional = append(positional, arg)
-	}
+	positional := positionalArgs(args)
 
 	// Check for `alpha generate` in positional arguments
 	for i := 0; i < len(positional)-1; i++ {
@@ -281,6 +315,24 @@ func isAlphaGenerateCommand(args []string) bool {
 	}
 
 	return false
+}
+
+// shouldIgnoreConfigLoadError returns true for commands that do not require a valid PROJECT file.
+// This keeps context-free commands like help, version, and completion working from arbitrary directories.
+func shouldIgnoreConfigLoadError(args []string) bool {
+	if slices.ContainsFunc(args, isHelpFlag) {
+		return true
+	}
+
+	positional := positionalArgs(args)
+	// With no subcommand, Cobra displays root help. Configuration is not required.
+	if len(positional) == 0 {
+		return len(args) == 0 || hasOnlyRootFlags(args)
+	}
+
+	return positional[0] == kubebuilderSubcommandHelp ||
+		positional[0] == kubebuilderSubcommandVersion ||
+		positional[0] == kubebuilderSubcommandCompletion
 }
 
 // patchProjectFileInMemoryIfNeeded updates deprecated plugin keys in the PROJECT file in place,

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -78,6 +78,13 @@ func hasSubCommand(cmd *cobra.Command, name string) bool {
 	return false
 }
 
+func filesystemWithInvalidProjectPath() machinery.Filesystem {
+	fs := machinery.Filesystem{FS: afero.NewBasePathFs(afero.NewOsFs(), GinkgoT().TempDir())}
+	Expect(fs.FS.Mkdir("PROJECT", machinery.DefaultDirectoryPermission)).To(Succeed())
+
+	return fs
+}
+
 type pluginChainCapturingSubcommand struct {
 	pluginChain []string
 }
@@ -673,7 +680,7 @@ plugins:
 				Expect(hasSubCommand(c.cmd, "version")).To(BeTrue())
 
 				// Test the version command
-				c.cmd.SetArgs([]string{"version"})
+				c.cmd.SetArgs([]string{kubebuilderSubcommandVersion})
 				// Overwrite stdout to read the output and reset it afterwards
 				r, w, _ := os.Pipe()
 				temp := os.Stdout
@@ -690,6 +697,28 @@ plugins:
 				Expect(string(printed)).To(Equal(
 					fmt.Sprintf("%s\n", version)))
 			})
+
+			It("should ignore an invalid PROJECT path for version", func() {
+				const version = "version string"
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandVersion}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion(version),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{kubebuilderSubcommandVersion})
+				Expect(c.cmd.Execute()).To(Succeed())
+			})
 		})
 
 		When("enabling completion", func() {
@@ -701,6 +730,165 @@ plugins:
 				)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(hasSubCommand(c.cmd, "completion")).To(BeTrue())
+			})
+
+			It("should ignore an invalid PROJECT path for completion", func() {
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandCompletion, shellZsh}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion("version string"),
+					WithCompletion(),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{kubebuilderSubcommandCompletion, shellZsh})
+				Expect(c.cmd.Execute()).To(Succeed())
+			})
+		})
+
+		When("requesting help", func() {
+			It("should ignore an invalid PROJECT path when a flag without a value precedes help", func() {
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandInit, pluginsFlagArg, helpFlagArg}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion("version string"),
+					WithCompletion(),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{kubebuilderSubcommandInit, pluginsFlagArg, helpFlagArg})
+				Expect(c.cmd.Execute()).To(MatchError("help displayed"))
+			})
+
+			It("should ignore an invalid PROJECT path for the help subcommand", func() {
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandHelp}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion("version string"),
+					WithCompletion(),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{kubebuilderSubcommandHelp})
+				Expect(c.cmd.Execute()).To(Succeed())
+			})
+
+			It("should ignore an invalid PROJECT path for the root command", func() {
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion("version string"),
+					WithCompletion(),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(c.cmd.Execute()).To(Succeed())
+			})
+
+			It("should ignore an invalid PROJECT path for root flags without a subcommand", func() {
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, pluginsFlagArg, pluginGoKubebuilderV4}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion("version string"),
+					WithCompletion(),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{pluginsFlagArg, pluginGoKubebuilderV4})
+				Expect(c.cmd.Execute()).To(Succeed())
+			})
+
+			It("should ignore an invalid PROJECT path when help is requested after a subcommand", func() {
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandInit, helpFlagArg}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithVersion("version string"),
+					WithCompletion(),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{kubebuilderSubcommandInit, helpFlagArg})
+				Expect(c.cmd.Execute()).To(Succeed())
+			})
+
+			It("should return a configuration error for commands requiring a project", func() {
+				const (
+					createSubcommand = "create"
+					apiSubcommand    = "api"
+					kindFlagArg      = "--kind"
+				)
+
+				args := os.Args
+				defer func() {
+					os.Args = args
+				}()
+				os.Args = []string{kubebuilderCommandName, createSubcommand, apiSubcommand, kindFlagArg, kubebuilderSubcommandHelp}
+
+				fs := filesystemWithInvalidProjectPath()
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				c.cmd.SetArgs([]string{createSubcommand, apiSubcommand, kindFlagArg, kubebuilderSubcommandHelp})
+				Expect(c.cmd.Execute()).To(MatchError(ContainSubstring("failed to read \"PROJECT\" file")))
 			})
 		})
 

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -44,14 +44,14 @@ MacOS:
 
 func (c CLI) newZshCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "zsh",
+		Use:   shellZsh,
 		Short: "Load zsh completions",
 		Example: fmt.Sprintf(`# If shell completion is not already enabled in your environment you will need
 # to enable it. You can execute the following once:
 $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
 # To load completions for each session, execute once:
-$ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+$ %[1]s completion `+shellZsh+` > "${fpath[1]}/_%[1]s"
 
 # You will need to start a new shell for this setup to take effect.
 `, c.commandName),

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -80,7 +80,7 @@ var _ = Describe("init", func() {
 	Context("flag descriptions", func() {
 		It("should use the same project version description for root and init", func() {
 			cli := CLI{
-				commandName:           "kubebuilder",
+				commandName:           kubebuilderCommandName,
 				defaultProjectVersion: config.Version{Number: 3},
 				plugins:               map[string]plugin.Plugin{},
 			}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -35,7 +35,7 @@ var (
 
 // isHelpFlag checks if the given string is a help flag
 func isHelpFlag(s string) bool {
-	return s == "--help" || s == "-h" || s == "help"
+	return s == helpFlagArg || s == "-h" || s == kubebuilderSubcommandHelp
 }
 
 // getShortKey converts a full plugin key to a short display key

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -24,10 +24,10 @@ import (
 
 func (c CLI) newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "version",
+		Use:     kubebuilderSubcommandVersion,
 		Short:   fmt.Sprintf("Print the %s version", c.commandName),
 		Long:    fmt.Sprintf("Print the %s version", c.commandName),
-		Example: fmt.Sprintf("%s version", c.commandName),
+		Example: fmt.Sprintf("%s %s", c.commandName, kubebuilderSubcommandVersion),
 		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Println(c.version)
 			return nil


### PR DESCRIPTION
Follow-up to #1755
Refs #2666

`kubebuilder version` and `kubebuilder help` still try to load `PROJECT` on startup.
If cwd has a `PROJECT/` directory, they blow up. Kinda silly, but real.

This addresses a remaining related case for context-free commands:
- `version`
- `help`
- `completion`

Commands that really need project state still fail like before.

Repro:
```sh
mkdir PROJECT
kubebuilder version
kubebuilder help
```

Before:
```text
Error: error loading configuration: unable to load the configuration: failed to read "PROJECT" file: read PROJECT: is a directory
```

Checks:
- `make lint-fix`
- `make generate`
- `make test-unit`
