### PR TITLE
🌱 (ci): authenticate pinact with GITHUB_TOKEN to avoid API rate limits

### DIFF
--- a/.github/workflows/lint-gha-workflows.yml
+++ b/.github/workflows/lint-gha-workflows.yml
@@ -47,6 +47,11 @@ jobs:
           git diff --name-only --diff-filter=d origin/${GITHUB_BASE_REF} HEAD
 
       - name: Run pinact on changed workflow files
+        env:
+          # Authenticate pinact's GitHub REST calls (tag/commit resolution and
+          # --verify) so they use the 5,000 req/hr limit instead of the 60 req/hr
+          # unauthenticated limit. Only contents:read is granted to this job.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git diff --name-only --diff-filter=d origin/${GITHUB_BASE_REF} HEAD \
           | grep -E 'workflows/.*\.ya?ml$' \


### PR DESCRIPTION
The `pinact` job runs `pinact run --diff --check --verify`, which calls the
GitHub REST API to resolve action tags to commit SHAs and verify the pins. The
step runs without a token, so those calls fall back to the unauthenticated
60 requests/hour limit and hit rate limiting (reported in #5817).

pinact reads `GITHUB_TOKEN` (or `PINACT_GITHUB_TOKEN`) to authenticate its API
calls, which raises the limit to 5,000 requests/hour. This passes the job's
`github.token` to the pinact step via `env:`. The job already declares
`permissions: { contents: read }`, so no new permissions are granted, and the
step-scoped `env:` keeps the token out of the earlier checkout/setup steps.

Validation (run locally against the change):
- yamllint (repo `.yamllint`): no new findings
- actionlint: no new findings
- zizmor v1.26.1: "No findings to report"

Fixes #5817