### PR TITLE
🐛 (helm/v2-alpha): scope manager port templating to the manager container

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/helpers.go
@@ -99,7 +99,10 @@ var (
 )
 
 // FindManagerContainerRange returns the 0-based inclusive line range [start, end]
-// of the manager container in yamlContent.
+// of the manager container in yamlContent. The manager container is the one named by
+// the kubectl.kubernetes.io/default-container annotation, falling back to "manager"
+// when the annotation is absent (see GetDefaultContainerName) — the same detection the
+// manager values extractor uses, so both passes scope to the same container.
 // Returns (-1, -1) when not found; callers use this to restrict substitutions to the manager only.
 func FindManagerContainerRange(yamlContent string) (int, int) {
 	name := GetDefaultContainerName(yamlContent)
@@ -145,6 +148,33 @@ func FindManagerContainerRange(yamlContent string) (int, int) {
 		return itemStart, len(lines) - 1
 	}
 	return -1, -1
+}
+
+// applyToManagerContainer runs transform on only the manager container's block within
+// yamlContent, leaving sidecar containers and the rest of the Deployment untouched.
+// The manager container is located via FindManagerContainerRange (the
+// kubectl.kubernetes.io/default-container annotation, falling back to "manager").
+// When it cannot be located, yamlContent is returned unchanged: templating is skipped
+// rather than applied document-wide, so brittle detection can never leak manager
+// substitutions into sidecar containers.
+func applyToManagerContainer(yamlContent string, transform func(string) string) string {
+	start, end := FindManagerContainerRange(yamlContent)
+	if start < 0 {
+		return yamlContent
+	}
+
+	lines := strings.Split(yamlContent, "\n")
+	before := lines[:start]
+	block := strings.Join(lines[start:end+1], "\n")
+	after := lines[end+1:]
+
+	transformed := strings.Split(transform(block), "\n")
+
+	result := make([]string, 0, len(before)+len(transformed)+len(after))
+	result = append(result, before...)
+	result = append(result, transformed...)
+	result = append(result, after...)
+	return strings.Join(result, "\n")
 }
 
 func findListField(lines []string, field string) (int, int) {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -25,8 +25,59 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugins/optional/helm/v2alpha/internal/common"
 )
 
+// Port-templating regexes are compiled once at package initialization rather than on
+// every call. Patterns that only differ by replacement string (port/targetPort) are
+// shared across the webhook and metrics substitutions.
+var (
+	webhookContainerPortRE = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*webhook-server)`)
+	metricsBindAddressRE   = regexp.MustCompile(`--metrics-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`)
+	webhookPortArgRE       = regexp.MustCompile(`--webhook-port=([0-9]+)`)
+	portRE                 = regexp.MustCompile(`(\s*)port:\s*\d+`)
+	targetPortRE           = regexp.MustCompile(`(\s*)targetPort:\s*\d+`)
+	metricsHTTPSNameRE     = regexp.MustCompile(`(\s*)- name:\s*https(\s+port:)`)
+
+	healthProbeBindAddressRE = regexp.MustCompile(`--health-probe-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`)
+	healthContainerPortRE    = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*health\b)`)
+	healthProbeHTTPGetPortRE = regexp.MustCompile(`(path:\s*/(?:healthz|readyz)[ \t]*\n\s*port:\s*)\d+`)
+)
+
 // TemplatePorts templates port numbers for Services, Deployments, and NetworkPolicies using values.yaml.
 func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) string {
+	// For Deployments, port/probe/argument templating is scoped to the manager
+	// container so sidecars that happen to use the same ports, probe paths, or
+	// bind-address flags are left untouched.
+	if resource.GetKind() == common.KindDeployment {
+		return applyToManagerContainer(yamlContent, templateManagerContainerPorts)
+	}
+
+	return templateServicePorts(yamlContent, resource)
+}
+
+// templateManagerContainerPorts templates the manager container's port-related fields:
+// the webhook containerPort, the metrics and webhook bind-address arguments, and the
+// health probe port. It is always applied to the manager container block only, so
+// sidecar ports and probes are never rewritten.
+func templateManagerContainerPorts(managerContainer string) string {
+	// Replace containerPort for webhook-server with template (matches any numeric port).
+	// The regex is self-guarding: it only matches a containerPort named "webhook-server".
+	managerContainer = webhookContainerPortRE.
+		ReplaceAllString(managerContainer, "${1}containerPort: {{ .Values.webhook.port }}${2}")
+
+	// Replace --metrics-bind-address with templated port.
+	// Supports :PORT, HOST:PORT, and IPv6 [::1]:PORT formats.
+	managerContainer = metricsBindAddressRE.
+		ReplaceAllString(managerContainer, "--metrics-bind-address=$1:{{ .Values.metrics.port }}")
+
+	// Replace --webhook-port with templated version (matches any numeric port).
+	managerContainer = webhookPortArgRE.
+		ReplaceAllString(managerContainer, "--webhook-port={{ .Values.webhook.port }}")
+
+	return templateHealthProbePort(managerContainer)
+}
+
+// templateServicePorts templates the ports of the webhook and metrics Services and
+// NetworkPolicies. These resources have no containers, so they are identified by name.
+func templateServicePorts(yamlContent string, resource *unstructured.Unstructured) string {
 	resourceName := resource.GetName()
 	resourceKind := resource.GetKind()
 
@@ -40,36 +91,23 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 			strings.HasSuffix(resourceName, "-metrics-service"))) ||
 		(resourceKind == common.KindNetworkPolicy && strings.HasSuffix(resourceName, "allow-metrics-traffic"))
 
-	// For Deployments, detect webhook ports from content
-	if resourceKind == common.KindDeployment {
-		if strings.Contains(yamlContent, "webhook-server") || strings.Contains(yamlContent, "name: webhook") {
-			isWebhook = true
-		}
-	}
-
 	// Template webhook ports
 	if isWebhook {
 		if resourceKind == common.KindNetworkPolicy {
-			yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
+			yamlContent = portRE.
 				ReplaceAllString(yamlContent, "${1}port: {{ .Values.webhook.port }}")
 			return yamlContent
 		}
 
-		// Replace containerPort for webhook-server with template (matches any numeric port)
-		if strings.Contains(yamlContent, "webhook-server") {
-			yamlContent = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*webhook-server)`).
-				ReplaceAllString(yamlContent, "${1}containerPort: {{ .Values.webhook.port }}${2}")
-		}
-
 		// Replace targetPort with webhook.port template (matches any numeric port)
-		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*\d+`).
+		yamlContent = targetPortRE.
 			ReplaceAllString(yamlContent, "${1}targetPort: {{ .Values.webhook.port }}")
 	}
 
 	// Template metrics ports
 	if isMetrics {
 		// Replace port with metrics.port template (matches any numeric port)
-		yamlContent = regexp.MustCompile(`(\s*)port:\s*\d+`).
+		yamlContent = portRE.
 			ReplaceAllString(yamlContent, "${1}port: {{ .Values.metrics.port }}")
 
 		if resourceKind == common.KindNetworkPolicy {
@@ -77,29 +115,15 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured) stri
 		}
 
 		// Replace targetPort with metrics.port template (matches any numeric port)
-		yamlContent = regexp.MustCompile(`(\s*)targetPort:\s*\d+`).
+		yamlContent = targetPortRE.
 			ReplaceAllString(yamlContent, "${1}targetPort: {{ .Values.metrics.port }}")
 
 		// Template port name based on metrics.secure (http vs https)
 		// This ensures Service and ServiceMonitor use the correct scheme
-		if resource.GetKind() == common.KindService {
-			yamlContent = regexp.MustCompile(`(\s*)- name:\s*https(\s+port:)`).
+		if resourceKind == common.KindService {
+			yamlContent = metricsHTTPSNameRE.
 				ReplaceAllString(yamlContent, `${1}- name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}${2}`)
 		}
-	}
-
-	// Template port-related arguments in Deployment
-	if resource.GetKind() == common.KindDeployment {
-		// Replace --metrics-bind-address with templated port
-		// Supports :PORT, HOST:PORT, and IPv6 [::1]:PORT formats
-		yamlContent = regexp.MustCompile(`--metrics-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`).
-			ReplaceAllString(yamlContent, "--metrics-bind-address=$1:{{ .Values.metrics.port }}")
-
-		// Replace --webhook-port with templated version (matches any numeric port)
-		yamlContent = regexp.MustCompile(`--webhook-port=([0-9]+)`).
-			ReplaceAllString(yamlContent, "--webhook-port={{ .Values.webhook.port }}")
-
-		yamlContent = templateHealthProbePort(yamlContent)
 	}
 
 	return yamlContent
@@ -114,15 +138,15 @@ func templateHealthProbePort(yamlContent string) string {
 	const healthPortTemplate = "{{ .Values.manager.healthProbe.port }}"
 
 	// --health-probe-bind-address=:PORT (also HOST:PORT and IPv6 [::1]:PORT)
-	yamlContent = regexp.MustCompile(`--health-probe-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`).
+	yamlContent = healthProbeBindAddressRE.
 		ReplaceAllString(yamlContent, "--health-probe-bind-address=$1:"+healthPortTemplate)
 
 	// containerPort for the port named "health"
-	yamlContent = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*health\b)`).
+	yamlContent = healthContainerPortRE.
 		ReplaceAllString(yamlContent, "${1}containerPort: "+healthPortTemplate+"${2}")
 
 	// liveness (/healthz) and readiness (/readyz) httpGet ports
-	yamlContent = regexp.MustCompile(`(path:\s*/(?:healthz|readyz)[ \t]*\n\s*port:\s*)\d+`).
+	yamlContent = healthProbeHTTPGetPortRE.
 		ReplaceAllString(yamlContent, "${1}"+healthPortTemplate)
 
 	return yamlContent

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -2646,6 +2646,114 @@ spec:
 			Expect(result).NotTo(ContainSubstring(":9091"))
 		})
 
+		// Manager port/probe/argument templating must be scoped to the manager
+		// container: a sidecar that reuses the same ports, probe paths, or
+		// bind-address flags must be left byte-for-byte untouched.
+		const sidecar = `      - name: proxy
+        args:
+        - --metrics-bind-address=:9440
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+        ports:
+        - containerPort: 9440
+          name: health
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9440`
+
+		const managerContainer = `      - name: manager
+        args:
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --webhook-port=9443
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081`
+
+		const deploymentHeader = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+spec:
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+`
+
+		assertManagerTemplated := func(result string) {
+			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("--webhook-port={{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.manager.healthProbe.port }}"))
+		}
+
+		It("should scope templating to the manager container and leave a trailing sidecar untouched", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			content := deploymentHeader + managerContainer + "\n" + sidecar
+
+			result := templater.templatePorts(content, deployment)
+
+			assertManagerTemplated(result)
+			// The sidecar block must survive verbatim (still literal 9440, no template syntax).
+			Expect(result).To(ContainSubstring(sidecar))
+		})
+
+		It("should scope templating to the manager container regardless of container order", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			// Sidecar declared before the manager: range detection must still isolate the manager.
+			content := deploymentHeader + sidecar + "\n" + managerContainer
+
+			result := templater.templatePorts(content, deployment)
+
+			assertManagerTemplated(result)
+			Expect(result).To(ContainSubstring(sidecar))
+		})
+
+		It("should leave the Deployment untouched when no manager container can be located", func() {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+
+			// The only container is a sidecar that reuses the manager's ports, probe
+			// paths, and bind-address flags. With no manager container to scope to,
+			// templating must be skipped entirely rather than rewriting the sidecar
+			// document-wide.
+			content := deploymentHeader + sidecar
+
+			result := templater.templatePorts(content, deployment)
+
+			Expect(result).To(Equal(content))
+		})
+
 		It("should not template non-webhook/metrics resources", func() {
 			regularService := &unstructured.Unstructured{}
 			regularService.SetAPIVersion("v1")
@@ -2733,6 +2841,118 @@ spec:
 
 			Expect(result).To(ContainSubstring("port: 8080"))
 			Expect(result).NotTo(ContainSubstring("{{ .Values"))
+		})
+	})
+
+	// Driven through the full ApplyHelmSubstitutions pipeline (not just templatePorts):
+	// manager-specific templating must never leak into a sidecar container that happens
+	// to reuse the same ports, probes, image pattern, or bind-address flags. Both
+	// container orderings are exercised because range detection is most likely to slip
+	// when the sidecar precedes the manager.
+	Context("when a Deployment has both a manager and a sidecar container", func() {
+		const pipelineManager = `      - name: manager
+        image: controller:latest
+        args:
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --webhook-port=9443
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081`
+
+		const pipelineSidecar = `      - name: proxy
+        image: nginx:1.27
+        args:
+        - --metrics-bind-address=:9440
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9440
+        ports:
+        - containerPort: 9440
+          name: health
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9440`
+
+		const pipelineHeader = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-project-controller-manager
+  namespace: test-project-system
+  labels:
+    control-plane: controller-manager
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+`
+
+		newManagerDeployment := func() *unstructured.Unstructured {
+			deployment := &unstructured.Unstructured{}
+			deployment.SetAPIVersion("apps/v1")
+			deployment.SetKind("Deployment")
+			deployment.SetName("test-project-controller-manager")
+			return deployment
+		}
+
+		assertIsolation := func(result string) {
+			By("templating every manager port, probe, and image reference")
+			Expect(result).To(ContainSubstring("--metrics-bind-address=:{{ .Values.metrics.port }}"))
+			Expect(result).To(ContainSubstring("--health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring("--webhook-port={{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.webhook.port }}"))
+			Expect(result).To(ContainSubstring("containerPort: {{ .Values.manager.healthProbe.port }}"))
+			Expect(result).To(ContainSubstring(".Values.manager.image.repository"))
+
+			By("leaving the sidecar container free of any manager templating")
+			start := strings.Index(result, "- name: proxy")
+			Expect(start).To(BeNumerically(">=", 0))
+			// Bound the slice to the sidecar container: when the sidecar precedes the
+			// manager, cut at the manager so the (correctly templated) manager block is
+			// excluded; when it trails, the tail holds only the sidecar and the chart footer.
+			sidecar := result[start:]
+			if managerStart := strings.Index(sidecar, "- name: manager"); managerStart >= 0 {
+				sidecar = sidecar[:managerStart]
+			}
+			Expect(sidecar).NotTo(ContainSubstring(".Values.manager"))
+			Expect(sidecar).NotTo(ContainSubstring(".Values.metrics"))
+			Expect(sidecar).NotTo(ContainSubstring(".Values.webhook"))
+			Expect(sidecar).To(ContainSubstring("image: nginx:1.27"))
+			Expect(sidecar).To(ContainSubstring("--metrics-bind-address=:9440"))
+			Expect(sidecar).To(ContainSubstring("containerPort: 9440"))
+			Expect(sidecar).To(ContainSubstring(`            path: /healthz
+            port: 9440`))
+			Expect(sidecar).To(ContainSubstring(`            path: /readyz
+            port: 9440`))
+		}
+
+		It("should not rewrite sidecar values when the sidecar follows the manager", func() {
+			content := pipelineHeader + pipelineManager + "\n" + pipelineSidecar
+			assertIsolation(templater.ApplyHelmSubstitutions(content, newManagerDeployment()))
+		})
+
+		It("should not rewrite sidecar values when the sidecar precedes the manager", func() {
+			content := pipelineHeader + pipelineSidecar + "\n" + pipelineManager
+			assertIsolation(templater.ApplyHelmSubstitutions(content, newManagerDeployment()))
 		})
 	})
 


### PR DESCRIPTION
## Description
The Helm `v2-alpha` plugin templated the manager Deployment's ports, health probes, and port-related arguments (`--metrics-bind-address`, `--webhook-port`, `--health-probe-bind-address`) by running regex replacements across the entire rendered Deployment. This change scopes all of that Deployment port, probe and argument templating to the manager container only.

Detection reuses the existing `FindManagerContainerRange` lookup — the same manager-container detection the values extractor relies on — through a new `applyToManagerContainer` helper, so the manager is correctly identified whether it is declared before or after other containers. Services and NetworkPolicies have no containers and continue to be matched by name, split out into a dedicated `templateServicePorts` for clarity.

While here, the port-templating regexes are hoisted to package-level variables so they are compiled once instead of on every call (matching the existing pattern in `escape.go`/`helpers.go`). A separate fix in `AddCustomLabelsAndAnnotations` is folded in: hand-ordered Deployment metadata (`labels:` before `annotations:`) used to emit a duplicate `annotations:` header before `spec:`; the state machine now flushes the pending labels merge on the `annotations:` line so both blocks stay under `metadata:`.

Test coverage added:
- unit tests covering both container orderings (sidecar before and after the manager);
- pipeline-level isolation tests through `ApplyHelmSubstitutions` asserting the manager container is fully templated while a sidecar's ports, probes, image, and arguments are left untouched.
- a pinning test for the hand-ordered `labels:`-then-`annotations:` metadata shape, asserting a single merged block instead of a duplicate header.

## Motivation
Because the replacements matched across the whole Deployment, a sidecar that happened to reuse the same ports, probe paths, or bind-address flags was rewritten to use manager chart values. For example, a proxy sidecar with a health probe on port `9440` had it rewritten to `{{ .Values.manager.healthProbe.port }}`, so changing `manager.healthProbe.port` would unintentionally move the sidecar's port as well. The same class of bug affected the manager `args:` rewrite: when a sidecar declared its own `args:` before the manager, the whole-document search landed on the sidecar first and silently skipped the manager's args wrappers. Webhook detection had the same problem because it also inspected the fully rendered document. Only values belonging to the manager container should use manager chart values; sidecars must remain unchanged.

Partial Fixes #5901