### PR TITLE
✨ (helm/v2-alpha): make the manager health probe port configurable

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:8081
+        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
@@ -102,12 +102,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: 8081
+        - containerPort: {{ .Values.healthProbe.port }}
           name: health
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}
@@ -116,7 +116,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -159,6 +159,13 @@ metrics:
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
 
+## Health probe endpoint.
+## Serves the liveness (/healthz) and readiness (/readyz) checks.
+##
+healthProbe:
+  # Health probe server port
+  port: 8081
+
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.
 ##

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:8081
+        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
@@ -96,18 +96,18 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: 8081
+        - containerPort: {{ .Values.healthProbe.port }}
           name: health
           protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -159,6 +159,13 @@ metrics:
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
 
+## Health probe endpoint.
+## Serves the liveness (/healthz) and readiness (/readyz) checks.
+##
+healthProbe:
+  # Health probe server port
+  port: 8081
+
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.
 ##

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:8081
+        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
@@ -102,12 +102,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: 8081
+        - containerPort: {{ .Values.healthProbe.port }}
           name: health
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}
@@ -116,7 +116,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -159,6 +159,13 @@ metrics:
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
 
+## Health probe endpoint.
+## Serves the liveness (/healthz) and readiness (/readyz) checks.
+##
+healthProbe:
+  # Health probe server port
+  port: 8081
+
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.
 ##

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -41,6 +41,7 @@ type FeatureSet struct {
 	HasClusterScopedRBAC    bool
 	WebhookPort             int
 	MetricsPort             int
+	HealthProbePort         int
 	RoleNamespaces          map[string]string
 }
 
@@ -49,9 +50,10 @@ type FeatureSet struct {
 // The managerNamespace is the namespace where the manager deployment runs.
 func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, managerNamespace string) FeatureSet {
 	features := FeatureSet{
-		WebhookPort:    9443,
-		MetricsPort:    8443,
-		RoleNamespaces: make(map[string]string),
+		WebhookPort:     9443,
+		MetricsPort:     8443,
+		HealthProbePort: 8081,
+		RoleNamespaces:  make(map[string]string),
 	}
 
 	features.HasCRDs = len(resources.CustomResourceDefinitions) > 0
@@ -102,6 +104,13 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 					break
 				}
 			}
+		}
+	}
+
+	// The health probe port is defined on the manager container's --health-probe-bind-address arg.
+	if resources.Deployment != nil {
+		if port := extractHealthProbePortFromDeployment(resources.Deployment); port > 0 {
+			features.HealthProbePort = port
 		}
 	}
 
@@ -192,6 +201,43 @@ func extractWebhookPortFromDeployment(deployment *unstructured.Unstructured) int
 		if isWebhookPortName(name) {
 			if cp, ok := toInt(portMap["containerPort"]); ok {
 				return cp
+			}
+		}
+	}
+
+	return 0
+}
+
+// extractHealthProbePortFromDeployment extracts the health probe port from the
+// manager container's --health-probe-bind-address argument.
+func extractHealthProbePortFromDeployment(deployment *unstructured.Unstructured) int {
+	specMap := extractDeploymentSpec(deployment)
+	if specMap == nil {
+		return 0
+	}
+	container := findManagerContainer(deployment, specMap)
+	if container == nil {
+		return 0
+	}
+
+	argsField, found, err := unstructured.NestedFieldNoCopy(container, "args")
+	if !found || err != nil {
+		return 0
+	}
+
+	argsList, ok := argsField.([]any)
+	if !ok {
+		return 0
+	}
+
+	for _, a := range argsList {
+		strArg, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if strings.Contains(strArg, "--health-probe-bind-address") {
+			if port := ExtractPortFromArg(strArg); port > 0 {
+				return port
 			}
 		}
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -98,7 +98,32 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 		// Replace --webhook-port with templated version (matches any numeric port)
 		yamlContent = regexp.MustCompile(`--webhook-port=([0-9]+)`).
 			ReplaceAllString(yamlContent, "--webhook-port={{ .Values.webhook.port }}")
+
+		yamlContent = templateHealthProbePort(yamlContent)
 	}
+
+	return yamlContent
+}
+
+// templateHealthProbePort templates the manager health probe port so it can be
+// configured from values.yaml, mirroring how metrics and webhook ports are handled.
+// It rewrites the four places the port appears in the manager Deployment: the
+// --health-probe-bind-address arg, the "health" containerPort, and the liveness
+// and readiness httpGet ports.
+func templateHealthProbePort(yamlContent string) string {
+	const healthPortTemplate = "{{ .Values.healthProbe.port }}"
+
+	// --health-probe-bind-address=:PORT (also HOST:PORT and IPv6 [::1]:PORT)
+	yamlContent = regexp.MustCompile(`--health-probe-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`).
+		ReplaceAllString(yamlContent, "--health-probe-bind-address=$1:"+healthPortTemplate)
+
+	// containerPort for the port named "health"
+	yamlContent = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*health\b)`).
+		ReplaceAllString(yamlContent, "${1}containerPort: "+healthPortTemplate+"${2}")
+
+	// liveness (/healthz) and readiness (/readyz) httpGet ports
+	yamlContent = regexp.MustCompile(`(path:\s*/(?:healthz|readyz)[ \t]*\n\s*port:\s*)\d+`).
+		ReplaceAllString(yamlContent, "${1}"+healthPortTemplate)
 
 	return yamlContent
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -198,7 +198,7 @@ spec:
 			Expect(result).To(ContainSubstring("{{- if not .Values.metrics.secure }}"))
 			Expect(result).To(ContainSubstring("- --metrics-secure=false"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=0"))
-			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:8081"))
+			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
 			Expect(result).To(ContainSubstring("{{- range .Values.manager.args }}"))
 			Expect(result).NotTo(ContainSubstring("BUSYBOX_IMAGE"))
 			Expect(result).NotTo(ContainSubstring("MEMCACHED_IMAGE"))
@@ -2414,8 +2414,53 @@ spec:
 
 			result := templater.templatePorts(content, deployment)
 
-			Expect(result).To(ContainSubstring("port: 8081"))
-			Expect(result).NotTo(ContainSubstring("{{ .Values"))
+			Expect(result).To(ContainSubstring("port: {{ .Values.healthProbe.port }}"))
+			Expect(result).NotTo(ContainSubstring("port: 8081"))
+		})
+
+		// Regression test for #5865: the health probe port must be templated in all
+		// four places it appears in the manager Deployment (bind-address arg, the
+		// "health" containerPort, and the liveness and readiness httpGet ports), so it
+		// can be configured from values.yaml like the metrics and webhook ports.
+		It("should template every health probe port reference in the manager Deployment", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --health-probe-bind-address=:8081
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring(`            path: /healthz
+            port: {{ .Values.healthProbe.port }}`))
+			Expect(result).To(ContainSubstring(`            path: /readyz
+            port: {{ .Values.healthProbe.port }}`))
+			Expect(result).NotTo(ContainSubstring("8081"))
 		})
 
 		It("should template port-related args in Deployment", func() {
@@ -2442,7 +2487,7 @@ spec:
 
 			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
 			Expect(result).NotTo(ContainSubstring("--metrics-bind-address=:8443"))
-			Expect(result).To(ContainSubstring("--health-probe-bind-address=:8081"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
 			Expect(result).To(ContainSubstring("--leader-elect"))
 		})
 
@@ -2470,6 +2515,7 @@ spec:
           name: webhook-server
         livenessProbe:
           httpGet:
+            path: /healthz
             port: 9091`
 
 			result := templater.templatePorts(content, deployment)
@@ -2477,8 +2523,9 @@ spec:
 			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
 			Expect(result).To(ContainSubstring("--webhook-port={{ .Values.webhook.port }}"))
 			Expect(result).To(ContainSubstring("containerPort: {{ .Values.webhook.port }}"))
-			Expect(result).To(ContainSubstring("--health-probe-bind-address=:9091"))
-			Expect(result).To(ContainSubstring("port: 9091"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("port: {{ .Values.healthProbe.port }}"))
+			Expect(result).NotTo(ContainSubstring(":9091"))
 		})
 
 		It("should not template non-webhook/metrics resources", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -124,6 +124,9 @@ crd:
 	// Metrics configuration (always present, enabled based on detected metrics artifacts)
 	f.addMetricsSection(&buf)
 
+	// Health probe configuration (always present; every manager exposes liveness/readiness probes)
+	f.addHealthProbeSection(&buf)
+
 	// Cert-manager configuration (always present)
 	// IMPORTANT: Webhooks REQUIRE cert-manager for TLS certificates.
 	// HasWebhooks = true means cert-manager MUST be enabled.
@@ -580,6 +583,22 @@ metrics:
   secure: true
 
 `)
+}
+
+// addHealthProbeSection adds health probe configuration
+func (f *HelmValues) addHealthProbeSection(buf *bytes.Buffer) {
+	port := 8081
+	if f.Extraction != nil && f.Extraction.Features.HealthProbePort > 0 {
+		port = f.Extraction.Features.HealthProbePort
+	}
+
+	buf.WriteString(`## Health probe endpoint.
+## Serves the liveness (/healthz) and readiness (/readyz) checks.
+##
+healthProbe:
+`)
+	buf.WriteString("  # Health probe server port\n")
+	fmt.Fprintf(buf, "  port: %d\n\n", port)
 }
 
 // addWebhookSection adds webhook configuration

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -168,6 +168,62 @@ var _ = Describe("kubebuilder", func() {
 			})
 		})
 
+		It("should install the HelmChart with custom metrics and health probe ports", func() {
+			By("generating a full-featured project with webhooks, metrics and conversion webhooks")
+			helpers.GenerateV4(kbc)
+
+			By("building installer and generating helm chart")
+			Expect(kbc.Make("build-installer")).To(Succeed())
+			Expect(kbc.EditHelmPlugin()).To(Succeed())
+
+			// metrics.port and healthProbe.port are wired into the manager through the
+			// --metrics-bind-address and --health-probe-bind-address flags, so overriding
+			// them in values.yaml changes the port the manager actually binds to. webhook.port
+			// is intentionally left at its default here: the scaffolded manager serves the
+			// webhook on controller-runtime's default port, so that value only affects the
+			// Service/containerPort and is exercised by the other webhook specs.
+			const (
+				customMetricsPort     = 8444
+				customHealthProbePort = 8082
+			)
+
+			By("overriding metrics.port and healthProbe.port in values.yaml")
+			valuesPath := filepath.Join(kbc.Dir, "dist", "chart", "values.yaml")
+			Expect(pluginutil.ReplaceInFile(valuesPath,
+				"port: 8443", fmt.Sprintf("port: %d", customMetricsPort))).To(Succeed())
+			Expect(pluginutil.ReplaceInFile(valuesPath,
+				"port: 8081", fmt.Sprintf("port: %d", customHealthProbePort))).To(Succeed())
+
+			By("deploying with the customized ports and validating the manager runs correctly")
+			// helpers.Run drives the full runtime verification against the customized chart:
+			// the pod only reaches Ready if the health probe answers on customHealthProbePort,
+			// the webhook flow keeps working, and the metrics are scraped from customMetricsPort.
+			helpers.Run(kbc, helpers.RunOptions{
+				HasWebhook:          true,
+				HasMetrics:          true,
+				HasNetworkPolicies:  false,
+				InstallMethod:       helpers.InstallMethodHelm,
+				MetricsPort:         customMetricsPort,
+				SkipChartGeneration: true, // Chart already generated and customized above
+			})
+
+			By("verifying the manager binds the probes and metrics to the custom ports")
+			controllerPodName := helpers.GetControllerPodName(kbc)
+			args, err := kbc.Kubectl.Get(true,
+				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].args}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(ContainSubstring(
+				fmt.Sprintf("--health-probe-bind-address=:%d", customHealthProbePort)))
+			Expect(args).To(ContainSubstring(
+				fmt.Sprintf("--metrics-bind-address=:%d", customMetricsPort)))
+
+			By("verifying the container declares the custom health probe port")
+			ports, err := kbc.Kubectl.Get(true,
+				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].ports}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ports).To(ContainSubstring(strconv.Itoa(customHealthProbePort)))
+		})
+
 		It("should generate a namespeced runnable project using webhooks and installed with the HelmChart", func() {
 			helpers.GenerateV4Namespaced(kbc)
 

--- a/test/e2e/internal/helpers/plugin_test_helper.go
+++ b/test/e2e/internal/helpers/plugin_test_helper.go
@@ -71,6 +71,10 @@ type RunOptions struct {
 	HelmFullnameOverride string
 	// SkipChartGeneration skips build-installer and chart generation (chart already prepared externally)
 	SkipChartGeneration bool
+	// MetricsPort is the port the metrics service is exposed on. Defaults to 8443 when zero.
+	// Set this when the chart's metrics.port has been customized so the metrics are scraped
+	// from the right port.
+	MetricsPort int
 }
 
 // Run executes common e2e tests for a scaffolded project.
@@ -310,7 +314,7 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 
 	if opts.HasMetrics {
 		By("checking the metrics values to validate that the created resource object gets reconciled")
-		metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc)
+		metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc, opts.MetricsPort)
 		Expect(metricsOutput).To(ContainSubstring(fmt.Sprintf(
 			`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
 			strings.ToLower(kbc.Kind),
@@ -408,7 +412,7 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 
 		if opts.HasMetrics {
 			By("validating conversion metrics to confirm conversion operations")
-			metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc)
+			metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc, opts.MetricsPort)
 			conversionMetric := `controller_runtime_reconcile_total{controller="conversiontest",result="success"} 1`
 			Expect(metricsOutput).To(ContainSubstring(conversionMetric),
 				"Expected metric for successful ConversionTest reconciliation")

--- a/test/e2e/internal/helpers/plugin_test_metrics.go
+++ b/test/e2e/internal/helpers/plugin_test_metrics.go
@@ -81,9 +81,13 @@ func GetControllerPodName(kbc *utils.TestContext) string {
 	return controllerPodName
 }
 
+// defaultMetricsPort is the port the metrics service listens on when values.yaml is not customized.
+const defaultMetricsPort = 8443
+
 // GetMetricsOutput returns the metrics output from curl pod
 // namePrefix is the prefix for service names (e.g., "e2e-{suffix}" or "custom-operator" from fullnameOverride)
-func GetMetricsOutput(controllerPodName, namePrefix string, kbc *utils.TestContext) string {
+// metricsPort is the port the metrics service is exposed on; pass 0 to use the default (8443).
+func GetMetricsOutput(controllerPodName, namePrefix string, kbc *utils.TestContext, metricsPort int) string {
 	var err error
 	// All Kubebuilder projects are cluster-scoped, so use ClusterRoleBinding
 	_, err = kbc.Kubectl.Command(
@@ -164,7 +168,7 @@ func GetMetricsOutput(controllerPodName, namePrefix string, kbc *utils.TestConte
 	}
 
 	By("creating a curl pod to access the metrics endpoint")
-	cmdOpts := cmdOptsToCreateCurlPod(namePrefix, kbc, token)
+	cmdOpts := cmdOptsToCreateCurlPod(namePrefix, kbc, token, metricsPort)
 	_, err = kbc.Kubectl.CommandInNamespace(cmdOpts...)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -215,7 +219,7 @@ func ValidateMetricsUnavailable(namePrefix string, kbc *utils.TestContext) {
 	Expect(token).NotTo(BeEmpty())
 
 	By("creating a curl pod to access the metrics endpoint")
-	cmdOpts := cmdOptsToCreateCurlPod(namePrefix, kbc, token)
+	cmdOpts := cmdOptsToCreateCurlPod(namePrefix, kbc, token, defaultMetricsPort)
 	_, err = kbc.Kubectl.CommandInNamespace(cmdOpts...)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -240,7 +244,10 @@ func ValidateMetricsUnavailable(namePrefix string, kbc *utils.TestContext) {
 	removeCurlPod(kbc)
 }
 
-func cmdOptsToCreateCurlPod(namePrefix string, kbc *utils.TestContext, token string) []string {
+func cmdOptsToCreateCurlPod(namePrefix string, kbc *utils.TestContext, token string, metricsPort int) []string {
+	if metricsPort == 0 {
+		metricsPort = defaultMetricsPort
+	}
 	cmdOpts := []string{
 		"run", "curl",
 		"--restart=Never",
@@ -256,7 +263,7 @@ func cmdOptsToCreateCurlPod(namePrefix string, kbc *utils.TestContext, token str
 					"args": [
 						"for i in $(seq 1 30); do `+
 			`curl -v -k -H 'Authorization: Bearer %s' `+
-			`https://%s-controller-manager-metrics-service.%s.svc.cluster.local:8443/metrics `+
+			`https://%s-controller-manager-metrics-service.%s.svc.cluster.local:%d/metrics `+
 			`&& exit 0 || sleep 2; done; exit 1"
 					],
 					"securityContext": {
@@ -274,7 +281,7 @@ func cmdOptsToCreateCurlPod(namePrefix string, kbc *utils.TestContext, token str
 				}],
 				"serviceAccountName": "%s"
 			}
-    }`, token, namePrefix, kbc.Kubectl.Namespace, kbc.Kubectl.ServiceAccount),
+    }`, token, namePrefix, kbc.Kubectl.Namespace, metricsPort, kbc.Kubectl.ServiceAccount),
 	}
 	return cmdOpts
 }

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:8081
+        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
@@ -113,12 +113,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: 8081
+        - containerPort: {{ .Values.healthProbe.port }}
           name: health
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}
@@ -127,7 +127,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: {{ .Values.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -176,6 +176,13 @@ metrics:
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
 
+## Health probe endpoint.
+## Serves the liveness (/healthz) and readiness (/readyz) checks.
+##
+healthProbe:
+  # Health probe server port
+  port: 8081
+
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.
 ##


### PR DESCRIPTION
Fixes #5865

## What this does

The `helm/v2-alpha` plugin extracts the metrics port and webhook port to `values.yaml` so chart consumers can set them at deploy time, but the health probe port stayed hardcoded as `8081` in the four places it appears in the generated `templates/manager/manager.yaml`:

* the `--health-probe-bind-address` arg
* the `health` `containerPort`
* the `livenessProbe` `httpGet` port
* the `readinessProbe` `httpGet` port

Changing the port meant editing all four by hand, and missing one silently points the probes at a port the manager is not listening on.

This templates all four references to `{{ .Values.healthProbe.port }}` and adds the value to `values.yaml`, following the same pattern already used for `metrics.port` and `webhook.port`:

```yaml
## Health probe endpoint.
## Serves the liveness (/healthz) and readiness (/readyz) checks.
##
healthProbe:
  # Health probe server port
  port: 8081
```

The port is detected from the manager's `--health-probe-bind-address` argument (defaulting to `8081`), so a project that customized it keeps its value.

## Changes

* `extractor`: add `HealthProbePort` to the detected feature set and read it from the manager container arg.
* `values.go`: emit a top-level `healthProbe.port` block.
* `ports.go`: template the four health probe references in the manager Deployment.
* Regenerated the helm chart testdata for the four sample projects.

## A note on placement

I put the value at the top level (`healthProbe.port`) to mirror the existing `metrics.port` and `webhook.port` blocks. The issue suggested `manager.healthProbePort`; I am happy to move it under `manager` if you prefer that grouping, just let me know.

## Testing

* Added a regression test in `templater_test.go` asserting all four references are templated (confirmed it fails when the templating is reverted).
* Updated the existing port tests to expect the templated output, including a custom port case.
* `go test ./pkg/plugins/optional/helm/v2alpha/...` is green, along with the `-tags integration` suite, on Linux.
* Regenerated the chart testdata and confirmed the only changes are the four health probe references plus the new values block.
