### PR TITLE
🌱 (go/v4): Assert domain is preserved when external flags are not re-supplied

### DIFF
--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -182,6 +182,7 @@ var _ = Describe("createWebhookSubcommand", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.External).To(BeTrue())
 		Expect(res.Path).To(Equal(externalPath))
+		Expect(res.Domain).To(Equal(testIO))
 	})
 
 	It("should find existing external resource when stored Domain differs from project domain", func() {


### PR DESCRIPTION
Closes #5922

The test "should retain path for existing external resource without
re-providing --external-api-path" asserted External and Path after
InjectResource, but not Domain.

InjectResource copies Path/Plural/External/Core/Module from the stored
resource but never reassigns Domain on the caller's resource pointer,
so Domain should remain unchanged (testIO) through the call.