### PR TITLE
📖 Correct “Edge-Base” to “Edge-Based”

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -20,7 +20,7 @@ Including:
 - Self-healing
 - Garbage Collection and Finalizers
 - Declarative vs Imperative APIs
-- Level-Based vs Edge-Base APIs
+- Level-Based vs Edge-Based APIs
 - Resources vs Subresources
 
 #### Kubernetes API extension developers


### PR DESCRIPTION
Small typo fix.