### PR TITLE
🐛 (go/v4): keep the SSA markers when re-running create api --force without --ssa ( follow up, ssa not released yet )

### DIFF
--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -143,16 +143,19 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 		p.options.DoController = util.YesNo(reader)
 	}
 
-	// When scaffolding a controller without an API (--resource=false), copy essential
-	// fields from the existing resource in the PROJECT file, such as Path and Plural.
-	// Note: API, Controllers, and Webhooks are managed separately by UpdateResource.
-	if !p.options.DoAPI {
-		if existingRes, err := p.config.GetResource(res.GVK); err == nil {
+	if existingRes, err := p.config.GetResource(res.GVK); err == nil {
+		// When scaffolding a controller without an API (--resource=false), copy essential
+		// fields from the existing resource in the PROJECT file, such as Path and Plural.
+		// Note: API, Controllers, and Webhooks are managed separately by UpdateResource.
+		if !p.options.DoAPI {
 			p.resource.Path = existingRes.Path
 			p.resource.Plural = existingRes.Plural
 			p.resource.External = existingRes.External
 			p.resource.Core = existingRes.Core
 			p.resource.Module = existingRes.Module
+		} else if existingRes.API != nil && existingRes.API.SSA {
+			// SSA cannot be disabled, so keep the value tracked in the PROJECT file.
+			p.options.SSA = true
 		}
 	}
 

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -36,6 +36,7 @@ const (
 	captains        = "captains"
 	shipGroup       = "ship"
 	frigateKind     = "Frigate"
+	frigates        = "frigates"
 
 	externalAPIModuleWithVersion = "github.com/external/api@v1.0.0"
 	relativeAPIPath              = "api/v1"
@@ -114,6 +115,51 @@ var _ = Describe("createAPISubcommand", func() {
 
 		Expect(subCmd.InjectResource(res)).To(Succeed())
 		Expect(res.API.SSA).To(BeTrue())
+	})
+
+	DescribeTable("should keep the SSA value tracked in the PROJECT file",
+		func(storedSSA, flagSSA, expected bool) {
+			existing := *res
+			existing.API = &resource.API{CRDVersion: "v1", Namespaced: true, SSA: storedSSA}
+			Expect(cfg.AddResource(existing)).To(Succeed())
+
+			subCmd.force = true
+			subCmd.options.DoAPI = true
+			subCmd.options.Namespaced = true
+			subCmd.options.SSA = flagSSA
+
+			Expect(subCmd.InjectResource(res)).To(Succeed())
+			Expect(res.API.SSA).To(Equal(expected))
+		},
+		Entry("when the flag is not provided for an API scaffolded with SSA", true, false, true),
+		Entry("when the flag is provided for an API scaffolded with SSA", true, true, true),
+		Entry("when the flag is provided for an API scaffolded without SSA", false, true, true),
+		Entry("when the flag is not provided for an API scaffolded without SSA", false, false, false),
+	)
+
+	It("should not enable SSA for a new API when another one has it enabled", func() {
+		other := *res
+		other.Kind = frigateKind
+		other.Plural = frigates
+		other.API = &resource.API{CRDVersion: "v1", Namespaced: true, SSA: true}
+		Expect(cfg.AddResource(other)).To(Succeed())
+
+		subCmd.options.DoAPI = true
+		subCmd.options.Namespaced = true
+
+		Expect(subCmd.InjectResource(res)).To(Succeed())
+		Expect(res.API.SSA).To(BeFalse())
+	})
+
+	It("should not reject --resource=false for an API scaffolded with SSA", func() {
+		existing := *res
+		existing.API = &resource.API{CRDVersion: "v1", Namespaced: true, SSA: true}
+		Expect(cfg.AddResource(existing)).To(Succeed())
+
+		subCmd.options.DoAPI = false
+		subCmd.options.DoController = true
+
+		Expect(subCmd.InjectResource(res)).To(Succeed())
 	})
 
 	It("should require external-api-path when using external-api-module", func() {
@@ -292,7 +338,7 @@ var _ = Describe("createAPISubcommand", func() {
 				Version: "v1",
 				Kind:    frigateKind,
 			},
-			Plural: "frigates",
+			Plural: frigates,
 			API:    &resource.API{CRDVersion: "v1"},
 		}
 		Expect(cfg.AddResource(firstRes)).To(Succeed())
@@ -319,7 +365,7 @@ var _ = Describe("createAPISubcommand", func() {
 				Version: "v1",
 				Kind:    frigateKind,
 			},
-			Plural: "frigates",
+			Plural: frigates,
 			API:    &resource.API{CRDVersion: "v1"},
 		}
 		Expect(cfg.AddResource(firstRes)).To(Succeed())

--- a/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
@@ -148,6 +148,90 @@ var _ = Describe("Server-Side Apply (--ssa) Scaffolding", func() {
 		Expect(string(projectContent)).To(ContainSubstring("controller: true"))
 	})
 
+	It("should keep the SSA scaffold when the API is recreated with --force and without --ssa", func() {
+		typesFile := filepath.Join(kbc.Dir, "api", "v1", "captain_types.go")
+
+		By("creating an API with Server-Side Apply enabled")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Captain",
+			"--resource", "--controller",
+			"--ssa",
+			"--make=false",
+		)).To(Succeed())
+
+		By("recreating the same API with --force and without --ssa")
+		Expect(kbc.CreateAPI(
+			"--group", "crew",
+			"--version", "v1",
+			"--kind", "Captain",
+			"--resource", "--controller",
+			"--force",
+			"--make=false",
+		)).To(Succeed())
+
+		By("verifying the SSA markers were kept in the regenerated types file")
+		typesContent, err := os.ReadFile(typesFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(typesContent)).To(ContainSubstring("+genclient"),
+			"the regenerated API must keep the SSA markers tracked in the PROJECT file")
+		Expect(string(typesContent)).To(ContainSubstring("+kubebuilder:resource:path=captains"))
+		Expect(string(typesContent)).NotTo(ContainSubstring("+kubebuilder:ac:generate=false"))
+
+		By("verifying the PROJECT file still tracks ssa")
+		projectContent, err := os.ReadFile(filepath.Join(kbc.Dir, "PROJECT"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(projectContent)).To(ContainSubstring("ssa: true"))
+
+		By("verifying 'make manifests' still generates the applyconfiguration code")
+		Expect(kbc.Make("manifests")).To(Succeed())
+		_, err = os.Stat(filepath.Join(kbc.Dir, "api", "v1", "applyconfiguration", "api", "v1", "captain.go"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable("should keep cluster-scoped SSA markers when the API is recreated with --force",
+		func(includeSSA bool) {
+			typesFile := filepath.Join(kbc.Dir, "api", "v1", "admiral_types.go")
+
+			By("creating a cluster-scoped API with Server-Side Apply enabled")
+			Expect(kbc.CreateAPI(
+				"--group", "crew",
+				"--version", "v1",
+				"--kind", "Admiral",
+				"--resource", "--controller",
+				"--namespaced=false",
+				"--ssa",
+				"--make=false",
+			)).To(Succeed())
+
+			By("recreating the same cluster-scoped API with --force")
+			forceOptions := []string{
+				"--group", "crew",
+				"--version", "v1",
+				"--kind", "Admiral",
+				"--resource", "--controller",
+				"--namespaced=false",
+				"--force",
+				"--make=false",
+			}
+			if includeSSA {
+				forceOptions = append(forceOptions, "--ssa")
+			}
+			Expect(kbc.CreateAPI(forceOptions...)).To(Succeed())
+
+			By("verifying the cluster-scoped SSA markers were kept in the regenerated types file")
+			typesContent, err := os.ReadFile(typesFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(typesContent)).To(ContainSubstring("// +genclient\n// +genclient:nonNamespaced"),
+				"the regenerated cluster-scoped API must keep the SSA client markers")
+			Expect(string(typesContent)).To(ContainSubstring(
+				"// +kubebuilder:resource:path=admirals,scope=Cluster"))
+		},
+		Entry("when --ssa is provided again", true),
+		Entry("when --ssa is omitted", false),
+	)
+
 	It("should complete 'create api --ssa' when groupversion_info.go was customized", func() {
 		By("creating a first SSA API to scaffold the group/version package")
 		Expect(kbc.CreateAPI(


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5936