### PR TITLE
🐛 fix: use fully qualified docker.io image refs in scaffolding

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/cronjob-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/getting-started/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/docs/book/src/getting-started/testdata/project/Dockerfile
+++ b/docs/book/src/getting-started/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
+++ b/docs/book/src/multiversion-tutorial/testdata/project/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/pkg/plugins/golang/v4/edit_test.go
+++ b/pkg/plugins/golang/v4/edit_test.go
@@ -172,7 +172,7 @@ var _ = Describe("editSubcommand", func() {
 			}
 
 			// Create necessary files for edit to work
-			err = os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte("FROM golang:1.23"), 0o644)
+			err = os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte("FROM docker.io/library/golang:1.23"), 0o644)
 			Expect(err).NotTo(HaveOccurred())
 
 			DeferCleanup(func() {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/devcontainer.go
@@ -29,10 +29,10 @@ import (
 //   - --privileged - Required for Docker daemon to run inside container (DinD)
 //   - --init - Properly handles zombie processes and signal forwarding
 //   - GO111MODULE=on - Ensures Go modules work consistently
-//   - Runs as root (golang:1.25 default) - no sudo needed in post-install script
+//   - Runs as root (docker.io/library/golang:1.25 default) - no sudo needed in post-install script
 const devContainerTemplate = `{
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerfile.go
@@ -39,7 +39,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 }
 
 const dockerfileTemplate = `# Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-multigroup/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/testdata/project-v4-multigroup/Dockerfile
+++ b/testdata/project-v4-multigroup/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
+++ b/testdata/project-v4-with-plugins/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/testdata/project-v4-with-plugins/Dockerfile
+++ b/testdata/project-v4-with-plugins/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/testdata/project-v4/.devcontainer/devcontainer.json
+++ b/testdata/project-v4/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.26",
+  "image": "docker.io/library/golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": false,

--- a/testdata/project-v4/Dockerfile
+++ b/testdata/project-v4/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Description

Scaffolded Dockerfiles and devcontainers use unqualified `golang:X` image names. Docker defaults those to `docker.io`, but **buildah/podman** do not, which breaks builds (issue #5719).

This restores fully qualified `docker.io/library/golang` refs in:

- `pkg/plugins/golang/v4` Dockerfile + devcontainer templates
- regenerated testdata / book tutorial projects

Related history: #4513 landed a similar fix and was later reverted in #4818.

## Which issue(s) this PR fixes

Fixes #5719

## Special notes for your reviewer

Intentional scope is Docker Hub golang images only; `gcr.io/distroless/...` was already fully qualified.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/kubernetes-sigs/kubebuilder/blob/master/CONTRIBUTING.md)
- [x] PR title uses conventional emoji style for release notes