### PR TITLE
✨ (helm/v2-alpha): document health port options and extend coverage. Move health probe under the manager ( follow up #5866 )

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}
@@ -105,12 +105,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: {{ .Values.healthProbe.port }}
+        - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}
@@ -119,7 +119,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -27,6 +27,13 @@ manager:
   args:
     - --leader-elect
 
+  ## Health probes.
+  ## The manager serves the liveness (/healthz) and readiness (/readyz) endpoints on this port.
+  ##
+  healthProbe:
+    # Health probe server port
+    port: 8081
+
   ## Image pull secrets
   ##
   # imagePullSecrets:
@@ -158,13 +165,6 @@ metrics:
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
-
-## Health probe endpoint.
-## Serves the liveness (/healthz) and readiness (/readyz) checks.
-##
-healthProbe:
-  # Health probe server port
-  port: 8081
 
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
@@ -96,18 +96,18 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: {{ .Values.healthProbe.port }}
+        - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -27,6 +27,13 @@ manager:
   args:
     - --leader-elect
 
+  ## Health probes.
+  ## The manager serves the liveness (/healthz) and readiness (/readyz) endpoints on this port.
+  ##
+  healthProbe:
+    # Health probe server port
+    port: 8081
+
   ## Image pull secrets
   ##
   # imagePullSecrets:
@@ -158,13 +165,6 @@ metrics:
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
-
-## Health probe endpoint.
-## Serves the liveness (/healthz) and readiness (/readyz) checks.
-##
-healthProbe:
-  # Health probe server port
-  port: 8081
 
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}
@@ -105,12 +105,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: {{ .Values.healthProbe.port }}
+        - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}
@@ -119,7 +119,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -27,6 +27,13 @@ manager:
   args:
     - --leader-elect
 
+  ## Health probes.
+  ## The manager serves the liveness (/healthz) and readiness (/readyz) endpoints on this port.
+  ##
+  healthProbe:
+    # Health probe server port
+    port: 8081
+
   ## Image pull secrets
   ##
   # imagePullSecrets:
@@ -158,13 +165,6 @@ metrics:
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
-
-## Health probe endpoint.
-## Serves the liveness (/healthz) and readiness (/readyz) checks.
-##
-healthProbe:
-  # Health probe server port
-  port: 8081
 
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -214,6 +214,18 @@ Webhook and metrics certificates (`webhook-certs`, `metrics-certs`) are managed 
 
 ### Metrics configuration
 
+#### `metrics.port`
+
+Set `metrics.port` to change the port used by the metrics endpoint. The chart applies the same value to the manager `--metrics-bind-address` argument, the metrics Service port and targetPort, and the metrics NetworkPolicy.
+
+For example, install the chart with the metrics endpoint on port `8444`:
+
+```bash
+helm install my-operator ./dist/chart --set metrics.port=8444
+```
+
+The default is `8443`, detected from your project configuration.
+
 #### `metrics.secure`
 
 Control transport security and authentication for the metrics endpoint (default: `true`).
@@ -244,6 +256,26 @@ For example, install the chart with the webhook server on port `9444`:
 ```bash
 helm install my-operator ./dist/chart --set webhook.port=9444
 ```
+
+The default is `9443`, detected from your project configuration.
+
+### Health probe port configuration
+
+Set `manager.healthProbe.port` to change the port where the manager serves its health probes. The liveness (`/healthz`) and readiness (`/readyz`) endpoints bind to this port. The chart applies the same value to the `--health-probe-bind-address` argument, the `health` container port, and the `httpGet` port of both probes.
+
+For example, install the chart with the health probes on port `8082`:
+
+```bash
+helm install my-operator ./dist/chart --set manager.healthProbe.port=8082
+```
+
+The default is `8081`, detected from your project configuration.
+
+### Port flags in manager.args
+
+Use `manager.args` for flags that the chart does not expose as values. For the ports above, always use `metrics.port`, `webhook.port`, and `manager.healthProbe.port`.
+
+The chart renders `--metrics-bind-address`, `--webhook-port`, and `--health-probe-bind-address` from these values. Setting one of these flags in `manager.args` overrides the manager listener, while the Service, NetworkPolicy, and probe ports keep the configured values, so traffic and probes target the wrong port. The plugin removes these flags from the extracted args when it generates the chart.
 
 ### NetworkPolicy configuration
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	keyName         = "name"
+	keyArgs         = "args"
 	keyReplicas     = "replicas"
 	keySecretName   = "secretName"
 	keyConfigMap    = "configMap"

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extractor
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("FeaturesExtractor", func() {
+	var featuresExtractor *FeaturesExtractor
+
+	BeforeEach(func() {
+		featuresExtractor = &FeaturesExtractor{}
+	})
+
+	deploymentWithManagerArgs := func(args ...string) *unstructured.Unstructured {
+		argsList := make([]any, len(args))
+		for i, a := range args {
+			argsList[i] = a
+		}
+		return makeDeployment(deploymentOpts{
+			containers: []map[string]any{{
+				keyName:  valManager,
+				keyImage: valControllerImage,
+				keyArgs:  argsList,
+			}},
+		})
+	}
+
+	detect := func(deployment *unstructured.Unstructured) FeatureSet {
+		return featuresExtractor.DetectFeatures(
+			&ResourceSet{Deployment: deployment}, "test-project", "test-system")
+	}
+
+	Describe("DetectFeatures port defaults", func() {
+		It("should default all ports when there is no deployment", func() {
+			features := detect(nil)
+
+			Expect(features.HealthProbePort).To(Equal(8081))
+			Expect(features.MetricsPort).To(Equal(8443))
+			Expect(features.WebhookPort).To(Equal(9443))
+		})
+	})
+
+	Describe("DetectFeatures health probe port", func() {
+		It("should default to 8081 when the bind-address arg is absent", func() {
+			features := detect(deploymentWithManagerArgs("--leader-elect"))
+
+			Expect(features.HealthProbePort).To(Equal(8081))
+		})
+
+		It("should detect a custom port from :PORT form", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=:9091"))
+
+			Expect(features.HealthProbePort).To(Equal(9091))
+		})
+
+		It("should detect a custom port from HOST:PORT form", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=localhost:9091"))
+
+			Expect(features.HealthProbePort).To(Equal(9091))
+		})
+
+		It("should detect a custom port from IPv6 [::1]:PORT form", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=[::1]:9091"))
+
+			Expect(features.HealthProbePort).To(Equal(9091))
+		})
+
+		It("should default to 8081 when the port is not numeric", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=:invalid"))
+
+			Expect(features.HealthProbePort).To(Equal(8081))
+		})
+
+		It("should default to 8081 when the port is out of range", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=:99999"))
+
+			Expect(features.HealthProbePort).To(Equal(8081))
+		})
+
+		It("should default to 8081 when probes are disabled with bind address 0", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=0"))
+
+			Expect(features.HealthProbePort).To(Equal(8081))
+		})
+
+		It("should accept the maximum valid port 65535", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address=:65535"))
+
+			Expect(features.HealthProbePort).To(Equal(65535))
+		})
+
+		It("should default to 8081 when the flag and address are separate args", func() {
+			features := detect(deploymentWithManagerArgs("--health-probe-bind-address", ":9091"))
+
+			Expect(features.HealthProbePort).To(Equal(8081))
+		})
+
+		It("should use the first valid value when the arg is duplicated", func() {
+			features := detect(deploymentWithManagerArgs(
+				"--health-probe-bind-address=:9091",
+				"--health-probe-bind-address=:9092",
+			))
+
+			Expect(features.HealthProbePort).To(Equal(9091))
+		})
+
+		It("should read the arg from the manager container, not a sidecar", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{
+						keyName:  valSidecar,
+						keyImage: valSidecarImage,
+						keyArgs:  []any{"--health-probe-bind-address=:7070"},
+					},
+					{
+						keyName:  valManager,
+						keyImage: valControllerImage,
+						keyArgs:  []any{"--health-probe-bind-address=:9091"},
+					},
+				},
+			})
+
+			features := detect(deployment)
+
+			Expect(features.HealthProbePort).To(Equal(9091))
+		})
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -111,7 +111,7 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 // --health-probe-bind-address arg, the "health" containerPort, and the liveness
 // and readiness httpGet ports.
 func templateHealthProbePort(yamlContent string) string {
-	const healthPortTemplate = "{{ .Values.healthProbe.port }}"
+	const healthPortTemplate = "{{ .Values.manager.healthProbe.port }}"
 
 	// --health-probe-bind-address=:PORT (also HOST:PORT and IPv6 [::1]:PORT)
 	yamlContent = regexp.MustCompile(`--health-probe-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`).

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -199,7 +199,7 @@ spec:
 			Expect(result).To(ContainSubstring("{{- if not .Values.metrics.secure }}"))
 			Expect(result).To(ContainSubstring("- --metrics-secure=false"))
 			Expect(result).To(ContainSubstring("- --metrics-bind-address=0"))
-			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
 			Expect(result).To(ContainSubstring(`{{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}`))
@@ -2442,7 +2442,7 @@ spec:
 
 			result := templater.templatePorts(content, deployment)
 
-			Expect(result).To(ContainSubstring("port: {{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("port: {{ .Values.manager.healthProbe.port }}"))
 			Expect(result).NotTo(ContainSubstring("port: 8081"))
 		})
 
@@ -2482,13 +2482,103 @@ spec:
 
 			result := templater.templatePorts(content, deployment)
 
-			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
-			Expect(result).To(ContainSubstring("containerPort: {{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.manager.healthProbe.port }}"))
 			Expect(result).To(ContainSubstring(`            path: /healthz
-            port: {{ .Values.healthProbe.port }}`))
+            port: {{ .Values.manager.healthProbe.port }}`))
 			Expect(result).To(ContainSubstring(`            path: /readyz
-            port: {{ .Values.healthProbe.port }}`))
+            port: {{ .Values.manager.healthProbe.port }}`))
 			Expect(result).NotTo(ContainSubstring("8081"))
+		})
+
+		It("should leave probes using the named health port untouched", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --health-probe-bind-address=:8081
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring(`            path: /healthz
+            port: health`))
+			Expect(result).To(ContainSubstring(`            path: /readyz
+            port: health`))
+		})
+
+		It("should preserve the host when templating bind-address args in HOST:PORT form", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --metrics-bind-address=localhost:8443
+        - --health-probe-bind-address=localhost:8081`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("--metrics-bind-address=localhost:{{ .Values.metrics.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=localhost:{{ .Values.manager.healthProbe.port }}"))
+		})
+
+		It("should preserve the host when templating bind-address args in IPv6 form", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --metrics-bind-address=[::1]:8443
+        - --health-probe-bind-address=[::1]:8081`
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(ContainSubstring("--metrics-bind-address=[::1]:{{ .Values.metrics.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=[::1]:{{ .Values.manager.healthProbe.port }}"))
 		})
 
 		It("should template port-related args in Deployment", func() {
@@ -2515,7 +2605,7 @@ spec:
 
 			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
 			Expect(result).NotTo(ContainSubstring("--metrics-bind-address=:8443"))
-			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
 			Expect(result).To(ContainSubstring("--leader-elect"))
 		})
 
@@ -2551,8 +2641,8 @@ spec:
 			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
 			Expect(result).To(ContainSubstring("--webhook-port={{ .Values.webhook.port }}"))
 			Expect(result).To(ContainSubstring("containerPort: {{ .Values.webhook.port }}"))
-			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.healthProbe.port }}"))
-			Expect(result).To(ContainSubstring("port: {{ .Values.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("port: {{ .Values.manager.healthProbe.port }}"))
 			Expect(result).NotTo(ContainSubstring(":9091"))
 		})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -124,9 +124,6 @@ crd:
 	// Metrics configuration (always present, enabled based on detected metrics artifacts)
 	f.addMetricsSection(&buf)
 
-	// Health probe configuration (always present; every manager exposes liveness/readiness probes)
-	f.addHealthProbeSection(&buf)
-
 	// Cert-manager configuration (always present)
 	// IMPORTANT: Webhooks REQUIRE cert-manager for TLS certificates.
 	// HasWebhooks = true means cert-manager MUST be enabled.
@@ -210,6 +207,9 @@ func (f *HelmValues) addImageSection(buf *bytes.Buffer) {
 func (f *HelmValues) addDeploymentConfig(buf *bytes.Buffer) {
 	// Args
 	f.addArgsSection(buf)
+
+	// Health probe (always present; every manager exposes liveness/readiness probes)
+	f.addHealthProbeSection(buf)
 
 	// Environment variables
 	f.addEnvSection(buf)
@@ -585,20 +585,20 @@ metrics:
 `)
 }
 
-// addHealthProbeSection adds health probe configuration
+// addHealthProbeSection adds health probe configuration under the manager section
 func (f *HelmValues) addHealthProbeSection(buf *bytes.Buffer) {
 	port := 8081
 	if f.Extraction != nil && f.Extraction.Features.HealthProbePort > 0 {
 		port = f.Extraction.Features.HealthProbePort
 	}
 
-	buf.WriteString(`## Health probe endpoint.
-## Serves the liveness (/healthz) and readiness (/readyz) checks.
-##
-healthProbe:
+	buf.WriteString(`  ## Health probes.
+  ## The manager serves the liveness (/healthz) and readiness (/readyz) endpoints on this port.
+  ##
+  healthProbe:
 `)
-	buf.WriteString("  # Health probe server port\n")
-	fmt.Fprintf(buf, "  port: %d\n\n", port)
+	buf.WriteString("    # Health probe server port\n")
+	fmt.Fprintf(buf, "    port: %d\n\n", port)
 }
 
 // addWebhookSection adds webhook configuration

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package templates
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -189,15 +190,16 @@ var _ = Describe("HelmValues", func() {
 	})
 
 	Describe("Custom ports extraction", func() {
-		Context("when using default ports", func() {
-			It("should use default metrics port 8443 and webhook port 9443", func() {
+		DescribeTable("port values emitted from detected features",
+			func(metricsPort, webhookPort, healthProbePort, wantMetrics, wantWebhook, wantHealthProbe int) {
 				values := &HelmValues{
 					Extraction: &extractor.Extraction{
 						Features: extractor.FeatureSet{
-							HasMetrics:  true,
-							HasWebhooks: true,
-							MetricsPort: 0,
-							WebhookPort: 0,
+							HasMetrics:      true,
+							HasWebhooks:     true,
+							MetricsPort:     metricsPort,
+							WebhookPort:     webhookPort,
+							HealthProbePort: healthProbePort,
 						},
 					},
 				}
@@ -205,83 +207,48 @@ var _ = Describe("HelmValues", func() {
 
 				result := values.generateValues()
 
-				metricsSection := extractSection(result, "metrics:")
-				Expect(metricsSection).To(ContainSubstring("port: 8443"))
+				Expect(extractSection(result, "metrics:")).To(
+					ContainSubstring(fmt.Sprintf("port: %d", wantMetrics)))
+				Expect(extractSection(result, "webhook:")).To(
+					ContainSubstring(fmt.Sprintf("port: %d", wantWebhook)))
+				Expect(extractSection(result, "healthProbe:")).To(
+					ContainSubstring(fmt.Sprintf("port: %d", wantHealthProbe)))
+			},
+			Entry("default ports", 0, 0, 0, 8443, 9443, 8081),
+			Entry("custom metrics port", 8080, 0, 0, 8080, 9443, 8081),
+			Entry("custom webhook port", 0, 9090, 0, 8443, 9090, 8081),
+			Entry("custom health probe port", 0, 0, 9091, 8443, 9443, 9091),
+			Entry("all custom ports", 8888, 9999, 7777, 8888, 9999, 7777),
+		)
 
-				webhookSection := extractSection(result, "webhook:")
-				Expect(webhookSection).To(ContainSubstring("port: 9443"))
+		Context("when the project has no webhooks or metrics", func() {
+			It("should still emit the healthProbe section with the default port", func() {
+				values := &HelmValues{
+					Extraction: &extractor.Extraction{
+						Features: extractor.FeatureSet{
+							HasMetrics:  false,
+							HasWebhooks: false,
+						},
+					},
+				}
+				values.ProjectName = testProjectName
+
+				result := values.generateValues()
+
+				healthProbeSection := extractSection(result, "healthProbe:")
+				Expect(healthProbeSection).To(ContainSubstring("port: 8081"))
 			})
 		})
 
-		Context("when using custom metrics port", func() {
-			It("should use custom metrics port 8080", func() {
-				values := &HelmValues{
-					Extraction: &extractor.Extraction{
-						Features: extractor.FeatureSet{
-							HasMetrics:  true,
-							HasWebhooks: true,
-							MetricsPort: 8080,
-							WebhookPort: 0,
-						},
-					},
-				}
+		Context("healthProbe placement", func() {
+			It("should nest the healthProbe block under the manager section", func() {
+				values := &HelmValues{}
 				values.ProjectName = testProjectName
 
 				result := values.generateValues()
 
-				metricsSection := extractSection(result, "metrics:")
-				Expect(metricsSection).To(ContainSubstring("port: 8080"))
-
-				webhookSection := extractSection(result, "webhook:")
-				Expect(webhookSection).To(ContainSubstring("port: 9443"))
-			})
-		})
-
-		Context("when using custom webhook port", func() {
-			It("should use custom webhook port 9090", func() {
-				values := &HelmValues{
-					Extraction: &extractor.Extraction{
-						Features: extractor.FeatureSet{
-							HasMetrics:  true,
-							HasWebhooks: true,
-							MetricsPort: 0,
-							WebhookPort: 9090,
-						},
-					},
-				}
-				values.ProjectName = testProjectName
-
-				result := values.generateValues()
-
-				metricsSection := extractSection(result, "metrics:")
-				Expect(metricsSection).To(ContainSubstring("port: 8443"))
-
-				webhookSection := extractSection(result, "webhook:")
-				Expect(webhookSection).To(ContainSubstring("port: 9090"))
-			})
-		})
-
-		Context("when using both custom ports", func() {
-			It("should use custom metrics port 8888 and webhook port 9999", func() {
-				values := &HelmValues{
-					Extraction: &extractor.Extraction{
-						Features: extractor.FeatureSet{
-							HasMetrics:  true,
-							HasWebhooks: true,
-							MetricsPort: 8888,
-							WebhookPort: 9999,
-						},
-					},
-				}
-				values.ProjectName = testProjectName
-
-				result := values.generateValues()
-
-				metricsSection := extractSection(result, "metrics:")
-				Expect(metricsSection).To(ContainSubstring("port: 8888"))
-
-				webhookSection := extractSection(result, "webhook:")
-				Expect(webhookSection).To(ContainSubstring("port: 9999"))
+				Expect(result).To(ContainSubstring("  healthProbe:\n    # Health probe server port\n    port: 8081\n"))
+				Expect(result).NotTo(ContainSubstring("\nhealthProbe:"))
 			})
 		})
 	})

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -199,13 +199,13 @@ var _ = Describe("kubebuilder", func() {
 			// helpers.Run drives the full runtime verification against the customized chart:
 			// the pod only reaches Ready if the health probe answers on customHealthProbePort,
 			// the defaulting, validating, and conversion webhook flows work through
-			// customWebhookPort, and the metrics are scraped from customMetricsPort.
+			// customWebhookPort, and the metrics are scraped through the Service port,
+			// which is asserted below to be customMetricsPort.
 			helpers.Run(kbc, helpers.RunOptions{
 				HasWebhook:          true,
 				HasMetrics:          true,
 				HasNetworkPolicies:  true,
 				InstallMethod:       helpers.InstallMethodHelm,
-				MetricsPort:         customMetricsPort,
 				SkipChartGeneration: true, // Chart already generated and customized above
 			})
 
@@ -226,6 +226,10 @@ var _ = Describe("kubebuilder", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ports).To(ContainSubstring(strconv.Itoa(customHealthProbePort)))
 			Expect(ports).To(ContainSubstring(strconv.Itoa(customWebhookPort)))
+
+			By("verifying the metrics Service exposes the custom port")
+			namePrefix := fmt.Sprintf("e2e-%s", kbc.TestSuffix)
+			Expect(helpers.GetMetricsServicePort(namePrefix, kbc)).To(Equal(customMetricsPort))
 		})
 
 		It("should generate a namespeced runnable project using webhooks and installed with the HelmChart", func() {

--- a/test/e2e/internal/helpers/plugin_test_helper.go
+++ b/test/e2e/internal/helpers/plugin_test_helper.go
@@ -71,10 +71,6 @@ type RunOptions struct {
 	HelmFullnameOverride string
 	// SkipChartGeneration skips build-installer and chart generation (chart already prepared externally)
 	SkipChartGeneration bool
-	// MetricsPort is the port the metrics service is exposed on. Defaults to 8443 when zero.
-	// Set this when the chart's metrics.port has been customized so the metrics are scraped
-	// from the right port.
-	MetricsPort int
 }
 
 // Run executes common e2e tests for a scaffolded project.
@@ -314,7 +310,7 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 
 	if opts.HasMetrics {
 		By("checking the metrics values to validate that the created resource object gets reconciled")
-		metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc, opts.MetricsPort)
+		metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc)
 		Expect(metricsOutput).To(ContainSubstring(fmt.Sprintf(
 			`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
 			strings.ToLower(kbc.Kind),
@@ -412,7 +408,7 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 
 		if opts.HasMetrics {
 			By("validating conversion metrics to confirm conversion operations")
-			metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc, opts.MetricsPort)
+			metricsOutput := GetMetricsOutput(controllerPodName, namePrefix, kbc)
 			conversionMetric := `controller_runtime_reconcile_total{controller="conversiontest",result="success"} 1`
 			Expect(metricsOutput).To(ContainSubstring(conversionMetric),
 				"Expected metric for successful ConversionTest reconciliation")

--- a/test/e2e/internal/helpers/plugin_test_metrics.go
+++ b/test/e2e/internal/helpers/plugin_test_metrics.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,13 +82,31 @@ func GetControllerPodName(kbc *utils.TestContext) string {
 	return controllerPodName
 }
 
-// defaultMetricsPort is the port the metrics service listens on when values.yaml is not customized.
+// defaultMetricsPort is the scaffolded metrics port, used by ValidateMetricsUnavailable
+// where no metrics service exists to read the port from.
 const defaultMetricsPort = 8443
+
+// GetMetricsServicePort returns the port exposed by the controller-manager metrics Service.
+// namePrefix is the prefix for service names (e.g., "e2e-{suffix}" or "custom-operator" from fullnameOverride)
+func GetMetricsServicePort(namePrefix string, kbc *utils.TestContext) int {
+	metricsServiceName := fmt.Sprintf("%s-controller-manager-metrics-service", namePrefix)
+	portOutput, err := kbc.Kubectl.Get(
+		true,
+		"service", metricsServiceName,
+		"-o", "jsonpath={.spec.ports[*].port}",
+	)
+	Expect(err).NotTo(HaveOccurred(), "Controller-manager service should exist")
+	ports := strings.Fields(portOutput)
+	Expect(ports).To(HaveLen(1), "Metrics service should expose exactly one port, got: %q", portOutput)
+	port, err := strconv.Atoi(ports[0])
+	Expect(err).NotTo(HaveOccurred(), "Metrics service port should be numeric")
+	return port
+}
 
 // GetMetricsOutput returns the metrics output from curl pod
 // namePrefix is the prefix for service names (e.g., "e2e-{suffix}" or "custom-operator" from fullnameOverride)
-// metricsPort is the port the metrics service is exposed on; pass 0 to use the default (8443).
-func GetMetricsOutput(controllerPodName, namePrefix string, kbc *utils.TestContext, metricsPort int) string {
+// The scrape port is read from the deployed metrics Service, so customized ports are honored automatically.
+func GetMetricsOutput(controllerPodName, namePrefix string, kbc *utils.TestContext) string {
 	var err error
 	// All Kubebuilder projects are cluster-scoped, so use ClusterRoleBinding
 	_, err = kbc.Kubectl.Command(
@@ -109,15 +128,12 @@ func GetMetricsOutput(controllerPodName, namePrefix string, kbc *utils.TestConte
 	Expect(token).NotTo(BeEmpty())
 
 	var metricsOutput string
-	By("validating that the controller-manager service is available")
-	_, err = kbc.Kubectl.Get(
-		true,
-		"service", fmt.Sprintf("%s-controller-manager-metrics-service", namePrefix),
-	)
-	Expect(err).NotTo(HaveOccurred(), "Controller-manager service should exist")
+	metricsServiceName := fmt.Sprintf("%s-controller-manager-metrics-service", namePrefix)
+
+	By("reading the metrics port from the controller-manager service")
+	metricsPort := GetMetricsServicePort(namePrefix, kbc)
 
 	By("ensuring the service endpoint is ready")
-	metricsServiceName := fmt.Sprintf("%s-controller-manager-metrics-service", namePrefix)
 	checkServiceEndpoint := func(g Gomega) {
 		var output string
 		output, err = kbc.Kubectl.Command(
@@ -245,9 +261,6 @@ func ValidateMetricsUnavailable(namePrefix string, kbc *utils.TestContext) {
 }
 
 func cmdOptsToCreateCurlPod(namePrefix string, kbc *utils.TestContext, token string, metricsPort int) []string {
-	if metricsPort == 0 {
-		metricsPort = defaultMetricsPort
-	}
 	cmdOpts := []string{
 		"run", "curl",
 		"--restart=Never",

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -83,7 +83,7 @@ spec:
         # Bind to :0 to disable the controller-runtime managed metrics server
         - --metrics-bind-address=0
         {{- end }}
-        - --health-probe-bind-address=:{{ .Values.healthProbe.port }}
+        - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}
@@ -116,12 +116,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: {{ .Values.healthProbe.port }}
+        - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}
@@ -130,7 +130,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: {{ .Values.healthProbe.port }}
+            port: {{ .Values.manager.healthProbe.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -27,6 +27,13 @@ manager:
   args:
     - --leader-elect
 
+  ## Health probes.
+  ## The manager serves the liveness (/healthz) and readiness (/readyz) endpoints on this port.
+  ##
+  healthProbe:
+    # Health probe server port
+    port: 8081
+
   ## Environment variables
   ##
   env:
@@ -175,13 +182,6 @@ metrics:
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
   # Note: Metrics authn/authz needs ClusterRole access.
   secure: true
-
-## Health probe endpoint.
-## Serves the liveness (/healthz) and readiness (/readyz) checks.
-##
-healthProbe:
-  # Health probe server port
-  port: 8081
 
 ## Cert-manager integration for TLS certificates.
 ## Required for webhook certificates and metrics endpoint certificates.


### PR DESCRIPTION
Follow-up to #5866, which made the health probe port configurable but did not update the plugin docs.

- Document `healthProbe.po the helm/v2-alpha bookpage, matching the existing webhook port section
- Cover health probe port r: defaults, `:PORT`,`HOST:PORT`, IPv6, invalid values, and manager vs sidecar container
- Cover all port combinatiion with a `DescribeTable`
- Cover `HOST:PORT` and IPv6 bind-address forms in the templater
- e2e: read the metrics sced Service instead ofpassing it through `RunOptions`, and assert the Service exposes the customized port

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
