### PR TITLE
🌱 Avoid file dependency in license check

### DIFF
--- a/test/check-license.sh
+++ b/test/check-license.sh
@@ -26,7 +26,7 @@ echo "Checking for license header..."
 allfiles=$(listFiles | grep -v -e './internal/bindata/...' -e '.devcontainer/post-install.sh' -e '.github/*')
 licRes=""
 for file in $allfiles; do
-  if [[ -f "$file" && "$(file --mime-type -b "$file")" == text/* ]]; then
+  if [[ -f "$file" ]]; then
     # Read the first few lines but skip build tags for Go files
     # Strip up to 3 lines starting with //go:build or // +build
     stripped=$(head -n 30 "$file" \


### PR DESCRIPTION
## Summary
- Remove the license check script's dependency on the external `file` command.
- Keep the existing license header scan over repository Go and shell files, which are already selected by `listFiles`.

Fixes #5849

## Testing
- [x] `./test/check-license.sh` with an exported failing `file` function
- [x] `bash -n test/check-license.sh`
- [x] `make verify-license`
- [x] `make test-unit`
- [x] `make lint-fix`
- [x] `git diff --check`
