### PR TITLE
🐛(go/v4): drop Custom prefix from scaffolded webhook struct names

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
@@ -48,8 +48,8 @@ Then, we set up the webhook with the manager.
 // SetupCronJobWebhookWithManager registers the webhook for CronJob in the manager.
 func SetupCronJobWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &batchv1.CronJob{}).
-		WithValidator(&CronJobCustomValidator{}).
-		WithDefaulter(&CronJobCustomDefaulter{
+		WithValidator(&CronJobValidator{}).
+		WithDefaulter(&CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv1.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,
@@ -71,12 +71,12 @@ This marker is responsible for generating a mutation webhook manifest.
 
 // +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob-v1.kb.io,admissionReviewVersions=v1
 
-// CronJobCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// CronJobDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind CronJob when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomDefaulter struct {
+type CronJobDefaulter struct {
 
 	// Default values for various CronJob fields
 	DefaultConcurrencyPolicy          batchv1.ConcurrencyPolicy
@@ -86,14 +86,14 @@ type CronJobCustomDefaulter struct {
 }
 
 /*
-We use the `webhook.CustomDefaulter`interface to set defaults to our CRD.
+We use the `admission.Defaulter`interface to set defaults to our CRD.
 A webhook will automatically be served that calls this defaulting.
 
 The `Default`method is expected to mutate the receiver, setting the defaults.
 */
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob.
-func (d *CronJobCustomDefaulter) Default(_ context.Context, obj *batchv1.CronJob) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind CronJob.
+func (d *CronJobDefaulter) Default(_ context.Context, obj *batchv1.CronJob) error {
 	cronjoblog.Info("Defaulting for CronJob", "name", obj.GetName())
 
 	// Set default values
@@ -102,7 +102,7 @@ func (d *CronJobCustomDefaulter) Default(_ context.Context, obj *batchv1.CronJob
 }
 
 // applyDefaults applies default values to CronJob fields.
-func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv1.CronJob) {
+func (d *CronJobDefaulter) applyDefaults(cronJob *batchv1.CronJob) {
 	if cronJob.Spec.ConcurrencyPolicy == "" {
 		cronJob.Spec.ConcurrencyPolicy = d.DefaultConcurrencyPolicy
 	}
@@ -128,7 +128,7 @@ sometimes more advanced use cases call for complex validation.
 For instance, we'll see below that we use this to validate a well-formed cron
 schedule without making up a long regular expression.
 
-If `webhook.CustomValidator` interface is implemented, a webhook will automatically be
+If `admission.Validator` interface is implemented, a webhook will automatically be
 served that calls the validation.
 
 The `ValidateCreate`, `ValidateUpdate` and `ValidateDelete` methods are expected
@@ -149,31 +149,31 @@ This marker is responsible for generating a validation webhook manifest.
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob-v1.kb.io,admissionReviewVersions=v1
 
-// CronJobCustomValidator struct is responsible for validating the CronJob resource
+// CronJobValidator struct is responsible for validating the CronJob resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomValidator struct {
+type CronJobValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateCreate(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateCreate(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon creation", "name", obj.GetName())
 
 	return nil, validateCronJob(obj)
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *batchv1.CronJob) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateUpdate(_ context.Context, oldObj, newObj *batchv1.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon update", "name", newObj.GetName())
 
 	return nil, validateCronJob(newObj)
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateDelete(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateDelete(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook_test.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook_test.go
@@ -28,8 +28,8 @@ var _ = Describe("CronJob Webhook", func() {
 	var (
 		obj       *batchv1.CronJob
 		oldObj    *batchv1.CronJob
-		validator CronJobCustomValidator
-		defaulter CronJobCustomDefaulter
+		validator CronJobValidator
+		defaulter CronJobDefaulter
 	)
 
 	const validCronJobName = "valid-cronjob-name"
@@ -58,8 +58,8 @@ var _ = Describe("CronJob Webhook", func() {
 		*oldObj.Spec.SuccessfulJobsHistoryLimit = 3
 		*oldObj.Spec.FailedJobsHistoryLimit = 1
 
-		validator = CronJobCustomValidator{}
-		defaulter = CronJobCustomDefaulter{
+		validator = CronJobValidator{}
+		defaulter = CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv1.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,

--- a/docs/book/src/cronjob-tutorial/webhook-implementation.md
+++ b/docs/book/src/cronjob-tutorial/webhook-implementation.md
@@ -1,8 +1,8 @@
 # Implementing defaulting/validating webhooks
 
 If you want to implement [admission webhooks](../reference/admission-webhook.md)
-for your CRD, the only thing you need to do is to implement the `CustomDefaulter`
-and (or) the `CustomValidator` interface.
+for your CRD, the only thing you need to do is to implement the `admission.Defaulter`
+and (or) the `admission.Validator` interface.
 
 Kubebuilder takes care of the rest for you, such as
 

--- a/docs/book/src/migration/port-code.md
+++ b/docs/book/src/migration/port-code.md
@@ -62,7 +62,7 @@ Controller files (typically *_controller.go):
 
 Webhook files (typically *_webhook.go):
 - OLD pattern: func (r *<Name>) Default(), func (r *<Name>) ValidateCreate() error
-- NEW pattern: type <Name>CustomDefaulter struct, func (d *<Name>CustomDefaulter) Default(ctx context.Context, obj *<Name>) error
+- NEW pattern: type <Name>Defaulter struct, func (d *<Name>Defaulter) Default(ctx context.Context, obj *<Name>) error
 - Conversion: func (*<Name>) Hub(), func (r *<Name>) ConvertTo(...), func (r *<Name>) ConvertFrom(...)
 
 Main file:
@@ -169,7 +169,7 @@ PORT CUSTOM CODE (in this order):
 
    Detect pattern by reading backup file:
    - Has "func (r *<Kind>) Default() {": OLD pattern (needs adaptation)
-   - Has "func (d *<Kind>CustomDefaulter) Default(ctx": NEW pattern (direct copy)
+   - Has "func (d *<Kind>Defaulter) Default(ctx": NEW pattern (direct copy)
 
    IF OLD pattern - ADAPT:
    - Default(): Extract logic, paste after type assertion, change 'r.' to '<kind>.', add return nil, REMOVE TODO
@@ -177,7 +177,7 @@ PORT CUSTOM CODE (in this order):
    - Conversion: Copy Hub/ConvertTo/ConvertFrom directly (no change needed)
 
    IF NEW pattern - DIRECT COPY:
-   - Copy CustomDefaulter/CustomValidator structs and all methods
+   - Copy Defaulter/Validator structs and all methods
    - Copy helper functions and imports
 
    After each: go mod tidy && make manifests && make build
@@ -368,7 +368,7 @@ func (r *Captain) Default() {
 
 **To go/v4 new project**:
 ```go
-func (d *CaptainCustomDefaulter) Default(ctx context.Context, obj *crewv1.Captain) error {
+func (d *CaptainDefaulter) Default(ctx context.Context, obj *crewv1.Captain) error {
     // Ported logic adapted (obj is type-safe, no assertion needed):
     if obj.Spec.Replicas == 0 {
         obj.Spec.Replicas = 1

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook.go
@@ -53,8 +53,8 @@ interfaces, a conversion webhook will be registered.
 // SetupCronJobWebhookWithManager registers the webhook for CronJob in the manager.
 func SetupCronJobWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &batchv1.CronJob{}).
-		WithValidator(&CronJobCustomValidator{}).
-		WithDefaulter(&CronJobCustomDefaulter{
+		WithValidator(&CronJobValidator{}).
+		WithDefaulter(&CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv1.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,
@@ -76,12 +76,12 @@ This marker is responsible for generating a mutation webhook manifest.
 
 // +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=mcronjob-v1.kb.io,admissionReviewVersions=v1
 
-// CronJobCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// CronJobDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind CronJob when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomDefaulter struct {
+type CronJobDefaulter struct {
 
 	// Default values for various CronJob fields
 	DefaultConcurrencyPolicy          batchv1.ConcurrencyPolicy
@@ -91,14 +91,14 @@ type CronJobCustomDefaulter struct {
 }
 
 /*
-We use the `webhook.CustomDefaulter`interface to set defaults to our CRD.
+We use the `admission.Defaulter`interface to set defaults to our CRD.
 A webhook will automatically be served that calls this defaulting.
 
 The `Default`method is expected to mutate the receiver, setting the defaults.
 */
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob.
-func (d *CronJobCustomDefaulter) Default(_ context.Context, obj *batchv1.CronJob) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind CronJob.
+func (d *CronJobDefaulter) Default(_ context.Context, obj *batchv1.CronJob) error {
 	cronjoblog.Info("Defaulting for CronJob", "name", obj.GetName())
 
 	// Set default values
@@ -107,7 +107,7 @@ func (d *CronJobCustomDefaulter) Default(_ context.Context, obj *batchv1.CronJob
 }
 
 // applyDefaults applies default values to CronJob fields.
-func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv1.CronJob) {
+func (d *CronJobDefaulter) applyDefaults(cronJob *batchv1.CronJob) {
 	if cronJob.Spec.ConcurrencyPolicy == "" {
 		cronJob.Spec.ConcurrencyPolicy = d.DefaultConcurrencyPolicy
 	}
@@ -133,7 +133,7 @@ sometimes more advanced use cases call for complex validation.
 For instance, we'll see below that we use this to validate a well-formed cron
 schedule without making up a long regular expression.
 
-If `webhook.CustomValidator` interface is implemented, a webhook will automatically be
+If `admission.Validator` interface is implemented, a webhook will automatically be
 served that calls the validation.
 
 The `ValidateCreate`, `ValidateUpdate` and `ValidateDelete` methods are expected
@@ -154,31 +154,31 @@ This marker is responsible for generating a validation webhook manifest.
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v1,name=vcronjob-v1.kb.io,admissionReviewVersions=v1
 
-// CronJobCustomValidator struct is responsible for validating the CronJob resource
+// CronJobValidator struct is responsible for validating the CronJob resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomValidator struct { // +kubebuilder:docs-gen:collapse=Remaining Webhook Code
+type CronJobValidator struct { // +kubebuilder:docs-gen:collapse=Remaining Webhook Code
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateCreate(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateCreate(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon creation", "name", obj.GetName())
 
 	return nil, validateCronJob(obj)
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *batchv1.CronJob) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateUpdate(_ context.Context, oldObj, newObj *batchv1.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon update", "name", newObj.GetName())
 
 	return nil, validateCronJob(newObj)
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateDelete(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateDelete(_ context.Context, obj *batchv1.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v1/cronjob_webhook_test.go
@@ -28,8 +28,8 @@ var _ = Describe("CronJob Webhook", func() {
 	var (
 		obj       *batchv1.CronJob
 		oldObj    *batchv1.CronJob
-		validator CronJobCustomValidator
-		defaulter CronJobCustomDefaulter
+		validator CronJobValidator
+		defaulter CronJobDefaulter
 	)
 
 	const validCronJobName = "valid-cronjob-name"
@@ -58,8 +58,8 @@ var _ = Describe("CronJob Webhook", func() {
 		*oldObj.Spec.SuccessfulJobsHistoryLimit = 3
 		*oldObj.Spec.FailedJobsHistoryLimit = 1
 
-		validator = CronJobCustomValidator{}
-		defaulter = CronJobCustomDefaulter{
+		validator = CronJobValidator{}
+		defaulter = CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv1.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook.go
@@ -43,8 +43,8 @@ var cronjoblog = logf.Log.WithName("cronjob-resource")
 // SetupCronJobWebhookWithManager registers the webhook for CronJob in the manager.
 func SetupCronJobWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &batchv2.CronJob{}).
-		WithValidator(&CronJobCustomValidator{}).
-		WithDefaulter(&CronJobCustomDefaulter{
+		WithValidator(&CronJobValidator{}).
+		WithDefaulter(&CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv2.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,
@@ -57,12 +57,12 @@ func SetupCronJobWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-batch-tutorial-kubebuilder-io-v2-cronjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v2,name=mcronjob-v2.kb.io,admissionReviewVersions=v1
 
-// CronJobCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// CronJobDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind CronJob when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomDefaulter struct {
+type CronJobDefaulter struct {
 	// Default values for various CronJob fields
 	DefaultConcurrencyPolicy          batchv2.ConcurrencyPolicy
 	DefaultSuspend                    bool
@@ -70,8 +70,8 @@ type CronJobCustomDefaulter struct {
 	DefaultFailedJobsHistoryLimit     int32
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob.
-func (d *CronJobCustomDefaulter) Default(_ context.Context, obj *batchv2.CronJob) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind CronJob.
+func (d *CronJobDefaulter) Default(_ context.Context, obj *batchv2.CronJob) error {
 	cronjoblog.Info("Defaulting for CronJob", "name", obj.GetName())
 
 	// Set default values
@@ -84,31 +84,31 @@ func (d *CronJobCustomDefaulter) Default(_ context.Context, obj *batchv2.CronJob
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-batch-tutorial-kubebuilder-io-v2-cronjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=batch.tutorial.kubebuilder.io,resources=cronjobs,verbs=create;update,versions=v2,name=vcronjob-v2.kb.io,admissionReviewVersions=v1
 
-// CronJobCustomValidator struct is responsible for validating the CronJob resource
+// CronJobValidator struct is responsible for validating the CronJob resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomValidator struct {
+type CronJobValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateCreate(_ context.Context, obj *batchv2.CronJob) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateCreate(_ context.Context, obj *batchv2.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon creation", "name", obj.GetName())
 
 	return nil, validateCronJob(obj)
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *batchv2.CronJob) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateUpdate(_ context.Context, oldObj, newObj *batchv2.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon update", "name", newObj.GetName())
 
 	return nil, validateCronJob(newObj)
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type CronJob.
-func (v *CronJobCustomValidator) ValidateDelete(_ context.Context, obj *batchv2.CronJob) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type CronJob.
+func (v *CronJobValidator) ValidateDelete(_ context.Context, obj *batchv2.CronJob) (admission.Warnings, error) {
 	cronjoblog.Info("Validation for CronJob upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.
@@ -117,7 +117,7 @@ func (v *CronJobCustomValidator) ValidateDelete(_ context.Context, obj *batchv2.
 }
 
 // applyDefaults applies default values to CronJob fields.
-func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
+func (d *CronJobDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
 	if cronJob.Spec.ConcurrencyPolicy == "" {
 		cronJob.Spec.ConcurrencyPolicy = d.DefaultConcurrencyPolicy
 	}

--- a/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook_test.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/internal/webhook/v2/cronjob_webhook_test.go
@@ -28,16 +28,16 @@ var _ = Describe("CronJob Webhook", func() {
 	var (
 		obj       *batchv2.CronJob
 		oldObj    *batchv2.CronJob
-		validator CronJobCustomValidator
-		defaulter CronJobCustomDefaulter
+		validator CronJobValidator
+		defaulter CronJobDefaulter
 	)
 
 	BeforeEach(func() {
 		obj = &batchv2.CronJob{}
 		oldObj = &batchv2.CronJob{}
-		validator = CronJobCustomValidator{}
+		validator = CronJobValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
-		defaulter = CronJobCustomDefaulter{}
+		defaulter = CronJobDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
+++ b/hack/docs/internal/cronjob-tutorial/generate_cronjob.go
@@ -478,8 +478,8 @@ Then, we set up the webhook with the manager.
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "internal/webhook/v1/cronjob_webhook.go"),
-		`WithDefaulter(&CronJobCustomDefaulter{}).`,
-		`WithDefaulter(&CronJobCustomDefaulter{
+		`WithDefaulter(&CronJobDefaulter{}).`,
+		`WithDefaulter(&CronJobDefaulter{
         DefaultConcurrencyPolicy:      batchv1.AllowConcurrent,
         DefaultSuspend:                false,
         DefaultSuccessfulJobsHistoryLimit: 3,
@@ -513,7 +513,7 @@ Then, we set up the webhook with the manager.
 
 	err = pluginutil.ReplaceInFile(
 		filepath.Join(sp.ctx.Dir, "internal/webhook/v1/cronjob_webhook.go"),
-		`// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob.`,
+		`// Default implements admission.Defaulter so a webhook will be registered for the Kind CronJob.`,
 		customInterfaceDefaultInfo)
 	hackutils.CheckError("fixing cronjob_webhook.go by adding validation logic upon object update", err)
 

--- a/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
+++ b/hack/docs/internal/cronjob-tutorial/webhook_implementation.go
@@ -33,7 +33,7 @@ const webhookDefaultingSettings = `// Set default values
 }
 
 // applyDefaults applies default values to CronJob fields.
-func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv1.CronJob) {
+func (d *CronJobDefaulter) applyDefaults(cronJob *batchv1.CronJob) {
 	if cronJob.Spec.ConcurrencyPolicy == "" {
 		cronJob.Spec.ConcurrencyPolicy = d.DefaultConcurrencyPolicy
 	}
@@ -74,7 +74,7 @@ sometimes more advanced use cases call for complex validation.
 For instance, we'll see below that we use this to validate a well-formed cron
 schedule without making up a long regular expression.
 
-If` + " `" + `webhook.CustomValidator` + "`" + ` interface is implemented, a webhook will automatically be
+If` + " `" + `admission.Validator` + "`" + ` interface is implemented, a webhook will automatically be
 served that calls the validation.
 
 The` + " `" + `ValidateCreate` + "`" + `, ` + "`" + `ValidateUpdate` + "`" + ` and` + " `" + `ValidateDelete` + "`" + ` methods are expected
@@ -95,13 +95,13 @@ This marker is responsible for generating a validation webhook manifest.
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.`
 
 const customInterfaceDefaultInfo = `/*
-We use the ` + "`" + `webhook.CustomDefaulter` + "`" + `interface to set defaults to our CRD.
+We use the ` + "`" + `admission.Defaulter` + "`" + `interface to set defaults to our CRD.
 A webhook will automatically be served that calls this defaulting.
 
 The ` + "`" + `Default` + "`" + `method is expected to mutate the receiver, setting the defaults.
 */
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind CronJob.`
+// Default implements admission.Defaulter so a webhook will be registered for the Kind CronJob.`
 
 const webhookValidateSpecMethods = `
 /*
@@ -312,15 +312,15 @@ const webhookTestingValidatingExampleFragment = `It("Should deny creation if the
 const webhookTestsVars = `var (
 		obj       *batchv1.CronJob
 		oldObj    *batchv1.CronJob
-		validator CronJobCustomValidator
-		defaulter CronJobCustomDefaulter
+		validator CronJobValidator
+		defaulter CronJobDefaulter
 	)`
 
 const webhookTestsConstants = `	var (
 		obj       *batchv1.CronJob
 		oldObj    *batchv1.CronJob
-		validator CronJobCustomValidator
-		defaulter CronJobCustomDefaulter
+		validator CronJobValidator
+		defaulter CronJobDefaulter
 	)
 
 	const validCronJobName = "valid-cronjob-name"
@@ -328,9 +328,9 @@ const webhookTestsConstants = `	var (
 
 const webhookTestsBeforeEachOriginal = `obj = &batchv1.CronJob{}
 		oldObj = &batchv1.CronJob{}
-		validator = CronJobCustomValidator{}
+		validator = CronJobValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
-		defaulter = CronJobCustomDefaulter{}
+		defaulter = CronJobDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")`
@@ -357,8 +357,8 @@ const webhookTestsBeforeEachChanged = `obj = &batchv1.CronJob{
 		*oldObj.Spec.SuccessfulJobsHistoryLimit = 3
 		*oldObj.Spec.FailedJobsHistoryLimit = 1
 
-		validator = CronJobCustomValidator{}
-		defaulter = CronJobCustomDefaulter{
+		validator = CronJobValidator{}
+		defaulter = CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv1.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,

--- a/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
+++ b/hack/docs/internal/multiversion-tutorial/generate_multiversion.go
@@ -85,7 +85,7 @@ func (sp *Sample) GenerateSampleProject() {
 		filepath.Join(sp.ctx.Dir, "internal/webhook/v1/cronjob_webhook.go"),
 		`// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CronJobCustomValidator struct {`,
+type CronJobValidator struct {`,
 		`// +kubebuilder:docs-gen:collapse=Remaining Webhook Code`)
 	hackutils.CheckError("adding marker collapse", err)
 }

--- a/hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go
+++ b/hack/docs/internal/multiversion-tutorial/webhook_v2_implementaton.go
@@ -30,7 +30,7 @@ const cronJobDefaultingLogic = `// Set default values
 
 const cronJobDefaultFunction = `
 // applyDefaults applies default values to CronJob fields.
-func (d *CronJobCustomDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
+func (d *CronJobDefaulter) applyDefaults(cronJob *batchv2.CronJob) {
 	if cronJob.Spec.ConcurrencyPolicy == "" {
 		cronJob.Spec.ConcurrencyPolicy = d.DefaultConcurrencyPolicy
 	}
@@ -113,16 +113,16 @@ func validateScheduleFormat(schedule string, fldPath *field.Path) *field.Error {
 const originalSetupManager = `// SetupCronJobWebhookWithManager registers the webhook for CronJob in the manager.
 func SetupCronJobWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &batchv2.CronJob{}).
-		WithValidator(&CronJobCustomValidator{}).
-		WithDefaulter(&CronJobCustomDefaulter{}).
+		WithValidator(&CronJobValidator{}).
+		WithDefaulter(&CronJobDefaulter{}).
 		Complete()
 }`
 
 const replaceSetupManager = `// SetupCronJobWebhookWithManager registers the webhook for CronJob in the manager.
 func SetupCronJobWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &batchv2.CronJob{}).
-		WithValidator(&CronJobCustomValidator{}).
-		WithDefaulter(&CronJobCustomDefaulter{
+		WithValidator(&CronJobValidator{}).
+		WithDefaulter(&CronJobDefaulter{
 			DefaultConcurrencyPolicy:          batchv2.AllowConcurrent,
 			DefaultSuspend:                    false,
 			DefaultSuccessfulJobsHistoryLimit: 3,

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook.go
@@ -110,13 +110,13 @@ func Setup{{ .Resource.Kind }}WebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &{{ .Resource.Kind }}{}).
 	{{- end }}
 		{{- if .Resource.HasValidationWebhook }}
-		WithValidator(&{{ .Resource.Kind }}CustomValidator{}).
+		WithValidator(&{{ .Resource.Kind }}Validator{}).
 		{{- if ne .Resource.Webhooks.ValidationPath "" }}
 		WithValidatorCustomPath("{{ .Resource.Webhooks.ValidationPath }}").
 		{{- end }}
 		{{- end }}
 		{{- if .Resource.HasDefaultingWebhook }}
-		WithDefaulter(&{{ .Resource.Kind }}CustomDefaulter{}).
+		WithDefaulter(&{{ .Resource.Kind }}Defaulter{}).
 		{{- if ne .Resource.Webhooks.DefaultingPath "" }}
 		WithDefaulterCustomPath("{{ .Resource.Webhooks.DefaultingPath }}").
 		{{- end }}
@@ -131,17 +131,17 @@ func Setup{{ .Resource.Kind }}WebhookWithManager(mgr ctrl.Manager) error {
 	defaultingWebhookTemplate = `
 // +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}{{- if ne .Resource.Webhooks.DefaultingPath "" -}}path={{ .Resource.Webhooks.DefaultingPath }}{{- else -}}path=/mutate-{{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}-{{ else }}{{ .QualifiedGroupWithDash }}-{{ end }}{{ .Resource.Version }}-{{ lower .Resource.Kind }}{{- end -}},mutating=true,failurePolicy=fail,sideEffects=None,groups={{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}""{{ else }}{{ .Resource.QualifiedGroup }}{{ end }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=m{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
-// {{ .Resource.Kind }}CustomDefaulter struct is responsible for setting default values on the custom resource of the
+// {{ .Resource.Kind }}Defaulter struct is responsible for setting default values on the custom resource of the
 // Kind {{ .Resource.Kind }} when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type {{ .Resource.Kind }}CustomDefaulter struct {
+type {{ .Resource.Kind }}Defaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind {{ .Resource.Kind }}.
-func (d *{{ .Resource.Kind }}CustomDefaulter) Default(_ context.Context, obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind {{ .Resource.Kind }}.
+func (d *{{ .Resource.Kind }}Defaulter) Default(_ context.Context, obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) error {
 	{{ lower .Resource.Kind }}log.Info("Defaulting for {{ .Resource.Kind }}", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -156,17 +156,17 @@ func (d *{{ .Resource.Kind }}CustomDefaulter) Default(_ context.Context, obj *{{
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:{{ if ne .Resource.Webhooks.WebhookVersion "v1" }}webhookVersions={{"{"}}{{ .Resource.Webhooks.WebhookVersion }}{{"}"}},{{ end }}{{- if ne .Resource.Webhooks.ValidationPath "" -}}path={{ .Resource.Webhooks.ValidationPath }}{{- else -}}path=/validate-{{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}-{{ else }}{{ .QualifiedGroupWithDash }}-{{ end }}{{ .Resource.Version }}-{{ lower .Resource.Kind }}{{- end -}},mutating=false,failurePolicy=fail,sideEffects=None,groups={{ if and .Resource.Core (eq .Resource.QualifiedGroup "core") }}""{{ else }}{{ .Resource.QualifiedGroup }}{{ end }},resources={{ .Resource.Plural }},verbs=create;update,versions={{ .Resource.Version }},name=v{{ lower .Resource.Kind }}-{{ .Resource.Version }}.kb.io,admissionReviewVersions={{ .AdmissionReviewVersions }}
 
-// {{ .Resource.Kind }}CustomValidator struct is responsible for validating the {{ .Resource.Kind }} resource
+// {{ .Resource.Kind }}Validator struct is responsible for validating the {{ .Resource.Kind }} resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type {{ .Resource.Kind }}CustomValidator struct{
+type {{ .Resource.Kind }}Validator struct{
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}.
-func (v *{{ .Resource.Kind }}CustomValidator) ValidateCreate(_ context.Context, obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type {{ .Resource.Kind }}.
+func (v *{{ .Resource.Kind }}Validator) ValidateCreate(_ context.Context, obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) (admission.Warnings, error) {
 	{{ lower .Resource.Kind }}log.Info("Validation for {{ .Resource.Kind }} upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -174,8 +174,8 @@ func (v *{{ .Resource.Kind }}CustomValidator) ValidateCreate(_ context.Context, 
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}.
-func (v *{{ .Resource.Kind }}CustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type {{ .Resource.Kind }}.
+func (v *{{ .Resource.Kind }}Validator) ValidateUpdate(_ context.Context, oldObj, newObj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) (admission.Warnings, error) {
 	{{ lower .Resource.Kind }}log.Info("Validation for {{ .Resource.Kind }} upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -183,8 +183,8 @@ func (v *{{ .Resource.Kind }}CustomValidator) ValidateUpdate(_ context.Context, 
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type {{ .Resource.Kind }}.
-func (v *{{ .Resource.Kind }}CustomValidator) ValidateDelete(_ context.Context, obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type {{ .Resource.Kind }}.
+func (v *{{ .Resource.Kind }}Validator) ValidateDelete(_ context.Context, obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}) (admission.Warnings, error) {
 	{{ lower .Resource.Kind }}log.Info("Validation for {{ .Resource.Kind }} upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_template.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_template.go
@@ -92,10 +92,10 @@ var _ = Describe("{{ .Resource.Kind }} Webhook", func() {
 		obj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}
 		oldObj *{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}
 		{{- if .Resource.HasValidationWebhook }}
-		validator {{ .Resource.Kind }}CustomValidator
+		validator {{ .Resource.Kind }}Validator
 		{{- end }}
 		{{- if .Resource.HasDefaultingWebhook }}
-		defaulter {{ .Resource.Kind }}CustomDefaulter
+		defaulter {{ .Resource.Kind }}Defaulter
 		{{- end }}
 	)
 
@@ -103,11 +103,11 @@ var _ = Describe("{{ .Resource.Kind }} Webhook", func() {
 		obj = &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
 		oldObj = &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{}
 		{{- if .Resource.HasValidationWebhook }}
-		validator = {{ .Resource.Kind }}CustomValidator{}
+		validator = {{ .Resource.Kind }}Validator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 		{{- end }}
 		{{- if .Resource.HasDefaultingWebhook }}
-		defaulter = {{ .Resource.Kind }}CustomDefaulter{}
+		defaulter = {{ .Resource.Kind }}Defaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		{{- end }}
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_updater.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_test_updater.go
@@ -78,7 +78,7 @@ func (f *WebhookTestUpdater) SetTemplateDefaults() error {
 	modified := false
 
 	// Check if we need to add validator variable and tests
-	validatorVar := fmt.Sprintf("validator %sCustomValidator", f.Resource.Kind)
+	validatorVar := fmt.Sprintf("validator %sValidator", f.Resource.Kind)
 	if f.Resource.HasValidationWebhook() && !bytes.Contains(content, []byte(validatorVar)) {
 		fileContent = f.addValidatorVariable(fileContent)
 		fileContent = f.addValidatorInit(fileContent)
@@ -87,7 +87,7 @@ func (f *WebhookTestUpdater) SetTemplateDefaults() error {
 	}
 
 	// Check if we need to add defaulter variable and tests
-	defaulterVar := fmt.Sprintf("defaulter %sCustomDefaulter", f.Resource.Kind)
+	defaulterVar := fmt.Sprintf("defaulter %sDefaulter", f.Resource.Kind)
 	if f.Resource.HasDefaultingWebhook() && !bytes.Contains(content, []byte(defaulterVar)) {
 		fileContent = f.addDefaulterVariable(fileContent)
 		fileContent = f.addDefaulterInit(fileContent)
@@ -115,14 +115,14 @@ func (f *WebhookTestUpdater) SetTemplateDefaults() error {
 // addValidatorVariable adds the validator variable to the var block
 func (f *WebhookTestUpdater) addValidatorVariable(content string) string {
 	varName := "validator"
-	typeName := f.Resource.Kind + "CustomValidator"
+	typeName := f.Resource.Kind + "Validator"
 	return f.addVariableToBlock(content, varName, typeName)
 }
 
 // addDefaulterVariable adds the defaulter variable to the var block
 func (f *WebhookTestUpdater) addDefaulterVariable(content string) string {
 	varName := "defaulter"
-	typeName := f.Resource.Kind + "CustomDefaulter"
+	typeName := f.Resource.Kind + "Defaulter"
 	return f.addVariableToBlock(content, varName, typeName)
 }
 
@@ -172,14 +172,14 @@ func (f *WebhookTestUpdater) detectIndentationInBlock(blockContent string) strin
 // addValidatorInit adds validator initialization in BeforeEach
 func (f *WebhookTestUpdater) addValidatorInit(content string) string {
 	varName := "validator"
-	typeName := f.Resource.Kind + "CustomValidator"
+	typeName := f.Resource.Kind + "Validator"
 	return f.addWebhookInit(content, varName, typeName)
 }
 
 // addDefaulterInit adds defaulter initialization in BeforeEach
 func (f *WebhookTestUpdater) addDefaulterInit(content string) string {
 	varName := "defaulter"
-	typeName := f.Resource.Kind + "CustomDefaulter"
+	typeName := f.Resource.Kind + "Defaulter"
 	return f.addWebhookInit(content, varName, typeName)
 }
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_updater.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_updater.go
@@ -84,7 +84,7 @@ func (f *WebhookUpdater) SetTemplateDefaults() error {
 	var newCode strings.Builder
 
 	// Add defaulting webhook if requested and not already present
-	defaulterType := fmt.Sprintf("%sCustomDefaulter", f.Resource.Kind)
+	defaulterType := fmt.Sprintf("%sDefaulter", f.Resource.Kind)
 	if f.Resource.HasDefaultingWebhook() {
 		typeDefPattern := regexp.MustCompile(fmt.Sprintf(`type\s+%s\s+struct`, defaulterType))
 		if typeDefPattern.MatchString(string(content)) {
@@ -103,7 +103,7 @@ func (f *WebhookUpdater) SetTemplateDefaults() error {
 	}
 
 	// Add validation webhook if requested and not already present
-	validatorType := fmt.Sprintf("%sCustomValidator", f.Resource.Kind)
+	validatorType := fmt.Sprintf("%sValidator", f.Resource.Kind)
 	if f.Resource.HasValidationWebhook() {
 		typeDefPattern := regexp.MustCompile(fmt.Sprintf(`type\s+%s\s+struct`, validatorType))
 		if typeDefPattern.MatchString(string(content)) {
@@ -245,7 +245,7 @@ func (f *WebhookUpdater) addAdmissionImport(content string) string {
 
 // generateDefaulterSetupCode generates the setup code for defaulting webhook
 func (f *WebhookUpdater) generateDefaulterSetupCode() string {
-	code := fmt.Sprintf("\t\tWithDefaulter(&%sCustomDefaulter{}).", f.Resource.Kind)
+	code := fmt.Sprintf("\t\tWithDefaulter(&%sDefaulter{}).", f.Resource.Kind)
 	if f.Resource.Webhooks.DefaultingPath != "" {
 		code += fmt.Sprintf("\n\t\tWithDefaulterCustomPath(\"%s\").", f.Resource.Webhooks.DefaultingPath)
 	}
@@ -254,7 +254,7 @@ func (f *WebhookUpdater) generateDefaulterSetupCode() string {
 
 // generateValidatorSetupCode generates the setup code for validation webhook
 func (f *WebhookUpdater) generateValidatorSetupCode() string {
-	code := fmt.Sprintf("\t\tWithValidator(&%sCustomValidator{}).", f.Resource.Kind)
+	code := fmt.Sprintf("\t\tWithValidator(&%sValidator{}).", f.Resource.Kind)
 	if f.Resource.Webhooks.ValidationPath != "" {
 		code += fmt.Sprintf("\n\t\tWithValidatorCustomPath(\"%s\").", f.Resource.Webhooks.ValidationPath)
 	}
@@ -281,12 +281,12 @@ func (f *WebhookUpdater) generateDefaultingWebhookCode() string {
 	fmt.Fprintf(&code, `
 // +kubebuilder:webhook:path=%s,mutating=true,failurePolicy=fail,sideEffects=None,groups=%s,resources=%s,verbs=create;update,versions=%s,name=m%s-%s.kb.io,admissionReviewVersions=%s
 
-// %sCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// %sDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind %s when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type %sCustomDefaulter struct {
+type %sDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
@@ -299,8 +299,8 @@ type %sCustomDefaulter struct {
 	// Default method
 	objType := f.Resource.ImportAlias() + "." + f.Resource.Kind
 
-	fmt.Fprintf(&code, `// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind %s.
-func (d *%sCustomDefaulter) Default(_ context.Context, obj *%s) error {
+	fmt.Fprintf(&code, `// Default implements admission.Defaulter so a webhook will be registered for the Kind %s.
+func (d *%sDefaulter) Default(_ context.Context, obj *%s) error {
 	%slog.Info("Defaulting for %s", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -337,12 +337,12 @@ func (f *WebhookUpdater) generateValidationWebhookCode() string {
 	//nolint:lll
 	fmt.Fprintf(&code, `// +kubebuilder:webhook:path=%s,mutating=false,failurePolicy=fail,sideEffects=None,groups=%s,resources=%s,verbs=create;update,versions=%s,name=v%s-%s.kb.io,admissionReviewVersions=%s
 
-// %sCustomValidator struct is responsible for validating the %s resource
+// %sValidator struct is responsible for validating the %s resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type %sCustomValidator struct{
+type %sValidator struct{
 	// TODO(user): Add more fields as needed for validation
 }
 
@@ -355,8 +355,8 @@ type %sCustomValidator struct{
 	objType := f.Resource.ImportAlias() + "." + f.Resource.Kind
 
 	fmt.Fprintf(&code,
-		`// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type %s.
-func (v *%sCustomValidator) ValidateCreate(_ context.Context, obj *%s) (admission.Warnings, error) {
+		`// ValidateCreate implements admission.Validator so a webhook will be registered for the type %s.
+func (v *%sValidator) ValidateCreate(_ context.Context, obj *%s) (admission.Warnings, error) {
 	%slog.Info("Validation for %s upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -364,8 +364,8 @@ func (v *%sCustomValidator) ValidateCreate(_ context.Context, obj *%s) (admissio
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type %s.
-func (v *%sCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *%s) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type %s.
+func (v *%sValidator) ValidateUpdate(_ context.Context, oldObj, newObj *%s) (admission.Warnings, error) {
 	%slog.Info("Validation for %s upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -373,8 +373,8 @@ func (v *%sCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *%s
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type %s.
-func (v *%sCustomValidator) ValidateDelete(_ context.Context, obj *%s) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type %s.
+func (v *%sValidator) ValidateDelete(_ context.Context, obj *%s) (admission.Warnings, error) {
 	%slog.Info("Validation for %s upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/pkg/plugins/golang/v4/scaffolds/webhook_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/webhook_test.go
@@ -135,8 +135,8 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			content, err := os.ReadFile(testFile)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(content)).To(ContainSubstring("defaulter TestIncrementalCustomDefaulter"))
-			Expect(string(content)).To(ContainSubstring("validator TestIncrementalCustomValidator"))
+			Expect(string(content)).To(ContainSubstring("defaulter TestIncrementalDefaulter"))
+			Expect(string(content)).To(ContainSubstring("validator TestIncrementalValidator"))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestIncremental under Defaulting Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating or updating TestIncremental under Validating Webhook\""))
 		})
@@ -177,8 +177,8 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			content, err := os.ReadFile(testFile)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(content)).To(ContainSubstring("validator TestReverseCustomValidator"))
-			Expect(string(content)).To(ContainSubstring("defaulter TestReverseCustomDefaulter"))
+			Expect(string(content)).To(ContainSubstring("validator TestReverseValidator"))
+			Expect(string(content)).To(ContainSubstring("defaulter TestReverseDefaulter"))
 		})
 
 		It("should support conversion-only webhooks without defaulting/validation", func() {
@@ -230,8 +230,8 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			Expect(string(webhookContent)).To(ContainSubstring("SetupTestConversionWebhookWithManager"))
 			Expect(string(webhookContent)).To(ContainSubstring("NewWebhookManagedBy(mgr, &testv1.TestConversion{})"))
 			Expect(string(webhookContent)).To(ContainSubstring("Complete()"))
-			Expect(string(webhookContent)).NotTo(ContainSubstring("CustomDefaulter"))
-			Expect(string(webhookContent)).NotTo(ContainSubstring("CustomValidator"))
+			Expect(string(webhookContent)).NotTo(ContainSubstring("TestConversionDefaulter"))
+			Expect(string(webhookContent)).NotTo(ContainSubstring("TestConversionValidator"))
 
 			By("verifying conversion webhook IS wired in main.go")
 			mainFile := filepath.Join(kbc.Dir, "cmd/main.go")
@@ -301,8 +301,8 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			content, err := os.ReadFile(testFile)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(content)).To(ContainSubstring("defaulter TestMultiCustomDefaulter"))
-			Expect(string(content)).To(ContainSubstring("validator TestMultiCustomValidator"))
+			Expect(string(content)).To(ContainSubstring("defaulter TestMultiDefaulter"))
+			Expect(string(content)).To(ContainSubstring("validator TestMultiValidator"))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestMulti under Conversion Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestMulti under Defaulting Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating or updating TestMulti under Validating Webhook\""))
@@ -392,7 +392,7 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			testContent, err = os.ReadFile(testFile)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(testContent)).To(ContainSubstring("validator TestCustomCustomValidator"))
+			Expect(string(testContent)).To(ContainSubstring("validator TestCustomValidator"))
 			Expect(string(testContent)).To(ContainSubstring("Context(\"When creating or updating TestCustom under Validating Webhook\""))
 
 			By("verifying user's renamed variables are preserved")
@@ -412,8 +412,8 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			Expect(string(webhookContent)).To(ContainSubstring("testcustom.Spec.Replicas = &replicas"))
 
 			By("verifying validator implementation was added")
-			Expect(string(webhookContent)).To(ContainSubstring("type TestCustomCustomValidator struct"))
-			Expect(string(webhookContent)).To(ContainSubstring("func (v *TestCustomCustomValidator) ValidateCreate"))
+			Expect(string(webhookContent)).To(ContainSubstring("type TestCustomValidator struct"))
+			Expect(string(webhookContent)).To(ContainSubstring("func (v *TestCustomValidator) ValidateCreate"))
 		})
 
 		It("should work when user removes TODO comments", func() {
@@ -462,7 +462,7 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			content, err = os.ReadFile(testFile)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(content)).To(ContainSubstring("defaulter TestNoTODOCustomDefaulter"))
+			Expect(string(content)).To(ContainSubstring("defaulter TestNoTODODefaulter"))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestNoTODO under Defaulting Webhook\""))
 		})
 
@@ -522,8 +522,8 @@ var _ = Describe("Webhook Incremental Scaffolding", func() {
 			content, err = os.ReadFile(testFile)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(string(content)).To(ContainSubstring("defaulter TestMultiversionCustomDefaulter"))
-			Expect(string(content)).To(ContainSubstring("validator TestMultiversionCustomValidator"))
+			Expect(string(content)).To(ContainSubstring("defaulter TestMultiversionDefaulter"))
+			Expect(string(content)).To(ContainSubstring("validator TestMultiversionValidator"))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestMultiversion under Conversion Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating TestMultiversion under Defaulting Webhook\""))
 			Expect(string(content)).To(ContainSubstring("Context(\"When creating or updating TestMultiversion under Validating Webhook\""))

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/deployment_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/deployment_webhook.go
@@ -33,8 +33,8 @@ var deploymentlog = logf.Log.WithName("deployment-resource")
 // SetupDeploymentWebhookWithManager registers the webhook for Deployment in the manager.
 func SetupDeploymentWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &appsv1.Deployment{}).
-		WithDefaulter(&DeploymentCustomDefaulter{}).
-		WithValidator(&DeploymentCustomValidator{}).
+		WithDefaulter(&DeploymentDefaulter{}).
+		WithValidator(&DeploymentValidator{}).
 		Complete()
 }
 
@@ -42,17 +42,17 @@ func SetupDeploymentWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-apps-v1-deployment,mutating=true,failurePolicy=fail,sideEffects=None,groups=apps,resources=deployments,verbs=create;update,versions=v1,name=mdeployment-v1.kb.io,admissionReviewVersions=v1
 
-// DeploymentCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// DeploymentDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Deployment when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type DeploymentCustomDefaulter struct {
+type DeploymentDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Deployment.
-func (d *DeploymentCustomDefaulter) Default(_ context.Context, obj *appsv1.Deployment) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Deployment.
+func (d *DeploymentDefaulter) Default(_ context.Context, obj *appsv1.Deployment) error {
 	deploymentlog.Info("Defaulting for Deployment", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -64,17 +64,17 @@ func (d *DeploymentCustomDefaulter) Default(_ context.Context, obj *appsv1.Deplo
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-apps-v1-deployment,mutating=false,failurePolicy=fail,sideEffects=None,groups=apps,resources=deployments,verbs=create;update,versions=v1,name=vdeployment-v1.kb.io,admissionReviewVersions=v1
 
-// DeploymentCustomValidator struct is responsible for validating the Deployment resource
+// DeploymentValidator struct is responsible for validating the Deployment resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type DeploymentCustomValidator struct {
+type DeploymentValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Deployment.
-func (v *DeploymentCustomValidator) ValidateCreate(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Deployment.
+func (v *DeploymentValidator) ValidateCreate(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
 	deploymentlog.Info("Validation for Deployment upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -82,8 +82,8 @@ func (v *DeploymentCustomValidator) ValidateCreate(_ context.Context, obj *appsv
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Deployment.
-func (v *DeploymentCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *appsv1.Deployment) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Deployment.
+func (v *DeploymentValidator) ValidateUpdate(_ context.Context, oldObj, newObj *appsv1.Deployment) (admission.Warnings, error) {
 	deploymentlog.Info("Validation for Deployment upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -91,8 +91,8 @@ func (v *DeploymentCustomValidator) ValidateUpdate(_ context.Context, oldObj, ne
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Deployment.
-func (v *DeploymentCustomValidator) ValidateDelete(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Deployment.
+func (v *DeploymentValidator) ValidateDelete(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
 	deploymentlog.Info("Validation for Deployment upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4-multigroup/internal/webhook/apps/v1/deployment_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/apps/v1/deployment_webhook_test.go
@@ -28,18 +28,18 @@ var _ = Describe("Deployment Webhook", func() {
 	var (
 		obj       *appsv1.Deployment
 		oldObj    *appsv1.Deployment
-		defaulter DeploymentCustomDefaulter
-		validator DeploymentCustomValidator
+		defaulter DeploymentDefaulter
+		validator DeploymentValidator
 	)
 
 	BeforeEach(func() {
 		obj = &appsv1.Deployment{}
 		oldObj = &appsv1.Deployment{}
-		defaulter = DeploymentCustomDefaulter{}
+		defaulter = DeploymentDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		validator = DeploymentCustomValidator{}
+		validator = DeploymentValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 	})
 

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/issuer_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/issuer_webhook.go
@@ -31,7 +31,7 @@ var issuerlog = logf.Log.WithName("issuer-resource")
 // SetupIssuerWebhookWithManager registers the webhook for Issuer in the manager.
 func SetupIssuerWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &certmanagerv1.Issuer{}).
-		WithDefaulter(&IssuerCustomDefaulter{}).
+		WithDefaulter(&IssuerDefaulter{}).
 		Complete()
 }
 
@@ -39,17 +39,17 @@ func SetupIssuerWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-cert-manager-io-v1-issuer,mutating=true,failurePolicy=fail,sideEffects=None,groups=cert-manager.io,resources=issuers,verbs=create;update,versions=v1,name=missuer-v1.kb.io,admissionReviewVersions=v1
 
-// IssuerCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// IssuerDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Issuer when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type IssuerCustomDefaulter struct {
+type IssuerDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Issuer.
-func (d *IssuerCustomDefaulter) Default(_ context.Context, obj *certmanagerv1.Issuer) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Issuer.
+func (d *IssuerDefaulter) Default(_ context.Context, obj *certmanagerv1.Issuer) error {
 	issuerlog.Info("Defaulting for Issuer", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.

--- a/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/issuer_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/cert-manager/v1/issuer_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Issuer Webhook", func() {
 	var (
 		obj       *certmanagerv1.Issuer
 		oldObj    *certmanagerv1.Issuer
-		defaulter IssuerCustomDefaulter
+		defaulter IssuerDefaulter
 	)
 
 	BeforeEach(func() {
 		obj = &certmanagerv1.Issuer{}
 		oldObj = &certmanagerv1.Issuer{}
-		defaulter = IssuerCustomDefaulter{}
+		defaulter = IssuerDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/pod_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/pod_webhook.go
@@ -32,7 +32,7 @@ var podlog = logf.Log.WithName("pod-resource")
 // SetupPodWebhookWithManager registers the webhook for Pod in the manager.
 func SetupPodWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &corev1.Pod{}).
-		WithValidator(&PodCustomValidator{}).
+		WithValidator(&PodValidator{}).
 		Complete()
 }
 
@@ -42,17 +42,17 @@ func SetupPodWebhookWithManager(mgr ctrl.Manager) error {
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate--v1-pod,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create;update,versions=v1,name=vpod-v1.kb.io,admissionReviewVersions=v1
 
-// PodCustomValidator struct is responsible for validating the Pod resource
+// PodValidator struct is responsible for validating the Pod resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type PodCustomValidator struct {
+type PodValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Pod.
-func (v *PodCustomValidator) ValidateCreate(_ context.Context, obj *corev1.Pod) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Pod.
+func (v *PodValidator) ValidateCreate(_ context.Context, obj *corev1.Pod) (admission.Warnings, error) {
 	podlog.Info("Validation for Pod upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -60,8 +60,8 @@ func (v *PodCustomValidator) ValidateCreate(_ context.Context, obj *corev1.Pod) 
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Pod.
-func (v *PodCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *corev1.Pod) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Pod.
+func (v *PodValidator) ValidateUpdate(_ context.Context, oldObj, newObj *corev1.Pod) (admission.Warnings, error) {
 	podlog.Info("Validation for Pod upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -69,8 +69,8 @@ func (v *PodCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *c
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Pod.
-func (v *PodCustomValidator) ValidateDelete(_ context.Context, obj *corev1.Pod) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Pod.
+func (v *PodValidator) ValidateDelete(_ context.Context, obj *corev1.Pod) (admission.Warnings, error) {
 	podlog.Info("Validation for Pod upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4-multigroup/internal/webhook/core/v1/pod_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/core/v1/pod_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Pod Webhook", func() {
 	var (
 		obj       *corev1.Pod
 		oldObj    *corev1.Pod
-		validator PodCustomValidator
+		validator PodValidator
 	)
 
 	BeforeEach(func() {
 		obj = &corev1.Pod{}
 		oldObj = &corev1.Pod{}
-		validator = PodCustomValidator{}
+		validator = PodValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/captain_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/captain_webhook.go
@@ -34,8 +34,8 @@ var captainlog = logf.Log.WithName("captain-resource")
 // SetupCaptainWebhookWithManager registers the webhook for Captain in the manager.
 func SetupCaptainWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &crewv1.Captain{}).
-		WithDefaulter(&CaptainCustomDefaulter{}).
-		WithValidator(&CaptainCustomValidator{}).
+		WithDefaulter(&CaptainDefaulter{}).
+		WithValidator(&CaptainValidator{}).
 		Complete()
 }
 
@@ -43,17 +43,17 @@ func SetupCaptainWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain-v1.kb.io,admissionReviewVersions=v1
 
-// CaptainCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// CaptainDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Captain when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type CaptainCustomDefaulter struct {
+type CaptainDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain.
-func (d *CaptainCustomDefaulter) Default(_ context.Context, obj *crewv1.Captain) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Captain.
+func (d *CaptainDefaulter) Default(_ context.Context, obj *crewv1.Captain) error {
 	captainlog.Info("Defaulting for Captain", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -65,17 +65,17 @@ func (d *CaptainCustomDefaulter) Default(_ context.Context, obj *crewv1.Captain)
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain-v1.kb.io,admissionReviewVersions=v1
 
-// CaptainCustomValidator struct is responsible for validating the Captain resource
+// CaptainValidator struct is responsible for validating the Captain resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CaptainCustomValidator struct {
+type CaptainValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
-func (v *CaptainCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Captain.
+func (v *CaptainValidator) ValidateCreate(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
 	captainlog.Info("Validation for Captain upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -83,8 +83,8 @@ func (v *CaptainCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.C
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
-func (v *CaptainCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Captain) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Captain.
+func (v *CaptainValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Captain) (admission.Warnings, error) {
 	captainlog.Info("Validation for Captain upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -92,8 +92,8 @@ func (v *CaptainCustomValidator) ValidateUpdate(_ context.Context, oldObj, newOb
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain.
-func (v *CaptainCustomValidator) ValidateDelete(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Captain.
+func (v *CaptainValidator) ValidateDelete(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
 	captainlog.Info("Validation for Captain upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4-multigroup/internal/webhook/crew/v1/captain_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/crew/v1/captain_webhook_test.go
@@ -28,18 +28,18 @@ var _ = Describe("Captain Webhook", func() {
 	var (
 		obj       *crewv1.Captain
 		oldObj    *crewv1.Captain
-		defaulter CaptainCustomDefaulter
-		validator CaptainCustomValidator
+		defaulter CaptainDefaulter
+		validator CaptainValidator
 	)
 
 	BeforeEach(func() {
 		obj = &crewv1.Captain{}
 		oldObj = &crewv1.Captain{}
-		defaulter = CaptainCustomDefaulter{}
+		defaulter = CaptainDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		validator = CaptainCustomValidator{}
+		validator = CaptainValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 	})
 

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/memcached_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/memcached_webhook.go
@@ -33,7 +33,7 @@ var memcachedlog = logf.Log.WithName("memcached-resource")
 // SetupMemcachedWebhookWithManager registers the webhook for Memcached in the manager.
 func SetupMemcachedWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &examplecomv1alpha1.Memcached{}).
-		WithValidator(&MemcachedCustomValidator{}).
+		WithValidator(&MemcachedValidator{}).
 		Complete()
 }
 
@@ -43,17 +43,17 @@ func SetupMemcachedWebhookWithManager(mgr ctrl.Manager) error {
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-example-com-testproject-org-v1alpha1-memcached,mutating=false,failurePolicy=fail,sideEffects=None,groups=example.com.testproject.org,resources=memcacheds,verbs=create;update,versions=v1alpha1,name=vmemcached-v1alpha1.kb.io,admissionReviewVersions=v1
 
-// MemcachedCustomValidator struct is responsible for validating the Memcached resource
+// MemcachedValidator struct is responsible for validating the Memcached resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type MemcachedCustomValidator struct {
+type MemcachedValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
-func (v *MemcachedCustomValidator) ValidateCreate(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Memcached.
+func (v *MemcachedValidator) ValidateCreate(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
 	memcachedlog.Info("Validation for Memcached upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -61,8 +61,8 @@ func (v *MemcachedCustomValidator) ValidateCreate(_ context.Context, obj *exampl
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
-func (v *MemcachedCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Memcached.
+func (v *MemcachedValidator) ValidateUpdate(_ context.Context, oldObj, newObj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
 	memcachedlog.Info("Validation for Memcached upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -70,8 +70,8 @@ func (v *MemcachedCustomValidator) ValidateUpdate(_ context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
-func (v *MemcachedCustomValidator) ValidateDelete(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Memcached.
+func (v *MemcachedValidator) ValidateDelete(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
 	memcachedlog.Info("Validation for Memcached upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/memcached_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/example.com/v1alpha1/memcached_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Memcached Webhook", func() {
 	var (
 		obj       *examplecomv1alpha1.Memcached
 		oldObj    *examplecomv1alpha1.Memcached
-		validator MemcachedCustomValidator
+		validator MemcachedValidator
 	)
 
 	BeforeEach(func() {
 		obj = &examplecomv1alpha1.Memcached{}
 		oldObj = &examplecomv1alpha1.Memcached{}
-		validator = MemcachedCustomValidator{}
+		validator = MemcachedValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/destroyer_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/destroyer_webhook.go
@@ -32,7 +32,7 @@ var destroyerlog = logf.Log.WithName("destroyer-resource")
 // SetupDestroyerWebhookWithManager registers the webhook for Destroyer in the manager.
 func SetupDestroyerWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &shipv1.Destroyer{}).
-		WithDefaulter(&DestroyerCustomDefaulter{}).
+		WithDefaulter(&DestroyerDefaulter{}).
 		Complete()
 }
 
@@ -40,17 +40,17 @@ func SetupDestroyerWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-ship-testproject-org-v1-destroyer,mutating=true,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=destroyers,verbs=create;update,versions=v1,name=mdestroyer-v1.kb.io,admissionReviewVersions=v1
 
-// DestroyerCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// DestroyerDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Destroyer when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type DestroyerCustomDefaulter struct {
+type DestroyerDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Destroyer.
-func (d *DestroyerCustomDefaulter) Default(_ context.Context, obj *shipv1.Destroyer) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Destroyer.
+func (d *DestroyerDefaulter) Default(_ context.Context, obj *shipv1.Destroyer) error {
 	destroyerlog.Info("Defaulting for Destroyer", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v1/destroyer_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v1/destroyer_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Destroyer Webhook", func() {
 	var (
 		obj       *shipv1.Destroyer
 		oldObj    *shipv1.Destroyer
-		defaulter DestroyerCustomDefaulter
+		defaulter DestroyerDefaulter
 	)
 
 	BeforeEach(func() {
 		obj = &shipv1.Destroyer{}
 		oldObj = &shipv1.Destroyer{}
-		defaulter = DestroyerCustomDefaulter{}
+		defaulter = DestroyerDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/cruiser_webhook.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/cruiser_webhook.go
@@ -33,7 +33,7 @@ var cruiserlog = logf.Log.WithName("cruiser-resource")
 // SetupCruiserWebhookWithManager registers the webhook for Cruiser in the manager.
 func SetupCruiserWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &shipv2alpha1.Cruiser{}).
-		WithValidator(&CruiserCustomValidator{}).
+		WithValidator(&CruiserValidator{}).
 		Complete()
 }
 
@@ -43,17 +43,17 @@ func SetupCruiserWebhookWithManager(mgr ctrl.Manager) error {
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-ship-testproject-org-v2alpha1-cruiser,mutating=false,failurePolicy=fail,sideEffects=None,groups=ship.testproject.org,resources=cruisers,verbs=create;update,versions=v2alpha1,name=vcruiser-v2alpha1.kb.io,admissionReviewVersions=v1
 
-// CruiserCustomValidator struct is responsible for validating the Cruiser resource
+// CruiserValidator struct is responsible for validating the Cruiser resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CruiserCustomValidator struct {
+type CruiserValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
-func (v *CruiserCustomValidator) ValidateCreate(_ context.Context, obj *shipv2alpha1.Cruiser) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Cruiser.
+func (v *CruiserValidator) ValidateCreate(_ context.Context, obj *shipv2alpha1.Cruiser) (admission.Warnings, error) {
 	cruiserlog.Info("Validation for Cruiser upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -61,8 +61,8 @@ func (v *CruiserCustomValidator) ValidateCreate(_ context.Context, obj *shipv2al
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
-func (v *CruiserCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *shipv2alpha1.Cruiser) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Cruiser.
+func (v *CruiserValidator) ValidateUpdate(_ context.Context, oldObj, newObj *shipv2alpha1.Cruiser) (admission.Warnings, error) {
 	cruiserlog.Info("Validation for Cruiser upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -70,8 +70,8 @@ func (v *CruiserCustomValidator) ValidateUpdate(_ context.Context, oldObj, newOb
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Cruiser.
-func (v *CruiserCustomValidator) ValidateDelete(_ context.Context, obj *shipv2alpha1.Cruiser) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Cruiser.
+func (v *CruiserValidator) ValidateDelete(_ context.Context, obj *shipv2alpha1.Cruiser) (admission.Warnings, error) {
 	cruiserlog.Info("Validation for Cruiser upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/cruiser_webhook_test.go
+++ b/testdata/project-v4-multigroup/internal/webhook/ship/v2alpha1/cruiser_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Cruiser Webhook", func() {
 	var (
 		obj       *shipv2alpha1.Cruiser
 		oldObj    *shipv2alpha1.Cruiser
-		validator CruiserCustomValidator
+		validator CruiserValidator
 	)
 
 	BeforeEach(func() {
 		obj = &shipv2alpha1.Cruiser{}
 		oldObj = &shipv2alpha1.Cruiser{}
-		validator = CruiserCustomValidator{}
+		validator = CruiserValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/memcached_webhook.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/memcached_webhook.go
@@ -33,7 +33,7 @@ var memcachedlog = logf.Log.WithName("memcached-resource")
 // SetupMemcachedWebhookWithManager registers the webhook for Memcached in the manager.
 func SetupMemcachedWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &examplecomv1alpha1.Memcached{}).
-		WithValidator(&MemcachedCustomValidator{}).
+		WithValidator(&MemcachedValidator{}).
 		Complete()
 }
 
@@ -43,17 +43,17 @@ func SetupMemcachedWebhookWithManager(mgr ctrl.Manager) error {
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-example-com-testproject-org-v1alpha1-memcached,mutating=false,failurePolicy=fail,sideEffects=None,groups=example.com.testproject.org,resources=memcacheds,verbs=create;update,versions=v1alpha1,name=vmemcached-v1alpha1.kb.io,admissionReviewVersions=v1
 
-// MemcachedCustomValidator struct is responsible for validating the Memcached resource
+// MemcachedValidator struct is responsible for validating the Memcached resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type MemcachedCustomValidator struct {
+type MemcachedValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
-func (v *MemcachedCustomValidator) ValidateCreate(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Memcached.
+func (v *MemcachedValidator) ValidateCreate(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
 	memcachedlog.Info("Validation for Memcached upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -61,8 +61,8 @@ func (v *MemcachedCustomValidator) ValidateCreate(_ context.Context, obj *exampl
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
-func (v *MemcachedCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Memcached.
+func (v *MemcachedValidator) ValidateUpdate(_ context.Context, oldObj, newObj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
 	memcachedlog.Info("Validation for Memcached upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -70,8 +70,8 @@ func (v *MemcachedCustomValidator) ValidateUpdate(_ context.Context, oldObj, new
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Memcached.
-func (v *MemcachedCustomValidator) ValidateDelete(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Memcached.
+func (v *MemcachedValidator) ValidateDelete(_ context.Context, obj *examplecomv1alpha1.Memcached) (admission.Warnings, error) {
 	memcachedlog.Info("Validation for Memcached upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/memcached_webhook_test.go
+++ b/testdata/project-v4-with-plugins/internal/webhook/v1alpha1/memcached_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Memcached Webhook", func() {
 	var (
 		obj       *examplecomv1alpha1.Memcached
 		oldObj    *examplecomv1alpha1.Memcached
-		validator MemcachedCustomValidator
+		validator MemcachedValidator
 	)
 
 	BeforeEach(func() {
 		obj = &examplecomv1alpha1.Memcached{}
 		oldObj = &examplecomv1alpha1.Memcached{}
-		validator = MemcachedCustomValidator{}
+		validator = MemcachedValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4/internal/webhook/v1/admiral_webhook.go
+++ b/testdata/project-v4/internal/webhook/v1/admiral_webhook.go
@@ -34,8 +34,8 @@ var admirallog = logf.Log.WithName("admiral-resource")
 // SetupAdmiralWebhookWithManager registers the webhook for Admiral in the manager.
 func SetupAdmiralWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &crewv1.Admiral{}).
-		WithDefaulter(&AdmiralCustomDefaulter{}).
-		WithValidator(&AdmiralCustomValidator{}).
+		WithDefaulter(&AdmiralDefaulter{}).
+		WithValidator(&AdmiralValidator{}).
 		WithValidatorCustomPath("/custom-validate-admiral").
 		Complete()
 }
@@ -44,17 +44,17 @@ func SetupAdmiralWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-admiral,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirales,verbs=create;update,versions=v1,name=madmiral-v1.kb.io,admissionReviewVersions=v1
 
-// AdmiralCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// AdmiralDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Admiral when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type AdmiralCustomDefaulter struct {
+type AdmiralDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Admiral.
-func (d *AdmiralCustomDefaulter) Default(_ context.Context, obj *crewv1.Admiral) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Admiral.
+func (d *AdmiralDefaulter) Default(_ context.Context, obj *crewv1.Admiral) error {
 	admirallog.Info("Defaulting for Admiral", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -66,17 +66,17 @@ func (d *AdmiralCustomDefaulter) Default(_ context.Context, obj *crewv1.Admiral)
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/custom-validate-admiral,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=admirales,verbs=create;update,versions=v1,name=vadmiral-v1.kb.io,admissionReviewVersions=v1
 
-// AdmiralCustomValidator struct is responsible for validating the Admiral resource
+// AdmiralValidator struct is responsible for validating the Admiral resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type AdmiralCustomValidator struct {
+type AdmiralValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Admiral.
-func (v *AdmiralCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.Admiral) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Admiral.
+func (v *AdmiralValidator) ValidateCreate(_ context.Context, obj *crewv1.Admiral) (admission.Warnings, error) {
 	admirallog.Info("Validation for Admiral upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -84,8 +84,8 @@ func (v *AdmiralCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.A
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Admiral.
-func (v *AdmiralCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Admiral) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Admiral.
+func (v *AdmiralValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Admiral) (admission.Warnings, error) {
 	admirallog.Info("Validation for Admiral upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -93,8 +93,8 @@ func (v *AdmiralCustomValidator) ValidateUpdate(_ context.Context, oldObj, newOb
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Admiral.
-func (v *AdmiralCustomValidator) ValidateDelete(_ context.Context, obj *crewv1.Admiral) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Admiral.
+func (v *AdmiralValidator) ValidateDelete(_ context.Context, obj *crewv1.Admiral) (admission.Warnings, error) {
 	admirallog.Info("Validation for Admiral upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4/internal/webhook/v1/admiral_webhook_test.go
+++ b/testdata/project-v4/internal/webhook/v1/admiral_webhook_test.go
@@ -28,18 +28,18 @@ var _ = Describe("Admiral Webhook", func() {
 	var (
 		obj       *crewv1.Admiral
 		oldObj    *crewv1.Admiral
-		defaulter AdmiralCustomDefaulter
-		validator AdmiralCustomValidator
+		defaulter AdmiralDefaulter
+		validator AdmiralValidator
 	)
 
 	BeforeEach(func() {
 		obj = &crewv1.Admiral{}
 		oldObj = &crewv1.Admiral{}
-		defaulter = AdmiralCustomDefaulter{}
+		defaulter = AdmiralDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		validator = AdmiralCustomValidator{}
+		validator = AdmiralValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 	})
 

--- a/testdata/project-v4/internal/webhook/v1/captain_webhook.go
+++ b/testdata/project-v4/internal/webhook/v1/captain_webhook.go
@@ -34,8 +34,8 @@ var captainlog = logf.Log.WithName("captain-resource")
 // SetupCaptainWebhookWithManager registers the webhook for Captain in the manager.
 func SetupCaptainWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &crewv1.Captain{}).
-		WithDefaulter(&CaptainCustomDefaulter{}).
-		WithValidator(&CaptainCustomValidator{}).
+		WithDefaulter(&CaptainDefaulter{}).
+		WithValidator(&CaptainValidator{}).
 		Complete()
 }
 
@@ -43,17 +43,17 @@ func SetupCaptainWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-crew-testproject-org-v1-captain,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=mcaptain-v1.kb.io,admissionReviewVersions=v1
 
-// CaptainCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// CaptainDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Captain when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type CaptainCustomDefaulter struct {
+type CaptainDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Captain.
-func (d *CaptainCustomDefaulter) Default(_ context.Context, obj *crewv1.Captain) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Captain.
+func (d *CaptainDefaulter) Default(_ context.Context, obj *crewv1.Captain) error {
 	captainlog.Info("Defaulting for Captain", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -65,17 +65,17 @@ func (d *CaptainCustomDefaulter) Default(_ context.Context, obj *crewv1.Captain)
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-crew-testproject-org-v1-captain,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=captains,verbs=create;update,versions=v1,name=vcaptain-v1.kb.io,admissionReviewVersions=v1
 
-// CaptainCustomValidator struct is responsible for validating the Captain resource
+// CaptainValidator struct is responsible for validating the Captain resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type CaptainCustomValidator struct {
+type CaptainValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
-func (v *CaptainCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Captain.
+func (v *CaptainValidator) ValidateCreate(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
 	captainlog.Info("Validation for Captain upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -83,8 +83,8 @@ func (v *CaptainCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.C
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Captain.
-func (v *CaptainCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Captain) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Captain.
+func (v *CaptainValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Captain) (admission.Warnings, error) {
 	captainlog.Info("Validation for Captain upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -92,8 +92,8 @@ func (v *CaptainCustomValidator) ValidateUpdate(_ context.Context, oldObj, newOb
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Captain.
-func (v *CaptainCustomValidator) ValidateDelete(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Captain.
+func (v *CaptainValidator) ValidateDelete(_ context.Context, obj *crewv1.Captain) (admission.Warnings, error) {
 	captainlog.Info("Validation for Captain upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4/internal/webhook/v1/captain_webhook_test.go
+++ b/testdata/project-v4/internal/webhook/v1/captain_webhook_test.go
@@ -28,18 +28,18 @@ var _ = Describe("Captain Webhook", func() {
 	var (
 		obj       *crewv1.Captain
 		oldObj    *crewv1.Captain
-		defaulter CaptainCustomDefaulter
-		validator CaptainCustomValidator
+		defaulter CaptainDefaulter
+		validator CaptainValidator
 	)
 
 	BeforeEach(func() {
 		obj = &crewv1.Captain{}
 		oldObj = &crewv1.Captain{}
-		defaulter = CaptainCustomDefaulter{}
+		defaulter = CaptainDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		validator = CaptainCustomValidator{}
+		validator = CaptainValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 	})
 

--- a/testdata/project-v4/internal/webhook/v1/deployment_webhook.go
+++ b/testdata/project-v4/internal/webhook/v1/deployment_webhook.go
@@ -33,8 +33,8 @@ var deploymentlog = logf.Log.WithName("deployment-resource")
 // SetupDeploymentWebhookWithManager registers the webhook for Deployment in the manager.
 func SetupDeploymentWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &appsv1.Deployment{}).
-		WithDefaulter(&DeploymentCustomDefaulter{}).
-		WithValidator(&DeploymentCustomValidator{}).
+		WithDefaulter(&DeploymentDefaulter{}).
+		WithValidator(&DeploymentValidator{}).
 		Complete()
 }
 
@@ -42,17 +42,17 @@ func SetupDeploymentWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-apps-v1-deployment,mutating=true,failurePolicy=fail,sideEffects=None,groups=apps,resources=deployments,verbs=create;update,versions=v1,name=mdeployment-v1.kb.io,admissionReviewVersions=v1
 
-// DeploymentCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// DeploymentDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Deployment when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type DeploymentCustomDefaulter struct {
+type DeploymentDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Deployment.
-func (d *DeploymentCustomDefaulter) Default(_ context.Context, obj *appsv1.Deployment) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Deployment.
+func (d *DeploymentDefaulter) Default(_ context.Context, obj *appsv1.Deployment) error {
 	deploymentlog.Info("Defaulting for Deployment", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -64,17 +64,17 @@ func (d *DeploymentCustomDefaulter) Default(_ context.Context, obj *appsv1.Deplo
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/validate-apps-v1-deployment,mutating=false,failurePolicy=fail,sideEffects=None,groups=apps,resources=deployments,verbs=create;update,versions=v1,name=vdeployment-v1.kb.io,admissionReviewVersions=v1
 
-// DeploymentCustomValidator struct is responsible for validating the Deployment resource
+// DeploymentValidator struct is responsible for validating the Deployment resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type DeploymentCustomValidator struct {
+type DeploymentValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Deployment.
-func (v *DeploymentCustomValidator) ValidateCreate(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Deployment.
+func (v *DeploymentValidator) ValidateCreate(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
 	deploymentlog.Info("Validation for Deployment upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -82,8 +82,8 @@ func (v *DeploymentCustomValidator) ValidateCreate(_ context.Context, obj *appsv
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Deployment.
-func (v *DeploymentCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *appsv1.Deployment) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Deployment.
+func (v *DeploymentValidator) ValidateUpdate(_ context.Context, oldObj, newObj *appsv1.Deployment) (admission.Warnings, error) {
 	deploymentlog.Info("Validation for Deployment upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -91,8 +91,8 @@ func (v *DeploymentCustomValidator) ValidateUpdate(_ context.Context, oldObj, ne
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Deployment.
-func (v *DeploymentCustomValidator) ValidateDelete(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Deployment.
+func (v *DeploymentValidator) ValidateDelete(_ context.Context, obj *appsv1.Deployment) (admission.Warnings, error) {
 	deploymentlog.Info("Validation for Deployment upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4/internal/webhook/v1/deployment_webhook_test.go
+++ b/testdata/project-v4/internal/webhook/v1/deployment_webhook_test.go
@@ -28,18 +28,18 @@ var _ = Describe("Deployment Webhook", func() {
 	var (
 		obj       *appsv1.Deployment
 		oldObj    *appsv1.Deployment
-		defaulter DeploymentCustomDefaulter
-		validator DeploymentCustomValidator
+		defaulter DeploymentDefaulter
+		validator DeploymentValidator
 	)
 
 	BeforeEach(func() {
 		obj = &appsv1.Deployment{}
 		oldObj = &appsv1.Deployment{}
-		defaulter = DeploymentCustomDefaulter{}
+		defaulter = DeploymentDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		validator = DeploymentCustomValidator{}
+		validator = DeploymentValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 	})
 

--- a/testdata/project-v4/internal/webhook/v1/issuer_webhook.go
+++ b/testdata/project-v4/internal/webhook/v1/issuer_webhook.go
@@ -31,7 +31,7 @@ var issuerlog = logf.Log.WithName("issuer-resource")
 // SetupIssuerWebhookWithManager registers the webhook for Issuer in the manager.
 func SetupIssuerWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &certmanagerv1.Issuer{}).
-		WithDefaulter(&IssuerCustomDefaulter{}).
+		WithDefaulter(&IssuerDefaulter{}).
 		Complete()
 }
 
@@ -39,17 +39,17 @@ func SetupIssuerWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate-cert-manager-io-v1-issuer,mutating=true,failurePolicy=fail,sideEffects=None,groups=cert-manager.io,resources=issuers,verbs=create;update,versions=v1,name=missuer-v1.kb.io,admissionReviewVersions=v1
 
-// IssuerCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// IssuerDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Issuer when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type IssuerCustomDefaulter struct {
+type IssuerDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Issuer.
-func (d *IssuerCustomDefaulter) Default(_ context.Context, obj *certmanagerv1.Issuer) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Issuer.
+func (d *IssuerDefaulter) Default(_ context.Context, obj *certmanagerv1.Issuer) error {
 	issuerlog.Info("Defaulting for Issuer", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.

--- a/testdata/project-v4/internal/webhook/v1/issuer_webhook_test.go
+++ b/testdata/project-v4/internal/webhook/v1/issuer_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Issuer Webhook", func() {
 	var (
 		obj       *certmanagerv1.Issuer
 		oldObj    *certmanagerv1.Issuer
-		defaulter IssuerCustomDefaulter
+		defaulter IssuerDefaulter
 	)
 
 	BeforeEach(func() {
 		obj = &certmanagerv1.Issuer{}
 		oldObj = &certmanagerv1.Issuer{}
-		defaulter = IssuerCustomDefaulter{}
+		defaulter = IssuerDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4/internal/webhook/v1/pod_webhook.go
+++ b/testdata/project-v4/internal/webhook/v1/pod_webhook.go
@@ -31,7 +31,7 @@ var podlog = logf.Log.WithName("pod-resource")
 // SetupPodWebhookWithManager registers the webhook for Pod in the manager.
 func SetupPodWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &corev1.Pod{}).
-		WithDefaulter(&PodCustomDefaulter{}).
+		WithDefaulter(&PodDefaulter{}).
 		Complete()
 }
 
@@ -39,17 +39,17 @@ func SetupPodWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod-v1.kb.io,admissionReviewVersions=v1
 
-// PodCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// PodDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Pod when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type PodCustomDefaulter struct {
+type PodDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Pod.
-func (d *PodCustomDefaulter) Default(_ context.Context, obj *corev1.Pod) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Pod.
+func (d *PodDefaulter) Default(_ context.Context, obj *corev1.Pod) error {
 	podlog.Info("Defaulting for Pod", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.

--- a/testdata/project-v4/internal/webhook/v1/pod_webhook_test.go
+++ b/testdata/project-v4/internal/webhook/v1/pod_webhook_test.go
@@ -28,13 +28,13 @@ var _ = Describe("Pod Webhook", func() {
 	var (
 		obj       *corev1.Pod
 		oldObj    *corev1.Pod
-		defaulter PodCustomDefaulter
+		defaulter PodDefaulter
 	)
 
 	BeforeEach(func() {
 		obj = &corev1.Pod{}
 		oldObj = &corev1.Pod{}
-		defaulter = PodCustomDefaulter{}
+		defaulter = PodDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")

--- a/testdata/project-v4/internal/webhook/v1/sailor_webhook.go
+++ b/testdata/project-v4/internal/webhook/v1/sailor_webhook.go
@@ -34,9 +34,9 @@ var sailorlog = logf.Log.WithName("sailor-resource")
 // SetupSailorWebhookWithManager registers the webhook for Sailor in the manager.
 func SetupSailorWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &crewv1.Sailor{}).
-		WithDefaulter(&SailorCustomDefaulter{}).
+		WithDefaulter(&SailorDefaulter{}).
 		WithDefaulterCustomPath("/custom-mutate-sailor").
-		WithValidator(&SailorCustomValidator{}).
+		WithValidator(&SailorValidator{}).
 		WithValidatorCustomPath("/custom-validate-sailor").
 		Complete()
 }
@@ -45,17 +45,17 @@ func SetupSailorWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/custom-mutate-sailor,mutating=true,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=sailors,verbs=create;update,versions=v1,name=msailor-v1.kb.io,admissionReviewVersions=v1
 
-// SailorCustomDefaulter struct is responsible for setting default values on the custom resource of the
+// SailorDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind Sailor when those are created or updated.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as it is used only for temporary operations and does not need to be deeply copied.
-type SailorCustomDefaulter struct {
+type SailorDefaulter struct {
 	// TODO(user): Add more fields as needed for defaulting
 }
 
-// Default implements webhook.CustomDefaulter so a webhook will be registered for the Kind Sailor.
-func (d *SailorCustomDefaulter) Default(_ context.Context, obj *crewv1.Sailor) error {
+// Default implements admission.Defaulter so a webhook will be registered for the Kind Sailor.
+func (d *SailorDefaulter) Default(_ context.Context, obj *crewv1.Sailor) error {
 	sailorlog.Info("Defaulting for Sailor", "name", obj.GetName())
 
 	// TODO(user): fill in your defaulting logic.
@@ -67,17 +67,17 @@ func (d *SailorCustomDefaulter) Default(_ context.Context, obj *crewv1.Sailor) e
 // NOTE: If you want to customise the 'path', use the flags '--defaulting-path' or '--validation-path'.
 // +kubebuilder:webhook:path=/custom-validate-sailor,mutating=false,failurePolicy=fail,sideEffects=None,groups=crew.testproject.org,resources=sailors,verbs=create;update,versions=v1,name=vsailor-v1.kb.io,admissionReviewVersions=v1
 
-// SailorCustomValidator struct is responsible for validating the Sailor resource
+// SailorValidator struct is responsible for validating the Sailor resource
 // when it is created, updated, or deleted.
 //
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
-type SailorCustomValidator struct {
+type SailorValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type Sailor.
-func (v *SailorCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.Sailor) (admission.Warnings, error) {
+// ValidateCreate implements admission.Validator so a webhook will be registered for the type Sailor.
+func (v *SailorValidator) ValidateCreate(_ context.Context, obj *crewv1.Sailor) (admission.Warnings, error) {
 	sailorlog.Info("Validation for Sailor upon creation", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object creation.
@@ -85,8 +85,8 @@ func (v *SailorCustomValidator) ValidateCreate(_ context.Context, obj *crewv1.Sa
 	return nil, nil
 }
 
-// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type Sailor.
-func (v *SailorCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Sailor) (admission.Warnings, error) {
+// ValidateUpdate implements admission.Validator so a webhook will be registered for the type Sailor.
+func (v *SailorValidator) ValidateUpdate(_ context.Context, oldObj, newObj *crewv1.Sailor) (admission.Warnings, error) {
 	sailorlog.Info("Validation for Sailor upon update", "name", newObj.GetName())
 
 	// TODO(user): fill in your validation logic upon object update.
@@ -94,8 +94,8 @@ func (v *SailorCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj
 	return nil, nil
 }
 
-// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type Sailor.
-func (v *SailorCustomValidator) ValidateDelete(_ context.Context, obj *crewv1.Sailor) (admission.Warnings, error) {
+// ValidateDelete implements admission.Validator so a webhook will be registered for the type Sailor.
+func (v *SailorValidator) ValidateDelete(_ context.Context, obj *crewv1.Sailor) (admission.Warnings, error) {
 	sailorlog.Info("Validation for Sailor upon deletion", "name", obj.GetName())
 
 	// TODO(user): fill in your validation logic upon object deletion.

--- a/testdata/project-v4/internal/webhook/v1/sailor_webhook_test.go
+++ b/testdata/project-v4/internal/webhook/v1/sailor_webhook_test.go
@@ -28,18 +28,18 @@ var _ = Describe("Sailor Webhook", func() {
 	var (
 		obj       *crewv1.Sailor
 		oldObj    *crewv1.Sailor
-		defaulter SailorCustomDefaulter
-		validator SailorCustomValidator
+		defaulter SailorDefaulter
+		validator SailorValidator
 	)
 
 	BeforeEach(func() {
 		obj = &crewv1.Sailor{}
 		oldObj = &crewv1.Sailor{}
-		defaulter = SailorCustomDefaulter{}
+		defaulter = SailorDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		validator = SailorCustomValidator{}
+		validator = SailorValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 	})
 


### PR DESCRIPTION
## Description 

The go/v4 webhook scaffold already implements the typed `admission.Defaulter[T]` and `admission.Validator[T]`  interfaces from controller-runtime, but named the generated structs `<Kind>CustomDefaulter` and `<Kind>CustomValidator ` - a leftover from the deprecated untyped webhook.CustomDefaulter/webhook.CustomValidator aliases. The method comments still said implements `webhook.CustomDefaulter`, which was doubly wrong: wrong package and wrong type name.

Rename the generated structs to `<Kind>Defaulter` and `<Kind>Validator` and fix all method comments to reference `admission.Defaulter` and `admission.Validator`. 
Updated: scaffold templates, updater, test template, test updater, all testdata files, docs tutorial testdata, hack/docs generator sources, and the integration test assertions.

Fixes #5874