### PR TITLE
🐛 fix(go/v4): resolve create webhook target when several share a GVK

### DIFF
--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -118,7 +118,8 @@ func (p *createAPISubcommand) BindFlags(fs *pflag.FlagSet) {
 			"Used to scaffold controllers for resources defined outside this project")
 
 	fs.StringVar(&p.options.ExternalAPIDomain, "external-api-domain", "",
-		"Domain name for the external API (e.g., cert-manager.io). "+
+		"Domain suffix for the external API, combined with --group to form the qualified group "+
+			"(e.g., --group cert-manager --external-api-domain io => cert-manager.io). "+
 			"Used to generate accurate RBAC markers and permissions for the external resources")
 
 	fs.StringVar(&p.options.ExternalAPIModule, "external-api-module", "",

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -115,9 +115,10 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 			"Used to scaffold webhooks for resources defined outside this project")
 
 	fs.StringVar(&p.options.ExternalAPIDomain, "external-api-domain", "",
-		"Domain for the external API (e.g., cert-manager.io). Selects the recorded resource when "+
-			"several share a group, version, and kind, and is used to generate accurate RBAC markers "+
-			"and permissions for the external resources")
+		"Domain suffix for the external API, combined with --group to form the qualified group "+
+			"(e.g., --group cert-manager --external-api-domain io => cert-manager.io). Selects the "+
+			"recorded resource when several share a group, version, and kind, and is used to generate "+
+			"accurate RBAC markers and permissions for the external resources")
 
 	fs.StringVar(&p.options.ExternalAPIModule, "external-api-module", "",
 		"External API module with optional version (e.g., github.com/cert-manager/cert-manager@v1.18.2)")
@@ -245,10 +246,15 @@ func (p *createWebhookSubcommand) PostScaffold() error {
 // updateResourceFromConfig fills res with the configuration recorded for its
 // Group/Version/Kind in the PROJECT file: Domain, Path, Plural, External, Core and Module.
 //
-// The lookup is by Group/Version/Kind rather than the full GVK because res still carries the
-// project domain, while an external resource keeps its own. Only external APIs can register the
-// same Group/Version/Kind under different domains, so when several match --external-api-domain
-// selects the intended one; without it resolution falls to the non-external (core/project) entry.
+// The lookup matches on Group/Version/Kind rather than the full GVK so that a single query
+// surfaces every recorded entry for that G/V/K, since more than one can share it under different
+// domains: two external variants, or a core type and a project API that collide. When several
+// match, --external-api-domain selects the intended one; without it resolution falls to the
+// non-external (core/project) entry via selectNonExternal.
+//
+// selectNonExternal breaks a core-vs-project tie by preferring the candidate whose domain equals
+// res.Domain. This relies on resolveDomain (pkg/cli/cmd_helpers.go) leaving res.Domain as the
+// project domain when several records match; revisit that tie-break if resolveDomain changes.
 func (p *createWebhookSubcommand) updateResourceFromConfig(res *resource.Resource) error {
 	resources, err := p.config.GetResources()
 	if err != nil {
@@ -265,21 +271,15 @@ func (p *createWebhookSubcommand) updateResourceFromConfig(res *resource.Resourc
 
 	domain := p.options.ExternalAPIDomain
 	var selected *resource.Resource
-	switch len(candidates) {
-	case 0:
+	switch {
+	case len(candidates) == 0:
 		return nil // nothing recorded for this GVK; keep res as built from the flags
-	case 1:
-		if domain == "" {
-			selected = &candidates[0] // recover the single record
-		} else {
-			selected, err = selectByDomain(candidates, domain, p.options.ExternalAPIPath)
-		}
+	case domain != "":
+		selected, err = selectByDomain(candidates, domain, p.options.ExternalAPIPath)
+	case len(candidates) == 1:
+		selected = &candidates[0] // recover the single record
 	default:
-		if domain == "" {
-			selected, err = selectNonExternal(candidates, res.Domain)
-		} else {
-			selected, err = selectByDomain(candidates, domain, p.options.ExternalAPIPath)
-		}
+		selected, err = selectNonExternal(candidates, res.Domain)
 	}
 	if err != nil {
 		return err
@@ -316,6 +316,13 @@ func selectByDomain(candidates []resource.Resource, domain, externalPath string)
 // selectNonExternal resolves several same-GVK candidates when no domain is given: the target is
 // the non-external (core/project) entry. When a core and project entry collide it keeps the
 // project (its domain equals projectDomain); when every candidate is external it refuses.
+//
+// Unlike selectByDomain, there is no --external-api-path escape hatch here: adding a new external
+// variant to an already-ambiguous G/V/K requires --external-api-domain. Without a domain,
+// resolveDomain (pkg/cli/resource.go) leaves res.Domain as the project domain when several records
+// match, and UpdateResource only overrides the domain when --external-api-domain is set. So a
+// path-only "new resource" would be recorded as external yet stamped with the project domain -- a
+// malformed entry. Refusing here forces the caller to name the variant with a domain.
 func selectNonExternal(candidates []resource.Resource, projectDomain string) (*resource.Resource, error) {
 	var nonExternal []resource.Resource
 	for _, c := range candidates {
@@ -346,7 +353,11 @@ func resolutionError(candidates []resource.Resource, domain string) error {
 	g, v, k := candidates[0].Group, candidates[0].Version, candidates[0].Kind
 	domains := make([]string, len(candidates))
 	for i, c := range candidates {
-		domains[i] = c.Domain
+		if c.Domain == "" {
+			domains[i] = "<empty>"
+		} else {
+			domains[i] = c.Domain
+		}
 	}
 
 	if domain != "" {

--- a/pkg/plugins/golang/v4/webhook.go
+++ b/pkg/plugins/golang/v4/webhook.go
@@ -115,8 +115,9 @@ func (p *createWebhookSubcommand) BindFlags(fs *pflag.FlagSet) {
 			"Used to scaffold webhooks for resources defined outside this project")
 
 	fs.StringVar(&p.options.ExternalAPIDomain, "external-api-domain", "",
-		"Domain name for the external API (e.g., cert-manager.io). "+
-			"Used to generate accurate RBAC markers and permissions for the external resources")
+		"Domain for the external API (e.g., cert-manager.io). Selects the recorded resource when "+
+			"several share a group, version, and kind, and is used to generate accurate RBAC markers "+
+			"and permissions for the external resources")
 
 	fs.StringVar(&p.options.ExternalAPIModule, "external-api-module", "",
 		"External API module with optional version (e.g., github.com/cert-manager/cert-manager@v1.18.2)")
@@ -241,30 +242,125 @@ func (p *createWebhookSubcommand) PostScaffold() error {
 	return nil
 }
 
-// updateResourceFromConfig copies existing resource configuration from PROJECT file.
+// updateResourceFromConfig fills res with the configuration recorded for its
+// Group/Version/Kind in the PROJECT file: Domain, Path, Plural, External, Core and Module.
+//
+// The lookup is by Group/Version/Kind rather than the full GVK because res still carries the
+// project domain, while an external resource keeps its own. Only external APIs can register the
+// same Group/Version/Kind under different domains, so when several match --external-api-domain
+// selects the intended one; without it resolution falls to the non-external (core/project) entry.
 func (p *createWebhookSubcommand) updateResourceFromConfig(res *resource.Resource) error {
-	// Match by Group, Version, and Kind because external APIs may have
-	// a different domain than the project domain.
 	resources, err := p.config.GetResources()
 	if err != nil {
 		return fmt.Errorf("failed to load resources from project configuration: %w", err)
 	}
 
-	for _, existingRes := range resources {
-		if existingRes.Group == res.Group &&
-			existingRes.Version == res.Version &&
-			existingRes.Kind == res.Kind {
-			p.resource.Domain = existingRes.Domain
-			p.resource.Path = existingRes.Path
-			p.resource.Plural = existingRes.Plural
-			p.resource.External = existingRes.External
-			p.resource.Core = existingRes.Core
-			p.resource.Module = existingRes.Module
-			break
+	// Collect every recorded resource sharing this Group/Version/Kind.
+	var candidates []resource.Resource
+	for _, r := range resources {
+		if r.Group == res.Group && r.Version == res.Version && r.Kind == res.Kind {
+			candidates = append(candidates, r)
 		}
 	}
 
+	domain := p.options.ExternalAPIDomain
+	var selected *resource.Resource
+	switch len(candidates) {
+	case 0:
+		return nil // nothing recorded for this GVK; keep res as built from the flags
+	case 1:
+		if domain == "" {
+			selected = &candidates[0] // recover the single record
+		} else {
+			selected, err = selectByDomain(candidates, domain, p.options.ExternalAPIPath)
+		}
+	default:
+		if domain == "" {
+			selected, err = selectNonExternal(candidates, res.Domain)
+		} else {
+			selected, err = selectByDomain(candidates, domain, p.options.ExternalAPIPath)
+		}
+	}
+	if err != nil {
+		return err
+	}
+	if selected == nil {
+		return nil // the flags describe a new resource
+	}
+
+	res.Domain = selected.Domain
+	res.Path = selected.Path
+	res.Plural = selected.Plural
+	res.External = selected.External
+	res.Core = selected.Core
+	res.Module = selected.Module
+
 	return nil
+}
+
+// selectByDomain resolves the candidate carrying the given --external-api-domain, for any number
+// of candidates. When none carries it, a non-empty external path means the flags describe a new
+// resource (nil, nil); otherwise the request is refused.
+func selectByDomain(candidates []resource.Resource, domain, externalPath string) (*resource.Resource, error) {
+	for i := range candidates {
+		if candidates[i].Domain == domain {
+			return &candidates[i], nil
+		}
+	}
+	if externalPath != "" {
+		return nil, nil
+	}
+	return nil, resolutionError(candidates, domain)
+}
+
+// selectNonExternal resolves several same-GVK candidates when no domain is given: the target is
+// the non-external (core/project) entry. When a core and project entry collide it keeps the
+// project (its domain equals projectDomain); when every candidate is external it refuses.
+func selectNonExternal(candidates []resource.Resource, projectDomain string) (*resource.Resource, error) {
+	var nonExternal []resource.Resource
+	for _, c := range candidates {
+		if !c.External {
+			nonExternal = append(nonExternal, c)
+		}
+	}
+
+	switch len(nonExternal) {
+	case 0:
+		return nil, resolutionError(candidates, "")
+	case 1:
+		return &nonExternal[0], nil
+	default:
+		// A core and a project resource share the GVK; keep the project one.
+		for i := range nonExternal {
+			if nonExternal[i].Domain == projectDomain {
+				return &nonExternal[i], nil
+			}
+		}
+		return nil, resolutionError(candidates, "")
+	}
+}
+
+// resolutionError reports why the candidates could not be resolved to one, naming their domains.
+// With a named domain it reports that none matched; without one it asks for --external-api-domain.
+func resolutionError(candidates []resource.Resource, domain string) error {
+	g, v, k := candidates[0].Group, candidates[0].Version, candidates[0].Kind
+	domains := make([]string, len(candidates))
+	for i, c := range candidates {
+		domains[i] = c.Domain
+	}
+
+	if domain != "" {
+		return fmt.Errorf(
+			"no resource matches --external-api-domain %q for group %q, version %q and kind %q "+
+				"(recorded domains: %s)",
+			domain, g, v, k, strings.Join(domains, ", "),
+		)
+	}
+	return fmt.Errorf(
+		"group %q, version %q and kind %q match more than one resource (domains: %s): "+
+			"pass --external-api-domain to choose the one to work on",
+		g, v, k, strings.Join(domains, ", "),
+	)
 }
 
 // Helper function to validate spoke versions

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -294,11 +294,16 @@ var _ = Describe("createWebhookSubcommand", func() {
 			Expect(err.Error()).To(ContainSubstring(domainIO))
 			Expect(err.Error()).To(ContainSubstring(domainK8s))
 
-			// Both entries keep their path and domain.
+			// Both entries keep their path, domain and (empty) webhooks: #5931 is about the
+			// webhook being silently bound to the first entry, so none may have gained one.
 			byDomain := storedByDomain()
 			Expect(byDomain).To(HaveLen(2))
 			Expect(byDomain[domainIO].Path).To(Equal(pathIO))
+			Expect(byDomain[domainIO].Domain).To(Equal(domainIO))
+			Expect(byDomain[domainIO].Webhooks == nil || byDomain[domainIO].Webhooks.IsEmpty()).To(BeTrue())
 			Expect(byDomain[domainK8s].Path).To(Equal(pathK8sIO))
+			Expect(byDomain[domainK8s].Domain).To(Equal(domainK8s))
+			Expect(byDomain[domainK8s].Webhooks == nil || byDomain[domainK8s].Webhooks.IsEmpty()).To(BeTrue())
 		})
 
 		It("should refuse regardless of the order the resources are recorded", func() {
@@ -359,6 +364,9 @@ var _ = Describe("createWebhookSubcommand", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("match more than one resource"))
+			// The empty domain is rendered explicitly so the list is not "(domains: , cert-manager.io)".
+			Expect(err.Error()).To(ContainSubstring("<empty>"))
+			Expect(err.Error()).To(ContainSubstring(domainIO))
 		})
 
 		It("should prefer the non-external entry when no domain is given", func() {

--- a/pkg/plugins/golang/v4/webhook_test.go
+++ b/pkg/plugins/golang/v4/webhook_test.go
@@ -27,6 +27,9 @@ import (
 	goPlugin "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang"
 )
 
+// coreAPIPath is the Go import path recorded for a core (Kubernetes built-in) resource in tests.
+const coreAPIPath = "k8s.io/api/core/v1"
+
 var _ = Describe("createWebhookSubcommand", func() {
 	var (
 		subCmd *createWebhookSubcommand
@@ -221,6 +224,294 @@ var _ = Describe("createWebhookSubcommand", func() {
 		Expect(err.Error()).To(ContainSubstring("no API found for"))
 		Expect(err.Error()).To(ContainSubstring("run 'create api' first"))
 		Expect(err.Error()).To(ContainSubstring("or pass --external-api-path for an external type"))
+	})
+
+	// updateResourceFromConfig resolves which recorded resource a create-webhook command refers to.
+	// The specs below cover the full decision, by number of recorded resources sharing the
+	// Group/Version/Kind and the flags given:
+	//
+	//	#  | matches | --external-api-domain | matches a record? | --external-api-path | outcome
+	//	---+---------+-----------------------+-------------------+---------------------+-------------------------
+	//	1  |   0     | any                   | -                 | any                 | keep res from the flags
+	//	2  |   1     | unset                 | -                 | -                   | use the record
+	//	3  |   1     | set                   | yes               | -                   | use the record
+	//	4  |   1     | set                   | no                | set                 | create a new resource
+	//	5  |   1     | set                   | no                | unset               | error (domain not found)
+	//	6  |  >=2    | set                   | yes               | -                   | use the record
+	//	7  |  >=2    | set                   | no                | set                 | create a new resource
+	//	8  |  >=2    | set                   | no                | unset               | error (domain not found)
+	//	9  |  >=2    | unset                 | -                 | -                   | error (all external)
+	//	10 |  >=2    | unset                 | - (1 non-external)| -                   | use the non-external one
+	//	11 |  >=2    | unset                 | - (project+core)  | -                   | use the project one
+	Context("when several external resources share the same Group/Version/Kind", func() {
+		const (
+			pathIO    = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+			pathK8sIO = "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+			domainIO  = "cert-manager.io"
+			domainK8s = "cert-manager.k8s.io"
+		)
+
+		// storeExternal records an external resource sharing crewGroup/v1/captainKind but under
+		// the given domain. Recorded resources are unique by full GVK, so distinct domains produce
+		// distinct entries that collide only on Group/Version/Kind.
+		storeExternal := func(domain, path string) {
+			Expect(cfg.AddResource(resource.Resource{
+				GVK: resource.GVK{
+					Group:   crewGroup,
+					Domain:  domain,
+					Version: "v1",
+					Kind:    captainKind,
+				},
+				External: true,
+				Path:     path,
+				Webhooks: &resource.Webhooks{},
+			})).To(Succeed())
+		}
+
+		// storedByDomain re-reads the recorded resources keyed by domain, to assert entries are
+		// left untouched.
+		storedByDomain := func() map[string]resource.Resource {
+			stored, err := cfg.GetResources()
+			Expect(err).NotTo(HaveOccurred())
+			byDomain := make(map[string]resource.Resource, len(stored))
+			for _, s := range stored {
+				byDomain[s.Domain] = s
+			}
+			return byDomain
+		}
+
+		It("should refuse and leave the PROJECT untouched when no domain is given", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			storeExternal(domainK8s, pathK8sIO)
+			subCmd.options.DoDefaulting = true
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("match more than one resource"))
+			Expect(err.Error()).To(ContainSubstring("pass --external-api-domain"))
+			Expect(err.Error()).To(ContainSubstring(domainIO))
+			Expect(err.Error()).To(ContainSubstring(domainK8s))
+
+			// Both entries keep their path and domain.
+			byDomain := storedByDomain()
+			Expect(byDomain).To(HaveLen(2))
+			Expect(byDomain[domainIO].Path).To(Equal(pathIO))
+			Expect(byDomain[domainK8s].Path).To(Equal(pathK8sIO))
+		})
+
+		It("should refuse regardless of the order the resources are recorded", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			// Reverse order from the previous test: nothing may depend on file order.
+			storeExternal(domainK8s, pathK8sIO)
+			storeExternal(domainIO, pathIO)
+			subCmd.options.DoDefaulting = true
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("match more than one resource"))
+		})
+
+		It("should work on the resource named by --external-api-domain and leave the other alone", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			storeExternal(domainK8s, pathK8sIO)
+			subCmd.options.DoDefaulting = true
+			subCmd.options.ExternalAPIDomain = domainK8s
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.External).To(BeTrue())
+			Expect(res.Domain).To(Equal(domainK8s))
+			Expect(res.Path).To(Equal(pathK8sIO))
+
+			// The unnamed entry is untouched.
+			Expect(storedByDomain()[domainIO].Path).To(Equal(pathIO))
+		})
+
+		It("should refuse when the given domain matches none of them", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			storeExternal(domainK8s, pathK8sIO)
+			subCmd.options.DoDefaulting = true
+			subCmd.options.ExternalAPIDomain = "does-not-exist.io"
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no resource matches --external-api-domain"))
+			Expect(err.Error()).To(ContainSubstring("does-not-exist.io"))
+			Expect(err.Error()).To(ContainSubstring(domainIO))
+			Expect(err.Error()).To(ContainSubstring(domainK8s))
+		})
+
+		It("should refuse without a domain even when one entry has an empty domain", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			// An empty flag must not silently select the empty-domain entry.
+			storeExternal("", pathK8sIO)
+			storeExternal(domainIO, pathIO)
+			subCmd.options.DoDefaulting = true
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("match more than one resource"))
+		})
+
+		It("should prefer the non-external entry when no domain is given", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			// A project (non-external) entry shares the GVK with an external one.
+			Expect(cfg.AddResource(resource.Resource{
+				GVK:      resource.GVK{Group: crewGroup, Domain: testIO, Version: "v1", Kind: captainKind},
+				Path:     "github.com/example/test/api/v1",
+				Webhooks: &resource.Webhooks{},
+			})).To(Succeed())
+			storeExternal(domainK8s, pathK8sIO)
+			subCmd.options.DoDefaulting = true
+
+			err := subCmd.InjectResource(res)
+
+			// Resolves to the non-external entry, not the external one, without a domain.
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.External).To(BeFalse())
+		})
+
+		It("should create a new external variant when the domain is new and a path is given", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			storeExternal(domainK8s, pathK8sIO)
+			subCmd.options.DoDefaulting = true
+			// A new domain plus a path fully describes a third external resource.
+			subCmd.options.ExternalAPIDomain = "cert-manager.new.io"
+			subCmd.options.ExternalAPIPath = "github.com/cert-manager/cert-manager/pkg/apis/new/v1"
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.External).To(BeTrue())
+			Expect(res.Domain).To(Equal("cert-manager.new.io"))
+		})
+
+		It("should resolve to the core entry over an external one when no domain is given", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainK8s, pathK8sIO)
+			// A core entry shares the GVK with the external one.
+			Expect(cfg.AddResource(resource.Resource{
+				GVK:      resource.GVK{Group: crewGroup, Domain: "k8s.io", Version: "v1", Kind: captainKind},
+				Core:     true,
+				Path:     coreAPIPath,
+				Webhooks: &resource.Webhooks{},
+			})).To(Succeed())
+			subCmd.options.DoDefaulting = true
+
+			err := subCmd.InjectResource(res)
+
+			// The lone non-external (core) entry wins; the external one is left out.
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Core).To(BeTrue())
+			Expect(res.External).To(BeFalse())
+		})
+
+		It("should keep the project entry when a project and core entry collide", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			// A project entry (res's own domain) and a core entry share the GVK.
+			Expect(cfg.AddResource(resource.Resource{
+				GVK:      resource.GVK{Group: crewGroup, Domain: testIO, Version: "v1", Kind: captainKind},
+				Path:     "github.com/example/test/api/v1",
+				Webhooks: &resource.Webhooks{},
+			})).To(Succeed())
+			Expect(cfg.AddResource(resource.Resource{
+				GVK:      resource.GVK{Group: crewGroup, Domain: "k8s.io", Version: "v1", Kind: captainKind},
+				Core:     true,
+				Path:     coreAPIPath,
+				Webhooks: &resource.Webhooks{},
+			})).To(Succeed())
+			subCmd.options.DoDefaulting = true
+
+			err := subCmd.InjectResource(res)
+
+			// The project entry (domain == res.Domain) is kept, not the core one.
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Core).To(BeFalse())
+			Expect(res.External).To(BeFalse())
+		})
+	})
+
+	Context("when a single external resource shares the Group/Version/Kind", func() {
+		const (
+			pathIO   = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+			domainIO = "cert-manager.io"
+		)
+
+		storeExternal := func(domain, path string) {
+			Expect(cfg.AddResource(resource.Resource{
+				GVK:      resource.GVK{Group: crewGroup, Domain: domain, Version: "v1", Kind: captainKind},
+				External: true,
+				Path:     path,
+				Webhooks: &resource.Webhooks{},
+			})).To(Succeed())
+		}
+
+		It("should use the recorded resource when --external-api-domain matches it", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			subCmd.options.DoDefaulting = true
+			subCmd.options.ExternalAPIDomain = domainIO
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.External).To(BeTrue())
+			Expect(res.Path).To(Equal(pathIO))
+			Expect(res.Domain).To(Equal(domainIO))
+		})
+
+		It("should refuse when --external-api-domain does not match and no path is given", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			subCmd.options.DoDefaulting = true
+			subCmd.options.ExternalAPIDomain = "cert-manager.k8s.io"
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no resource matches --external-api-domain"))
+			Expect(err.Error()).To(ContainSubstring(domainIO))
+		})
+
+		It("should create a new external resource when the domain is new and a path is given", func() {
+			Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+			storeExternal(domainIO, pathIO)
+			subCmd.options.DoDefaulting = true
+			subCmd.options.ExternalAPIDomain = "cert-manager.k8s.io"
+			subCmd.options.ExternalAPIPath = "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+
+			err := subCmd.InjectResource(res)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.External).To(BeTrue())
+			Expect(res.Domain).To(Equal("cert-manager.k8s.io"))
+		})
+	})
+
+	It("should resolve a core type without --external-api-domain", func() {
+		Expect(subCmd.InjectConfig(cfg)).To(Succeed())
+		// A single recorded core type must resolve without --external-api-domain.
+		Expect(cfg.AddResource(resource.Resource{
+			GVK:      res.GVK,
+			Core:     true,
+			Path:     coreAPIPath,
+			Webhooks: &resource.Webhooks{},
+		})).To(Succeed())
+		subCmd.options.DoDefaulting = true
+
+		err := subCmd.InjectResource(res)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Core).To(BeTrue())
 	})
 
 	Context("isValidVersion", func() {


### PR DESCRIPTION
`create webhook` matched a recorded resource by Group, Version and Kind and took the first hit. When a project records more than one external resource that shares a GVK under different domains, it silently bound the webhook to whichever entry the PROJECT file listed first, and passing --external-api-domain to select another one failed outright.

Collect every Group/Version/Kind match instead of taking the first. With a single match, behave as before. With several, use --external-api-domain to select one, and return an error when it is missing or matches none so the command never guesses and leaves the PROJECT file unchanged.

Fixes #5931

## Change

`updateResourceFromConfig` now collects **every** Group/Version/Kind match instead of taking the first:

- **one match** → behaves as before (recovers the recorded config);
- **several matches** → uses `--external-api-domain` to select one, and returns an
  error when it is missing or matches none — so the command never guesses and
  leaves the PROJECT file unchanged.

`create api` is unaffected; it already looks resources up by the full GVK.

## Tests

Unit specs in `webhook_test.go`:
- ambiguous command (no domain) → refuses, both entries keep their path/domain;
- same scenario with entries in reverse order → still refuses (order-independent);
- naming one with `--external-api-domain` → works on that resource, leaves the other alone;
- `--external-api-domain` matching none → refuses;
- single match still works (existing coverage).
