### PR TITLE
🐛 fix(golang/v4): reuse external API config when creating webhooks

### DIFF
--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -133,15 +133,8 @@ func (p *createWebhookSubcommand) InjectConfig(c config.Config) error {
 func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 	p.resource = res
 
-	// Copy essential fields from existing resource in PROJECT file (Path, Plural,
-	// External, Core, Module). API/Controllers/Webhooks are managed separately
-	// by UpdateResource.
-	if existingRes, err := p.config.GetResource(res.GVK); err == nil {
-		p.resource.Path = existingRes.Path
-		p.resource.Plural = existingRes.Plural
-		p.resource.External = existingRes.External
-		p.resource.Core = existingRes.Core
-		p.resource.Module = existingRes.Module
+	if err := p.updateResourceFromConfig(res); err != nil {
+		return err
 	}
 
 	for _, spoke := range p.options.Spoke {
@@ -181,7 +174,13 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 	res = &resValue
 	if err != nil {
 		if !p.resource.External && !p.resource.Core {
-			return fmt.Errorf("%s create webhook requires a previously created API ", p.commandName)
+			return fmt.Errorf(
+				"no API found for %s/%s, Kind %s: run 'create api' first, "+
+					"or pass --external-api-path for an external type",
+				p.resource.QualifiedGroup(),
+				p.resource.Version,
+				p.resource.Kind,
+			)
 		}
 	} else if res.Webhooks != nil && !res.Webhooks.IsEmpty() && !p.force {
 		// Check if user is trying to add a webhook type that already exists
@@ -238,6 +237,32 @@ func (p *createWebhookSubcommand) PostScaffold() error {
 	}
 
 	fmt.Print("Next: implement your new Webhook and generate the manifests with:\n$ make manifests\n")
+
+	return nil
+}
+
+// updateResourceFromConfig copies existing resource configuration from PROJECT file.
+func (p *createWebhookSubcommand) updateResourceFromConfig(res *resource.Resource) error {
+	// Match by Group, Version, and Kind because external APIs may have
+	// a different domain than the project domain.
+	resources, err := p.config.GetResources()
+	if err != nil {
+		return fmt.Errorf("failed to load resources from project configuration: %w", err)
+	}
+
+	for _, existingRes := range resources {
+		if existingRes.Group == res.Group &&
+			existingRes.Version == res.Version &&
+			existingRes.Kind == res.Kind {
+			p.resource.Domain = existingRes.Domain
+			p.resource.Path = existingRes.Path
+			p.resource.Plural = existingRes.Plural
+			p.resource.External = existingRes.External
+			p.resource.Core = existingRes.Core
+			p.resource.Module = existingRes.Module
+			break
+		}
+	}
 
 	return nil
 }

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -184,31 +184,42 @@ var _ = Describe("createWebhookSubcommand", func() {
 		Expect(res.Path).To(Equal(externalPath))
 	})
 
-	It("should find existing external resource when stored Domain differs from project domain", func() {
+	It("should reuse external API configuration from PROJECT without external flags", func() {
 		const externalPath = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 		const externalDomain = "cert-manager.io"
 
 		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
 
-		// Resource was originally scaffolded with --external-api-domain=cert-manager.io,
-		// so PROJECT stores Domain="cert-manager.io". A fresh CLI invocation without
-		// --external-api-domain runs resolveDomain up in cmd_helpers before the GVK
-		// reaches InjectResource, so by this point res.Domain has already been reconciled
-		// to the stored external domain — mirror that here.
+		// Simulate an external API in the PROJECT file
 		storedRes := *res
 		storedRes.External = true
 		storedRes.Path = externalPath
 		storedRes.Domain = externalDomain
 		Expect(cfg.AddResource(storedRes)).To(Succeed())
 
+		// Simulate user running create webhook without any external flags.
+		// res.Domain will be the default project domain initially.
 		subCmd.options.DoDefaulting = true
-		res.Domain = externalDomain
 
 		err := subCmd.InjectResource(res)
 
+		// Expected: success, and fields are correctly reused.
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.External).To(BeTrue())
 		Expect(res.Path).To(Equal(externalPath))
+		Expect(res.Domain).To(Equal(externalDomain))
+	})
+
+	It("should return improved error message when API is missing", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no API found for"))
+		Expect(err.Error()).To(ContainSubstring("run 'create api' first"))
+		Expect(err.Error()).To(ContainSubstring("or pass --external-api-path for an external type"))
 	})
 
 	Context("isValidVersion", func() {


### PR DESCRIPTION
Fixes #5912

### What changed

kubebuilder create webhook failed for previously created external APIs when users omitted the --external-api-* flags.

The resource lookup relied on the incoming GVK, which included the default project domain. For external APIs, the PROJECT file stores the resource with its external domain, causing the lookup to fail.

This change:

- Looks up existing resources from PROJECT using Group, Version, and Kind.
- Restores stored resource configuration before webhook generation.
- Reuses:
  - Domain
  - Path
  - Plural
  - External
  - Core
  - Module

It intentionally avoids copying API, Controllers, and Webhooks because those are managed separately by UpdateResource().

### Error handling improvement

Improved missing API error message.

Before:

create webhook requires a previously created API


After:

no API found for unknown.example.com/v1, Kind Missing:
run 'create api' first, or pass --external-api-path for an external type


### Tests

Updated regression coverage to reproduce the real CLI flow:

- External API exists in PROJECT with an external domain.
- create webhook is executed without external flags.
- Verify InjectResource() restores the external configuration.

Validated with:

go test ./pkg/plugins/golang/v4/...


Result:

ok   sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4
ok   sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds
ok   sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4/scaffolds/internal/templates/hack