### PR TITLE
🐛 (helm/v2-alpha): `prometheus.enabled` in the generated chart now reflects the kustomize output (true when a ServiceMonitor is present) instead of always defaulting to false.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -183,7 +183,7 @@ webhook:
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enabled: false
+  enabled: true
 
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -183,7 +183,7 @@ webhook:
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enabled: false
+  enabled: true
 
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -151,14 +151,15 @@ certManager:
 		f.addWebhookSection(&buf)
 	}
 
-	// Prometheus configuration (always present)
+	// Prometheus configuration (always present, enabled when the kustomize output provides a ServiceMonitor)
+	prometheusEnabled := f.Extraction != nil && f.Extraction.Features.HasPrometheus
+
 	buf.WriteString(`## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.
 ##
 prometheus:
-  enabled: false
-
 `)
+	fmt.Fprintf(&buf, "  enabled: %t\n\n", prometheusEnabled)
 
 	// NetworkPolicy configuration (always present, enabled when NetworkPolicy resources exist)
 	networkPolicyEnabled := f.Extraction != nil && f.Extraction.Features.HasNetworkPolicy

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
@@ -72,6 +72,32 @@ var _ = Describe("HelmValues", func() {
 		})
 	})
 
+	Describe("Prometheus section", func() {
+		It("should default prometheus.enabled to false when no ServiceMonitor exists", func() {
+			values := &HelmValues{Extraction: nil}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("prometheus:\n  enabled: false"))
+		})
+
+		It("should set prometheus.enabled to true when a ServiceMonitor is detected", func() {
+			values := &HelmValues{
+				Extraction: &extractor.Extraction{
+					Features: extractor.FeatureSet{
+						HasPrometheus: true,
+					},
+				},
+			}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("prometheus:\n  enabled: true"))
+		})
+	})
+
 	Describe("RoleNamespaces rendering", func() {
 		Context("when no roleNamespaces are detected", func() {
 			It("should not include roleNamespaces section when Extraction is nil", func() {


### PR DESCRIPTION
In the generated Helm chart, each feature is turned on by default when we find it in the kustomize output — like metrics, networkPolicy, certManager, and crd. Prometheus was the odd one out: prometheus.enabled was always false, even when a ServiceMonitor was already there.

This change makes Prometheus behave like the rest. If a ServiceMonitor is present in the kustomize output, prometheus.enabled is true. If it isn't, it stays false