### PR TITLE
🐛 (go/v4): Add context import for incremental webhooks

### DIFF
--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_updater.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_updater.go
@@ -127,6 +127,7 @@ func (f *WebhookUpdater) SetTemplateDefaults() error {
 
 	// Append new webhook code at the end of the file
 	if newCode.Len() > 0 {
+		fileContent = f.addContextImport(fileContent)
 		fileContent = strings.TrimRight(fileContent, "\n") + "\n" + newCode.String()
 	}
 
@@ -240,6 +241,24 @@ func (f *WebhookUpdater) addAdmissionImport(content string) string {
 	log.Warn("Could not add admission import",
 		"kind", f.Resource.Kind,
 		"suggestion", "Manually add: "+admissionImport)
+	return content
+}
+
+// addContextImport adds the context package import required by admission webhooks.
+func (f *WebhookUpdater) addContextImport(content string) string {
+	const contextImport = `"context"`
+	if strings.Contains(content, contextImport) {
+		return content
+	}
+
+	importBlockPattern := regexp.MustCompile(`(?s)(import\s*\()`)
+	if match := importBlockPattern.FindStringSubmatch(content); len(match) > 1 {
+		return strings.Replace(content, match[1], match[1]+"\n\t"+contextImport, 1)
+	}
+
+	log.Warn("Could not add context import",
+		"kind", f.Resource.Kind,
+		"suggestion", "Manually add: context")
 	return content
 }
 

--- a/pkg/plugins/golang/v4/scaffolds/webhook_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook_test.go
@@ -482,7 +482,7 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 				"--group", "test",
 				"--version", "v2",
 				"--kind", "TestMultiversion",
-				"--resource=false", "--controller=false",
+				"--resource", "--controller=false",
 				"--make=false",
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -527,6 +527,16 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestMultiversion under Conversion Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestMultiversion under Defaulting Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating or updating TestMultiversion under Validating Webhook\""))
+
+			By("verifying the webhook implementation imports context")
+			webhookFile := filepath.Join(kbc.Dir, "internal/webhook/v1/testmultiversion_webhook.go")
+			content, err = os.ReadFile(webhookFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring(`"context"`))
+
+			By("building and linting the project with all webhook types")
+			Expect(kbc.Make("all")).To(Succeed())
+			Expect(kbc.Make("lint")).To(Succeed())
 		})
 
 		It("should correctly scaffold conversion webhook and storage version marker", func() {


### PR DESCRIPTION
Fixes #5870

Adding admission webhooks after a conversion webhook missed the `context` import, so `go build ./...` failed. This adds it plus a regression test. Small gotcha, now all good

Repro:
```shell
kubebuilder init --domain example.org --repo example.com/demo
kubebuilder create api --group crew --version v1 --kind Charlie --resource --controller
kubebuilder create api --group crew --version v2 --kind Charlie --resource --controller=false
kubebuilder create webhook --group crew --version v1 --kind Charlie --conversion --spoke v2
kubebuilder create webhook --group crew --version v1 --kind Charlie --defaulting --programmatic-validation
go build ./...
```