### PR TITLE
🐛 (go/v4): return an errors when is not possible to update the resources instead of failing silently

### DIFF
--- a/pkg/plugins/golang/deploy-image/v1alpha1/api.go
+++ b/pkg/plugins/golang/deploy-image/v1alpha1/api.go
@@ -146,7 +146,9 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 	p.options.DoController = true
 	p.options.Namespaced = true
 
-	p.options.UpdateResource(p.resource, p.config)
+	if err := p.options.UpdateResource(p.resource, p.config); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
 
 	if err := p.resource.Validate(); err != nil {
 		return fmt.Errorf("error validating resource: %w", err)

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package golang
 
 import (
+	"fmt"
 	log "log/slog"
 	"path"
 	"strings"
@@ -100,7 +101,7 @@ type Options struct {
 }
 
 // UpdateResource updates the provided resource with the options
-func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
+func (opts Options) UpdateResource(res *resource.Resource, c config.Config) error {
 	if opts.Plural != "" {
 		res.Plural = opts.Plural
 	}
@@ -116,7 +117,9 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 
 	if opts.DoController {
-		opts.updateControllers(res)
+		if err := opts.updateControllers(res); err != nil {
+			return err
+		}
 	}
 
 	if opts.DoDefaulting || opts.DoValidation || opts.DoConversion {
@@ -182,11 +185,13 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 			}
 		}
 	}
+
+	return nil
 }
 
 // updateControllers applies controller-related options to the resource.
 // It handles both legacy (--controller) and new (--controller-name) controller creation.
-func (opts Options) updateControllers(res *resource.Resource) {
+func (opts Options) updateControllers(res *resource.Resource) error {
 	if opts.ControllerName == "" {
 		// No controller name specified: use legacy mode
 		if res.Controllers == nil || res.Controllers.IsEmpty() {
@@ -195,7 +200,7 @@ func (opts Options) updateControllers(res *resource.Resource) {
 			// Warn when trying to use legacy mode on a resource with named controllers
 			log.Warn("resource already has named controllers; use --controller-name to add another controller")
 		}
-		return
+		return nil
 	}
 
 	// Controller name specified: migrate from legacy format if needed
@@ -205,7 +210,9 @@ func (opts Options) updateControllers(res *resource.Resource) {
 		}
 		// Convert the legacy controller: true to a named controller
 		defaultName := strings.ToLower(res.Kind)
-		_ = res.Controllers.AddController(defaultName)
+		if err := res.Controllers.AddController(defaultName); err != nil {
+			return fmt.Errorf("error adding default controller %q: %w", defaultName, err)
+		}
 		res.Controller = false
 	}
 
@@ -215,5 +222,8 @@ func (opts Options) updateControllers(res *resource.Resource) {
 	}
 
 	// Add the new named controller (AddController validates and checks for duplicates)
-	_ = res.Controllers.AddController(opts.ControllerName)
+	if err := res.Controllers.AddController(opts.ControllerName); err != nil {
+		return fmt.Errorf("error adding controller %q: %w", opts.ControllerName, err)
+	}
+	return nil
 }

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Options", func() {
 						Webhooks: &resource.Webhooks{},
 					}
 
-					options.UpdateResource(&res, cfg)
+					Expect(options.UpdateResource(&res, cfg)).To(Succeed())
 					Expect(res.Validate()).To(Succeed())
 					Expect(res.GVK.IsEqualTo(gvk)).To(BeTrue())
 					if options.Plural != "" {
@@ -142,7 +142,7 @@ var _ = Describe("Options", func() {
 					Webhooks: &resource.Webhooks{},
 				}
 
-				Options{DoController: true}.UpdateResource(&res, cfg)
+				Expect(Options{DoController: true}.UpdateResource(&res, cfg)).To(Succeed())
 
 				Expect(res.External).To(BeTrue())
 				Expect(res.Path).To(Equal(externalPath))
@@ -169,7 +169,7 @@ var _ = Describe("Options", func() {
 				}
 
 				// DoDefaulting without ExternalAPIPath — simulates webhook flow without re-providing the flag
-				Options{DoDefaulting: true}.UpdateResource(&res, cfg)
+				Expect(Options{DoDefaulting: true}.UpdateResource(&res, cfg)).To(Succeed())
 
 				Expect(res.External).To(BeTrue())
 				Expect(res.GVK.Domain).To(Equal(externalDomain),
@@ -201,7 +201,7 @@ var _ = Describe("Options", func() {
 						Webhooks: &resource.Webhooks{},
 					}
 
-					options.UpdateResource(&res, cfg)
+					Expect(options.UpdateResource(&res, cfg)).To(Succeed())
 					Expect(res.Validate()).To(Succeed())
 
 					Expect(res.Path).To(Equal(path.Join("k8s.io", "api", group, version)))
@@ -241,7 +241,7 @@ var _ = Describe("Options", func() {
 						Webhooks: &resource.Webhooks{},
 					}
 
-					options.UpdateResource(&res, cfg)
+					Expect(options.UpdateResource(&res, cfg)).To(Succeed())
 					Expect(res.Validate()).To(Succeed())
 
 					Expect(res.Path).To(Equal(path.Join("k8s.io", "api", group, version)))
@@ -252,5 +252,41 @@ var _ = Describe("Options", func() {
 			Entry("for `apps`", "apps", "apps"),
 			Entry("for `authentication`", "authentication", "authentication.k8s.io"),
 		)
+
+		Context("ControllerName validation", func() {
+			const backupControllerName = "backup-controller"
+
+			var res resource.Resource
+
+			BeforeEach(func() {
+				res = resource.Resource{
+					GVK:      gvk,
+					Plural:   plural,
+					API:      &resource.API{},
+					Webhooks: &resource.Webhooks{},
+				}
+			})
+
+			It("should add the named controller and succeed for a valid name", func() {
+				options := Options{DoController: true, ControllerName: backupControllerName}
+				Expect(options.UpdateResource(&res, cfg)).To(Succeed())
+				Expect(res.Controllers.GetControllerNames()).To(ConsistOf(backupControllerName))
+			})
+
+			It("should return an error and not silently fall back for an invalid name", func() {
+				options := Options{DoController: true, ControllerName: "Backup_Controller"}
+				err := options.UpdateResource(&res, cfg)
+				Expect(err).To(HaveOccurred())
+				Expect(res.Controllers.IsEmpty()).To(BeTrue())
+			})
+
+			It("should return an error for a duplicate controller name", func() {
+				options := Options{DoController: true, ControllerName: backupControllerName}
+				Expect(options.UpdateResource(&res, cfg)).To(Succeed())
+
+				dup := Options{DoController: true, ControllerName: backupControllerName}
+				Expect(dup.UpdateResource(&res, cfg)).NotTo(Succeed())
+			})
+		})
 	})
 })

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Options", func() {
 						Webhooks: &resource.Webhooks{},
 					}
 
-					options.UpdateResource(&res, cfg)
+					Expect(options.UpdateResource(&res, cfg)).To(Succeed())
 					Expect(res.Validate()).To(Succeed())
 					Expect(res.GVK.IsEqualTo(gvk)).To(BeTrue())
 					if options.Plural != "" {
@@ -140,7 +140,7 @@ var _ = Describe("Options", func() {
 					Webhooks: &resource.Webhooks{},
 				}
 
-				Options{DoController: true}.UpdateResource(&res, cfg)
+				Expect(Options{DoController: true}.UpdateResource(&res, cfg)).To(Succeed())
 
 				Expect(res.External).To(BeTrue())
 				Expect(res.Path).To(Equal(externalPath))
@@ -167,7 +167,7 @@ var _ = Describe("Options", func() {
 				}
 
 				// DoDefaulting without ExternalAPIPath — simulates webhook flow without re-providing the flag
-				Options{DoDefaulting: true}.UpdateResource(&res, cfg)
+				Expect(Options{DoDefaulting: true}.UpdateResource(&res, cfg)).To(Succeed())
 
 				Expect(res.External).To(BeTrue())
 				Expect(res.GVK.Domain).To(Equal(externalDomain),
@@ -199,7 +199,7 @@ var _ = Describe("Options", func() {
 						Webhooks: &resource.Webhooks{},
 					}
 
-					options.UpdateResource(&res, cfg)
+					Expect(options.UpdateResource(&res, cfg)).To(Succeed())
 					Expect(res.Validate()).To(Succeed())
 
 					Expect(res.Path).To(Equal(path.Join("k8s.io", "api", group, version)))
@@ -239,7 +239,7 @@ var _ = Describe("Options", func() {
 						Webhooks: &resource.Webhooks{},
 					}
 
-					options.UpdateResource(&res, cfg)
+					Expect(options.UpdateResource(&res, cfg)).To(Succeed())
 					Expect(res.Validate()).To(Succeed())
 
 					Expect(res.Path).To(Equal(path.Join("k8s.io", "api", group, version)))
@@ -250,5 +250,41 @@ var _ = Describe("Options", func() {
 			Entry("for `apps`", "apps", "apps"),
 			Entry("for `authentication`", "authentication", "authentication.k8s.io"),
 		)
+
+		Context("ControllerName validation", func() {
+			const backupControllerName = "backup-controller"
+
+			var res resource.Resource
+
+			BeforeEach(func() {
+				res = resource.Resource{
+					GVK:      gvk,
+					Plural:   plural,
+					API:      &resource.API{},
+					Webhooks: &resource.Webhooks{},
+				}
+			})
+
+			It("should add the named controller and succeed for a valid name", func() {
+				options := Options{DoController: true, ControllerName: backupControllerName}
+				Expect(options.UpdateResource(&res, cfg)).To(Succeed())
+				Expect(res.Controllers.GetControllerNames()).To(ConsistOf(backupControllerName))
+			})
+
+			It("should return an error and not silently fall back for an invalid name", func() {
+				options := Options{DoController: true, ControllerName: "Backup_Controller"}
+				err := options.UpdateResource(&res, cfg)
+				Expect(err).To(HaveOccurred())
+				Expect(res.Controllers.IsEmpty()).To(BeTrue())
+			})
+
+			It("should return an error for a duplicate controller name", func() {
+				options := Options{DoController: true, ControllerName: backupControllerName}
+				Expect(options.UpdateResource(&res, cfg)).To(Succeed())
+
+				dup := Options{DoController: true, ControllerName: backupControllerName}
+				Expect(dup.UpdateResource(&res, cfg)).NotTo(Succeed())
+			})
+		})
 	})
 })

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -178,7 +178,9 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 		return errors.New("'--ssa' can only be used when creating an API resource ('--resource=true')")
 	}
 
-	p.options.UpdateResource(p.resource, p.config)
+	if err := p.options.UpdateResource(p.resource, p.config); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
 
 	if err := p.resource.Validate(); err != nil {
 		return fmt.Errorf("error validating resource: %w", err)

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -181,7 +181,9 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 		return errors.New("'--ssa' can only be used when creating an API resource ('--resource=true')")
 	}
 
-	p.options.UpdateResource(p.resource, p.config)
+	if err := p.options.UpdateResource(p.resource, p.config); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
 
 	if err := p.resource.Validate(); err != nil {
 		return fmt.Errorf("error validating resource: %w", err)

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -165,7 +165,9 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 		return errors.New("'--external-api-module' requires '--external-api-path' to be specified")
 	}
 
-	p.options.UpdateResource(p.resource, p.config)
+	if err := p.options.UpdateResource(p.resource, p.config); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
 
 	if err := p.resource.Validate(); err != nil {
 		return fmt.Errorf("error validating resource: %w", err)

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -158,7 +158,9 @@ func (p *createWebhookSubcommand) InjectResource(res *resource.Resource) error {
 		return errors.New("'--external-api-module' requires '--external-api-path' to be specified")
 	}
 
-	p.options.UpdateResource(p.resource, p.config)
+	if err := p.options.UpdateResource(p.resource, p.config); err != nil {
+		return fmt.Errorf("error updating resource: %w", err)
+	}
 
 	if err := p.resource.Validate(); err != nil {
 		return fmt.Errorf("error validating resource: %w", err)


### PR DESCRIPTION
## Description

`updateControllers` in `pkg/plugins/golang/options.go` discarded both calls to `Controllers.AddController` with `_ =`. `AddController` validates the name as a DNS-1035 label and rejects duplicates, but the error was never propagated anywhere.

`validateController` in `pkg/plugins/golang/v4/api.go` only checks emptiness/duplicates against the resource already persisted in the PROJECT file, and never runs its format check for a brand-new resource (`p.config.GetResource` returns an error for a resource that doesn't exist yet, so `validateController` returns `nil` immediately).

Net effect: for a new API, an invalid `--controller-name` (e.g. `Backup_Ctrl`, which fails DNS-1035 validation uppercase/underscore not allowed) was silently discarded. `res.Controllers` stayed empty, and the scaffolding logic in `api.go` fell back to the default kind-derived controller name instead, while the CLI reported success. The user's chosen
name was silently ignored.

Found this by reading the controller-scaffolding path end to end while looking for real, self-contained bugs to contribute. It's a genuine correctness gap (not defensive-only) reachable by any snake_case or otherwise-invalid `--controller-name` on first use, and the affected file  had zero test coverage for `ControllerName` at all beforehand.

## What this PR does

- `updateControllers` and `UpdateResource` (`pkg/plugins/golang/options.go`)  now return `error` and propagate both `AddController` calls instead of discarding them.
- Propagates that error through the three call sites (`pkg/plugins/golang/v4/api.go`, `pkg/plugins/golang/v4/webhook.go`,
  `pkg/plugins/golang/deploy-image/v1alpha1/api.go`), wrapped as `"error updating resource: %w"` to match the existing convention already used right below each of those call sites.
- Adds a `ControllerName validation` test block in `options_test.go`:  valid name (succeeds, controller added), invalid name (returns an error,
  `Controllers` stays empty instead of silently falling back), and duplicate name (returns an error).
- Updates the five pre-existing bare `options.UpdateResource(...)` calls in the same test file to assert `Succeed()`, since they now discard the same class of error the production code used to.

Verified locally: `go build ./...`, the `golang`/`v4`/`deploy-image`Ginkgo suites all pass, `golangci-lint run` (pinned v2.12.2, repo config) reports 0 issues. Also verified the new tests aren't vacuous by temporarily reverting the fix both the "invalid name" and "duplicate name" cases went red with the expected failure messages, then passed again after reverting
back.

Fixes: none filed this PR is the record; happy to file one if a maintainer would prefer it tracked separately.
