### PR TITLE
✨ (go/v4,helm/v2-alpha): Add support for custom webhook ports to the manager

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -77,6 +77,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -93,6 +94,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -126,6 +128,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_webhook_patch.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/manager_webhook_patch.yaml
@@ -6,6 +6,11 @@
   path: /spec/template/spec/containers/0/args/-
   value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
 
+# Add the --webhook-port argument to match the webhook Service target port
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-port=9443
+
 # Add the volumeMount for the webhook certificates
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -84,6 +84,7 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --webhook-port={{ .Values.webhook.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/install.yaml
@@ -4359,6 +4359,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        - --webhook-port=9443
         command:
         - /manager
         image: controller:latest

--- a/docs/book/src/getting-started/testdata/project/cmd/main.go
+++ b/docs/book/src/getting-started/testdata/project/cmd/main.go
@@ -57,6 +57,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -73,6 +74,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -106,6 +108,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
@@ -76,6 +76,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -92,6 +93,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -127,6 +129,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_webhook_patch.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/manager_webhook_patch.yaml
@@ -6,6 +6,11 @@
   path: /spec/template/spec/containers/0/args/-
   value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
 
+# Add the --webhook-port argument to match the webhook Service target port
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-port=9443
+
 # Add the volumeMount for the webhook certificates
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -84,6 +84,7 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --webhook-port={{ .Values.webhook.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/install.yaml
@@ -8405,6 +8405,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        - --webhook-port=9443
         command:
         - /manager
         image: controller:latest

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -235,6 +235,16 @@ The `metrics-auth-role` and `metrics-reader` are always ClusterRoles, even when 
 
 </aside>
 
+### Webhook port configuration
+
+Set `webhook.port` to change the port used by the manager webhook server. The chart applies the same value to the manager argument, container port, webhook service, and webhook NetworkPolicy.
+
+For example, install the chart with the webhook server on port `9444`:
+
+```bash
+helm install my-operator ./dist/chart --set webhook.port=9444
+```
+
 ### NetworkPolicy configuration
 
 Set `networkPolicy.enabled: true` to install NetworkPolicy resources for the manager pod.

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/webhook_manager_patch.go
@@ -59,6 +59,11 @@ const managerWebhookPatchTemplate = `# This patch ensures the webhook certificat
   path: /spec/template/spec/containers/0/args/-
   value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
 
+# Add the --webhook-port argument to match the webhook Service target port
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-port=9443
+
 # Add the volumeMount for the webhook certificates
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
@@ -296,6 +296,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -312,6 +313,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -345,6 +347,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
@@ -442,6 +442,9 @@ func extractContainerArgs(container map[string]any, config map[string]any) {
 		if strings.Contains(strArg, "--health-probe-bind-address") {
 			continue
 		}
+		if strings.Contains(strArg, "--webhook-port") {
+			continue
+		}
 		if strings.Contains(strArg, "--webhook-cert-path") ||
 			strings.Contains(strArg, "--metrics-cert-path") {
 			continue

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -174,6 +174,7 @@ var _ = Describe("ChartConverter", func() {
 						"--leader-elect",
 						"--custom-flag=value",
 						"--health-probe-bind-address=:8081",
+						"--webhook-port=9443",
 						"--webhook-cert-path=/tmp/k8s-webhook-server/serving-certs",
 					},
 					"env": []any{
@@ -218,6 +219,7 @@ var _ = Describe("ChartConverter", func() {
 			Expect(args).To(ContainElement("--custom-flag=value"))
 			Expect(args).NotTo(ContainElement("--metrics-bind-address=:8443"))
 			Expect(args).NotTo(ContainElement("--health-probe-bind-address=:8081"))
+			Expect(args).NotTo(ContainElement("--webhook-port=9443"))
 		})
 
 		It("should extract port configurations from args", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -624,6 +624,7 @@ func templateControllerManagerArgs(yamlContent string) string {
 		metricsLine    string
 		metricsIndent  string
 		healthLine     string
+		webhookLine    string
 		preservedLines []string
 	)
 
@@ -648,6 +649,8 @@ func templateControllerManagerArgs(yamlContent string) string {
 			}
 		case strings.Contains(trimmed, "--health-probe-bind-address"):
 			healthLine = line
+		case strings.Contains(trimmed, "--webhook-port"):
+			webhookLine = line
 		case strings.Contains(trimmed, "--webhook-cert-path"),
 			strings.Contains(trimmed, "--metrics-cert-path"):
 			preservedLines = append(preservedLines, line)
@@ -685,6 +688,10 @@ func templateControllerManagerArgs(yamlContent string) string {
 	}
 	if healthLine != "" {
 		builder.WriteString(healthLine)
+		builder.WriteString("\n")
+	}
+	if webhookLine != "" {
+		builder.WriteString(webhookLine)
 		builder.WriteString("\n")
 	}
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -163,6 +163,7 @@ spec:
       - args:
         - --metrics-bind-address=:8443
         - --health-probe-bind-address=:8081
+        - --webhook-port=9443
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs/tls.crt
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs/tls.crt
         - --leader-elect
@@ -199,6 +200,7 @@ spec:
 			Expect(result).To(ContainSubstring("- --metrics-secure=false"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=0"))
 			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("- --webhook-port={{ .Values.webhook.port }}"))
 			Expect(result).To(ContainSubstring("{{- range .Values.manager.args }}"))
 			Expect(result).NotTo(ContainSubstring("BUSYBOX_IMAGE"))
 			Expect(result).NotTo(ContainSubstring("MEMCACHED_IMAGE"))

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -184,7 +184,7 @@ var _ = Describe("kubebuilder", func() {
 				customWebhookPort     = 9444
 			)
 
-			By("overriding metrics.port, healthProbe.port, and webhook.port in values.yaml")
+			By("overriding ports and enabling network policies in values.yaml")
 			valuesPath := filepath.Join(kbc.Dir, "dist", "chart", "values.yaml")
 			Expect(pluginutil.ReplaceInFile(valuesPath,
 				"port: 8443", fmt.Sprintf("port: %d", customMetricsPort))).To(Succeed())
@@ -192,6 +192,8 @@ var _ = Describe("kubebuilder", func() {
 				"port: 8081", fmt.Sprintf("port: %d", customHealthProbePort))).To(Succeed())
 			Expect(pluginutil.ReplaceInFile(valuesPath,
 				"port: 9443", fmt.Sprintf("port: %d", customWebhookPort))).To(Succeed())
+			Expect(pluginutil.ReplaceInFile(valuesPath,
+				"networkPolicy:\n  enabled: false", "networkPolicy:\n  enabled: true")).To(Succeed())
 
 			By("deploying with the customized ports and validating the manager runs correctly")
 			// helpers.Run drives the full runtime verification against the customized chart:

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -196,8 +196,8 @@ var _ = Describe("kubebuilder", func() {
 			By("deploying with the customized ports and validating the manager runs correctly")
 			// helpers.Run drives the full runtime verification against the customized chart:
 			// the pod only reaches Ready if the health probe answers on customHealthProbePort,
-			// the webhook flow works through customWebhookPort, and the metrics are scraped
-			// from customMetricsPort.
+			// the defaulting, validating, and conversion webhook flows work through
+			// customWebhookPort, and the metrics are scraped from customMetricsPort.
 			helpers.Run(kbc, helpers.RunOptions{
 				HasWebhook:          true,
 				HasMetrics:          true,

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -168,7 +168,7 @@ var _ = Describe("kubebuilder", func() {
 			})
 		})
 
-		It("should install the HelmChart with custom metrics and health probe ports", func() {
+		It("should install the HelmChart with custom metrics, health probe, and webhook ports", func() {
 			By("generating a full-featured project with webhooks, metrics and conversion webhooks")
 			helpers.GenerateV4(kbc)
 
@@ -176,38 +176,38 @@ var _ = Describe("kubebuilder", func() {
 			Expect(kbc.Make("build-installer")).To(Succeed())
 			Expect(kbc.EditHelmPlugin()).To(Succeed())
 
-			// metrics.port and healthProbe.port are wired into the manager through the
-			// --metrics-bind-address and --health-probe-bind-address flags, so overriding
-			// them in values.yaml changes the port the manager actually binds to. webhook.port
-			// is intentionally left at its default here: the scaffolded manager serves the
-			// webhook on controller-runtime's default port, so that value only affects the
-			// Service/containerPort and is exercised by the other webhook specs.
+			// Each port value is wired into the manager, so overriding it in values.yaml
+			// changes both the manager listener and the Kubernetes resources that target it.
 			const (
 				customMetricsPort     = 8444
 				customHealthProbePort = 8082
+				customWebhookPort     = 9444
 			)
 
-			By("overriding metrics.port and healthProbe.port in values.yaml")
+			By("overriding metrics.port, healthProbe.port, and webhook.port in values.yaml")
 			valuesPath := filepath.Join(kbc.Dir, "dist", "chart", "values.yaml")
 			Expect(pluginutil.ReplaceInFile(valuesPath,
 				"port: 8443", fmt.Sprintf("port: %d", customMetricsPort))).To(Succeed())
 			Expect(pluginutil.ReplaceInFile(valuesPath,
 				"port: 8081", fmt.Sprintf("port: %d", customHealthProbePort))).To(Succeed())
+			Expect(pluginutil.ReplaceInFile(valuesPath,
+				"port: 9443", fmt.Sprintf("port: %d", customWebhookPort))).To(Succeed())
 
 			By("deploying with the customized ports and validating the manager runs correctly")
 			// helpers.Run drives the full runtime verification against the customized chart:
 			// the pod only reaches Ready if the health probe answers on customHealthProbePort,
-			// the webhook flow keeps working, and the metrics are scraped from customMetricsPort.
+			// the webhook flow works through customWebhookPort, and the metrics are scraped
+			// from customMetricsPort.
 			helpers.Run(kbc, helpers.RunOptions{
 				HasWebhook:          true,
 				HasMetrics:          true,
-				HasNetworkPolicies:  false,
+				HasNetworkPolicies:  true,
 				InstallMethod:       helpers.InstallMethodHelm,
 				MetricsPort:         customMetricsPort,
 				SkipChartGeneration: true, // Chart already generated and customized above
 			})
 
-			By("verifying the manager binds the probes and metrics to the custom ports")
+			By("verifying the manager binds probes, metrics, and webhooks to the custom ports")
 			controllerPodName := helpers.GetControllerPodName(kbc)
 			args, err := kbc.Kubectl.Get(true,
 				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].args}")
@@ -216,12 +216,14 @@ var _ = Describe("kubebuilder", func() {
 				fmt.Sprintf("--health-probe-bind-address=:%d", customHealthProbePort)))
 			Expect(args).To(ContainSubstring(
 				fmt.Sprintf("--metrics-bind-address=:%d", customMetricsPort)))
+			Expect(args).To(ContainSubstring(fmt.Sprintf("--webhook-port=%d", customWebhookPort)))
 
 			By("verifying the container declares the custom health probe port")
 			ports, err := kbc.Kubectl.Get(true,
 				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].ports}")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ports).To(ContainSubstring(strconv.Itoa(customHealthProbePort)))
+			Expect(ports).To(ContainSubstring(strconv.Itoa(customWebhookPort)))
 		})
 
 		It("should generate a namespeced runnable project using webhooks and installed with the HelmChart", func() {

--- a/test/e2e/all/plugin_v4_test.go
+++ b/test/e2e/all/plugin_v4_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package all
 
 import (
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -99,6 +101,34 @@ var _ = Describe("kubebuilder", func() {
 				HasNetworkPolicies: true,
 				InstallMethod:      helpers.InstallMethodKustomize,
 			})
+		})
+
+		It("should generate a runnable project with a custom webhook port protected by network policies", func() {
+			helpers.GenerateV4WithNetworkPolicies(kbc)
+
+			By("configuring the manager and webhook Service to use a custom webhook port")
+			const customWebhookPort = "9444"
+			Expect(util.ReplaceInFile(
+				filepath.Join(kbc.Dir, "config", "default", "manager_webhook_patch.yaml"),
+				"9443", customWebhookPort)).To(Succeed())
+			Expect(util.ReplaceInFile(
+				filepath.Join(kbc.Dir, "config", "webhook", "service.yaml"),
+				"targetPort: 9443", "targetPort: "+customWebhookPort)).To(Succeed())
+
+			By("deploying with the custom webhook port and validating all webhook flows")
+			helpers.Run(kbc, helpers.RunOptions{
+				HasWebhook:         true,
+				HasMetrics:         true,
+				HasNetworkPolicies: true,
+				InstallMethod:      helpers.InstallMethodKustomize,
+			})
+
+			By("verifying the manager is configured with the custom webhook port")
+			controllerPodName := helpers.GetControllerPodName(kbc)
+			args, err := kbc.Kubectl.Get(true,
+				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].args}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(ContainSubstring("--webhook-port=" + customWebhookPort))
 		})
 
 		It("should generate a runnable project with the manager running "+

--- a/testdata/project-v4-multigroup/cmd/main.go
+++ b/testdata/project-v4-multigroup/cmd/main.go
@@ -100,6 +100,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -116,6 +117,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -149,6 +151,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/testdata/project-v4-multigroup/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4-multigroup/config/default/manager_webhook_patch.yaml
@@ -6,6 +6,11 @@
   path: /spec/template/spec/containers/0/args/-
   value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
 
+# Add the --webhook-port argument to match the webhook Service target port
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-port=9443
+
 # Add the volumeMount for the webhook certificates
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/testdata/project-v4-multigroup/dist/install.yaml
+++ b/testdata/project-v4-multigroup/dist/install.yaml
@@ -3139,6 +3139,7 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        - --webhook-port=9443
         command:
         - /manager
         env:

--- a/testdata/project-v4-with-plugins/cmd/main.go
+++ b/testdata/project-v4-with-plugins/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -108,6 +109,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -141,6 +143,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/testdata/project-v4-with-plugins/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4-with-plugins/config/default/manager_webhook_patch.yaml
@@ -6,6 +6,11 @@
   path: /spec/template/spec/containers/0/args/-
   value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
 
+# Add the --webhook-port argument to match the webhook Service target port
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-port=9443
+
 # Add the volumeMount for the webhook certificates
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -84,6 +84,7 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --webhook-port={{ .Values.webhook.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}

--- a/testdata/project-v4-with-plugins/dist/install.yaml
+++ b/testdata/project-v4-with-plugins/dist/install.yaml
@@ -995,6 +995,7 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        - --webhook-port=9443
         command:
         - /manager
         env:

--- a/testdata/project-v4/cmd/main.go
+++ b/testdata/project-v4/cmd/main.go
@@ -63,6 +63,7 @@ func main() {
 	var metricsAddr string
 	var metricsCertPath, metricsCertName, metricsCertKey string
 	var webhookCertPath, webhookCertName, webhookCertKey string
+	var webhookPort int
 	var enableLeaderElection bool
 	var probeAddr string
 	var secureMetrics bool
@@ -79,6 +80,7 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
@@ -112,6 +114,7 @@ func main() {
 	webhookTLSOpts := tlsOpts
 	webhookServerOptions := webhook.Options{
 		TLSOpts: webhookTLSOpts,
+		Port:    webhookPort,
 	}
 
 	if len(webhookCertPath) > 0 {

--- a/testdata/project-v4/config/default/manager_webhook_patch.yaml
+++ b/testdata/project-v4/config/default/manager_webhook_patch.yaml
@@ -6,6 +6,11 @@
   path: /spec/template/spec/containers/0/args/-
   value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
 
+# Add the --webhook-port argument to match the webhook Service target port
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-port=9443
+
 # Add the volumeMount for the webhook certificates
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-

--- a/testdata/project-v4/dist/install.yaml
+++ b/testdata/project-v4/dist/install.yaml
@@ -1372,6 +1372,7 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        - --webhook-port=9443
         command:
         - /manager
         image: controller:latest


### PR DESCRIPTION
## Summary

- Add a configurable --webhook-port manager flag and pass it to controller-runtime.
- Add the default webhook port argument to the Kustomize webhook patch.
- Bind Helm webhook.port to the manager argument, container port, Service, and NetworkPolicy.
- Add regression coverage, regenerate samples, and document the Helm override.

## Root cause

The chart exposed webhook.port but only applied it to Kubernetes-side references. The manager continued to listen on controller-runtime's default port.

## Validation

- make lint-fix
- make test-unit
- make verify-helm
- Rendered the chart with webhook.port=9444 and verified the manager, Service, container port, and NetworkPolicy.

Fixes #5867