### PR TITLE
🐛 (helm/v2-alpha): Gate webhook port argument (follow-up to #5868)

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -84,7 +84,9 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- end }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -84,7 +84,9 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- end }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -691,8 +691,12 @@ func templateControllerManagerArgs(yamlContent string) string {
 		builder.WriteString("\n")
 	}
 	if webhookLine != "" {
+		builder.WriteString(itemIndent)
+		builder.WriteString("{{- if .Values.webhook.enabled }}\n")
 		builder.WriteString(webhookLine)
 		builder.WriteString("\n")
+		builder.WriteString(itemIndent)
+		builder.WriteString("{{- end }}\n")
 	}
 
 	builder.WriteString(itemIndent)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -200,7 +200,9 @@ spec:
 			Expect(result).To(ContainSubstring("- --metrics-secure=false"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=0"))
 			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
-			Expect(result).To(ContainSubstring("- --webhook-port={{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring(`{{- if .Values.webhook.enabled }}
+        - --webhook-port={{ .Values.webhook.port }}
+        {{- end }}`))
 			Expect(result).To(ContainSubstring("{{- range .Values.manager.args }}"))
 			Expect(result).NotTo(ContainSubstring("BUSYBOX_IMAGE"))
 			Expect(result).NotTo(ContainSubstring("MEMCACHED_IMAGE"))

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -216,6 +216,30 @@ spec:
 			Expect(result).NotTo(ContainSubstring("controller:latest"))
 		})
 
+		It("should not template a webhook port when the project has no webhook", func() {
+			deploymentResource := &unstructured.Unstructured{}
+			deploymentResource.SetAPIVersion("apps/v1")
+			deploymentResource.SetKind("Deployment")
+			deploymentResource.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        name: manager`
+
+			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
+
+			Expect(result).NotTo(ContainSubstring("--webhook-port"))
+			Expect(result).NotTo(ContainSubstring("{{- if .Values.webhook.enabled }}"))
+		})
+
 		It("should handle volume mounts with proper indentation", func() {
 			deploymentResource := &unstructured.Unstructured{}
 			deploymentResource.SetAPIVersion("apps/v1")

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -84,7 +84,9 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- end }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}


### PR DESCRIPTION
## Summary

- Render `--webhook-port` only when `webhook.enabled` is true.
- Regenerate the affected Helm chart fixtures.
- Cover the conditional manager argument template.

## Why

The webhook port argument was emitted even when the Helm chart disabled webhooks.

## Validation

- `make lint-fix`
- `make test-unit`
- `make verify-helm`
- Rendered the chart with webhooks disabled and enabled with a custom port.