### PR TITLE
🐛 (go/v4, helm/v2-alpha): ensure NetworkPolicies are correct and consistent

### DIFF
--- a/.github/workflows/test-e2e-samples.yml
+++ b/.github/workflows/test-e2e-samples.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           # Enable [METRICS-WITH-CERTS] by uncommenting the lines in kustomization.yaml
           KUSTOMIZATION_FILE_PATH="testdata/project-v4/config/default/kustomization.yaml"
-          sed -i '47,49s/^#//' $KUSTOMIZATION_FILE_PATH
+          sed -i '46,48s/^#//' "$KUSTOMIZATION_FILE_PATH"
           cd testdata/project-v4/
           go mod tidy
 

--- a/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           helm lint ./dist/chart
 
-
       - name: Install cert-manager via Helm (wait for readiness)
         run: |
           helm repo add jetstack https://charts.jetstack.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/default/kustomization.yaml
@@ -29,10 +29,9 @@ resources:
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -1,6 +1,5 @@
-# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,7 +16,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -1,6 +1,8 @@
-# This NetworkPolicy allows ingress traffic to your webhook server running
-# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
-# will only work when applied in namespaces labeled with 'webhook: enabled'
+# Allow ingress to the webhook server's pod port (9443) from all sources.
+# The webhook Service exposes port 443 and forwards traffic to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,11 +19,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label webhook: enabled
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled # Only from namespaces with this label
-      ports:
-        - port: 443
+    - ports:
+        - port: 9443
           protocol: TCP

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled .Values.webhook.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -93,7 +93,7 @@ spec:
         {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         {{- end }}
-        {{- if .Values.certManager.enabled }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         {{- end }}
         command:
@@ -143,7 +143,7 @@ spec:
             name: metrics-certs
             readOnly: true
           {{- end }}
-          {{- if .Values.certManager.enabled }}
+          {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: webhook-certs
             readOnly: true
@@ -175,7 +175,7 @@ spec:
             optional: false
             secretName: metrics-server-cert
         {{- end }}
-        {{- if .Values.certManager.enabled }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,5 +1,10 @@
 {{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
 ---
+# Allow ingress to the webhook server's pod port from all sources.
+# The webhook Service forwards traffic from its Service port to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,11 +21,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled
-      ports:
+    - ports:
         - port: {{ .Values.webhook.port }}
           protocol: TCP
 {{- end }}

--- a/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/default/kustomization.yaml
@@ -27,10 +27,9 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/docs/book/src/getting-started/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -1,6 +1,5 @@
-# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,7 +16,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -172,6 +172,13 @@ metrics:
 certManager:
   enabled: false
 
+## Webhook server configuration
+##
+webhook:
+  enabled: false
+  # Webhook server port
+  port: 9443
+
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##

--- a/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.github/workflows/test-chart.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           helm lint ./dist/chart
 
-
       - name: Install cert-manager via Helm (wait for readiness)
         run: |
           helm repo add jetstack https://charts.jetstack.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/default/kustomization.yaml
@@ -29,10 +29,9 @@ resources:
 - ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-metrics-traffic.yaml
@@ -1,6 +1,5 @@
-# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,7 +16,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/config/network-policy/allow-webhook-traffic.yaml
@@ -1,6 +1,8 @@
-# This NetworkPolicy allows ingress traffic to your webhook server running
-# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
-# will only work when applied in namespaces labeled with 'webhook: enabled'
+# Allow ingress to the webhook server's pod port (9443) from all sources.
+# The webhook Service exposes port 443 and forwards traffic to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,11 +19,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label webhook: enabled
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled # Only from namespaces with this label
-      ports:
-        - port: 443
+    - ports:
+        - port: 9443
           protocol: TCP

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled .Values.webhook.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/crd/cronjobs.batch.tutorial.kubebuilder.io.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.crd.enabled (not .Values.webhook.enabled) }}
+{{- fail "webhook.enabled must be true for CRD conversion" }}
+{{- end }}
 {{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -93,7 +93,7 @@ spec:
         {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         {{- end }}
-        {{- if .Values.certManager.enabled }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         {{- end }}
         command:
@@ -143,7 +143,7 @@ spec:
             name: metrics-certs
             readOnly: true
           {{- end }}
-          {{- if .Values.certManager.enabled }}
+          {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: webhook-certs
             readOnly: true
@@ -175,7 +175,7 @@ spec:
             optional: false
             secretName: metrics-server-cert
         {{- end }}
-        {{- if .Values.certManager.enabled }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,5 +1,10 @@
 {{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
 ---
+# Allow ingress to the webhook server's pod port from all sources.
+# The webhook Service forwards traffic from its Service port to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,11 +21,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled
-      ports:
+    - ports:
         - port: {{ .Values.webhook.port }}
           protocol: TCP
 {{- end }}

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -183,25 +183,34 @@ make helm-status
 Install manually with all features enabled:
 
 ```bash
-helm install my-release ./dist/chart --namespace my-project-system --create-namespace
+$ helm install my-release ./dist/chart --namespace my-project-system --create-namespace
 ```
 
-Install only CRDs and RBAC:
+For charts without conversion webhooks, disable the manager and all optional
+components by setting all of these values to `false`:
 
 ```bash
-helm install my-release ./dist/chart --set manager.enabled=false --set webhook.enabled=false
+$ helm install my-release ./dist/chart \
+  --set manager.enabled=false \
+  --set metrics.enabled=false \
+  --set webhook.enabled=false \
+  --set prometheus.enabled=false \
+  --set certManager.enabled=false \
+  --set networkPolicy.enabled=false
 ```
 
-Install without webhooks:
+For charts without conversion webhooks, install without webhooks:
 
 ```bash
-helm install my-release ./dist/chart --set webhook.enabled=false --set certManager.enabled=false
+$ helm install my-release ./dist/chart --set webhook.enabled=false --set certManager.enabled=false
 ```
+
+Charts with CR version conversion reject `webhook.enabled=false`. The API server needs the webhook Service to convert custom resources.
 
 Install with NetworkPolicy resources:
 
 ```bash
-helm install my-release ./dist/chart --set networkPolicy.enabled=true
+$ helm install my-release ./dist/chart --set networkPolicy.enabled=true
 ```
 
 ### Extra volumes
@@ -249,7 +258,7 @@ The `metrics-auth-role` and `metrics-reader` are always ClusterRoles, even when 
 
 ### Webhook port configuration
 
-Set `webhook.port` to change the port used by the manager webhook server. The chart applies the same value to the manager argument, container port, webhook service, and webhook NetworkPolicy.
+Set `webhook.port` to change the manager argument, container port, Service target port, and NetworkPolicy. The Service's exposed port remains unchanged (`443` in the default manifests).
 
 For example, install the chart with the webhook server on port `9444`:
 
@@ -297,7 +306,19 @@ The chart already exposes `--metrics-bind-address`, `--webhook-port`, and `--hea
 
 Set `networkPolicy.enabled: true` to install NetworkPolicy resources for the manager pod.
 
-When the kustomize output includes `NetworkPolicy` resources, the plugin converts them into chart templates and sets `networkPolicy.enabled: true`. When no `NetworkPolicy` resources are present in the kustomize output, the plugin generates default templates for metrics traffic, and also for webhook traffic when webhooks are detected in the provided kustomize input files.
+When the kustomize output includes `NetworkPolicy` resources, the plugin converts and enables them. Otherwise, it generates a default metrics policy and, when it detects an admission or CRD conversion webhook, a default webhook policy.
+
+The plugin preserves default NetworkPolicy templates unless you pass `--force`. Policies from the kustomize output always regenerate, so edit them in `config/network-policy/`.
+
+The generated metrics policy is rendered only when both `networkPolicy.enabled` and `metrics.enabled` are `true`. The generated webhook policy is rendered only when both `networkPolicy.enabled` and `webhook.enabled` are `true`.
+
+The metrics policy allows ingress only from pods in namespaces labeled `metrics: enabled`. Label each namespace whose pods should scrape metrics:
+
+```bash
+$ kubectl label namespace <namespace> metrics=enabled
+```
+
+The default webhook policy allows ingress from all sources to the manager pod's webhook port. The API server reaches this port through the webhook Service for admission and CRD conversion webhooks. To restrict admission requests by namespace, set `namespaceSelector` on the `MutatingWebhookConfiguration` or `ValidatingWebhookConfiguration`. This setting controls which requests invoke an admission webhook; it does not restrict NetworkPolicy traffic.
 
 ### Custom labels and annotations
 

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -352,19 +352,31 @@ project to use certificates managed by CertManager.
     integration with Prometheus. To enable the integration with Prometheus, you need uncomment the `#- ../certmanager`
     in the `config/default/kustomization.yaml`. For more information, see [Exporting Metrics for Prometheus](#exporting-metrics-for-prometheus).
 
-### **(Optional)** By using network policy (disabled by default)
+### **(Optional)** Use a NetworkPolicy (disabled by default)
 
-NetworkPolicy acts as a basic firewall for pods within a Kubernetes cluster, controlling traffic
-flow at the IP address or port level. However, it does not handle `authn/authz`.
+NetworkPolicy controls network traffic to and from pods. It does not provide authentication or
+authorization.
 
 Uncomment the following line in the `config/default/kustomization.yaml`:
 
 ```yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' are able to gather the metrics.
-# Only CR(s) which uses webhooks and applied on namespaces labeled 'webhooks: enabled' are able to work properly.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 ```
+
+Then, label each namespace whose pods should scrape metrics:
+
+```bash
+$ kubectl label namespace <namespace> metrics=enabled
+```
+
+The webhook NetworkPolicy allows ingress from all sources to the manager pod's webhook port.
+The Kubernetes API server reaches this port through the webhook Service for admission and CRD
+conversion webhooks. To restrict admission requests by namespace, set `namespaceSelector` on the
+`MutatingWebhookConfiguration` or `ValidatingWebhookConfiguration`. This setting controls which
+requests invoke an admission webhook; it does not restrict NetworkPolicy traffic.
 
 ## Exporting metrics for Prometheus
 

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go
@@ -73,10 +73,9 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-metrics-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-metrics-traffic.go
@@ -42,9 +42,8 @@ func (f *PolicyAllowMetrics) SetTemplateDefaults() error {
 	return nil
 }
 
-const metricsNetworkPolicyTemplate = `# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+const metricsNetworkPolicyTemplate = `# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -61,7 +60,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
+++ b/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/network-policy/allow-webhook-traffic.go
@@ -24,8 +24,7 @@ import (
 
 var _ machinery.Template = &PolicyAllowWebhooks{}
 
-// PolicyAllowWebhooks in scaffolds a file that defines the NetworkPolicy
-// to allow the webhook server can communicate
+// PolicyAllowWebhooks scaffolds a NetworkPolicy that allows traffic to the webhook server.
 type PolicyAllowWebhooks struct {
 	machinery.TemplateMixin
 	machinery.ProjectNameMixin
@@ -42,9 +41,11 @@ func (f *PolicyAllowWebhooks) SetTemplateDefaults() error {
 	return nil
 }
 
-const webhooksNetworkPolicyTemplate = `# This NetworkPolicy allows ingress traffic to your webhook server running
-# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
-# will only work when applied in namespaces labeled with 'webhook: enabled'
+const webhooksNetworkPolicyTemplate = `# Allow ingress to the webhook server's pod port (9443) from all sources.
+# The webhook Service exposes port 443 and forwards traffic to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -61,12 +62,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label webhook: enabled
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled # Only from namespaces with this label
-      ports:
-        - port: 443
+    - ports:
+        - port: 9443
           protocol: TCP
 `

--- a/pkg/plugins/optional/helm/v2alpha/edit.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -55,11 +54,11 @@ type editSubcommand struct {
 
 //nolint:lll
 func (p *editSubcommand) UpdateMetadata(cliMeta plugin.CLIMetadata, subcmdMeta *plugin.SubcommandMetadata) {
-	subcmdMeta.Description = `Generate a Helm chart from your project's kustomize output.
+	subcmdMeta.Description = `Generate a Helm chart from your project's Kustomize output.
 
-Parses 'make build-installer' output (dist/install.yaml) and generates chart to allow easy
-distribution of your project. It also scaffolds default ServiceMonitor and NetworkPolicy templates
-when the kustomize output does not provide them. When enabled, adds Helm helpers targets to Makefile`
+The command reads 'make build-installer' output from dist/install.yaml by default. It adds default
+ServiceMonitor and NetworkPolicy templates when they are missing. On the first run, it also adds
+Helm deployment targets to the Makefile.`
 
 	subcmdMeta.Examples = fmt.Sprintf(`# Generate Helm chart from default manifests (dist/install.yaml) to default output (dist/)
   %[1]s edit --plugins=%[2]s
@@ -82,10 +81,9 @@ when the kustomize output does not provide them. When enabled, adds Helm helpers
 
 **NOTE**: Chart.yaml is never overwritten (contains user-managed version info).
 Without --force, the plugin also preserves values.yaml, NOTES.txt, _helpers.tpl, .helmignore,
-.github/workflows/test-chart.yml, network-policy/allow-metrics-traffic.yaml, and
-network-policy/allow-webhook-traffic.yaml.
-All other template files in templates/ are always regenerated to match your current
-kustomize output. Use --force to regenerate all files except Chart.yaml.
+.github/workflows/test-chart.yml, and default NetworkPolicy and ServiceMonitor templates.
+Templates from the kustomize output always regenerate. Use --force to regenerate all files
+except Chart.yaml.
 
 The generated chart structure mirrors your config/ directory:
 <output>/chart/
@@ -205,43 +203,6 @@ func (p *editSubcommand) ensureManifestsExist() error {
 	}
 
 	slog.Info("Successfully generated manifests file", "file", p.manifestsFile)
-	return nil
-}
-
-func (p *editSubcommand) PostScaffold() error {
-	hasWebhooks := hasWebhooksWith(p.config)
-
-	if hasWebhooks {
-		workflowFile := filepath.Join(".github", "workflows", "test-chart.yml")
-		if _, err := os.Stat(workflowFile); err != nil {
-			slog.Info(
-				"Workflow file not found, unable to uncomment cert-manager installation",
-				"error", err,
-				"file", workflowFile,
-			)
-			return nil
-		}
-		target := `
-#      - name: Install cert-manager via Helm (wait for readiness)
-#        run: |
-#          helm repo add jetstack https://charts.jetstack.io
-#          helm repo update
-#          helm install cert-manager jetstack/cert-manager \
-#            --namespace cert-manager \
-#            --create-namespace \
-#            --set crds.enabled=true \
-#            --wait \
-#            --timeout 300s`
-		if err := util.UncommentCode(workflowFile, target, "#"); err != nil {
-			hasUncommented, errCheck := util.HasFileContentWith(workflowFile, "- name: Install cert-manager via Helm")
-			if !hasUncommented || errCheck != nil {
-				slog.Warn("Failed to uncomment cert-manager installation in workflow file", "error", err, "file", workflowFile)
-			}
-		} else {
-			target = `# TODO: Uncomment if cert-manager is enabled`
-			_ = util.ReplaceInFile(workflowFile, target, "")
-		}
-	}
 	return nil
 }
 
@@ -379,21 +340,6 @@ helm-rollback: ## Rollback to previous Helm release.
 
 func helmMakefileTemplate(namespace, release, outputDir string) string {
 	return fmt.Sprintf(helmMakefileTemplateFormat, namespace, release, outputDir)
-}
-
-func hasWebhooksWith(c config.Config) bool {
-	resources, err := c.GetResources()
-	if err != nil {
-		return false
-	}
-
-	for _, res := range resources {
-		if res.HasDefaultingWebhook() || res.HasValidationWebhook() || res.HasConversionWebhook() {
-			return true
-		}
-	}
-
-	return false
 }
 
 // removeV1AlphaPluginEntry removes the deprecated helm.kubebuilder.io/v1-alpha plugin entry.

--- a/pkg/plugins/optional/helm/v2alpha/edit_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/edit_test.go
@@ -74,7 +74,7 @@ version: "3"
 			editCmd.UpdateMetadata(cliMeta, &meta)
 
 			Expect(meta.Description).To(ContainSubstring("Generate a Helm chart"))
-			Expect(meta.Description).To(ContainSubstring("kustomize"))
+			Expect(meta.Description).To(ContainSubstring("Kustomize"))
 			Expect(meta.Examples).NotTo(BeEmpty())
 		})
 	})
@@ -103,13 +103,6 @@ version: "3"
 			err := editCmd.InjectConfig(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(editCmd.config).To(Equal(cfg))
-		})
-	})
-
-	Context("hasWebhooksWith", func() {
-		It("should return false for config without webhooks", func() {
-			result := hasWebhooksWith(cfg)
-			Expect(result).To(BeFalse())
 		})
 	})
 
@@ -211,61 +204,6 @@ version: "3"
 			err = reloadedCfg.DecodePluginConfig(v1AlphaPluginKey, &v1AlphaCfg)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("plugin key"))
-		})
-	})
-
-	Context("PostScaffold", func() {
-		BeforeEach(func() {
-			// Create the directory structure
-			err := fs.FS.MkdirAll(".github/workflows", 0o755)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should not modify workflow file when no webhooks present", func() {
-			// Create test workflow file
-			workflowContent := `name: Test Chart
-on:
-  push:
-    branches: [main]
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-#      - name: Install cert-manager via Helm
-#        run: |
-#          helm repo add jetstack https://charts.jetstack.io
-#          helm repo update
-#          helm install cert-manager jetstack/cert-manager \
-#            --namespace cert-manager --create-namespace --set crds.enabled=true
-#
-#      - name: Wait for cert-manager to be ready
-#        run: |
-#          kubectl wait --namespace cert-manager --for=condition=available \
-#            --timeout=300s deployment/cert-manager
-#          kubectl wait --namespace cert-manager --for=condition=available \
-#            --timeout=300s deployment/cert-manager-cainjector
-#          kubectl wait --namespace cert-manager --for=condition=available \
-#            --timeout=300s deployment/cert-manager-webhook
-`
-			workflowPath := filepath.Join(".github", "workflows", "test-chart.yml")
-			err := afero.WriteFile(fs.FS, workflowPath, []byte(workflowContent), 0o644)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = editCmd.PostScaffold()
-			Expect(err).NotTo(HaveOccurred())
-
-			// Content should remain unchanged
-			content, err := afero.ReadFile(fs.FS, workflowPath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(ContainSubstring("#      - name: Install cert-manager via Helm"))
-		})
-
-		It("should handle missing workflow file gracefully", func() {
-			editCmd.config = cfg
-			err := editCmd.PostScaffold()
-			Expect(err).NotTo(HaveOccurred()) // Should not error even if file doesn't exist
 		})
 	})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder.go
@@ -122,7 +122,10 @@ func (s *ChartScaffolder) PrepareTemplates(_ machinery.Filesystem) ([]machinery.
 	chartBuilders := chartConverter.GetChartBuilders()
 
 	builders := []machinery.Builder{
-		&github.HelmChartCI{Force: s.config.Force},
+		&github.HelmChartCI{
+			Force:       s.config.Force,
+			HasWebhooks: extraction.Features.HasWebhooks,
+		},
 		&templates.HelmChart{
 			OutputDir:     s.config.OutputDir,
 			ChartMetadata: extraction.Metadata,

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/chart_scaffolder_test.go
@@ -45,7 +45,8 @@ var _ = Describe("ChartScaffolder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			rendered := string(content)
-			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(rendered).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(rendered).To(ContainSubstring("kind: NetworkPolicy"))
 			Expect(rendered).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))
@@ -83,7 +84,6 @@ var _ = Describe("ChartScaffolder", func() {
 				"dist/chart/templates/network-policy/allow-webhook-traffic.yaml",
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(webhookPolicy)).To(ContainSubstring("webhook: enabled"))
 			Expect(string(webhookPolicy)).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
 		})
 
@@ -100,7 +100,8 @@ var _ = Describe("ChartScaffolder", func() {
 			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			rendered := string(content)
-			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(rendered).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(rendered).To(ContainSubstring("metrics: enabled"))
 			Expect(rendered).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
@@ -110,6 +111,54 @@ var _ = Describe("ChartScaffolder", func() {
 			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: true"))
+		})
+
+		It("should produce only the metrics policy when kustomize output has no webhook", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithMetricsNetworkPolicyNoWebhooks),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-metrics-traffic.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
+			Expect(string(content)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+
+			_, err = afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-webhook-traffic.yaml")
+			Expect(err).To(HaveOccurred())
+
+			values, err := afero.ReadFile(fs, "dist/chart/values.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(values)).To(ContainSubstring("networkPolicy:\n  enabled: true"))
+		})
+
+		It("should preserve an egress NetworkPolicy from kustomize output", func() {
+			manifestsPath := filepath.Join(GinkgoT().TempDir(), "install.yaml")
+			Expect(os.WriteFile(
+				manifestsPath,
+				[]byte(manifestsWithEgressNetworkPolicy),
+				0o600,
+			)).To(Succeed())
+
+			fs := executeChartScaffolder(manifestsPath)
+
+			content, err := afero.ReadFile(fs, "dist/chart/templates/network-policy/allow-egress-dns.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rendered := string(content)
+			// Custom policies are gated on networkPolicy.enabled only, regardless of direction.
+			Expect(rendered).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(rendered).NotTo(ContainSubstring(".Values.metrics.enabled"))
+			// Egress ports target other services and must not be rewritten to a manager port.
+			Expect(rendered).To(ContainSubstring("policyTypes:"))
+			Expect(rendered).To(ContainSubstring("- Egress"))
+			Expect(rendered).To(ContainSubstring("port: 53"))
+			Expect(rendered).NotTo(ContainSubstring(".Values.metrics.port"))
+			Expect(rendered).NotTo(ContainSubstring(".Values.webhook.port"))
 		})
 
 		It("should place all NetworkPolicies from kustomize output in the network-policy directory", func() {
@@ -127,7 +176,8 @@ var _ = Describe("ChartScaffolder", func() {
 				"dist/chart/templates/network-policy/allow-metrics-traffic.yaml",
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(metricsPolicy)).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(string(metricsPolicy)).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(string(metricsPolicy)).To(ContainSubstring("metrics: enabled"))
 			Expect(string(metricsPolicy)).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
 
@@ -352,6 +402,50 @@ metadata:
 webhooks: []
 `
 
+const manifestsWithEgressNetworkPolicy = manifestsWithoutNetworkPolicy + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-egress-dns
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+`
+
+const manifestsWithMetricsNetworkPolicyNoWebhooks = manifestsWithoutNetworkPolicy + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-project-allow-metrics-traffic
+  namespace: test-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: test-project
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+`
+
 const manifestsWithMultipleNetworkPolicies = manifestsWithoutNetworkPolicy + `---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -413,7 +507,7 @@ spec:
           matchLabels:
             webhook: enabled
       ports:
-        - port: 443
+        - port: 9443
           protocol: TCP
 `
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -23,15 +23,26 @@ import (
 )
 
 const (
-	keyName         = "name"
-	keyArgs         = "args"
-	keyReplicas     = "replicas"
-	keySecretName   = "secretName"
-	keyConfigMap    = "configMap"
-	keyImage        = "image"
-	keySecret       = "secret"
-	keyVolumeMounts = "volumeMounts"
-	keyMountPath    = "mountPath"
+	keyName          = "name"
+	keyArgs          = "args"
+	keyContainers    = "containers"
+	keyPorts         = "ports"
+	keyContainerPort = "containerPort"
+	keyReplicas      = "replicas"
+	keySecretName    = "secretName"
+	keyConfigMap     = "configMap"
+	keyImage         = "image"
+	keySecret        = "secret"
+	keyVolumeMounts  = "volumeMounts"
+	keyVolumes       = "volumes"
+	keyMountPath     = "mountPath"
+	keyAPIVersion    = "apiVersion"
+	keyKind          = "kind"
+	keyMetadata      = "metadata"
+	keyAnnotations   = "annotations"
+	keySpec          = "spec"
+	keyTemplate      = "template"
+	keyControlPlane  = "control-plane"
 
 	valAppsV1            = "apps/v1"
 	valDeployment        = "Deployment"
@@ -70,33 +81,33 @@ func makeDeployment(opts deploymentOpts) *unstructured.Unstructured {
 		for i, c := range opts.containers {
 			cs[i] = c
 		}
-		podSpec["containers"] = cs
+		podSpec[keyContainers] = cs
 	}
 	if opts.volumes != nil {
-		podSpec["volumes"] = opts.volumes
+		podSpec[keyVolumes] = opts.volumes
 	}
-	template := map[string]any{"spec": podSpec}
+	template := map[string]any{keySpec: podSpec}
 	if opts.annotations != nil {
 		annotations := make(map[string]any, len(opts.annotations))
 		for k, v := range opts.annotations {
 			annotations[k] = v
 		}
-		template["metadata"] = map[string]any{"annotations": annotations}
+		template[keyMetadata] = map[string]any{keyAnnotations: annotations}
 	}
 	return &unstructured.Unstructured{
 		Object: map[string]any{
-			"apiVersion": valAppsV1,
-			"kind":       valDeployment,
-			"metadata":   map[string]any{keyName: valTestDeploy},
-			"spec": map[string]any{
-				"template": template,
+			keyAPIVersion: valAppsV1,
+			keyKind:       valDeployment,
+			keyMetadata:   map[string]any{keyName: valTestDeploy},
+			keySpec: map[string]any{
+				keyTemplate: template,
 			},
 		},
 	}
 }
 
 func podSpec(d *unstructured.Unstructured) map[string]any {
-	spec, _, _ := unstructured.NestedFieldNoCopy(d.Object, "spec", "template", "spec")
+	spec, _, _ := unstructured.NestedFieldNoCopy(d.Object, keySpec, keyTemplate, keySpec)
 	m, _ := spec.(map[string]any)
 	return m
 }
@@ -124,7 +135,7 @@ var _ = Describe("DeploymentExtractor", func() {
 		})
 
 		It("should preserve scale-to-zero", func() {
-			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(0)
+			deployment.Object[keySpec].(map[string]any)[keyReplicas] = int64(0)
 			result, err := extractor.ExtractDeploymentConfig(deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).NotTo(BeNil())
@@ -132,7 +143,7 @@ var _ = Describe("DeploymentExtractor", func() {
 		})
 
 		It("should extract replicas value", func() {
-			deployment.Object["spec"].(map[string]any)[keyReplicas] = int64(3)
+			deployment.Object[keySpec].(map[string]any)[keyReplicas] = int64(3)
 			result, err := extractor.ExtractDeploymentConfig(deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Manager.Replicas).NotTo(BeNil())
@@ -343,7 +354,7 @@ var _ = Describe("DeploymentExtractor", func() {
 				other := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: valManager}}})
 				winner := makeDeployment(deploymentOpts{containers: []map[string]any{{keyName: "other"}}})
 				winner.SetName("winner")
-				winner.SetLabels(map[string]string{"control-plane": "controller-manager"})
+				winner.SetLabels(map[string]string{keyControlPlane: "controller-manager"})
 
 				result := FindManagerDeployment([]*unstructured.Unstructured{other, winner})
 				Expect(result).To(Equal(winner))
@@ -453,7 +464,7 @@ var _ = Describe("DeploymentExtractor", func() {
 					{
 						keyName:  valManager,
 						keyImage: valControllerImage,
-						"args": []any{
+						keyArgs: []any{
 							"--webhook-port=9443",
 						},
 					},
@@ -471,13 +482,13 @@ var _ = Describe("DeploymentExtractor", func() {
 					{
 						keyName:  valManager,
 						keyImage: valControllerImage,
-						"args": []any{
+						keyArgs: []any{
 							"--webhook-port=8443",
 						},
-						"ports": []any{
+						keyPorts: []any{
 							map[string]any{
-								"name":          "webhook-server",
-								"containerPort": int64(9443),
+								keyName:          "webhook-server",
+								keyContainerPort: int64(9443),
 							},
 						},
 					},

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -58,7 +58,8 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 	}
 
 	features.HasCRDs = len(resources.CustomResourceDefinitions) > 0
-	features.HasWebhooks = len(resources.WebhookConfigurations) > 0
+	features.HasWebhooks = len(resources.WebhookConfigurations) > 0 ||
+		hasConversionWebhooks(resources.CustomResourceDefinitions)
 
 	features.HasCertManager = resources.Issuer != nil || len(resources.Certificates) > 0
 
@@ -94,12 +95,12 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 			}
 		}
 
-		// Only extract from service if we didn't find it in deployment
+		// The webhook server listens on the Service targetPort (the pod port), not the exposed 443.
 		if !webhookPortFromDeployment {
 			for _, svc := range resources.Services {
 				name := svc.GetName()
 				if strings.HasSuffix(name, "-webhook-service") {
-					if port := extractPortFromService(svc); port > 0 {
+					if port := extractTargetPortFromService(svc); port > 0 {
 						features.WebhookPort = port
 					}
 					break
@@ -157,25 +158,61 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 	return features
 }
 
-// extractPortFromService extracts the port number from a service.
-func extractPortFromService(svc *unstructured.Unstructured) int {
+// firstServicePort returns the first entry of a service's spec.ports, or false when absent.
+func firstServicePort(svc *unstructured.Unstructured) (map[string]any, bool) {
 	ports, found, err := unstructured.NestedFieldNoCopy(svc.Object, "spec", "ports")
 	if !found || err != nil {
-		return 0
+		return nil, false
 	}
 
 	portsList, ok := ports.([]any)
 	if !ok || len(portsList) == 0 {
-		return 0
+		return nil, false
 	}
 
 	firstPort, ok := portsList[0].(map[string]any)
+	return firstPort, ok
+}
+
+// extractPortFromService extracts the exposed port of a service's first port.
+func extractPortFromService(svc *unstructured.Unstructured) int {
+	firstPort, ok := firstServicePort(svc)
 	if !ok {
 		return 0
 	}
 
 	port, _ := toInt(firstPort["port"])
 	return port
+}
+
+// extractTargetPortFromService returns the numeric targetPort of a Service's first port.
+// It returns 0 for a named targetPort because the pod port cannot be resolved here.
+func extractTargetPortFromService(svc *unstructured.Unstructured) int {
+	firstPort, ok := firstServicePort(svc)
+	if !ok {
+		return 0
+	}
+
+	if targetPort, ok := toInt(firstPort["targetPort"]); ok && targetPort > 0 {
+		return targetPort
+	}
+
+	if _, named := firstPort["targetPort"].(string); named {
+		return 0
+	}
+
+	port, _ := toInt(firstPort["port"])
+	return port
+}
+
+func hasConversionWebhooks(crds []*unstructured.Unstructured) bool {
+	for _, crd := range crds {
+		strategy, found, err := unstructured.NestedString(crd.Object, "spec", "conversion", "strategy")
+		if err == nil && found && strategy == "Webhook" {
+			return true
+		}
+	}
+	return false
 }
 
 // extractWebhookPortFromDeployment extracts the webhook port from the manager

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
@@ -211,4 +211,113 @@ var _ = Describe("FeaturesExtractor", func() {
 			Expect(features.MetricsSecure).To(HaveValue(BeFalse()))
 		})
 	})
+
+	Describe("DetectFeatures webhook port", func() {
+		It("uses the webhook Service targetPort, not the exposed port, when the deployment omits it", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{{keyName: valManager, keyImage: valControllerImage}},
+			})
+
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Deployment:            deployment,
+				Services:              []*unstructured.Unstructured{newWebhookService(9443)},
+				WebhookConfigurations: []*unstructured.Unstructured{newValidatingWebhookConfig()},
+			}, "test-project", "test-system")
+
+			Expect(features.WebhookPort).To(Equal(9443))
+		})
+
+		It("prefers the webhook port declared on the manager container args", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{{
+					keyName:  valManager,
+					keyImage: valControllerImage,
+					keyArgs:  []any{"--webhook-port=9444"},
+				}},
+			})
+
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Deployment:            deployment,
+				Services:              []*unstructured.Unstructured{newWebhookService(9443)},
+				WebhookConfigurations: []*unstructured.Unstructured{newValidatingWebhookConfig()},
+			}, "test-project", "test-system")
+
+			Expect(features.WebhookPort).To(Equal(9444))
+		})
+
+		It("detects a conversion webhook when no admission webhook configurations exist", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{{keyName: valManager, keyImage: valControllerImage}},
+			})
+
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Deployment:                deployment,
+				Services:                  []*unstructured.Unstructured{newWebhookService(9443)},
+				CustomResourceDefinitions: []*unstructured.Unstructured{newConversionCRD()},
+			}, "test-project", "test-system")
+
+			Expect(features.HasWebhooks).To(BeTrue())
+			Expect(features.WebhookPort).To(Equal(9443))
+		})
+
+		It("does not treat an unused webhook Service as a webhook", func() {
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Services: []*unstructured.Unstructured{newWebhookService(9443)},
+			}, "test-project", "test-system")
+
+			Expect(features.HasWebhooks).To(BeFalse())
+		})
+
+		It("keeps the default webhook port when the targetPort is a named port", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{{keyName: valManager, keyImage: valControllerImage}},
+			})
+
+			// A named targetPort can't be resolved to a number, so the default (9443) is kept
+			// rather than the exposed Service port (443), which is not the pod's webhook port.
+			features := featuresExtractor.DetectFeatures(&ResourceSet{
+				Deployment:            deployment,
+				Services:              []*unstructured.Unstructured{newWebhookService("webhook-server")},
+				WebhookConfigurations: []*unstructured.Unstructured{newValidatingWebhookConfig()},
+			}, "test-project", "test-system")
+
+			Expect(features.WebhookPort).To(Equal(9443))
+		})
+	})
 })
+
+// newValidatingWebhookConfig builds a minimal ValidatingWebhookConfiguration for feature detection.
+func newValidatingWebhookConfig() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		keyAPIVersion: "admissionregistration.k8s.io/v1",
+		keyKind:       "ValidatingWebhookConfiguration",
+		keyMetadata:   map[string]any{keyName: "test-project-validating-webhook-configuration"},
+	}}
+}
+
+// newWebhookService builds a webhook Service exposing 443 and forwarding to targetPort.
+// targetPort is any so tests can pass a named (string) port to exercise the numeric fallback.
+func newWebhookService(targetPort any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		keyAPIVersion: "v1",
+		keyKind:       "Service",
+		keyMetadata:   map[string]any{keyName: "test-project-webhook-service"},
+		keySpec: map[string]any{
+			"ports": []any{map[string]any{
+				"port":       int64(443),
+				"targetPort": targetPort,
+			}},
+		},
+	}}
+}
+
+func newConversionCRD() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		keyAPIVersion: "apiextensions.k8s.io/v1",
+		keyKind:       "CustomResourceDefinition",
+		keyMetadata:   map[string]any{keyName: "widgets.example.io"},
+		keySpec: map[string]any{
+			"conversion": map[string]any{"strategy": "Webhook"},
+		},
+	}}
+}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -161,6 +161,32 @@ var _ = Describe("ChartConverter", func() {
 		})
 	})
 
+	Context("kustomize-derived templates regenerate", func() {
+		It("always regenerates kustomize-provided templates to match the source", func() {
+			networkPolicy := &unstructured.Unstructured{}
+			networkPolicy.SetAPIVersion("networking.k8s.io/v1")
+			networkPolicy.SetKind("NetworkPolicy")
+			networkPolicy.SetName("test-project-allow-metrics-traffic")
+			resources.NetworkPolicies = []*unstructured.Unstructured{networkPolicy}
+
+			serviceMonitor := &unstructured.Unstructured{}
+			serviceMonitor.SetAPIVersion("monitoring.coreos.com/v1")
+			serviceMonitor.SetKind("ServiceMonitor")
+			serviceMonitor.SetName("test-project-controller-manager-metrics-monitor")
+			resources.ServiceMonitors = []*unstructured.Unstructured{serviceMonitor}
+
+			builders := converter.GetChartBuilders()
+
+			for _, b := range builders {
+				dynamicTemplate, ok := b.(*DynamicTemplate)
+				Expect(ok).To(BeTrue())
+				Expect(dynamicTemplate.SetTemplateDefaults()).To(Succeed())
+				Expect(dynamicTemplate.IfExistsAction).To(Equal(machinery.OverwriteFile),
+					"kustomize-derived template %q must always regenerate", dynamicTemplate.RelativePath)
+			}
+		})
+	})
+
 	Context("ExtractDeploymentConfig", func() {
 		It("should extract deployment configuration correctly", func() {
 			// Set up deployment with environment variables

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/dynamic_template.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/dynamic_template.go
@@ -62,7 +62,7 @@ func (f *DynamicTemplate) SetTemplateDefaults() error {
 	// This prevents machinery from trying to execute Helm templates as Go templates
 	f.SetDelim("<%", "%>")
 
-	// Always overwrite - these are generated files that should match current kustomize output
+	// Kustomize-derived files always regenerate; user-owned defaults have their own builders.
 	f.IfExistsAction = machinery.OverwriteFile
 
 	return nil

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -28,7 +28,9 @@ import (
 
 // AddConditionalWrappers wraps resources with appropriate {{- if .Values.* }} conditionals.
 // Each resource type gets wrapped based on its purpose and dependencies.
-func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructured) string {
+func AddConditionalWrappers(
+	yamlContent string, resource *unstructured.Unstructured, detectedPrefix string,
+) string {
 	kind := resource.GetKind()
 	apiVersion := resource.GetAPIVersion()
 	name := resource.GetName()
@@ -39,22 +41,36 @@ func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructu
 	case kind == common.KindCRD:
 		// Add resource-policy annotation to prevent deletion on helm uninstall
 		yamlContent = InjectCRDResourcePolicyAnnotation(yamlContent)
-		return fmt.Sprintf("{{- if .Values.crd.enabled }}\n%s{{- end }}\n", yamlContent)
+		yamlContent = fmt.Sprintf("{{- if .Values.crd.enabled }}\n%s{{- end }}\n", yamlContent)
+		if !hasWebhookConversion(resource) {
+			return yamlContent
+		}
+		return fmt.Sprintf(`{{- if and .Values.crd.enabled (not .Values.webhook.enabled) }}
+{{- fail "webhook.enabled must be true for CRD conversion" }}
+{{- end }}
+%s`, yamlContent)
 	case kind == common.KindCertificate && apiVersion == common.APIVersionCertManager:
-		return HandleCertificateConditionalWrappers(yamlContent, name)
+		return HandleCertificateConditionalWrappers(yamlContent, name, detectedPrefix)
 	case kind == common.KindIssuer && apiVersion == common.APIVersionCertManager:
 		return fmt.Sprintf("{{- if .Values.certManager.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceMonitor && apiVersion == common.APIVersionMonitoring:
 		// CRITICAL: newline before {{- end }} prevents whitespace chomping from eating content
 		return fmt.Sprintf("{{- if .Values.prometheus.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindNetworkPolicy && apiVersion == common.APIVersionNetworking:
-		if strings.HasSuffix(name, "allow-webhook-traffic") {
+		switch {
+		case IsScaffoldedPolicyName(name, detectedPrefix, "allow-webhook-traffic"):
 			return fmt.Sprintf(
 				"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}\n%s\n{{- end }}",
 				yamlContent,
 			)
+		case IsScaffoldedPolicyName(name, detectedPrefix, "allow-metrics-traffic"):
+			return fmt.Sprintf(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}\n%s\n{{- end }}",
+				yamlContent,
+			)
+		default:
+			return fmt.Sprintf("{{- if .Values.networkPolicy.enabled }}\n%s\n{{- end }}", yamlContent)
 		}
-		return fmt.Sprintf("{{- if .Values.networkPolicy.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceAccount, kind == common.KindRole, kind == common.KindClusterRole,
 		kind == common.KindRoleBinding, kind == common.KindClusterRoleBinding:
 		return HandleRBACConditionalWrappers(yamlContent, kind, name)
@@ -78,9 +94,14 @@ func AddConditionalWrappers(yamlContent string, resource *unstructured.Unstructu
 	}
 }
 
+func hasWebhookConversion(resource *unstructured.Unstructured) bool {
+	strategy, found, err := unstructured.NestedString(resource.Object, "spec", "conversion", "strategy")
+	return err == nil && found && strategy == "Webhook"
+}
+
 // HandleCertificateConditionalWrappers handles conditional logic for Certificate resources.
-// Uses suffix matching to avoid false positives when project name contains "metrics".
-func HandleCertificateConditionalWrappers(yamlContent, name string) string {
+// It identifies the scaffolded webhook certificate by its exact generated name.
+func HandleCertificateConditionalWrappers(yamlContent, name, detectedPrefix string) string {
 	isMetricsCert := strings.HasSuffix(name, "-metrics-certs") || strings.HasSuffix(name, "-metrics-cert")
 	if isMetricsCert {
 		// Metrics certificates require certManager AND metrics.secure=true (TLS enabled)
@@ -88,7 +109,11 @@ func HandleCertificateConditionalWrappers(yamlContent, name string) string {
 			"{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}\n%s{{- end }}\n",
 			yamlContent)
 	}
-	// Webhook serving certificates only need certManager
+	if name == detectedPrefix+"-serving-cert" {
+		// The scaffolded webhook serving certificate requires both features.
+		return fmt.Sprintf(
+			"{{- if and .Values.certManager.enabled .Values.webhook.enabled }}\n%s{{- end }}", yamlContent)
+	}
 	return fmt.Sprintf("{{- if .Values.certManager.enabled }}\n%s{{- end }}", yamlContent)
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appliers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func networkPolicy(name string) *unstructured.Unstructured {
+	np := &unstructured.Unstructured{}
+	np.SetAPIVersion("networking.k8s.io/v1")
+	np.SetKind("NetworkPolicy")
+	np.SetName(name)
+	return np
+}
+
+func certificate(name string) *unstructured.Unstructured {
+	cert := &unstructured.Unstructured{}
+	cert.SetAPIVersion("cert-manager.io/v1")
+	cert.SetKind("Certificate")
+	cert.SetName(name)
+	return cert
+}
+
+func conversionCRD() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		apiVersionKey: "apiextensions.k8s.io/v1",
+		kindKey:       "CustomResourceDefinition",
+		"metadata":    map[string]any{"name": "widgets.example.io"},
+		"spec": map[string]any{
+			"conversion": map[string]any{"strategy": "Webhook"},
+		},
+	}}
+}
+
+var _ = Describe("AddConditionalWrappers", func() {
+	It("rejects disabling a webhook required by CRD conversion", func() {
+		result := AddConditionalWrappers("kind: CustomResourceDefinition\n", conversionCRD(), "test-project")
+
+		Expect(result).To(ContainSubstring(`{{- if and .Values.crd.enabled (not .Values.webhook.enabled) }}`))
+		Expect(result).To(ContainSubstring(
+			`fail "webhook.enabled must be true for CRD conversion"`))
+		Expect(result).To(ContainSubstring("{{- if .Values.crd.enabled }}"))
+	})
+
+	It("does not require a webhook when conversion CRDs are disabled", func() {
+		result := AddConditionalWrappers("kind: CustomResourceDefinition\n", conversionCRD(), "test-project")
+
+		Expect(result).To(ContainSubstring(".Values.crd.enabled"))
+		Expect(result).To(ContainSubstring(".Values.webhook.enabled"))
+		Expect(result).NotTo(ContainSubstring("{{- if not .Values.webhook.enabled }}"))
+	})
+
+	It("keeps custom serving certificates under the cert-manager conditional", func() {
+		result := AddConditionalWrappers(
+			"kind: Certificate\n", certificate("test-project-custom-serving-cert"), "test-project")
+
+		Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
+		Expect(result).NotTo(ContainSubstring(".Values.webhook.enabled"))
+	})
+
+	It("gates the metrics policy on both networkPolicy.enabled and metrics.enabled", func() {
+		result := AddConditionalWrappers(
+			"kind: NetworkPolicy\n", networkPolicy("test-project-allow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring(
+			"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
+		Expect(result).To(ContainSubstring("{{- end }}"))
+	})
+
+	It("gates the webhook policy on both networkPolicy.enabled and webhook.enabled", func() {
+		result := AddConditionalWrappers(
+			"kind: NetworkPolicy\n", networkPolicy("test-project-allow-webhook-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring(
+			"{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}"))
+		Expect(result).To(ContainSubstring("{{- end }}"))
+	})
+
+	It("gates a custom policy on networkPolicy.enabled only", func() {
+		result := AddConditionalWrappers(
+			"kind: NetworkPolicy\n", networkPolicy("test-project-allow-dns-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+		Expect(result).NotTo(ContainSubstring(".Values.metrics.enabled"))
+		Expect(result).NotTo(ContainSubstring(".Values.webhook.enabled"))
+	})
+
+	It("does not classify a custom policy with an unrelated prefix as scaffolded", func() {
+		result := AddConditionalWrappers(
+			"kind: NetworkPolicy\n", networkPolicy("team-allow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+		Expect(result).NotTo(ContainSubstring(".Values.metrics.enabled"))
+	})
+
+	It("gates a policy whose name only resembles the scaffolded ones on networkPolicy.enabled only", func() {
+		for _, name := range []string{"test-project-disallow-metrics-traffic", "test-project-disallow-webhook-traffic"} {
+			result := AddConditionalWrappers("kind: NetworkPolicy\n", networkPolicy(name), "test-project")
+
+			Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(result).NotTo(ContainSubstring(".Values.metrics.enabled"))
+			Expect(result).NotTo(ContainSubstring(".Values.webhook.enabled"))
+		}
+	})
+
+	It("does not wrap a NetworkPolicy served by a non-standard apiVersion", func() {
+		np := networkPolicy("custom-policy")
+		np.SetAPIVersion("acme.io/v1")
+
+		result := AddConditionalWrappers("kind: NetworkPolicy\n", np, "test-project")
+
+		Expect(result).NotTo(ContainSubstring(".Values.networkPolicy.enabled"))
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -61,10 +61,10 @@ func IsManagerDeployment(resource *unstructured.Unstructured) bool {
 	return strings.Contains(resource.GetName(), "controller-manager")
 }
 
-// MakeYamlContent wraps a YAML block with a cert-manager conditional.
+// wrapWebhookCertificateBlock wraps a webhook certificate block with its feature conditions.
 // Shifts by 2 spaces to align with the child indent used by appendToListFromValues.
-func MakeYamlContent(match string) string {
-	return wrapBlock(match, "{{- if .Values.certManager.enabled }}")
+func wrapWebhookCertificateBlock(match string) string {
+	return wrapBlock(match, "{{- if and .Values.certManager.enabled .Values.webhook.enabled }}")
 }
 
 // wrapBlock wraps a YAML block match with the given Helm conditional string.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 const (
+	apiVersionKey = "apiVersion"
+	kindKey       = "kind"
 	nameKey       = "name"
 	cpuKey        = "cpu"
 	memoryKey     = "memory"
@@ -362,8 +364,8 @@ var _ = Describe("FindManagerContainerRange", func() {
 
 	It("should work on real yaml.Marshal output with sidecar before manager", func() {
 		deployment := map[string]any{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
+			apiVersionKey: "apps/v1",
+			kindKey:       "Deployment",
 			metadataKey: map[string]any{
 				nameKey: "test-controller-manager",
 			},
@@ -424,8 +426,8 @@ var _ = Describe("FindManagerContainerRange", func() {
 
 	It("should not false-positive on nested name fields in yaml.Marshal output", func() {
 		deployment := map[string]any{
-			"apiVersion": "apps/v1",
-			"kind":       "Deployment",
+			apiVersionKey: "apps/v1",
+			kindKey:       "Deployment",
 			metadataKey: map[string]any{
 				nameKey: "test-controller-manager",
 			},

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -1291,9 +1291,9 @@ func detectChildIndent(lines []string, parentIndent string) string {
 	return parentIndent + "  "
 }
 
-// MakeContainerArgsConditional makes webhook-cert-path and metrics-cert-path args conditional.
+// MakeContainerArgsConditional makes certificate path args conditional.
 func MakeContainerArgsConditional(yamlContent string) string {
-	// Make webhook-cert-path arg conditional on certManager.enabled
+	// Make webhook-cert-path arg conditional on certManager.enabled AND webhook.enabled
 	if strings.Contains(yamlContent, "--webhook-cert-path") {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		webhookArgPattern := regexp.MustCompile(`([ \t]+)-\s*--webhook-cert-path=[^\n]*`)
@@ -1305,7 +1305,7 @@ func MakeContainerArgsConditional(yamlContent string) string {
 			}
 
 			argLine := strings.TrimSpace(match)
-			return fmt.Sprintf("%s{{- if .Values.certManager.enabled }}\n%s%s\n%s{{- end }}",
+			return fmt.Sprintf("%s{{- if and .Values.certManager.enabled .Values.webhook.enabled }}\n%s%s\n%s{{- end }}",
 				indent, indent, argLine, indent)
 		})
 	}
@@ -1331,27 +1331,26 @@ func MakeContainerArgsConditional(yamlContent string) string {
 	return yamlContent
 }
 
-// MakeWebhookVolumesConditional makes webhook volumes conditional on certManager.enabled.
+// MakeWebhookVolumesConditional makes webhook volumes conditional on certManager.enabled and webhook.enabled.
 func MakeWebhookVolumesConditional(yamlContent string) string {
-	// Make webhook volumes conditional on certManager.enabled
 	if strings.Contains(yamlContent, "webhook-certs") && strings.Contains(yamlContent, "secretName: webhook-server-cert") {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		volumePattern := regexp.MustCompile(`([ \t]+)-\s*name:\s*webhook-certs[\s\S]*?secretName:\s*webhook-server-cert`)
-		yamlContent = volumePattern.ReplaceAllStringFunc(yamlContent, MakeYamlContent)
+		yamlContent = volumePattern.ReplaceAllStringFunc(yamlContent, wrapWebhookCertificateBlock)
 	}
 
 	return yamlContent
 }
 
-// MakeWebhookVolumeMountsConditional makes webhook volumeMounts conditional on certManager.enabled.
+// MakeWebhookVolumeMountsConditional makes webhook volume mounts conditional
+// on certManager.enabled and webhook.enabled.
 func MakeWebhookVolumeMountsConditional(yamlContent string) string {
-	// Make webhook volumeMounts conditional on certManager.enabled
 	webhookCertsPath := "/tmp/k8s-webhook-server/serving-certs"
 	if strings.Contains(yamlContent, "webhook-certs") && strings.Contains(yamlContent, webhookCertsPath) {
 		// Match only spaces/tabs for indent to avoid consuming the newline
 		mountPattern := regexp.MustCompile(
 			`([ \t]+)-\s*mountPath:\s*/tmp/k8s-webhook-server/serving-certs[\s\S]*?readOnly:\s*true`)
-		yamlContent = mountPattern.ReplaceAllStringFunc(yamlContent, MakeYamlContent)
+		yamlContent = mountPattern.ReplaceAllStringFunc(yamlContent, wrapWebhookCertificateBlock)
 	}
 
 	return yamlContent

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -25,20 +25,28 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
+// IsScaffoldedPolicyName reports whether name is the bare scaffolded NetworkPolicy name
+// or the policy name prefixed by the detected project prefix.
+func IsScaffoldedPolicyName(name, detectedPrefix, policy string) bool {
+	return name == policy || (detectedPrefix != "" && name == detectedPrefix+"-"+policy)
+}
+
 // TemplatePorts templates port numbers for Services, Deployments, and NetworkPolicies using values.yaml.
-func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) string {
+func TemplatePorts(yamlContent string, resource *unstructured.Unstructured, detectedPrefix string) string {
 	resourceName := resource.GetName()
 	resourceKind := resource.GetKind()
 
 	// Use suffix matching to avoid false positives when project name contains "webhook"
 	isWebhook := (resourceKind == common.KindService && strings.HasSuffix(resourceName, "-webhook-service")) ||
-		(resourceKind == common.KindNetworkPolicy && strings.HasSuffix(resourceName, "allow-webhook-traffic"))
+		(resourceKind == common.KindNetworkPolicy &&
+			IsScaffoldedPolicyName(resourceName, detectedPrefix, "allow-webhook-traffic"))
 
 	// Use suffix matching to avoid false positives when project name contains "metrics"
 	isMetrics := (resourceKind == common.KindService &&
 		(strings.HasSuffix(resourceName, "-controller-manager-metrics-service") ||
 			strings.HasSuffix(resourceName, "-metrics-service"))) ||
-		(resourceKind == common.KindNetworkPolicy && strings.HasSuffix(resourceName, "allow-metrics-traffic"))
+		(resourceKind == common.KindNetworkPolicy &&
+			IsScaffoldedPolicyName(resourceName, detectedPrefix, "allow-metrics-traffic"))
 
 	// For Deployments, detect webhook ports from content
 	if resourceKind == common.KindDeployment {
@@ -50,9 +58,7 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 	// Template webhook ports
 	if isWebhook {
 		if resourceKind == common.KindNetworkPolicy {
-			yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
-				ReplaceAllString(yamlContent, "${1}port: {{ .Values.webhook.port }}")
-			return yamlContent
+			return templateNetworkPolicyIngressPort(yamlContent, "{{ .Values.webhook.port }}")
 		}
 
 		// Replace containerPort for webhook-server with template (matches any numeric port)
@@ -68,20 +74,19 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 
 	// Template metrics ports
 	if isMetrics {
+		if resourceKind == common.KindNetworkPolicy {
+			return templateNetworkPolicyIngressPort(yamlContent, "{{ .Values.metrics.port }}")
+		}
+
 		// Replace port with metrics.port template (matches any numeric port)
 		yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
 			ReplaceAllString(yamlContent, "${1}port: {{ .Values.metrics.port }}")
-
-		if resourceKind == common.KindNetworkPolicy {
-			return yamlContent
-		}
 
 		// Replace targetPort with metrics.port template (matches any numeric port)
 		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*\d+`).
 			ReplaceAllString(yamlContent, "${1}targetPort: {{ .Values.metrics.port }}")
 
-		// Template port name based on metrics.secure (http vs https)
-		// This ensures Service and ServiceMonitor use the correct scheme
+		// The port name follows metrics.secure so Service and ServiceMonitor agree on the scheme.
 		if resource.GetKind() == common.KindService {
 			yamlContent = regexp.MustCompile(`(\s*)- name:\s*https(\s+port:)`).
 				ReplaceAllString(yamlContent, `${1}- name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}${2}`)
@@ -103,6 +108,37 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 	}
 
 	return yamlContent
+}
+
+// templateNetworkPolicyIngressPort rewrites the port only inside the NetworkPolicy's
+// ingress rule. The ingress block spans the lines indented deeper than the `ingress:` key;
+// it ends at the next sibling key (e.g. `egress:`) or the end of the spec. Ports under an
+// egress rule target other services and must be left as-is, and scoping this way also avoids
+// rewriting an unrelated port that follows the ingress block.
+func templateNetworkPolicyIngressPort(yamlContent, portTemplate string) string {
+	portRe := regexp.MustCompile(`(\s*)port:\s*\d+`)
+	lines := strings.Split(yamlContent, "\n")
+	inIngress := false
+	ingressIndent := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		switch {
+		case strings.HasPrefix(trimmed, "ingress:"):
+			inIngress = true
+			ingressIndent = indent
+		case inIngress && indent <= ingressIndent && !strings.HasPrefix(trimmed, "-"):
+			// A sibling key (e.g. egress:) at or above the ingress indentation ends the block.
+			// List items (- ...) at the same indentation are still part of the ingress rule.
+			inIngress = false
+		case inIngress:
+			lines[i] = portRe.ReplaceAllString(line, "${1}port: "+portTemplate)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // templateHealthProbePort templates the manager health probe port so it can be

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appliers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TemplatePorts NetworkPolicy", func() {
+	const metricsPolicy = `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+`
+
+	It("templates the metrics policy ingress port", func() {
+		result := TemplatePorts(metricsPolicy, networkPolicy("test-project-allow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 8443"))
+	})
+
+	It("templates the webhook policy ingress port", func() {
+		webhookPolicy := `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: 9443
+          protocol: TCP
+`
+		result := TemplatePorts(webhookPolicy, networkPolicy("test-project-allow-webhook-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 9443"))
+	})
+
+	It("templates the webhook policy ingress port when the rule has no source selector", func() {
+		webhookPolicy := `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+`
+		result := TemplatePorts(webhookPolicy, networkPolicy("test-project-allow-webhook-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 9443"))
+	})
+
+	It("leaves the ports of a policy whose name only resembles the scaffolded ones untouched", func() {
+		policy := `spec:
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+`
+		result := TemplatePorts(policy, networkPolicy("test-project-disallow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: 8443"))
+		Expect(result).NotTo(ContainSubstring(".Values."))
+	})
+
+	It("leaves a custom policy's ports untouched", func() {
+		dnsPolicy := `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 5353
+          protocol: UDP
+`
+		result := TemplatePorts(dnsPolicy, networkPolicy("test-project-allow-dns-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: 5353"))
+		Expect(result).NotTo(ContainSubstring(".Values."))
+	})
+
+	It("leaves a custom policy with an unrelated prefix untouched", func() {
+		policy := `spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+`
+		result := TemplatePorts(policy, networkPolicy("team-allow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: 8443"))
+		Expect(result).NotTo(ContainSubstring(".Values.metrics.port"))
+	})
+
+	It("does not rewrite a port that follows the ingress block", func() {
+		policy := `spec:
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+  someField:
+    port: 9999
+`
+		result := TemplatePorts(policy, networkPolicy("test-project-allow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+		Expect(result).To(ContainSubstring("port: 9999"), "a port outside the ingress block must not be rewritten")
+	})
+
+	It("templates only the ingress port and preserves egress ports of a metrics policy", func() {
+		mixedPolicy := `spec:
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8443
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+`
+		result := TemplatePorts(mixedPolicy, networkPolicy("test-project-allow-metrics-traffic"), "test-project")
+
+		Expect(result).To(ContainSubstring("port: {{ .Values.metrics.port }}"))
+		Expect(result).NotTo(ContainSubstring("port: 8443"))
+		Expect(result).To(ContainSubstring("port: 53"), "egress port must not be rewritten")
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
@@ -65,7 +65,7 @@ func (t *Templater) GetManagerNamespace() string {
 // This is the main transformation orchestrator that coordinates all template substitutions.
 func (t *Templater) ApplyHelmSubstitutions(yamlContent string, resource *unstructured.Unstructured) string {
 	yamlContent = appliers.EscapeExistingTemplateSyntax(yamlContent)
-	yamlContent = appliers.AddConditionalWrappers(yamlContent, resource)
+	yamlContent = appliers.AddConditionalWrappers(yamlContent, resource, t.detectedPrefix)
 	yamlContent = appliers.SubstituteProjectNames(yamlContent, resource)
 	yamlContent = appliers.SubstituteNamespace(
 		t.detectedPrefix, t.chartName, t.managerNamespace, t.roleNamespaces, yamlContent, resource)
@@ -88,7 +88,7 @@ func (t *Templater) ApplyHelmSubstitutions(yamlContent string, resource *unstruc
 	if resource.GetKind() == common.KindService ||
 		resource.GetKind() == common.KindDeployment ||
 		resource.GetKind() == common.KindNetworkPolicy {
-		yamlContent = appliers.TemplatePorts(yamlContent, resource)
+		yamlContent = appliers.TemplatePorts(yamlContent, resource, t.detectedPrefix)
 	}
 	if resource.GetKind() == common.KindServiceMonitor {
 		yamlContent = appliers.TemplateServiceMonitor(yamlContent)
@@ -100,5 +100,5 @@ func (t *Templater) ApplyHelmSubstitutions(yamlContent string, resource *unstruc
 
 // templatePorts is a wrapper for testing purposes, exposing the appliers.TemplatePorts function
 func (t *Templater) templatePorts(yamlContent string, resource *unstructured.Unstructured) string {
-	return appliers.TemplatePorts(yamlContent, resource)
+	return appliers.TemplatePorts(yamlContent, resource, t.detectedPrefix)
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -203,6 +203,9 @@ spec:
 			Expect(result).To(ContainSubstring(`{{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}`))
+			Expect(result).To(ContainSubstring(
+				"{{- if and .Values.certManager.enabled .Values.webhook.enabled }}\n" +
+					"        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs/tls.crt"))
 			Expect(result).To(ContainSubstring("{{- range .Values.manager.args }}"))
 			Expect(result).NotTo(ContainSubstring("BUSYBOX_IMAGE"))
 			Expect(result).NotTo(ContainSubstring("MEMCACHED_IMAGE"))
@@ -262,8 +265,9 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, deploymentResource)
 
-			// Should have conditional blocks for webhook certs
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
+			// Webhook certificates require both features.
+			Expect(result).To(ContainSubstring(
+				"{{- if and .Values.certManager.enabled .Values.webhook.enabled }}"))
 			Expect(result).To(ContainSubstring("mountPath: /tmp/k8s-webhook-server/serving-certs"))
 
 			// Should have conditional blocks for metrics certs
@@ -584,7 +588,8 @@ spec:
 
 			result := templater.ApplyHelmSubstitutions(content, networkPolicyResource)
 
-			Expect(result).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(result).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -871,7 +876,7 @@ metadata:
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
-		It("should add cert-manager conditional for Certificate resources", func() {
+		It("should add cert-manager and webhook conditionals for webhook certificates", func() {
 			certResource := &unstructured.Unstructured{}
 			certResource.SetAPIVersion("cert-manager.io/v1")
 			certResource.SetKind("Certificate")
@@ -884,8 +889,8 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, certResource)
 
-			// Should be wrapped with certManager enabled conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
+			Expect(result).To(ContainSubstring(
+				"{{- if and .Values.certManager.enabled .Values.webhook.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
@@ -907,6 +912,23 @@ metadata:
 			Expect(result).To(ContainSubstring(
 				"{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
+		})
+
+		It("should not tie a custom certificate to webhook.enabled", func() {
+			certResource := &unstructured.Unstructured{}
+			certResource.SetAPIVersion("cert-manager.io/v1")
+			certResource.SetKind("Certificate")
+			certResource.SetName("test-project-database-cert")
+
+			content := `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-project-database-cert`
+
+			result := templater.ApplyHelmSubstitutions(content, certResource)
+
+			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
+			Expect(result).NotTo(ContainSubstring(".Values.webhook.enabled"))
 		})
 
 		It("should add kind conditionals to essential ClusterRole resources", func() {
@@ -2704,13 +2726,13 @@ metadata:
 spec:
   ingress:
   - ports:
-    - port: 443
+    - port: 9443
       protocol: TCP`
 
 			result := templater.templatePorts(content, networkPolicy)
 
 			Expect(result).To(ContainSubstring("port: {{ .Values.webhook.port }}"))
-			Expect(result).NotTo(ContainSubstring("port: 443"))
+			Expect(result).NotTo(ContainSubstring("port: 9443"))
 		})
 
 		It("should not template custom NetworkPolicy ports", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy.go
@@ -69,7 +69,8 @@ func (f *NetworkPolicy) SetTemplateDefaults() error {
 	return nil
 }
 
-const networkPolicyTemplate = `{{` + "`" + `{{- if .Values.networkPolicy.enabled }}` + "`" + `}}
+const networkPolicyTemplate = `{{` + "`" +
+	`{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}` + "`" + `}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -99,6 +100,11 @@ spec:
 const webhookNetworkPolicyTemplate = `{{` + "`" +
 	`{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}` + "`" + `}}
 ---
+# Allow ingress to the webhook server's pod port from all sources.
+# The webhook Service forwards traffic from its Service port to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -115,11 +121,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled
-      ports:
+    - ports:
         - port: {{ "{{ .Values.webhook.port }}" }}
           protocol: TCP
 {{` + "`" + `{{- end }}` + "`" + `}}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/networkpolicy_test.go
@@ -69,7 +69,8 @@ var _ = Describe("NetworkPolicy", func() {
 			err := networkPolicy.SetTemplateDefaults()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(networkPolicy.TemplateBody).To(ContainSubstring("{{`{{- if .Values.networkPolicy.enabled }}`}}"))
+			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
+				"{{`{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}`}}"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring("kind: NetworkPolicy"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
 				`name: {{ "{{ include \"test-project.resourceName\" ` +
@@ -91,7 +92,6 @@ var _ = Describe("NetworkPolicy", func() {
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(
 				`name: {{ "{{ include \"test-project.resourceName\" ` +
 					`(dict \"suffix\" \"allow-webhook-traffic\" \"context\" $) }}" }}`))
-			Expect(networkPolicy.TemplateBody).To(ContainSubstring("webhook: enabled"))
 			Expect(networkPolicy.TemplateBody).To(ContainSubstring(`port: {{ "{{ .Values.webhook.port }}" }}`))
 			Expect(networkPolicy.TemplateBody).NotTo(ContainSubstring("allow-metrics-traffic"))
 		})
@@ -118,7 +118,8 @@ var _ = Describe("NetworkPolicy", func() {
 			Expect(err).NotTo(HaveOccurred())
 			webhookPolicy := string(content)
 
-			Expect(metricsPolicy).To(ContainSubstring("{{- if .Values.networkPolicy.enabled }}"))
+			Expect(metricsPolicy).To(ContainSubstring(
+				"{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}"))
 			Expect(metricsPolicy).To(ContainSubstring(`{{ include "test-project.name" . }}`))
 			Expect(metricsPolicy).To(ContainSubstring(
 				`name: {{ include "test-project.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}`))

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -53,7 +53,12 @@ func (f *ServiceMonitor) SetTemplateDefaults() error {
 	chartName := f.ProjectName
 	f.TemplateBody = fmt.Sprintf(serviceMonitorTemplate, chartName, chartName, chartName, chartName)
 
-	f.IfExistsAction = machinery.OverwriteFile
+	// User-owned file: preserve local edits on regeneration unless --force is set.
+	if f.Force {
+		f.IfExistsAction = machinery.OverwriteFile
+	} else {
+		f.IfExistsAction = machinery.SkipFile
+	}
 
 	return nil
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package charttemplates
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+var _ = Describe("ServiceMonitor", func() {
+	Context("SetTemplateDefaults", func() {
+		var serviceMonitor *ServiceMonitor
+
+		BeforeEach(func() {
+			serviceMonitor = &ServiceMonitor{
+				OutputDir:   helmChartOutputDir,
+				ServiceName: "test-project-controller-manager-metrics-service",
+			}
+			serviceMonitor.InjectProjectName("test-project")
+		})
+
+		It("preserves an existing file (SkipFile) when Force is false", func() {
+			serviceMonitor.Force = false
+			Expect(serviceMonitor.SetTemplateDefaults()).To(Succeed())
+			Expect(serviceMonitor.IfExistsAction).To(Equal(machinery.SkipFile))
+		})
+
+		It("overwrites (OverwriteFile) when Force is true", func() {
+			serviceMonitor.Force = true
+			Expect(serviceMonitor.SetTemplateDefaults()).To(Succeed())
+			Expect(serviceMonitor.IfExistsAction).To(Equal(machinery.OverwriteFile))
+		})
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/github/test_chart.go
@@ -31,6 +31,8 @@ type HelmChartCI struct {
 
 	// Force if true allows overwriting the scaffolded file
 	Force bool
+	// HasWebhooks enables cert-manager installation in the workflow
+	HasWebhooks bool
 }
 
 // SetTemplateDefaults implements machinery.Template
@@ -101,7 +103,18 @@ jobs:
       - name: Lint Helm Chart
         run: |
           helm lint ./dist/chart
-
+{{ if .HasWebhooks }}
+      - name: Install cert-manager via Helm (wait for readiness)
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm install cert-manager jetstack/cert-manager \
+            --namespace cert-manager \
+            --create-namespace \
+            --set crds.enabled=true \
+            --wait \
+            --timeout 300s
+{{ else }}
 # TODO: Uncomment if cert-manager is enabled
 #      - name: Install cert-manager via Helm (wait for readiness)
 #        run: |
@@ -113,7 +126,7 @@ jobs:
 #            --set crds.enabled=true \
 #            --wait \
 #            --timeout 300s
-
+{{ end }}
 # TODO: Uncomment if Prometheus is enabled
 #      - name: Install Prometheus Operator CRDs
 #        run: |

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -146,10 +146,8 @@ certManager:
 `)
 	}
 
-	// Webhook configuration
-	if f.Extraction != nil && f.Extraction.Features.HasWebhooks {
-		f.addWebhookSection(&buf)
-	}
+	// Webhook configuration (always present so templates can reference webhook.enabled)
+	f.addWebhookSection(&buf)
 
 	// Prometheus configuration (always present, enabled when the kustomize output provides a ServiceMonitor)
 	prometheusEnabled := f.Extraction != nil && f.Extraction.Features.HasPrometheus
@@ -161,7 +159,7 @@ prometheus:
 `)
 	fmt.Fprintf(&buf, "  enabled: %t\n\n", prometheusEnabled)
 
-	// NetworkPolicy configuration (always present, enabled when NetworkPolicy resources exist)
+	// NetworkPolicy configuration (always present, enabled when the kustomize output provides a NetworkPolicy)
 	networkPolicyEnabled := f.Extraction != nil && f.Extraction.Features.HasNetworkPolicy
 
 	buf.WriteString(`## Network policies for controlling traffic flow.
@@ -608,16 +606,20 @@ func (f *HelmValues) addHealthProbeSection(buf *bytes.Buffer) {
 // addWebhookSection adds webhook configuration
 func (f *HelmValues) addWebhookSection(buf *bytes.Buffer) {
 	port := 9443
-	if f.Extraction != nil && f.Extraction.Features.WebhookPort > 0 {
-		port = f.Extraction.Features.WebhookPort
+	enabled := false
+	if f.Extraction != nil {
+		enabled = f.Extraction.Features.HasWebhooks
+		if f.Extraction.Features.WebhookPort > 0 {
+			port = f.Extraction.Features.WebhookPort
+		}
 	}
 
 	buf.WriteString(`## Webhook server configuration
 ##
 webhook:
-  enabled: true
-  # Webhook server port
 `)
+	fmt.Fprintf(buf, "  enabled: %t\n", enabled)
+	buf.WriteString("  # Webhook server port\n")
 	fmt.Fprintf(buf, "  port: %d\n\n", port)
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
@@ -307,6 +307,24 @@ var _ = Describe("HelmValues", func() {
 				healthProbeSection := extractSection(result, "healthProbe:")
 				Expect(healthProbeSection).To(ContainSubstring("port: 8081"))
 			})
+
+			It("should emit the webhook section disabled so templates can reference webhook.enabled", func() {
+				values := &HelmValues{
+					Extraction: &extractor.Extraction{
+						Features: extractor.FeatureSet{
+							HasMetrics:  false,
+							HasWebhooks: false,
+						},
+					},
+				}
+				values.ProjectName = testProjectName
+
+				result := values.generateValues()
+
+				webhookSection := extractSection(result, "webhook:")
+				Expect(webhookSection).To(ContainSubstring("enabled: false"))
+				Expect(webhookSection).To(ContainSubstring("port: 9443"))
+			})
 		})
 
 		Context("healthProbe placement", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -134,6 +134,12 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 				_, err := os.Stat(filePath)
 				Expect(err).NotTo(HaveOccurred(), "File %s should exist", file)
 			}
+
+			By("keeping cert-manager commented when kustomize output has no webhooks")
+			workflow, err := os.ReadFile(filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(workflow)).To(ContainSubstring(
+				"#      - name: Install cert-manager via Helm (wait for readiness)"))
 		})
 	})
 
@@ -157,6 +163,14 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			info, err := os.Stat(webhookDir)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info.IsDir()).To(BeTrue())
+
+			By("enabling cert-manager when kustomize output has webhooks")
+			workflow, err := os.ReadFile(filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(workflow)).To(ContainSubstring(
+				"      - name: Install cert-manager via Helm (wait for readiness)"))
+			Expect(string(workflow)).NotTo(ContainSubstring(
+				"#      - name: Install cert-manager via Helm (wait for readiness)"))
 
 			By("verifying webhook configuration files exist")
 			files, err := afero.ReadDir(afero.NewOsFs(), webhookDir)
@@ -582,6 +596,235 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 
 			Expect(strings.Count(sa, "app.kubernetes.io/name:")).To(Equal(1),
 				"a user override must not add a second app.kubernetes.io/name label, got:\n%s", sa)
+		})
+	})
+
+	Context("NetworkPolicy (rendered)", func() {
+		// networkPolicyDoc returns the NetworkPolicy document whose name ends with the given
+		// suffix from a multi-document render, or "" when it was not rendered.
+		networkPolicyDoc := func(rendered, suffix string) string {
+			for _, doc := range strings.Split(rendered, "\n---") {
+				if strings.Contains(doc, "\nkind: NetworkPolicy\n") && strings.Contains(doc, suffix) {
+					return doc
+				}
+			}
+			return ""
+		}
+
+		renderWithNetworkPolicies := func(setArgs ...string) string {
+			out, err := helmTemplate(createKustomizeWithWebhooks("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("renders both policies with the metrics and webhook ports when enabled", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=true",
+			)
+
+			metricsPolicy := networkPolicyDoc(rendered, "allow-metrics-traffic")
+			Expect(metricsPolicy).NotTo(BeEmpty(), "metrics NetworkPolicy should be rendered")
+			Expect(metricsPolicy).To(ContainSubstring("metrics: enabled"))
+			Expect(metricsPolicy).To(ContainSubstring("port: 8443"))
+
+			webhookPolicy := networkPolicyDoc(rendered, "allow-webhook-traffic")
+			Expect(webhookPolicy).NotTo(BeEmpty(), "webhook NetworkPolicy should be rendered")
+			Expect(webhookPolicy).To(ContainSubstring("port: 9443"))
+		})
+
+		DescribeTable("renders no NetworkPolicy when networkPolicy.enabled is false",
+			func(metricsEnabled, webhookEnabled string) {
+				rendered := renderWithNetworkPolicies(
+					"--set", "networkPolicy.enabled=false",
+					"--set", "metrics.enabled="+metricsEnabled,
+					"--set", "webhook.enabled="+webhookEnabled,
+				)
+
+				Expect(rendered).NotTo(ContainSubstring("kind: NetworkPolicy"))
+			},
+			Entry("with metrics and webhook enabled", "true", "true"),
+			Entry("with only metrics enabled", "true", "false"),
+			Entry("with only webhook enabled", "false", "true"),
+			Entry("with both disabled", "false", "false"),
+		)
+
+		It("suppresses the metrics policy when metrics are disabled but keeps the webhook policy", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=false",
+				"--set", "webhook.enabled=true",
+			)
+
+			Expect(networkPolicyDoc(rendered, "allow-metrics-traffic")).To(BeEmpty(),
+				"metrics NetworkPolicy must be gated by metrics.enabled")
+			Expect(networkPolicyDoc(rendered, "allow-webhook-traffic")).NotTo(BeEmpty(),
+				"webhook NetworkPolicy should still render")
+		})
+
+		It("suppresses the webhook policy when webhooks are disabled but keeps the metrics policy", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=false",
+			)
+
+			Expect(networkPolicyDoc(rendered, "allow-webhook-traffic")).To(BeEmpty(),
+				"webhook NetworkPolicy must be gated by webhook.enabled")
+			Expect(networkPolicyDoc(rendered, "allow-metrics-traffic")).NotTo(BeEmpty(),
+				"metrics NetworkPolicy should still render")
+		})
+
+		It("renders no NetworkPolicy when networkPolicy is enabled but metrics and webhooks are disabled", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=false",
+				"--set", "webhook.enabled=false",
+			)
+
+			Expect(rendered).NotTo(ContainSubstring("kind: NetworkPolicy"),
+				"both policies must be gated off when their features are disabled")
+		})
+
+		It("tracks custom metrics and webhook ports in the rendered policies", func() {
+			rendered := renderWithNetworkPolicies(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true", "--set", "metrics.port=9000",
+				"--set", "webhook.enabled=true", "--set", "webhook.port=9001",
+			)
+
+			Expect(networkPolicyDoc(rendered, "allow-metrics-traffic")).To(ContainSubstring("port: 9000"))
+			Expect(networkPolicyDoc(rendered, "allow-webhook-traffic")).To(ContainSubstring("port: 9001"))
+		})
+	})
+
+	Context("Disabled admission webhooks (rendered)", func() {
+		It("does not render webhook resources when cert-manager stays enabled", func() {
+			rendered, err := helmTemplate(
+				createKustomizeWithWebhooksAndCertManager("test-project"),
+				"--set", "webhook.enabled=false",
+				"--set", "certManager.enabled=true",
+				"--set", "networkPolicy.enabled=true",
+			)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", rendered)
+
+			Expect(rendered).NotTo(ContainSubstring("kind: ValidatingWebhookConfiguration"))
+			Expect(rendered).NotTo(ContainSubstring("-serving-cert"))
+			Expect(rendered).NotTo(ContainSubstring("webhook-server-cert"))
+			Expect(rendered).NotTo(ContainSubstring("-webhook-service"))
+			Expect(rendered).NotTo(ContainSubstring("allow-webhook-traffic"))
+			Expect(rendered).To(ContainSubstring("kind: Issuer"),
+				"cert-manager resources unrelated to the disabled webhook should remain")
+		})
+	})
+
+	Context("NetworkPolicy conversion from kustomize (rendered)", func() {
+		networkPolicyDoc := func(rendered, suffix string) string {
+			for _, doc := range strings.Split(rendered, "\n---") {
+				if strings.Contains(doc, "\nkind: NetworkPolicy\n") && strings.Contains(doc, suffix) {
+					return doc
+				}
+			}
+			return ""
+		}
+
+		renderConverted := func(setArgs ...string) string {
+			out, err := helmTemplate(createKustomizeWithWebhooksAndNetworkPolicies("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("renders all converted policies with their gates and ports when everything is enabled", func() {
+			rendered := renderConverted(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=true",
+			)
+
+			Expect(networkPolicyDoc(rendered, "-allow-metrics-traffic")).To(ContainSubstring("port: 8443"))
+			Expect(networkPolicyDoc(rendered, "-allow-webhook-traffic")).To(ContainSubstring("port: 9443"))
+			Expect(networkPolicyDoc(rendered, "allow-dns-traffic")).To(ContainSubstring("port: 5353"))
+			Expect(networkPolicyDoc(rendered, "disallow-metrics-traffic")).To(ContainSubstring("port: 7777"),
+				"a policy whose name only resembles the scaffolded ones must keep its port")
+		})
+
+		It("renders no converted policy when networkPolicy.enabled is false", func() {
+			rendered := renderConverted(
+				"--set", "networkPolicy.enabled=false",
+				"--set", "metrics.enabled=true",
+				"--set", "webhook.enabled=true",
+			)
+
+			Expect(rendered).NotTo(ContainSubstring("kind: NetworkPolicy"))
+		})
+
+		It("gates only the scaffolded policies on their feature toggles", func() {
+			rendered := renderConverted(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=false",
+				"--set", "webhook.enabled=false",
+			)
+
+			Expect(networkPolicyDoc(rendered, "-allow-metrics-traffic")).To(BeEmpty(),
+				"converted metrics policy must be gated by metrics.enabled")
+			Expect(networkPolicyDoc(rendered, "-allow-webhook-traffic")).To(BeEmpty(),
+				"converted webhook policy must be gated by webhook.enabled")
+			Expect(networkPolicyDoc(rendered, "allow-dns-traffic")).NotTo(BeEmpty(),
+				"custom policies must only be gated by networkPolicy.enabled")
+			Expect(networkPolicyDoc(rendered, "disallow-metrics-traffic")).NotTo(BeEmpty(),
+				"a policy whose name only resembles the scaffolded ones must only be gated by networkPolicy.enabled")
+		})
+
+		It("renders a conversion webhook chart and rejects disabling its webhook", func() {
+			out, err := helmTemplate(createKustomizeConversionOnlyWithNetworkPolicies("test-project"))
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+
+			var crd string
+			for _, doc := range strings.Split(out, "\n---") {
+				if strings.Contains(doc, "\nkind: CustomResourceDefinition\n") {
+					crd = doc
+					break
+				}
+			}
+			Expect(crd).NotTo(BeEmpty(), "the conversion CRD must render")
+			Expect(crd).To(ContainSubstring("strategy: Webhook"))
+			Expect(crd).To(ContainSubstring("name: my-release-test-project-webhook-service"))
+			Expect(crd).To(ContainSubstring("namespace: my-namespace"))
+			Expect(networkPolicyDoc(out, "-allow-webhook-traffic")).To(ContainSubstring("port: 9443"),
+				"the webhook NetworkPolicy must render with webhook.enabled defaulting to true")
+
+			workflow, err := os.ReadFile(filepath.Join(tmpDir, ".github", "workflows", "test-chart.yml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(workflow)).To(ContainSubstring(
+				"      - name: Install cert-manager via Helm (wait for readiness)"),
+				"conversion webhooks from kustomize output must enable cert-manager in the workflow")
+			Expect(string(workflow)).NotTo(ContainSubstring(
+				"#      - name: Install cert-manager via Helm (wait for readiness)"))
+
+			out, err = helmTemplate(createKustomizeConversionOnlyWithNetworkPolicies("test-project"),
+				"--set", "webhook.enabled=false")
+			Expect(err).To(HaveOccurred(), "helm template should reject disabling a required webhook: %s", out)
+			Expect(out).To(ContainSubstring(
+				"webhook.enabled must be true for CRD conversion"))
+
+			out, err = helmTemplate(createKustomizeConversionOnlyWithNetworkPolicies("test-project"),
+				"--set", "crd.enabled=false", "--set", "webhook.enabled=false")
+			Expect(err).NotTo(HaveOccurred(),
+				"helm template should allow disabling an unrendered conversion CRD: %s", out)
+		})
+
+		It("tracks custom ports in the converted scaffolded policies only", func() {
+			rendered := renderConverted(
+				"--set", "networkPolicy.enabled=true",
+				"--set", "metrics.enabled=true", "--set", "metrics.port=9100",
+				"--set", "webhook.enabled=true", "--set", "webhook.port=9101",
+			)
+
+			Expect(networkPolicyDoc(rendered, "-allow-metrics-traffic")).To(ContainSubstring("port: 9100"))
+			Expect(networkPolicyDoc(rendered, "-allow-webhook-traffic")).To(ContainSubstring("port: 9101"))
+			Expect(networkPolicyDoc(rendered, "allow-dns-traffic")).To(ContainSubstring("port: 5353"))
+			Expect(networkPolicyDoc(rendered, "disallow-metrics-traffic")).To(ContainSubstring("port: 7777"))
 		})
 	})
 
@@ -1156,6 +1399,149 @@ webhooks:
       path: /validate
   name: validate.example.com
   sideEffects: None
+`
+}
+
+func createKustomizeConversionOnlyWithNetworkPolicies(projectName string) string {
+	return createBasicKustomizeOutput(projectName) + `---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: ` + projectName + `-webhook-service
+          namespace: ` + projectName + `-system
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: example.io
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+      served: true
+      storage: true
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          type: object
+      served: true
+      storage: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+  name: ` + projectName + `-webhook-service
+  namespace: ` + projectName + `-system
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ` + projectName + `-allow-webhook-traffic
+  namespace: ` + projectName + `-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+`
+}
+
+func createKustomizeWithWebhooksAndNetworkPolicies(projectName string) string {
+	return createKustomizeWithWebhooks(projectName) + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ` + projectName + `-allow-metrics-traffic
+  namespace: ` + projectName + `-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: 8443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ` + projectName + `-allow-webhook-traffic
+  namespace: ` + projectName + `-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ` + projectName + `-allow-dns-traffic
+  namespace: ` + projectName + `-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 5353
+          protocol: UDP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ` + projectName + `-disallow-metrics-traffic
+  namespace: ` + projectName + `-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 7777
+          protocol: TCP
 `
 }
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_never_overwrite_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_never_overwrite_test.go
@@ -152,6 +152,49 @@ maintainers:
 		Expect(string(content)).To(ContainSubstring("My custom description"))
 	})
 
+	It("should preserve user edits to NetworkPolicy and ServiceMonitor unless --force", func() {
+		networkPolicyPath := filepath.Join(tmpDir, outputDir, "chart", "templates",
+			"network-policy", "allow-metrics-traffic.yaml")
+		serviceMonitorPath := filepath.Join(tmpDir, outputDir, "chart", "templates",
+			"prometheus", "controller-manager-metrics-monitor.yaml")
+
+		scaffoldChart := func(force bool) {
+			s := scaffolds.NewChartScaffolder(projectConfig, force, manifestsFile, outputDir)
+			s.InjectFS(fs)
+			Expect(s.Scaffold()).To(Succeed())
+		}
+
+		// Initial scaffold creates the user-owned files (SkipFile still writes when absent).
+		scaffoldChart(false)
+		Expect(networkPolicyPath).To(BeAnExistingFile(), "initial scaffold must create the NetworkPolicy")
+		Expect(serviceMonitorPath).To(BeAnExistingFile(), "initial scaffold must create the ServiceMonitor")
+
+		Expect(os.WriteFile(networkPolicyPath, []byte("custom-network-policy\n"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(serviceMonitorPath, []byte("custom-service-monitor\n"), 0o644)).To(Succeed())
+
+		// Regenerating without --force must keep the local edits.
+		scaffoldChart(false)
+		networkPolicyContent, err := os.ReadFile(networkPolicyPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(networkPolicyContent)).To(Equal("custom-network-policy\n"),
+			"NetworkPolicy should be preserved without --force")
+		serviceMonitorContent, err := os.ReadFile(serviceMonitorPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(serviceMonitorContent)).To(Equal("custom-service-monitor\n"),
+			"ServiceMonitor should be preserved without --force")
+
+		// Regenerating with --force must overwrite them.
+		scaffoldChart(true)
+		networkPolicyContent, err = os.ReadFile(networkPolicyPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(networkPolicyContent)).To(ContainSubstring("kind: NetworkPolicy"),
+			"NetworkPolicy should be regenerated with --force")
+		serviceMonitorContent, err = os.ReadFile(serviceMonitorPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(serviceMonitorContent)).To(ContainSubstring("kind: ServiceMonitor"),
+			"ServiceMonitor should be regenerated with --force")
+	})
+
 	It("should preserve Chart.yaml on initial scaffold if file already exists", func() {
 		// Create Chart.yaml before any scaffolding
 		chartPath := filepath.Join(tmpDir, outputDir, "chart", "Chart.yaml")

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -119,14 +119,16 @@ var _ = Describe("kubebuilder", func() {
 			})
 		})
 
-		It("should generate a runnable project with webhooks and metrics protected by network policies", func() {
+		It("should deploy admission and conversion webhooks protected by network policies", func() {
 			helpers.GenerateV4WithNetworkPolicies(kbc)
+			helpers.EnableWebhookNamespaceGating(kbc)
 
 			helpers.Run(kbc, helpers.RunOptions{
-				HasWebhook:         true,
-				HasMetrics:         true,
-				HasNetworkPolicies: true,
-				InstallMethod:      helpers.InstallMethodHelm,
+				HasWebhook:             true,
+				HasMetrics:             true,
+				HasNetworkPolicies:     true,
+				WebhookNamespaceGating: true,
+				InstallMethod:          helpers.InstallMethodHelm,
 			})
 		})
 
@@ -205,6 +207,8 @@ var _ = Describe("kubebuilder", func() {
 				HasWebhook:          true,
 				HasMetrics:          true,
 				HasNetworkPolicies:  true,
+				MetricsPort:         customMetricsPort,
+				WebhookPort:         customWebhookPort,
 				InstallMethod:       helpers.InstallMethodHelm,
 				SkipChartGeneration: true, // Chart already generated and customized above
 			})

--- a/test/e2e/all/plugin_v4_test.go
+++ b/test/e2e/all/plugin_v4_test.go
@@ -93,20 +93,22 @@ var _ = Describe("kubebuilder", func() {
 			})
 		})
 
-		It("should generate a runnable project with webhooks and metrics protected by network policies", func() {
+		It("should deploy admission and conversion webhooks protected by network policies", func() {
 			helpers.GenerateV4WithNetworkPolicies(kbc)
+			helpers.EnableWebhookNamespaceGating(kbc)
 			helpers.Run(kbc, helpers.RunOptions{
-				HasWebhook:         true,
-				HasMetrics:         true,
-				HasNetworkPolicies: true,
-				InstallMethod:      helpers.InstallMethodKustomize,
+				HasWebhook:             true,
+				HasMetrics:             true,
+				HasNetworkPolicies:     true,
+				WebhookNamespaceGating: true,
+				InstallMethod:          helpers.InstallMethodKustomize,
 			})
 		})
 
 		It("should generate a runnable project with a custom webhook port protected by network policies", func() {
 			helpers.GenerateV4WithNetworkPolicies(kbc)
 
-			By("configuring the manager and webhook Service to use a custom webhook port")
+			By("configuring the manager, webhook Service, and webhook NetworkPolicy to use a custom port")
 			const customWebhookPort = "9444"
 			Expect(util.ReplaceInFile(
 				filepath.Join(kbc.Dir, "config", "default", "manager_webhook_patch.yaml"),
@@ -114,12 +116,18 @@ var _ = Describe("kubebuilder", func() {
 			Expect(util.ReplaceInFile(
 				filepath.Join(kbc.Dir, "config", "webhook", "service.yaml"),
 				"targetPort: 9443", "targetPort: "+customWebhookPort)).To(Succeed())
+			// The webhook NetworkPolicy must allow the same pod port, otherwise a CNI that
+			// enforces NetworkPolicies would block admission traffic to the custom port.
+			Expect(util.ReplaceInFile(
+				filepath.Join(kbc.Dir, "config", "network-policy", "allow-webhook-traffic.yaml"),
+				"port: 9443", "port: "+customWebhookPort)).To(Succeed())
 
 			By("deploying with the custom webhook port and validating all webhook flows")
 			helpers.Run(kbc, helpers.RunOptions{
 				HasWebhook:         true,
 				HasMetrics:         true,
 				HasNetworkPolicies: true,
+				WebhookPort:        9444,
 				InstallMethod:      helpers.InstallMethodKustomize,
 			})
 

--- a/test/e2e/internal/helpers/generate_v4.go
+++ b/test/e2e/internal/helpers/generate_v4.go
@@ -167,6 +167,35 @@ func GenerateV4WithNetworkPolicies(kbc *utils.TestContext) {
 		"#- ../network-policy", "#")).To(Succeed())
 }
 
+// EnableWebhookNamespaceGating adds the namespaceSelector emitted by the controller-tools patch marker.
+// The kustomize patch can be removed after Kubebuilder updates to a release that includes the marker.
+func EnableWebhookNamespaceGating(kbc *utils.TestContext) {
+	By("patching the webhook configurations to only admit resources from labeled namespaces")
+	const anchor = `- path: manager_metrics_patch.yaml
+  target:
+    kind: Deployment`
+	const gatingPatches = anchor + `
+- patch: |-
+    - op: add
+      path: /webhooks/0/namespaceSelector
+      value:
+        matchLabels:
+          webhook: enabled
+  target:
+    kind: MutatingWebhookConfiguration
+- patch: |-
+    - op: add
+      path: /webhooks/0/namespaceSelector
+      value:
+        matchLabels:
+          webhook: enabled
+  target:
+    kind: ValidatingWebhookConfiguration`
+	ExpectWithOffset(1, pluginutil.ReplaceInFile(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		anchor, gatingPatches)).To(Succeed())
+}
+
 // GenerateV4WithoutWebhooks implements a go/v4 plugin with APIs and enable Prometheus and CertManager
 func GenerateV4WithoutWebhooks(kbc *utils.TestContext) {
 	initingTheProject(kbc)

--- a/test/e2e/internal/helpers/plugin_test_helper.go
+++ b/test/e2e/internal/helpers/plugin_test_helper.go
@@ -63,6 +63,13 @@ type RunOptions struct {
 	HasMetrics bool
 	// HasNetworkPolicies indicates if network policies are enabled
 	HasNetworkPolicies bool
+	// MetricsPort is the expected metrics port the metrics NetworkPolicy must allow (defaults to 8443)
+	MetricsPort int
+	// WebhookPort is the expected webhook port the webhook NetworkPolicy must allow (defaults to 9443)
+	WebhookPort int
+	// WebhookNamespaceGating indicates the webhook configurations were patched with a
+	// namespaceSelector so admission only runs for namespaces labeled 'webhook: enabled'
+	WebhookNamespaceGating bool
 	// IsNamespaced indicates if project is namespace-scoped
 	IsNamespaced bool
 	// InstallMethod specifies how to install the project
@@ -178,12 +185,22 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 	Expect(err).NotTo(HaveOccurred())
 
 	if opts.HasNetworkPolicies {
-		if opts.HasMetrics {
-			By("labeling the namespace to allow consume the metrics")
-			Expect(kbc.Kubectl.Command("label", "namespaces", kbc.Kubectl.Namespace,
-				"metrics=enabled")).Error().NotTo(HaveOccurred())
+		metricsPort := opts.MetricsPort
+		if metricsPort == 0 {
+			metricsPort = defaultMetricsPort
+		}
+		webhookPort := opts.WebhookPort
+		if webhookPort == 0 {
+			webhookPort = defaultWebhookPort
+		}
 
-			By("Ensuring the Allow Metrics Traffic NetworkPolicy exists", func() {
+		if opts.HasMetrics {
+			By("labeling the namespace to allow metrics access")
+			_, err = kbc.Kubectl.Command("label", "namespaces", kbc.Kubectl.Namespace,
+				"metrics=enabled")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("ensuring the metrics NetworkPolicy allows the metrics port", func() {
 				var output string
 				output, err = kbc.Kubectl.Get(
 					true,
@@ -192,16 +209,22 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 				Expect(err).NotTo(HaveOccurred(), "NetworkPolicy allow-metrics-traffic should exist in the namespace")
 				Expect(output).To(ContainSubstring("allow-metrics-traffic"), "NetworkPolicy allow-metrics-traffic "+
 					"should be present in the output")
+
+				// The NetworkPolicy must allow the pod's metrics port, otherwise it blocks scraping.
+				var port string
+				port, err = kbc.Kubectl.Get(
+					true,
+					"networkpolicy", fmt.Sprintf("e2e-%s-allow-metrics-traffic", kbc.TestSuffix),
+					"-o", "jsonpath={.spec.ingress[*].ports[*].port}",
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(port).To(Equal(strconv.Itoa(metricsPort)),
+					"metrics NetworkPolicy must allow the metrics port")
 			})
 		}
 
 		if opts.HasWebhook {
-			By("labeling the namespace to allow webhooks traffic")
-			_, err = kbc.Kubectl.Command("label", "namespaces", kbc.Kubectl.Namespace,
-				"webhook=enabled")
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Ensuring the allow-webhook-traffic NetworkPolicy exists", func() {
+			By("ensuring the webhook NetworkPolicy allows the webhook port", func() {
 				var output string
 				output, err = kbc.Kubectl.Get(
 					true,
@@ -210,8 +233,53 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 				Expect(err).NotTo(HaveOccurred(), "NetworkPolicy allow-webhook-traffic should exist in the namespace")
 				Expect(output).To(ContainSubstring("allow-webhook-traffic"), "NetworkPolicy allow-webhook-traffic "+
 					"should be present in the output")
+
+				// The policy must allow the webhook container port; the Service port (443) never matches pod traffic.
+				var port string
+				port, err = kbc.Kubectl.Get(
+					true,
+					"networkpolicy", fmt.Sprintf("e2e-%s-allow-webhook-traffic", kbc.TestSuffix),
+					"-o", "jsonpath={.spec.ingress[*].ports[*].port}",
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(port).To(Equal(strconv.Itoa(webhookPort)),
+					"webhook NetworkPolicy must allow the webhook container port")
 			})
 		}
+
+		if opts.HasMetrics {
+			ValidateNetworkPolicyEnforcement(
+				controllerPodName, namePrefix, webhookPort, opts.HasWebhook, kbc)
+		}
+	}
+
+	if opts.HasWebhook && opts.WebhookNamespaceGating {
+		By("ensuring the webhook configurations are scoped with the namespaceSelector")
+		webhookConfigs := map[string]string{
+			"mutatingwebhookconfigurations":   fmt.Sprintf("%s-mutating-webhook-configuration", namePrefix),
+			"validatingwebhookconfigurations": fmt.Sprintf("%s-validating-webhook-configuration", namePrefix),
+		}
+		for kind, name := range webhookConfigs {
+			var selectors string
+			selectors, err = kbc.Kubectl.Get(
+				false,
+				kind, name,
+				"-o", `jsonpath={range .webhooks[*]}{.namespaceSelector.matchLabels.webhook}{"\n"}{end}`,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			entries := strings.Split(strings.TrimSuffix(selectors, "\n"), "\n")
+			Expect(entries).NotTo(BeEmpty(), "%s must have webhook entries", name)
+			for _, entry := range entries {
+				Expect(entry).To(Equal("enabled"),
+					"every webhook in %s must carry the namespaceSelector so only labeled namespaces trigger admission",
+					name)
+			}
+		}
+
+		By("labeling the manager namespace so the scoped webhooks run for resources in it")
+		_, err = kbc.Kubectl.Command("label", "namespaces", kbc.Kubectl.Namespace,
+			"webhook=enabled", "--overwrite")
+		Expect(err).NotTo(HaveOccurred())
 	}
 
 	if opts.HasWebhook {
@@ -349,6 +417,28 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 		}
 		Eventually(applySampleNamespaced, 2*time.Minute, time.Second).Should(Succeed())
 
+		if opts.WebhookNamespaceGating {
+			By("validating that webhooks are skipped in a namespace without the 'webhook: enabled' label")
+			var cnt string
+			cnt, err = kbc.Kubectl.Get(
+				false,
+				"-n", namespace,
+				"-f", sampleFile,
+				"-o", "jsonpath={.spec.count}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cnt).To(BeEmpty(),
+				"the mutating webhook must not run for namespaces without the 'webhook: enabled' label")
+
+			By("labeling the namespace so the webhooks run for resources in it")
+			_, err = kbc.Kubectl.Command("label", "namespaces", namespace, "webhook=enabled")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("recreating the CR so admission runs with the label in place")
+			_, err = kbc.Kubectl.Delete(false, "-n", namespace, "-f", sampleFile)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(applySampleNamespaced, 2*time.Minute, time.Second).Should(Succeed())
+		}
+
 		// Note: Webhooks are cluster-scoped and validate/mutate CRs in ALL namespaces,
 		// even in namespace-scoped managers. The manager won't reconcile CRs outside
 		// its WATCH_NAMESPACE, but webhooks will still enforce validation/mutation rules.
@@ -367,8 +457,8 @@ func Run(kbc *utils.TestContext, opts RunOptions) {
 			"the mutating webhook should set the count to 5")
 
 		By("removing the namespace")
-		Expect(kbc.Kubectl.Command("delete", "namespace", namespace)).
-			Error().NotTo(HaveOccurred(), "namespace should be removed successfully")
+		_, err = kbc.Kubectl.Command("delete", "namespace", namespace)
+		Expect(err).NotTo(HaveOccurred(), "namespace should be removed successfully")
 
 		By("validating the conversion")
 

--- a/test/e2e/internal/helpers/plugin_test_metrics.go
+++ b/test/e2e/internal/helpers/plugin_test_metrics.go
@@ -82,9 +82,14 @@ func GetControllerPodName(kbc *utils.TestContext) string {
 	return controllerPodName
 }
 
-// defaultMetricsPort is the scaffolded metrics port, used by ValidateMetricsUnavailable
-// where no metrics service exists to read the port from.
+// healthProbePort is the scaffolded health probe port; no NetworkPolicy allows it
+const healthProbePort = 8081
+
+// defaultMetricsPort is the scaffolded metrics port
 const defaultMetricsPort = 8443
+
+// defaultWebhookPort is the scaffolded webhook server port
+const defaultWebhookPort = 9443
 
 // GetMetricsServicePort returns the port exposed by the controller-manager metrics Service.
 // namePrefix is the prefix for service names (e.g., "e2e-{suffix}" or "custom-operator" from fullnameOverride)
@@ -303,6 +308,162 @@ func removeCurlPod(kbc *utils.TestContext) {
 	By("cleaning up the curl pod")
 	_, err := kbc.Kubectl.Delete(true, "pods/curl", "--grace-period=0", "--force")
 	Expect(err).NotTo(HaveOccurred())
+}
+
+// ValidateNetworkPolicyEnforcement checks allowed and blocked manager traffic.
+func ValidateNetworkPolicyEnforcement(
+	controllerPodName, namePrefix string,
+	webhookPort int,
+	hasWebhook bool,
+	kbc *utils.TestContext,
+) {
+	metricsServiceName := fmt.Sprintf("%s-controller-manager-metrics-service", namePrefix)
+	metricsPort := GetMetricsServicePort(namePrefix, kbc)
+
+	By("ensuring the metrics endpoint is ready so a blocked request cannot be mistaken for a slow start")
+	Eventually(func(g Gomega) {
+		output, err := kbc.Kubectl.Command(
+			"get", "endpointslices.discovery.k8s.io",
+			"-n", kbc.Kubectl.Namespace,
+			"-l", fmt.Sprintf("kubernetes.io/service-name=%s", metricsServiceName),
+			"-o", "jsonpath={range .items[*]}{range .endpoints[*]}{.addresses[*]}{end}{end}",
+		)
+		g.Expect(err).NotTo(HaveOccurred(), "endpointslices should exist")
+		g.Expect(output).ShouldNot(BeEmpty(), "no endpoints found")
+	}, 2*time.Minute, time.Second).Should(Succeed())
+
+	By("ensuring the controller pod is ready")
+	Eventually(func(g Gomega) {
+		output, err := kbc.Kubectl.Get(
+			true,
+			"pod", controllerPodName,
+			"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+		)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(output).To(Equal("True"), "Controller pod not ready")
+	}, defaultTimeout, defaultPollingInterval).Should(Succeed())
+
+	By("proving the metrics NetworkPolicy blocks scrapes from namespaces without the 'metrics: enabled' label")
+	unlabeledNamespace := fmt.Sprintf("test-np-denied-%s", kbc.TestSuffix)
+	_, err := kbc.Kubectl.Command("create", "namespace", unlabeledNamespace)
+	Expect(err).NotTo(HaveOccurred(), "namespace should be created successfully")
+	DeferCleanup(func() {
+		_, _ = kbc.Kubectl.Command("delete", "namespace", unlabeledNamespace, "--ignore-not-found")
+	})
+
+	metricsURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d/metrics",
+		metricsServiceName, kbc.Kubectl.Namespace, metricsPort)
+	expectRequestTimedOut(kbc, "np-denied-metrics", unlabeledNamespace, metricsURL)
+
+	By("proving the NetworkPolicies deny ingress to a manager port they do not allow")
+	podIP, err := kbc.Kubectl.Get(
+		true,
+		"pod", controllerPodName,
+		"-o", "jsonpath={.status.podIP}",
+	)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(podIP).NotTo(BeEmpty(), "controller pod should have an IP assigned")
+
+	healthURL := fmt.Sprintf("http://%s:%d/healthz", podIP, healthProbePort)
+	expectRequestTimedOut(kbc, "np-denied-port", kbc.Kubectl.Namespace, healthURL)
+
+	if hasWebhook {
+		By("proving the webhook NetworkPolicy allows traffic from an unlabeled namespace")
+		webhookURL := fmt.Sprintf("https://%s:%d/", podIP, webhookPort)
+		expectRequestAllowed(kbc, "np-allowed-webhook", unlabeledNamespace, webhookURL)
+	}
+}
+
+// expectRequestTimedOut runs a curl pod against url and expects the request to time out
+// (curl exit code 28), which is how a NetworkPolicy drop surfaces. The pod retries a few
+// times so a request sent before the CNI programs the policy does not flake the test.
+func expectRequestTimedOut(kbc *utils.TestContext, podName, namespace, url string) {
+	script := fmt.Sprintf(
+		"for i in $(seq 1 6); do "+
+			"curl -sk -o /dev/null --max-time 10 %s; rc=$?; "+
+			"if [ $rc -eq 28 ]; then echo BLOCKED; exit 0; fi; "+
+			"echo attempt $i exited with $rc; sleep 5; "+
+			"done; echo NOT-BLOCKED; exit 1", url)
+
+	runCurlPod(kbc, podName, namespace, script)
+
+	By(fmt.Sprintf("validating that the request from pod %s timed out", podName))
+	Eventually(func(g Gomega) {
+		status, errStatus := kbc.Kubectl.Command(
+			"get", "pods", podName,
+			"-n", namespace,
+			"-o", "jsonpath={.status.phase}",
+		)
+		g.Expect(errStatus).NotTo(HaveOccurred())
+		g.Expect(status).To(Equal("Succeeded"),
+			"curl should time out on the blocked endpoint; check the pod logs for the exit codes seen")
+
+		logs, errLogs := kbc.Kubectl.Command("logs", podName, "-n", namespace)
+		g.Expect(errLogs).NotTo(HaveOccurred())
+		g.Expect(logs).To(ContainSubstring("BLOCKED"),
+			"the request should be dropped by the NetworkPolicy, not answered or refused")
+	}, 3*time.Minute, time.Second).Should(Succeed())
+}
+
+func expectRequestAllowed(kbc *utils.TestContext, podName, namespace, url string) {
+	script := fmt.Sprintf(
+		"for i in $(seq 1 6); do "+
+			"if curl -sk -o /dev/null --max-time 5 %s; then echo ALLOWED; exit 0; fi; "+
+			"sleep 2; "+
+			"done; echo BLOCKED; exit 1", url)
+	runCurlPod(kbc, podName, namespace, script)
+
+	By(fmt.Sprintf("validating that the request from pod %s succeeded", podName))
+	Eventually(func(g Gomega) {
+		status, errStatus := kbc.Kubectl.Command(
+			"get", "pods", podName,
+			"-n", namespace,
+			"-o", "jsonpath={.status.phase}",
+		)
+		g.Expect(errStatus).NotTo(HaveOccurred())
+		g.Expect(status).To(Equal("Succeeded"), "the webhook port should accept traffic")
+
+		logs, errLogs := kbc.Kubectl.Command("logs", podName, "-n", namespace)
+		g.Expect(errLogs).NotTo(HaveOccurred())
+		g.Expect(logs).To(ContainSubstring("ALLOWED"))
+	}, 2*time.Minute, time.Second).Should(Succeed())
+}
+
+func runCurlPod(kbc *utils.TestContext, podName, namespace, script string) {
+	_, err := kbc.Kubectl.Command(
+		"run", podName,
+		"--restart=Never",
+		"--namespace", namespace,
+		"--image=curlimages/curl:latest",
+		"--overrides",
+		fmt.Sprintf(`{
+			"spec": {
+				"containers": [{
+					"name": "%s",
+					"image": "curlimages/curl:latest",
+					"command": ["/bin/sh", "-c"],
+					"args": ["%s"],
+					"securityContext": {
+						"readOnlyRootFilesystem": true,
+						"allowPrivilegeEscalation": false,
+						"capabilities": {
+							"drop": ["ALL"]
+						},
+						"runAsNonRoot": true,
+						"runAsUser": 1000,
+						"seccompProfile": {
+							"type": "RuntimeDefault"
+						}
+					}
+				}]
+			}
+		}`, podName, script),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		_, _ = kbc.Kubectl.Command("delete", "pods", podName, "-n", namespace,
+			"--ignore-not-found", "--grace-period=0", "--force")
+	})
 }
 
 // serviceAccountToken provides a helper function that can provide you with a service account

--- a/testdata/project-v4-multigroup/config/default/kustomization.yaml
+++ b/testdata/project-v4-multigroup/config/default/kustomization.yaml
@@ -27,10 +27,9 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/testdata/project-v4-multigroup/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-metrics-traffic.yaml
@@ -1,6 +1,5 @@
-# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,7 +16,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-multigroup/config/network-policy/allow-webhook-traffic.yaml
@@ -1,6 +1,8 @@
-# This NetworkPolicy allows ingress traffic to your webhook server running
-# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
-# will only work when applied in namespaces labeled with 'webhook: enabled'
+# Allow ingress to the webhook server's pod port (9443) from all sources.
+# The webhook Service exposes port 443 and forwards traffic to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,11 +19,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label webhook: enabled
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled # Only from namespaces with this label
-      ports:
-        - port: 443
+    - ports:
+        - port: 9443
           protocol: TCP

--- a/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
+++ b/testdata/project-v4-with-plugins/.github/workflows/test-chart.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           helm lint ./dist/chart
 
-
       - name: Install cert-manager via Helm (wait for readiness)
         run: |
           helm repo add jetstack https://charts.jetstack.io

--- a/testdata/project-v4-with-plugins/config/default/kustomization.yaml
+++ b/testdata/project-v4-with-plugins/config/default/kustomization.yaml
@@ -27,10 +27,9 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/testdata/project-v4-with-plugins/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/config/network-policy/allow-metrics-traffic.yaml
@@ -1,6 +1,5 @@
-# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,7 +16,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/testdata/project-v4-with-plugins/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/config/network-policy/allow-webhook-traffic.yaml
@@ -1,6 +1,8 @@
-# This NetworkPolicy allows ingress traffic to your webhook server running
-# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
-# will only work when applied in namespaces labeled with 'webhook: enabled'
+# Allow ingress to the webhook server's pod port (9443) from all sources.
+# The webhook Service exposes port 443 and forwards traffic to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,11 +19,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label webhook: enabled
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled # Only from namespaces with this label
-      ports:
-        - port: 443
+    - ports:
+        - port: 9443
           protocol: TCP

--- a/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.certManager.enabled }}
+{{- if and .Values.certManager.enabled .Values.webhook.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/crd/wordpresses.example.com.testproject.org.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/crd/wordpresses.example.com.testproject.org.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.crd.enabled (not .Values.webhook.enabled) }}
+{{- fail "webhook.enabled must be true for CRD conversion" }}
+{{- end }}
 {{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -90,7 +90,7 @@ spec:
         {{- range .Values.manager.args }}
         - {{ tpl . $ }}
         {{- end }}
-        {{- if .Values.certManager.enabled }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         {{- end }}
         command:
@@ -149,7 +149,7 @@ spec:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}
           {{- end }}
-          {{- if .Values.certManager.enabled }}
+          {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: webhook-certs
             readOnly: true
@@ -168,7 +168,7 @@ spec:
         {{- if .Values.manager.extraVolumes }}
         {{- toYaml .Values.manager.extraVolumes | nindent 8 }}
         {{- end }}
-        {{- if .Values.certManager.enabled }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - name: webhook-certs
           secret:
             secretName: webhook-server-cert

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled .Values.metrics.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,5 +1,10 @@
 {{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
 ---
+# Allow ingress to the webhook server's pod port from all sources.
+# The webhook Service forwards traffic from its Service port to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,11 +21,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled
-      ports:
+    - ports:
         - port: {{ .Values.webhook.port }}
           protocol: TCP
 {{- end }}

--- a/testdata/project-v4/config/default/kustomization.yaml
+++ b/testdata/project-v4/config/default/kustomization.yaml
@@ -27,10 +27,9 @@ resources:
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
-# [NETWORK POLICY] Protect the /metrics endpoint and Webhook Server with NetworkPolicy.
-# Only Pod(s) running a namespace labeled with 'metrics: enabled' will be able to gather the metrics.
-# Only CR(s) which requires webhooks and are applied on namespaces labeled with 'webhooks: enabled' will
-# be able to communicate with the Webhook Server.
+# [NETWORK POLICY] Control ingress to metrics and webhook ports.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Allow webhook traffic from all sources.
 #- ../network-policy
 
 # Uncomment the patches line if you enable Metrics

--- a/testdata/project-v4/config/network-policy/allow-metrics-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-metrics-traffic.yaml
@@ -1,6 +1,5 @@
-# This NetworkPolicy allows ingress traffic
-# with Pods running on namespaces labeled with 'metrics: enabled'. Only Pods on those
-# namespaces are able to gather data from the metrics endpoint.
+# Allow metrics traffic from pods in namespaces labeled 'metrics: enabled'.
+# Add this label to namespaces whose pods should scrape metrics.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,7 +16,7 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label metrics: enabled
+    # Allow pods in namespaces labeled 'metrics: enabled' to scrape metrics.
     - from:
       - namespaceSelector:
           matchLabels:

--- a/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
+++ b/testdata/project-v4/config/network-policy/allow-webhook-traffic.yaml
@@ -1,6 +1,8 @@
-# This NetworkPolicy allows ingress traffic to your webhook server running
-# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
-# will only work when applied in namespaces labeled with 'webhook: enabled'
+# Allow ingress to the webhook server's pod port (9443) from all sources.
+# The webhook Service exposes port 443 and forwards traffic to the pod port.
+# The Kubernetes API server uses the Service to reach admission and CRD conversion webhooks.
+# To restrict admission requests by namespace, configure namespaceSelector in the
+# MutatingWebhookConfiguration or ValidatingWebhookConfiguration.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,11 +19,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # This allows ingress traffic from any namespace with the label webhook: enabled
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            webhook: enabled # Only from namespaces with this label
-      ports:
-        - port: 443
+    - ports:
+        - port: 9443
           protocol: TCP


### PR DESCRIPTION
### Problem

NetworkPolicy generation was inconsistent between Kustomize and Helm. The Kustomize webhook policy used the Service port (443) and a namespace selector that could block API server admission requests. Helm also generated policies when their features were disabled, rewrote unrelated egress ports, detected the wrong webhook port, and overwrote user-owned templates during regeneration.

### Solution

This change:

- Uses the webhook pod port (9443), not the Service port.
- Allows API server traffic to reach the webhook.
- Keeps metrics access restricted to labeled namespaces.
- Gates metrics and webhook policies on their feature flags.
- Preserves egress and custom ports.
- Uses the Service targetPort for webhook detection.
- Preserves default NetworkPolicies and ServiceMonitors unless --force is used.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5906