### PR TITLE
✨ (go/v4, API): reject bare-domain external Resource.Path

### DIFF
--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -84,9 +84,13 @@ func (r Resource) Validate() error {
 		if err := module.CheckImportPath(r.Path); err != nil {
 			return fmt.Errorf("invalid Path: must be a valid Go import path: %w", err)
 		}
-		first, _, _ := strings.Cut(r.Path, "/")
+		first, rest, _ := strings.Cut(r.Path, "/")
 		if !strings.Contains(first, ".") || strings.HasPrefix(first, ".") {
 			return fmt.Errorf("invalid Path: must be a fully-qualified Go import path " +
+				"(e.g., github.com/org/repo/api/v1)")
+		}
+		if rest == "" {
+			return fmt.Errorf("invalid Path: must include a package sub-path " +
 				"(e.g., github.com/org/repo/api/v1)")
 		}
 	} else if r.Path != "" {

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -143,6 +143,7 @@ var _ = Describe("Resource", func() {
 				Expect(err.Error()).To(ContainSubstring(message))
 			},
 			Entry("empty path", "", "external resources must specify a path"),
+			Entry("bare domain", "example.com", "must include a package sub-path"),
 			Entry("absolute filesystem path", "/absolute/path", "must be a valid Go import path"),
 			Entry("relative package path", "api/v1", "must be a fully-qualified Go import path"),
 			Entry("leading-dot pseudo-domain", ".com/api/v1", "must be a fully-qualified Go import path"),

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -151,6 +151,18 @@ var _ = Describe("createAPISubcommand", func() {
 		Expect(err.Error()).To(ContainSubstring("must be a fully-qualified Go import path"))
 	})
 
+	It("should reject bare domain external-api-path", func() {
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+		subCmd.options.ExternalAPIPath = "example.com"
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid Path"))
+		Expect(err.Error()).To(ContainSubstring("must include a package sub-path"))
+	})
+
 	It("should reject leading-dot pseudo-domain external-api-path", func() {
 		subCmd.options.DoAPI = false
 		subCmd.options.DoController = true

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -103,10 +103,12 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 		"Comma-separated list of spoke versions to be added to the conversion webhook (e.g., --spoke v1,v2)")
 
 	fs.StringVar(&p.options.DefaultingPath, "defaulting-path", "",
-		"Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path); only valid with --defaulting")
+		"[Optional] Custom path for the defaulting/mutating webhook (e.g., /my-custom-mutate-path). "+
+			"Only valid with --defaulting")
 
 	fs.StringVar(&p.options.ValidationPath, "validation-path", "",
-		"Custom path for the validation webhook (e.g., /my-custom-validate-path); only valid with --programmatic-validation")
+		"[Optional] Custom path for the validation webhook (e.g., /my-custom-validate-path). "+
+			"Only valid with --programmatic-validation")
 
 	fs.StringVar(&p.options.ExternalAPIPath, "external-api-path", "",
 		"Go package import path for the external API (e.g., github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1). "+


### PR DESCRIPTION
Follow-up to #5766: external path validation accepted a bare domain (e.g. "example.com") because strings.Cut's found result was ignored, letting invalid paths persist and fail later at build time. Now require a package sub-path, add resource and plugin-layer tests, and restore the [Optional] prefix on the --defaulting-path/--validation-path flag help.
