### PR TITLE
🌱 (go/v4): revert #5887 scaffold change before release and document the Podman limitation. Keep CI check and enhance it.

### DIFF
--- a/.github/workflows/test-dockerignore.yml
+++ b/.github/workflows/test-dockerignore.yml
@@ -19,29 +19,16 @@ on:
 permissions: {}
 
 jobs:
-  # Container tools disagree on whether they descend into an ignored directory to
-  # evaluate a re-include such as "!**/*.go". Build the sample project with each of
-  # them so the scaffolded .dockerignore cannot regress on any one of them.
-  build-context-testdata:
-    name: ${{ matrix.name }} / testdata sample
+  # The scaffolded .dockerignore re-includes every Go source with !**/*.go, so the
+  # image builds no matter which directories hold the code. Only docker (BuildKit)
+  # evaluates that re-include; podman and buildah do not (containers/buildah#6417)
+  # and are best effort, documented in the FAQ. project-v4 already carries an API
+  # and webhooks, so it exercises cmd/, api/ and internal/.
+  build-context:
+    name: docker
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: docker (BuildKit)
-            tool: docker
-            buildkit: '1'
-          - name: docker (classic builder)
-            tool: docker
-            buildkit: '0'
-          - name: podman
-            tool: podman
-            buildkit: ''
-    env:
-      DOCKER_BUILDKIT: ${{ matrix.buildkit }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -53,71 +40,15 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Prepare project-v4
+      # testdata go.sum is gitignored; generate it so the context is complete and the
+      # image can build.
+      - name: Generate the sample go.sum
         working-directory: testdata/project-v4
         run: go mod tidy
 
-      - name: Verify the build context
-        env:
-          CONTAINER_TOOL: ${{ matrix.tool }}
-        run: ./test/verify-docker-build-context.sh testdata/project-v4
+      - name: Verify the build context holds only the manager sources
+        run: make test-docker-build-context
 
       - name: Build the manager image
         working-directory: testdata/project-v4
-        env:
-          CONTAINER_TOOL: ${{ matrix.tool }}
-        run: make docker-build IMG=controller:ci CONTAINER_TOOL="${CONTAINER_TOOL}"
-
-  # Covers the case reported in #5886: a freshly scaffolded project, no APIs yet.
-  build-context-scaffolded:
-    name: ${{ matrix.name }} / freshly scaffolded
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: docker (BuildKit)
-            tool: docker
-            buildkit: '1'
-          - name: docker (classic builder)
-            tool: docker
-            buildkit: '0'
-          - name: podman
-            tool: podman
-            buildkit: ''
-    env:
-      DOCKER_BUILDKIT: ${{ matrix.buildkit }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-
-      - name: Build kubebuilder CLI from this repo
-        run: make install
-
-      - name: Scaffold a go/v4 project
-        run: |
-          mkdir -p /tmp/dockerignore-project
-          cd /tmp/dockerignore-project
-          kubebuilder init --plugins go/v4 --domain example.com --repo example.com/dockerignore-operator
-          kubebuilder create api --group crew --version v1 --kind Captain --resource --controller
-          go mod tidy
-
-      - name: Verify the build context
-        env:
-          CONTAINER_TOOL: ${{ matrix.tool }}
-        run: ${GITHUB_WORKSPACE}/test/verify-docker-build-context.sh /tmp/dockerignore-project
-
-      - name: Build the manager image
-        working-directory: /tmp/dockerignore-project
-        env:
-          CONTAINER_TOOL: ${{ matrix.tool }}
-        run: make docker-build IMG=controller:ci CONTAINER_TOOL="${CONTAINER_TOOL}"
+        run: make docker-build IMG=controller:ci

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,10 @@ test-book: ## Run the cronjob tutorial's unit tests to make sure we don't break 
 test-gomod:  ## Run the Go module compatibility check
 	go run ./hack/test/check_go_module.go
 
+.PHONY: test-docker-build-context
+test-docker-build-context: ## Check the scaffolded .dockerignore ships only the manager sources to the image build
+	./test/verify-docker-build-context.sh testdata/project-v4
+
 .PHONY: test-external-plugin
 test-external-plugin: install  ## Run tests for external plugin
 	make -C docs/book/src/simple-external-plugin-tutorial/testdata/sampleexternalplugin/v1 install

--- a/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/cronjob-tutorial/testdata/project/.dockerignore
@@ -2,14 +2,13 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go

--- a/docs/book/src/faq.md
+++ b/docs/book/src/faq.md
@@ -176,7 +176,21 @@ type StructName struct {
 - Users still receive error notifications from the Kubernetes API for invalid `timeField` values.
 - Developers can directly use the parsed TimeField in their code without additional parsing, reducing errors and improving efficiency.
 
+## When I build the image with Podman or Buildah, the build fails with `cmd/main.go: no such file or directory`. How to solve it?
 
+While we do our best to keep the scaffold working with other container tools, Kubebuilder is officially tested and supported with **Docker**.
+
+The scaffolded `.dockerignore` re-includes all Go source files with `!**/*.go`. Docker honors this pattern. Podman and Buildah do not: they skip ignored directories, so no Go source reaches the build context. This is tracked upstream in [buildah#6417][dockerignore-buildah-issue] and was reported in [kubebuilder#5181][dockerignore-kb-issue].
+
+If you use Podman, re-include your source directories by name in `.dockerignore`:
+
+```text
+!cmd
+!api
+!internal
+```
+
+Add any other directory in your project that holds Go source files.
 
 [k8s-obj-creation]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#how-to-create-objects
 [gvk]: ./cronjob-tutorial/gvks.md
@@ -187,3 +201,5 @@ type StructName struct {
 [permission-PR]: https://github.com/kubernetes/kubernetes/pull/89193
 [controller-gen]: ./reference/controller-gen.html
 [k8s-ssa-docs]: https://kubernetes.io/docs/reference/using-api/server-side-apply/
+[dockerignore-kb-issue]: https://github.com/kubernetes-sigs/kubebuilder/issues/5181
+[dockerignore-buildah-issue]: https://github.com/containers/buildah/issues/6417

--- a/docs/book/src/getting-started/testdata/project/.dockerignore
+++ b/docs/book/src/getting-started/testdata/project/.dockerignore
@@ -2,14 +2,13 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go

--- a/docs/book/src/migration/reorganize-layout.md
+++ b/docs/book/src/migration/reorganize-layout.md
@@ -23,6 +23,16 @@ Always validate changes carefully.
 
 </aside>
 
+<aside class="note" role="note">
+
+<p class="note-title">Building with Podman or Buildah</p>
+
+Podman does not honor the `!**/*.go` re-include in the scaffolded `.dockerignore`.
+If you use Podman, re-include your source directories by name. See the
+[FAQ](../faq.md#when-i-build-the-image-with-podman-or-buildah-the-build-fails-with-cmdmaingo-no-such-file-or-directory-how-to-solve-it) for details.
+
+</aside>
+
 ## Instructions to provide to your AI assistant
 
 Copy and paste these instructions to your AI assistant:
@@ -104,10 +114,17 @@ Option 1 - Simplify (recommended):
 
 Ensure .dockerignore has:
     **
-    !**/*.go
-    **/*_test.go
     !go.mod
     !go.sum
+    !**/*.go
+    **/*_test.go
+
+Note: Podman does not honor the !**/*.go re-include
+(https://github.com/containers/buildah/issues/6417). If the project is built
+with Podman, also re-include the source directories by name:
+    !cmd
+    !api
+    !internal
 
 Option 2 - Update explicit paths:
     COPY cmd/ cmd/

--- a/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
+++ b/docs/book/src/multiversion-tutorial/testdata/project/.dockerignore
@@ -2,14 +2,13 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/dockerignore.go
@@ -42,15 +42,14 @@ const dockerignorefileTemplate = `# More info: https://docs.docker.com/engine/re
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go
 `

--- a/test/verify-docker-build-context.sh
+++ b/test/verify-docker-build-context.sh
@@ -14,64 +14,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Verifies the scaffolded .dockerignore: the builder stage must receive every Go source
-# needed to build the manager, and none of the files that must not reach the image.
+# Checks that the scaffolded .dockerignore sends exactly the Go sources that build the
+# manager to the image build context: every non-test *.go in the project, wherever it
+# lives, plus go.mod and go.sum, and nothing else.
 #
-# Container tools disagree on whether they descend into an ignored directory to evaluate
-# a re-include such as "!**/*.go": BuildKit does, the classic Docker builder and
-# Podman/buildah do not. Run this against each of them.
+# Docker (BuildKit) is the supported tool. Podman and Buildah do not evaluate the
+# !**/*.go re-include (containers/buildah#6417) and fail this check by design; the
+# limitation and its workaround are documented in the FAQ.
 #
-# Usage: CONTAINER_TOOL=docker ./test/verify-docker-build-context.sh <project-dir>
+# Usage: ./test/verify-docker-build-context.sh <project-dir>
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
+# Sort by bytes on the host so the ordering matches the container's C-locale sort,
+# on both Linux and macOS.
+export LC_ALL=C
+
+# The !**/*.go re-include needs BuildKit, the default builder since Docker 23.
+export DOCKER_BUILDKIT=1
+
 CONTAINER_TOOL="${CONTAINER_TOOL:-docker}"
 PROJECT_DIR="${1:?usage: $0 <project-dir>}"
 
+if ! command -v "${CONTAINER_TOOL}" >/dev/null 2>&1; then
+  echo "ERROR: '${CONTAINER_TOOL}' is not installed. Install Docker or Podman," >&2
+  echo "       or set CONTAINER_TOOL to a container tool that is on PATH." >&2
+  exit 1
+fi
+
 cd "${PROJECT_DIR}"
+
+# The files the build context must hold, derived from the project itself: every
+# non-test Go source, no matter the directory, plus the module files.
+# go.sum is only present once modules are resolved, so include it only if it exists.
+expected="$( { find . -type f -name '*.go' ! -name '*_test.go' | sed 's|^\./||'
+               ls go.mod go.sum 2>/dev/null || true; } | sort )"
 
 IMG="dockerignore-context-probe:$$"
 trap '${CONTAINER_TOOL} rmi -f "${IMG}" >/dev/null 2>&1 || true' EXIT
 
-# Stop at the builder stage: it still has a shell, and it is the stage that consumes
-# the build context. The final image is distroless and only holds the binary.
-echo "Building the builder stage with ${CONTAINER_TOOL} ..."
-"${CONTAINER_TOOL}" build --target builder -t "${IMG}" .
+# Copy the build context into a throwaway image so we can list what the .dockerignore
+# let through, without running the real (slow) manager build.
+"${CONTAINER_TOOL}" build -q -t "${IMG}" -f - . >/dev/null <<'EOF'
+FROM busybox
+WORKDIR /context
+COPY . .
+EOF
 
-context="$("${CONTAINER_TOOL}" run --rm "${IMG}" \
-  sh -c 'cd /workspace && find . -type f | sed "s|^\./||" | sort')"
+actual="$("${CONTAINER_TOOL}" run --rm "${IMG}" \
+  sh -c 'cd /context && find . -type f | sed "s|^\./||" | sort')"
 
-echo "Files the builder stage received:"
-echo "${context}" | sed 's/^/  /'
-
-fail=0
-
-# Every non-test Go source under the scaffolded source dirs has to be there, or the
-# build either breaks now or breaks later when a controller starts importing it.
-required="$(find ./cmd ./api ./internal -type f -name '*.go' ! -name '*_test.go' 2>/dev/null \
-  | sed 's|^\./||' | sort || true)"
-required="$(printf '%s\ngo.mod\ngo.sum\n' "${required}" | grep -v '^$' | sort)"
-
-missing="$(comm -23 <(echo "${required}") <(echo "${context}"))"
-if [[ -n "${missing}" ]]; then
-  echo "ERROR: these files are missing from the build context:"
-  echo "${missing}" | sed 's/^/  /'
-  fail=1
-fi
-
-# Nothing that belongs to the repo rather than the binary may reach the context.
-forbidden="$(echo "${context}" | grep -E \
-  '^(config/|dist/|bin/|hack/|grafana/|\.git/|Makefile$|PROJECT$|Dockerfile$|.*\.md$)|_test\.go$' || true)"
-if [[ -n "${forbidden}" ]]; then
-  echo "ERROR: these files must not be in the build context:"
-  echo "${forbidden}" | sed 's/^/  /'
-  fail=1
-fi
-
-if [[ "${fail}" -ne 0 ]]; then
+if ! diff <(echo "${expected}") <(echo "${actual}"); then
+  echo "ERROR: ${CONTAINER_TOOL} build context does not match the manager sources."
+  echo "       '<' expected, '>' present in the context."
   exit 1
 fi
 
-echo "OK: ${CONTAINER_TOOL} build context contains the manager sources and nothing else."
+echo "OK: ${CONTAINER_TOOL} build context holds exactly the manager sources."

--- a/testdata/project-v4-multigroup/.dockerignore
+++ b/testdata/project-v4-multigroup/.dockerignore
@@ -2,14 +2,13 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go

--- a/testdata/project-v4-with-plugins/.dockerignore
+++ b/testdata/project-v4-with-plugins/.dockerignore
@@ -2,14 +2,13 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go

--- a/testdata/project-v4/.dockerignore
+++ b/testdata/project-v4/.dockerignore
@@ -2,14 +2,13 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include Go source files (but not *_test.go)
+# If you use Podman, re-include your source directories by name,
+# such as !cmd, !api, and !internal.
+# See https://github.com/containers/buildah/issues/6417
+!**/*.go
+**/*_test.go
+
 # Re-include Go module files
 !go.mod
 !go.sum
-
-# Re-include Go source files (but not *_test.go). The source dirs are named because
-# Podman and the classic Docker builder skip ignored dirs; add your own dirs here too.
-!**/*.go
-!cmd
-!api
-!internal
-**/*_test.go


### PR DESCRIPTION
Description:

#5887 changed the scaffolded .dockerignore to list the source directories
(!cmd, !api, !internal). That forces users to edit the file whenever their Go
sources live anywhere else, which is a burden we do not want in the scaffold.
Since #5887 was not released, this PR reverts it before the release.

The scaffolded .dockerignore behaves exactly as before #5887: the !**/*.go
re-include sends every Go source to the build, no matter which directories
hold the code. The only delta is a comment noting the Podman limitation:
Podman does not honor the !**/*.go re-include (containers/buildah#6417,
reported in kubebuilder#5181), so Podman users must re-include their source
directories by name. Kubebuilder officially supports Docker; other tools are
best effort.

Changes:
- Revert the scaffolded .dockerignore (template, testdata, and docs samples)
  to the pre-#5887 content, adding odman limitation.
- Add a FAQ entry explaining why the build fails with Podman/Buildah and the
  workaround.
- Link the FAQ from the reorganize-layout migration guide.
- CI verifies the build context wits this check by
  design until fixed upstream. The check derives the expected files from every
  non-test Go source in the project.