### PR TITLE
🐛 (go/v4): make scaffolded .dockerignore build on Podman and the classic Docker builder

### DIFF
--- a/.github/workflows/test-dockerignore.yml
+++ b/.github/workflows/test-dockerignore.yml
@@ -1,0 +1,123 @@
+name: Docker Build Context
+
+on:
+  push:
+    paths:
+      - '**/.dockerignore'
+      - 'pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go'
+      - 'pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go'
+      - 'test/verify-docker-build-context.sh'
+      - '.github/workflows/test-dockerignore.yml'
+  pull_request:
+    paths:
+      - '**/.dockerignore'
+      - 'pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go'
+      - 'pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go'
+      - 'test/verify-docker-build-context.sh'
+      - '.github/workflows/test-dockerignore.yml'
+
+permissions: {}
+
+jobs:
+  # Container tools disagree on whether they descend into an ignored directory to
+  # evaluate a re-include such as "!**/*.go". Build the sample project with each of
+  # them so the scaffolded .dockerignore cannot regress on any one of them.
+  build-context-testdata:
+    name: ${{ matrix.name }} / testdata sample
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: docker (BuildKit)
+            tool: docker
+            buildkit: '1'
+          - name: docker (classic builder)
+            tool: docker
+            buildkit: '0'
+          - name: podman
+            tool: podman
+            buildkit: ''
+    env:
+      DOCKER_BUILDKIT: ${{ matrix.buildkit }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Prepare project-v4
+        working-directory: testdata/project-v4
+        run: go mod tidy
+
+      - name: Verify the build context
+        env:
+          CONTAINER_TOOL: ${{ matrix.tool }}
+        run: ./test/verify-docker-build-context.sh testdata/project-v4
+
+      - name: Build the manager image
+        working-directory: testdata/project-v4
+        env:
+          CONTAINER_TOOL: ${{ matrix.tool }}
+        run: make docker-build IMG=controller:ci CONTAINER_TOOL="${CONTAINER_TOOL}"
+
+  # Covers the case reported in #5886: a freshly scaffolded project, no APIs yet.
+  build-context-scaffolded:
+    name: ${{ matrix.name }} / freshly scaffolded
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: docker (BuildKit)
+            tool: docker
+            buildkit: '1'
+          - name: docker (classic builder)
+            tool: docker
+            buildkit: '0'
+          - name: podman
+            tool: podman
+            buildkit: ''
+    env:
+      DOCKER_BUILDKIT: ${{ matrix.buildkit }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build kubebuilder CLI from this repo
+        run: make install
+
+      - name: Scaffold a go/v4 project
+        run: |
+          mkdir -p /tmp/dockerignore-project
+          cd /tmp/dockerignore-project
+          kubebuilder init --plugins go/v4 --domain example.com --repo example.com/dockerignore-operator
+          kubebuilder create api --group crew --version v1 --kind Captain --resource --controller
+          go mod tidy
+
+      - name: Verify the build context
+        env:
+          CONTAINER_TOOL: ${{ matrix.tool }}
+        run: ${GITHUB_WORKSPACE}/test/verify-docker-build-context.sh /tmp/dockerignore-project
+
+      - name: Build the manager image
+        working-directory: /tmp/dockerignore-project
+        env:
+          CONTAINER_TOOL: ${{ matrix.tool }}
+        run: make docker-build IMG=controller:ci CONTAINER_TOOL="${CONTAINER_TOOL}"

--- a/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
@@ -6,10 +6,8 @@
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
@@ -2,10 +2,16 @@
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go

--- a/docs/book/src/getting-started/testdata/project/.dockerignore
+++ b/docs/book/src/getting-started/testdata/project/.dockerignore
@@ -6,10 +6,8 @@
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/docs/book/src/getting-started/testdata/project/.dockerignore
+++ b/docs/book/src/getting-started/testdata/project/.dockerignore
@@ -2,10 +2,16 @@
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go

--- a/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
@@ -6,10 +6,8 @@
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
@@ -2,10 +2,16 @@
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
@@ -42,11 +42,17 @@ const dockerignorefileTemplate = `# More info: https://docs.docker.com/engine/re
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go
 `

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
@@ -46,10 +46,8 @@ const dockerignorefileTemplate = `# More info: https://docs.docker.com/engine/re
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/test/verify-docker-build-context.sh
+++ b/test/verify-docker-build-context.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies the scaffolded .dockerignore: the builder stage must receive every Go source
+# needed to build the manager, and none of the files that must not reach the image.
+#
+# Container tools disagree on whether they descend into an ignored directory to evaluate
+# a re-include such as "!**/*.go": BuildKit does, the classic Docker builder and
+# Podman/buildah do not. Run this against each of them.
+#
+# Usage: CONTAINER_TOOL=docker ./test/verify-docker-build-context.sh <project-dir>
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
+PROJECT_DIR="${1:?usage: $0 <project-dir>}"
+
+cd "${PROJECT_DIR}"
+
+IMG="dockerignore-context-probe:$$"
+trap '${CONTAINER_TOOL} rmi -f "${IMG}" >/dev/null 2>&1 || true' EXIT
+
+# Stop at the builder stage: it still has a shell, and it is the stage that consumes
+# the build context. The final image is distroless and only holds the binary.
+echo "Building the builder stage with ${CONTAINER_TOOL} ..."
+"${CONTAINER_TOOL}" build --target builder -t "${IMG}" .
+
+context="$("${CONTAINER_TOOL}" run --rm "${IMG}" \
+  sh -c 'cd /workspace && find . -type f | sed "s|^\./||" | sort')"
+
+echo "Files the builder stage received:"
+echo "${context}" | sed 's/^/  /'
+
+fail=0
+
+# Every non-test Go source under the scaffolded source dirs has to be there, or the
+# build either breaks now or breaks later when a controller starts importing it.
+required="$(find ./cmd ./api ./internal -type f -name '*.go' ! -name '*_test.go' 2>/dev/null \
+  | sed 's|^\./||' | sort || true)"
+required="$(printf '%s\ngo.mod\ngo.sum\n' "${required}" | grep -v '^$' | sort)"
+
+missing="$(comm -23 <(echo "${required}") <(echo "${context}"))"
+if [[ -n "${missing}" ]]; then
+  echo "ERROR: these files are missing from the build context:"
+  echo "${missing}" | sed 's/^/  /'
+  fail=1
+fi
+
+# Nothing that belongs to the repo rather than the binary may reach the context.
+forbidden="$(echo "${context}" | grep -E \
+  '^(config/|dist/|bin/|hack/|grafana/|\.git/|Makefile$|PROJECT$|Dockerfile$|.*\.md$)|_test\.go$' || true)"
+if [[ -n "${forbidden}" ]]; then
+  echo "ERROR: these files must not be in the build context:"
+  echo "${forbidden}" | sed 's/^/  /'
+  fail=1
+fi
+
+if [[ "${fail}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "OK: ${CONTAINER_TOOL} build context contains the manager sources and nothing else."

--- a/testdata/project-v4-multigroup/.dockerignore
+++ b/testdata/project-v4-multigroup/.dockerignore
@@ -6,10 +6,8 @@
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/testdata/project-v4-multigroup/.dockerignore
+++ b/testdata/project-v4-multigroup/.dockerignore
@@ -2,10 +2,16 @@
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go

--- a/testdata/project-v4-with-plugins/.dockerignore
+++ b/testdata/project-v4-with-plugins/.dockerignore
@@ -6,10 +6,8 @@
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/testdata/project-v4-with-plugins/.dockerignore
+++ b/testdata/project-v4-with-plugins/.dockerignore
@@ -2,10 +2,16 @@
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go

--- a/testdata/project-v4/.dockerignore
+++ b/testdata/project-v4/.dockerignore
@@ -6,10 +6,8 @@
 !go.mod
 !go.sum
 
-# Re-include Go source files (but not *_test.go).
-# The source directories are listed as well so that the legacy Docker builder (used when
-# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
-# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+# Re-include Go source files (but not *_test.go). The source dirs are named because
+# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
 !**/*.go
 !cmd
 !api

--- a/testdata/project-v4/.dockerignore
+++ b/testdata/project-v4/.dockerignore
@@ -2,10 +2,16 @@
 # Ignore everything by default and re-include only needed files
 **
 
-# Re-include Go source files (but not *_test.go)
-!**/*.go
-**/*_test.go
-
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include Go source files (but not *_test.go).
+# The source directories are listed as well so that the legacy Docker builder (used when
+# BuildKit/buildx is not available) re-includes files whose parent directory would otherwise
+# stay ignored; on BuildKit "!**/*.go" already re-includes them on its own.
+!**/*.go
+!cmd
+!api
+!internal
+**/*_test.go


### PR DESCRIPTION
Fixes #5886

## What was wrong

`make docker-build` fails on a freshly scaffolded project on any container tool that is not BuildKit. On the classic Docker builder (BuildKit/buildx not available) and on Podman the build stops with a misleading error:

```
Step 9/14 : RUN ... go build -a -o manager cmd/main.go
package cmd/main.go is not in std (/usr/local/go/src/cmd/main.go)
```

The `go build` line looks broken, but it is a symptom. The scaffolded `.dockerignore` re-includes sources with an allow-list (`**` then `!**/*.go`). That only re-includes anything if the engine descends into a directory it has already excluded. BuildKit descends. The classic builder does not (moby#30018, moby#45608) and neither does buildah, which is what Podman shells out to (containers/buildah#6615, fix still open in containers/buildah#6927). On those engines `COPY . .` copies only `go.mod` and `go.sum`, so the `main` package is never in the build context.

This is the same root cause as the Podman failure in #5181, which is currently closed as an upstream bug. Thanks to @nuromirg for the precise root-cause analysis in the issue.

## The fix

Re-include the `cmd`, `api` and `internal` source directories in addition to the existing `!**/*.go`:

```
**

# Re-include Go module files
!go.mod
!go.sum

# Re-include Go source files (but not *_test.go). The source dirs are named because
# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
!**/*.go
!cmd
!api
!internal
**/*_test.go
```

Naming the directories re-includes the parent, which is the one thing all three engines agree on. BuildKit still re-includes any `.go` through `!**/*.go` on its own, so its behavior and its build context are unchanged.

I first tried the shorter `!**/` (re-include every directory). That turns out to re-include every *file* too, on both builders (all of `config/`, `dist/`, `.git/`, `bin/`, the `Makefile`, ...), which defeats the point of the allow-list and bloats the context. The directory-scoped form above keeps the context minimal.

## Verification

Build context of `testdata/project-v4`, measured by building a probe image and listing what the builder stage received:

| engine | before | after |
| --- | --- | --- |
| BuildKit | 36 files, builds | same 36 files, builds |
| classic builder (`DOCKER_BUILDKIT=0`) | 3 files, fails with `package cmd/main.go is not in std` | 35 files, builds |
| buildah / Podman | 3 files, fails with `package cmd/main.go is not in std` | 35 files, builds |

Also built the manager image end to end with buildah on `testdata/project-v4`: it fails before this change and builds through to the distroless stage after it.

The 35 vs 36 difference is `test/utils/utils.go`, a non-test `.go` file outside the three source dirs that BuildKit re-includes on its own. It is an e2e helper the manager never imports, so no build is affected. On BuildKit the context is the same set of files as before this PR, so multi-arch builds see exactly what they see today.

Nothing here touches `docker build` versus `docker buildx build`, so this is orthogonal to #5853 and #5848, and `.dockerignore` does not participate in platform selection so the `docker-buildx` target is unaffected.

## Tests

`test/verify-docker-build-context.sh` builds the builder stage, which is the stage that consumes the build context and still has a shell, and asserts that it holds every non-test Go source needed to build the manager plus `go.mod`/`go.sum`, and none of `config/`, `dist/`, `bin/`, `hack/`, `grafana/`, `.git/`, `Makefile`, `PROJECT`, `*.md` or any `_test.go`. It honors `CONTAINER_TOOL` so it can be pointed at Podman.

`.github/workflows/test-dockerignore.yml` runs it on BuildKit, the classic builder and Podman, against both `testdata/project-v4` and a freshly scaffolded project, and then runs a real `make docker-build` on each.

The test fails on the bug: with the `.dockerignore` from master it passes on BuildKit and fails on the classic builder with `package cmd/main.go is not in std`.

Also done:
- Regenerated the `.dockerignore` for every sample project (`make generate` produces no diff; the scaffolder output matches the committed testdata byte for byte).
- `go test ./pkg/plugins/golang/v4/...` green, `gofmt` and `go vet` clean.

## One tradeoff

On the classic builder and on Podman, Go code placed in a top-level directory other than `cmd`, `api` or `internal` (for example `pkg/`) needs a `!pkg` line added by the user; the scaffolded comment says so. BuildKit is unaffected, and those engines did not build at all before, so this is a net improvement rather than a regression.

An alternative shape is to drop the allow-list and ignore only what must not be shipped, which is layout independent and needs no re-include semantics at all. I measured that too and it works identically on all three engines. Happy to switch if preferred; the tradeoff is that it is a denylist, so anything a user adds later is in the context until they exclude it.
