### PR TITLE
🌱 (helm/v2-alpha): Extract webhook port from manager --webhook-port argument (follow up of #5884 and #5868)

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
@@ -442,7 +442,13 @@ func extractContainerArgs(container map[string]any, config map[string]any) {
 		if strings.Contains(strArg, "--health-probe-bind-address") {
 			continue
 		}
+		// Extract port from webhook-port. The arg itself is filtered out.
 		if strings.Contains(strArg, "--webhook-port") {
+			if port := ExtractPortFromArg(strArg); port > 0 {
+				if _, exists := config["webhookPort"]; !exists {
+					config["webhookPort"] = port
+				}
+			}
 			continue
 		}
 		if strings.Contains(strArg, "--webhook-cert-path") ||

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -416,6 +416,53 @@ var _ = Describe("DeploymentExtractor", func() {
 		)
 	})
 
+	Describe("Webhook port extraction", func() {
+		It("should extract webhook port from --webhook-port argument in deployment args", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{
+						keyName:  valManager,
+						keyImage: valControllerImage,
+						"args": []any{
+							"--webhook-port=9443",
+						},
+					},
+				},
+			})
+
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.WebhookPort).To(Equal(9443))
+		})
+
+		It("should prioritize --webhook-port argument over container ports", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{
+						keyName:  valManager,
+						keyImage: valControllerImage,
+						"args": []any{
+							"--webhook-port=8443",
+						},
+						"ports": []any{
+							map[string]any{
+								"name":          "webhook-server",
+								"containerPort": int64(9443),
+							},
+						},
+					},
+				},
+			})
+
+			config, err := (&DeploymentExtractor{}).ExtractDeploymentConfig(deployment)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.WebhookPort).To(Equal(8443))
+
+			portFromDeployment := extractWebhookPortFromDeployment(deployment)
+			Expect(portFromDeployment).To(Equal(8443))
+		})
+	})
+
 	Describe("ExtractDeploymentConfig extraVolumes extraction", func() {
 		It("should extract custom volumes without mutating the deployment", func() {
 			deployment := makeDeployment(deploymentOpts{

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -170,7 +170,8 @@ func extractPortFromService(svc *unstructured.Unstructured) int {
 	return port
 }
 
-// extractWebhookPortFromDeployment extracts the webhook port from deployment container ports.
+// extractWebhookPortFromDeployment extracts the webhook port from the manager
+// container's --webhook-port argument, or from the container ports.
 func extractWebhookPortFromDeployment(deployment *unstructured.Unstructured) int {
 	specMap := extractDeploymentSpec(deployment)
 	if specMap == nil {
@@ -179,6 +180,20 @@ func extractWebhookPortFromDeployment(deployment *unstructured.Unstructured) int
 	container := findManagerContainer(deployment, specMap)
 	if container == nil {
 		return 0
+	}
+
+	// The manager binds the port from its --webhook-port argument, so that
+	// value wins over the declared container port.
+	if argsField, found, err := unstructured.NestedFieldNoCopy(container, "args"); found && err == nil {
+		if argsList, ok := argsField.([]any); ok {
+			for _, a := range argsList {
+				if strArg, ok := a.(string); ok && strings.Contains(strArg, "--webhook-port") {
+					if port := ExtractPortFromArg(strArg); port > 0 {
+						return port
+					}
+				}
+			}
+		}
 	}
 
 	portsField, found, err := unstructured.NestedFieldNoCopy(container, "ports")


### PR DESCRIPTION
Fixes #5890

### Motivation
Previously, the `helm/v2-alpha` plugin extractor parsed metrics and health probe ports from manager container arguments (`--metrics-bind-address` and `--health-probe-bind-address`) using `ExtractPortFromArg`. However, the webhook port was only read from the container's declared `ports` list in `extractWebhookPortFromDeployment`, and `--webhook-port` was filtered out in `extractContainerArgs` without reading its value.

Since the manager process actually binds the port specified in `--webhook-port`, the argument value should take precedence over the declared container port, making port extraction consistent across metrics, health probe, and webhook servers.

### Changes
1. **`pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go`**:
   - Updated `extractWebhookPortFromDeployment` to scan container `args` for `--webhook-port=` first, reusing `ExtractPortFromArg`, with container ports as fallback.
2. **`pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go`**:
   - Updated `extractContainerArgs` to extract the port from `--webhook-port` into `config["webhookPort"]` before filtering the argument out.
3. **`pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go`**:
   - Added unit tests verifying `--webhook-port` argument extraction and its precedence over declared container ports.