### PR TITLE
✨ (helm/v2-alpha): Allow `manager.args` values to be templated

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}
         {{- range .Values.manager.args }}
-        - {{ . }}
+        - {{ tpl . $ }}
         {{- end }}
         {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -85,7 +85,7 @@ spec:
         {{- end }}
         - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- range .Values.manager.args }}
-        - {{ . }}
+        - {{ tpl . $ }}
         {{- end }}
         command:
         - /manager

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}
         {{- range .Values.manager.args }}
-        - {{ . }}
+        - {{ tpl . $ }}
         {{- end }}
         {{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -271,11 +271,27 @@ helm install my-operator ./dist/chart --set manager.healthProbe.port=8082
 
 The default is `8081`, detected from your project configuration.
 
-### Port flags in manager.args
+### Passing args for the manager
 
-Use `manager.args` for flags that the chart does not expose as values. For the ports above, always use `metrics.port`, `webhook.port`, and `manager.healthProbe.port`.
+Use `manager.args` in `values.yaml` to pass extra flags to the manager container that the chart does not expose as dedicated values. The chart renders each entry through Helm's `tpl` function, evaluated against the chart's root context, so an arg can reference other values, release information, or chart template functions instead of only a static string.
 
-The chart renders `--metrics-bind-address`, `--webhook-port`, and `--health-probe-bind-address` from these values. Setting one of these flags in `manager.args` overrides the manager listener, while the Service, NetworkPolicy, and probe ports keep the configured values, so traffic and probes target the wrong port. The plugin removes these flags from the extracted args when it generates the chart.
+For example, set the leader election namespace from the release namespace and add a plain flag:
+
+```yaml
+manager:
+  args:
+  - --leader-election-namespace={{ .Release.Namespace }}
+  - --leader-elect
+```
+
+Helm evaluates `{{ .Release.Namespace }}` at render time, so the manager container receives `--leader-election-namespace=<release-namespace>`. The `--leader-elect` flag has no template syntax, so it renders unchanged.
+
+<aside class="note" role="note">
+<p class="note-title">Do not set the metrics, webhook, or health probe flags in manager.args</p>
+
+The chart already exposes `--metrics-bind-address`, `--webhook-port`, and `--health-probe-bind-address` as `metrics.port`, `webhook.port`, and `manager.healthProbe.port`. Set those values instead of adding the flags to `manager.args`. The plugin removes these flags from the extracted args when it generates the chart, so adding one back through `manager.args`, templated or not, creates a duplicate flag alongside the value-driven one. The Service, NetworkPolicy, and probes keep using the configured port, so traffic and probes then target the wrong port.
+
+</aside>
 
 ### NetworkPolicy configuration
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -702,7 +702,7 @@ func templateControllerManagerArgs(yamlContent string) string {
 	builder.WriteString(itemIndent)
 	builder.WriteString("{{- range .Values.manager.args }}\n")
 	builder.WriteString(itemIndent)
-	builder.WriteString("- {{ . }}\n")
+	builder.WriteString("- {{ tpl . $ }}\n")
 	builder.WriteString(itemIndent)
 	builder.WriteString("{{- end }}\n")
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -931,6 +931,113 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			Expect(lintResult.Errors).To(BeEmpty(), "helm lint failed: %v", lintResult.Errors)
 		})
 	})
+
+	// The `tpl` change in templateControllerManagerArgs evaluates each manager.args entry as a
+	// Helm template (`{{ tpl . $ }}`) instead of rendering it verbatim (`{{ . }}`). These specs
+	// render the chart with `helm template` to prove every combination resolves correctly: the
+	// chart's own default extracted args (no values override), plain literal args (backwards
+	// compatibility), a single templated arg, several templated args together, templated and
+	// literal args mixed in the same list, and a templated arg that calls a Helm template
+	// function.
+	Context("Manager args templating (rendered)", func() {
+		writeValuesFile := func(content string) string {
+			valuesFile := filepath.Join(tmpDir, "manager-args-values.yaml")
+			Expect(os.WriteFile(valuesFile, []byte(content), 0o600)).To(Succeed())
+			return valuesFile
+		}
+
+		// renderWithArgs scaffolds the chart and renders it with `helm template`. When
+		// valuesContent is empty, no `-f` override is passed, so the chart renders with its own
+		// generated values.yaml (i.e. the default manager.args extracted from the kustomize
+		// output), exercising the same code path production users hit before ever touching
+		// manager.args themselves.
+		renderWithArgs := func(valuesContent string) string {
+			var setArgs []string
+			if valuesContent != "" {
+				setArgs = []string{"-f", writeValuesFile(valuesContent)}
+			}
+			out, err := helmTemplate(createKustomizeWithFullDeploymentConfig("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		// managerArgsLines extracts every rendered "- --flag..." list item so assertions do not
+		// depend on indentation and are not confused by other list items in the manifest.
+		managerArgsLines := func(rendered string) []string {
+			var args []string
+			for _, line := range strings.Split(rendered, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "- --") {
+					args = append(args, strings.TrimPrefix(trimmed, "- "))
+				}
+			}
+			return args
+		}
+
+		It("should render the manager Deployment successfully when manager.args uses the chart's own "+
+			"default values (no values override)", func() {
+			rendered := renderWithArgs("")
+
+			By("the default extracted arg renders as a literal, unaffected by tpl")
+			Expect(managerArgsLines(rendered)).To(ContainElement("--leader-elect"))
+		})
+
+		DescribeTable("should resolve manager.args entries through tpl when values are provided",
+			func(valuesContent string, wantArgs []string, unwantedSubstrings []string) {
+				rendered := renderWithArgs(valuesContent)
+
+				args := managerArgsLines(rendered)
+				for _, want := range wantArgs {
+					Expect(args).To(ContainElement(want), "rendered manager args: %v", args)
+				}
+				for _, unwanted := range unwantedSubstrings {
+					Expect(rendered).NotTo(ContainSubstring(unwanted))
+				}
+			},
+			Entry("should keep plain literal args unchanged when no template syntax is used (backwards compatible)",
+				"manager:\n  args:\n  - --leader-elect\n  - --zap-log-level=info\n",
+				[]string{"--leader-elect", "--zap-log-level=info"},
+				[]string(nil),
+			),
+			Entry("should resolve to the release namespace when an arg references .Release.Namespace",
+				"manager:\n  args:\n  - --leader-election-namespace={{ .Release.Namespace }}\n",
+				[]string{"--leader-election-namespace=my-namespace"},
+				[]string{"{{ .Release.Namespace }}"},
+			),
+			Entry("should resolve every arg independently and keep list order when multiple args are templated",
+				"manager:\n  args:\n"+
+					"  - --leader-election-namespace={{ .Release.Namespace }}\n"+
+					"  - --release-name={{ .Release.Name }}\n"+
+					"  - --chart-name={{ .Chart.Name }}\n",
+				[]string{
+					"--leader-election-namespace=my-namespace",
+					"--release-name=my-release",
+					"--chart-name=test-project",
+				},
+				[]string{"{{ .Release", "{{ .Chart"},
+			),
+			Entry("should resolve templated args and keep literal args unchanged when both appear in the same list",
+				"manager:\n  args:\n"+
+					"  - --leader-elect\n"+
+					"  - --leader-election-namespace={{ .Release.Namespace }}\n"+
+					"  - --zap-log-level=info\n",
+				[]string{
+					"--leader-elect",
+					"--leader-election-namespace=my-namespace",
+					"--zap-log-level=info",
+				},
+				[]string(nil),
+			),
+			Entry("should resolve an arg when it calls a Helm template function",
+				`manager:
+  args:
+  - --extra-flag={{ printf "%s-%s" .Release.Name .Release.Namespace }}
+`,
+				[]string{"--extra-flag=my-release-my-namespace"},
+				[]string{"{{ printf"},
+			),
+		)
+	})
 })
 
 // Helper functions to create kustomize YAML outputs for different scenarios

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
         - --webhook-port={{ .Values.webhook.port }}
         {{- end }}
         {{- range .Values.manager.args }}
-        - {{ . }}
+        - {{ tpl . $ }}
         {{- end }}
         {{- if .Values.certManager.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs


### PR DESCRIPTION
## Description

The Helm plugin (`helm/v2-alpha`) now renders each entry of `manager.args` in
`templates/manager/manager.yaml` through Helm's `tpl` function, evaluated
against the root chart context (`{{ tpl . $ }}`), instead of emitting the
value verbatim (`{{ . }}`).

## Motivation

Previously, values placed in `manager.args` in `values.yaml` were rendered
as plain strings, so they could not reference other Helm values, built-in
objects (e.g. `.Release.Namespace`), or template functions. This made it
impossible to parameterize controller manager arguments that depend on
release-specific or values-driven data without hand-editing the generated
chart.

With this change, `manager.args` entries are evaluated as Helm templates
before being rendered, so a value such as
`--leader-election-namespace={{ .Release.Namespace }}` now resolves
correctly. Plain, non-template strings (e.g. `--leader-elect`) are
unaffected and continue to render exactly as before, so this change is
fully backwards compatible with existing generated charts and values files.

Verified with `helm lint` against the regenerated `project-v4-with-plugins`
testdata chart and the `getting-started`, `cronjob-tutorial`, and
`multiversion-tutorial` doc sample charts, plus the existing helm plugin
unit/integration test suites.