### PR TITLE
⚠️ (API): always record controllers in `controllers`, deprecate `controller`

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/PROJECT
+++ b/docs/book/src/cronjob-tutorial/testdata/project/PROJECT
@@ -16,7 +16,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: cronjob
   domain: tutorial.kubebuilder.io
   group: batch
   kind: CronJob

--- a/docs/book/src/getting-started/testdata/project/PROJECT
+++ b/docs/book/src/getting-started/testdata/project/PROJECT
@@ -17,7 +17,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: memcached
   domain: example.com
   group: cache
   kind: Memcached

--- a/docs/book/src/migration/manual-process.md
+++ b/docs/book/src/migration/manual-process.md
@@ -276,7 +276,8 @@ resources:
   - api:
       crdVersion: v1
       namespaced: true
-    controller: true
+    controllers:
+      - name: cronjob
     group: batch
     kind: CronJob
     version: v1

--- a/docs/book/src/migration/multi-group.md
+++ b/docs/book/src/migration/multi-group.md
@@ -198,7 +198,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: cronjob
   group: batch
   kind: CronJob
   path: tutorial.kubebuilder.io/project/api/v1  # Old path
@@ -211,7 +212,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: cronjob
   group: batch
   kind: CronJob
   path: tutorial.kubebuilder.io/project/api/batch/v1  # New path with group
@@ -351,7 +353,8 @@ Steps to execute:
      - api:
          crdVersion: v1
          namespaced: true
-       controller: true
+       controllers:
+       - name: cronjob
        domain: tutorial.kubebuilder.io
        group: batch
        kind: CronJob

--- a/docs/book/src/multiversion-tutorial/testdata/project/PROJECT
+++ b/docs/book/src/multiversion-tutorial/testdata/project/PROJECT
@@ -16,7 +16,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: cronjob
   domain: tutorial.kubebuilder.io
   group: batch
   kind: CronJob

--- a/docs/book/src/reference/multiple-controllers.md
+++ b/docs/book/src/reference/multiple-controllers.md
@@ -9,14 +9,28 @@ Kubebuilder supports multiple named controllers for the same API resource. This 
 ```bash
 kubebuilder create api --group crew --version v1 --kind Captain \
   --resource=true \
-  --controller=true \
-  --controller-name=captain
+  --controller=true
 ```
 
 Creates:
 - API types in `api/v1/captain_types.go`
 - Controller in `internal/controller/captain_controller.go` with struct `CaptainReconciler`
 - Registration in `cmd/main.go`
+
+Kubebuilder records the controller under its default name, the lowercase kind:
+
+```yaml
+resources:
+- api:
+    crdVersion: v1
+  controllers:
+  - name: captain
+  group: crew
+  kind: Captain
+  version: v1
+```
+
+Pass `--controller-name` if you want a different name for this first controller.
 
 ### Adding additional controllers
 
@@ -33,22 +47,6 @@ Creates:
 
 The API is only created once. Additional controllers reference the existing API.
 
-## PROJECT file format
-
-### Legacy format (still supported)
-
-```yaml
-resources:
-- api:
-    crdVersion: v1
-  controller: true
-  group: crew
-  kind: Captain
-  version: v1
-```
-
-### Multiple controllers format
-
 ```yaml
 resources:
 - api:
@@ -61,12 +59,11 @@ resources:
   version: v1
 ```
 
-When both formats exist on the same resource (due to manual editing), the `controllers:` array takes precedence and `controller: true` is automatically cleared.
-
 ## Controller naming
 
 ### Storage
-Controller names are stored in the PROJECT file exactly as provided by the user.
+Controller names are stored in the PROJECT file exactly as given to `--controller-name`.
+When the flag is omitted, the lowercase kind is stored.
 
 ### Code generation
 Names are normalized for Go code:
@@ -80,7 +77,7 @@ Names are normalized for Go code:
 
 1. Names must be unique within a resource
 2. Names must be valid DNS labels: lowercase, alphanumeric, and hyphens only, max 63 characters
-3. Different names that normalize to the same identifier are rejected (e.g., `captain-backup` and `captainbackup`)
+3. Different names that generate the same reconciler struct are rejected (e.g., `captain-backup` and `captain--backup`)
 
 ## Controller coordination
 
@@ -93,48 +90,20 @@ Multiple controllers for the same resource require coordination to avoid conflic
 
 Kubebuilder scaffolds the controllers but does not manage coordination between them.
 
-## Migration from legacy format
+<aside class="note" role="note">
+<p class="note-title">If a PROJECT file carries both formats</p>
 
-Existing projects with `controller: true` continue to work unchanged. When adding named controllers to a resource with `controller: true`, Kubebuilder automatically migrates the format:
-
-**Before migration:**
-```yaml
-resources:
-- api:
-    crdVersion: v1
-  controller: true
-  group: crew
-  kind: Captain
-  version: v1
-```
-
-**After adding a named controller:**
-```bash
-kubebuilder create api --group crew --version v1 --kind Captain \
-  --resource=false \
-  --controller=true \
-  --controller-name=captain-backup
-```
-
-**Result:**
-```yaml
-resources:
-- api:
-    crdVersion: v1
-  controllers:
-  - name: captain
-  - name: captain-backup
-  group: crew
-  kind: Captain
-  version: v1
-```
-
-The original unnamed controller is assigned the name `captain` (lowercase kind) and the `controller: true` flag is automatically cleared. This maintains backward compatibility while enabling multiple controllers.
+Only hand-editing can produce a resource with both `controller: true` and `controllers:`.
+Kubebuilder keeps both: the legacy entry is recorded under its default name, the lowercase
+kind, alongside the names already listed. Nothing is discarded.
+</aside>
 
 ## Common errors
 
 **"duplicate controller name"**: Two controllers have the same name. Use unique names.
 
-**"conflicts with ... both normalize to"**: Different names generate the same struct name. Choose distinct names.
+**"conflicts with ... both generate"**: Different names generate the same reconciler struct name. Choose distinct names.
 
 **"controller with name ... already exists"**: Controller already exists for this resource. Use a different name.
+
+**"resource already has controllers defined"**: Adding a controller with `--resource=false` to a resource that already has more than one, or one with a non-default name, so Kubebuilder cannot tell which you mean. Pass `--controller-name`, or `--controller=false` to skip scaffolding a controller.

--- a/docs/book/src/reference/project-config.md
+++ b/docs/book/src/reference/project-config.md
@@ -41,7 +41,8 @@ resources:
   - api:
       crdVersion: v1
       namespaced: true
-    controller: true
+    controllers:
+      - name: memcached
     domain: testproject.org
     group: example.com
     kind: Memcached
@@ -53,13 +54,15 @@ resources:
   - api:
       crdVersion: v1
       namespaced: true
-    controller: true
+    controllers:
+      - name: busybox
     domain: testproject.org
     group: example.com
     kind: Busybox
     path: sigs.k8s.io/kubebuilder/testdata/project-v4-with-deploy-image/api/v1alpha1
     version: v1alpha1
-  - controller: true
+  - controllers:
+      - name: certificate
     domain: io
     external: true
     group: cert-manager
@@ -117,7 +120,8 @@ resources:
   - api:
       crdVersion: v1
       namespaced: true
-    controller: true
+    controllers:
+      - name: memcached
     domain: testproject.org
     group: example.com
     kind: Memcached
@@ -129,13 +133,15 @@ resources:
   - api:
       crdVersion: v1
       namespaced: true
-    controller: true
+    controllers:
+      - name: busybox
     domain: testproject.org
     group: example.com
     kind: Busybox
     path: sigs.k8s.io/kubebuilder/testdata/project-v4-with-deploy-image/api/v1alpha1
     version: v1alpha1
-  - controller: true
+  - controllers:
+      - name: certificate
     domain: io
     external: true
     group: cert-manager
@@ -163,7 +169,8 @@ Now let us check its layout fields definition:
 | `resources.api.crdVersion`          | The Kubernetes API version (`apiVersion`) used to do the scaffolding for the CRD resource.                                                                                                                                                                                      |
 | `resources.api.namespaced`          | The API RBAC permissions which can be namespaced or cluster scoped.                                                                                                                                                                                                             |
 | `resources.api.ssa`                 | **(Optional, Alpha)** When set to `true`, the API was scaffolded with Server-Side Apply support via `create api --ssa`. The scaffold adds the `+genclient` marker and generates apply configurations for the type. Alpha feature: it may change in future releases. Default is `false` (omitted from the PROJECT file). |
-| `resources.controller`              | Indicates whether you scaffolded a controller for the API.                                                                                                                                                                                                                      |
+| `resources.controllers`             | The list of controllers you scaffolded for the API. Each entry holds a `name`, and a resource can have more than one.                                                                                                                                                            |
+| `resources.controller`              | **(Deprecated)** Indicates whether you scaffolded a controller for the API. Replaced by `resources.controllers`. Kubebuilder still reads it, so projects using it keep working, but no longer writes it. The migration is automatic and transparent: the next command that writes the PROJECT file converts every resource to `resources.controllers`, and nothing else about your project changes. |
 | `resources.domain`                  | The domain of the resource that you provided by the `--domain` flag when you initialized the project or via the flag `--external-api-domain` when you used it to scaffold controllers for an [External Type][external-type].                                                   |
 | `resources.group`                   | The GKV group of the resource that you provide by the `--group` flag when you use the sub-command `create api`.                                                                                                                                                                |
 | `resources.version`                 | The GKV version of the resource that you provide by the `--version` flag when you use the sub-command `create api`.                                                                                                                                                            |

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -573,25 +573,20 @@ func createAPI(res resource.Resource) error {
 
 // Creates controllers for a resource.
 // This function supports multiple controllers per resource (GVK).
+// A legacy `controller: true` entry is replayed under its default kind-based name,
+// so regenerating the project also migrates it to the `controllers` list.
 func createControllers(res resource.Resource) error {
-	if res.Controllers == nil || res.Controllers.IsEmpty() {
-		if !res.Controller {
-			return nil
-		}
-		return createControllerWithName(res, "")
-	}
-
-	for _, controller := range *res.Controllers {
-		if err := createControllerWithName(res, controller.Name); err != nil {
-			return fmt.Errorf("failed to create controller %q: %w", controller.Name, err)
+	for _, name := range res.GetControllerNames() {
+		if err := createControllerWithName(res, name); err != nil {
+			return fmt.Errorf("failed to create controller %q: %w", name, err)
 		}
 	}
 
 	return nil
 }
 
-// Creates a single controller for a resource with a specific name.
-func createControllerWithName(res resource.Resource, controllerName string) error {
+// Builds the `create api` arguments that scaffold a single named controller.
+func getControllerFlags(res resource.Resource, controllerName string) []string {
 	args := append([]string{kubebuilderSubcommandCreate, kubebuilderSubcommandAPI}, getGVKFlags(res)...)
 
 	// Always set --resource=false since we're only creating the controller
@@ -612,6 +607,13 @@ func createControllerWithName(res resource.Resource, controllerName string) erro
 			args = append(args, "--external-api-module", res.Module)
 		}
 	}
+
+	return args
+}
+
+// Creates a single controller for a resource with a specific name.
+func createControllerWithName(res resource.Resource, controllerName string) error {
+	args := getControllerFlags(res, controllerName)
 
 	if err := util.RunCmd("kubebuilder create api", "kubebuilder", args...); err != nil {
 		return fmt.Errorf("failed to run kubebuilder create api command: %w", err)

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -346,8 +346,13 @@ var _ = Describe("generate: file-helpers", func() {
 
 var _ = Describe("generate: get-args-helpers", func() {
 	const (
-		fooDomain = "foo.com"
-		barRepo   = "bar"
+		fooDomain      = "foo.com"
+		barRepo        = "bar"
+		crewGroup      = "crew"
+		captainKind    = "Captain"
+		captainCtrl    = "captain"
+		captainBackup  = "captain-backup"
+		certManagerMod = "github.com/cert-manager/cert-manager@v1.18.2"
 	)
 
 	// getInitArgs
@@ -516,6 +521,86 @@ var _ = Describe("generate: get-args-helpers", func() {
 		})
 	})
 
+	// getControllerFlags
+	Context("getControllerFlags", func() {
+		var res resource.Resource
+		BeforeEach(func() {
+			res = resource.Resource{
+				GVK: resource.GVK{Group: crewGroup, Version: "v1", Kind: captainKind},
+			}
+		})
+
+		It("replays a named controller with its name", func() {
+			Expect(getControllerFlags(res, captainBackup)).To(ContainElements(
+				"--resource=false", "--controller=true", "--controller-name", captainBackup))
+		})
+
+		It("replays an external resource with its API flags", func() {
+			res.External = true
+			res.Path = "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+			res.Domain = "io"
+			res.Module = certManagerMod
+
+			Expect(getControllerFlags(res, "certificate")).To(ContainElements(
+				"--controller-name", "certificate",
+				"--external-api-path", res.Path,
+				"--external-api-domain", "io",
+				"--external-api-module", res.Module))
+		})
+	})
+
+	// createControllers runs one `create api` per name reported by GetControllerNames,
+	// so the commands it issues are what re-scaffolds a project.
+	Context("createControllers", func() {
+		var issued [][]string
+
+		replay := func(res resource.Resource) {
+			names := res.GetControllerNames()
+			issued = make([][]string, 0, len(names))
+			for _, name := range names {
+				issued = append(issued, getControllerFlags(res, name))
+			}
+		}
+
+		It("replays a legacy controller under its default kind-based name", func() {
+			replay(resource.Resource{
+				GVK:        resource.GVK{Group: crewGroup, Version: "v1", Kind: captainKind},
+				Controller: true,
+			})
+
+			Expect(issued).To(HaveLen(1))
+			Expect(issued[0]).To(ContainElements("--controller-name", captainCtrl))
+		})
+
+		It("replays one command per named controller", func() {
+			replay(resource.Resource{
+				GVK:         resource.GVK{Group: crewGroup, Version: "v1", Kind: captainKind},
+				Controllers: &resource.Controllers{{Name: captainCtrl}, {Name: captainBackup}},
+			})
+
+			Expect(issued).To(HaveLen(2))
+			Expect(issued[0]).To(ContainElements("--controller-name", captainCtrl))
+			Expect(issued[1]).To(ContainElements("--controller-name", captainBackup))
+		})
+
+		It("replays a hand-edited resource carrying both fields without dropping one", func() {
+			replay(resource.Resource{
+				GVK:         resource.GVK{Group: crewGroup, Version: "v1", Kind: captainKind},
+				Controller:  true,
+				Controllers: &resource.Controllers{{Name: captainBackup}},
+			})
+
+			Expect(issued).To(HaveLen(2), "the legacy controller must be replayed too")
+			Expect(issued[1]).To(ContainElements("--controller-name", captainCtrl))
+		})
+
+		It("issues nothing for a resource without a controller", func() {
+			replay(resource.Resource{GVK: resource.GVK{Group: crewGroup, Version: "v1", Kind: captainKind}})
+
+			Expect(issued).To(BeEmpty())
+		})
+	})
+
 	// getAPIResourceFlags
 	Context("getAPIResourceFlags", func() {
 		var res resource.Resource
@@ -525,7 +610,7 @@ var _ = Describe("generate: get-args-helpers", func() {
 
 		Context("returns correct flags", func() {
 			It("for nil API with Controller set", func() {
-				res.Controller = true
+				res.Controller = true //nolint:staticcheck // exercising the deprecated field is the point
 				// Controllers are now created separately, so always --controller=false in API step
 				Expect(getAPIResourceFlags(res)).To(ContainElements("--resource=false", "--controller=false"))
 			})

--- a/pkg/cli/resource_test.go
+++ b/pkg/cli/resource_test.go
@@ -87,7 +87,7 @@ var _ = Describe("resourceOptions", func() {
 				Expect(resource.API).NotTo(BeNil())
 				Expect(resource.API.CRDVersion).To(Equal(""))
 				Expect(resource.API.Namespaced).To(BeFalse())
-				Expect(resource.Controller).To(BeFalse())
+				Expect(resource.HasController()).To(BeFalse())
 				Expect(resource.Webhooks).NotTo(BeNil())
 				Expect(resource.Webhooks.WebhookVersion).To(Equal(""))
 				Expect(resource.Webhooks.Defaulting).To(BeFalse())

--- a/pkg/config/v3/config.go
+++ b/pkg/config/v3/config.go
@@ -368,6 +368,12 @@ func (c *Cfg) EncodePluginConfig(key string, configObj any) error {
 // MarshalYAML implements config.Config
 func (c Cfg) MarshalYAML() ([]byte, error) {
 	for i, r := range c.Resources {
+		// Writing the file is what moves a project to the current format, including
+		// resources this command did not touch.
+		if err := c.Resources[i].Migrate(); err != nil {
+			return nil, config.MarshalError{Err: err}
+		}
+
 		// If API is empty, omit it (prevents `api: {}`).
 		if r.API != nil && r.API.IsEmpty() {
 			c.Resources[i].API = nil
@@ -375,6 +381,10 @@ func (c Cfg) MarshalYAML() ([]byte, error) {
 		// If Webhooks is empty, omit it (prevents `webhooks: {}`).
 		if r.Webhooks != nil && r.Webhooks.IsEmpty() {
 			c.Resources[i].Webhooks = nil
+		}
+		// If Controllers is empty, omit it (prevents `controllers: []`).
+		if r.Controllers != nil && r.Controllers.IsEmpty() {
+			c.Resources[i].Controllers = nil
 		}
 	}
 
@@ -393,11 +403,6 @@ func (c *Cfg) UnmarshalYAML(b []byte) error {
 	// with newer fields and simply ignore unknown fields.
 	if err := yaml.Unmarshal(b, c); err != nil {
 		return config.UnmarshalError{Err: err}
-	}
-
-	// Normalize resources to auto-migrate legacy controller: true format
-	for i := range c.Resources {
-		c.Resources[i].Normalize()
 	}
 
 	return nil

--- a/pkg/config/v3/config_test.go
+++ b/pkg/config/v3/config_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Cfg", func() {
 					Expect(result.API.CRDVersion).To(Equal(expected.API.CRDVersion))
 					Expect(result.API.Namespaced).To(Equal(expected.API.Namespaced))
 				}
-				Expect(result.Controller).To(Equal(expected.Controller))
+				Expect(result.GetControllerNames()).To(Equal(expected.GetControllerNames()))
 				if expected.Webhooks == nil {
 					Expect(result.Webhooks).To(BeNil())
 				} else {
@@ -597,6 +597,107 @@ version: "3"
 			Entry("for a basic configuration", func() Cfg { return c1 }, func() string { return s1 }),
 			Entry("for a full configuration", func() Cfg { return c2 }, func() string { return s2 }),
 		)
+
+		Context("controller migration", func() {
+			// roundTrip reads a PROJECT body and writes it back out. Migration happens on
+			// write, so this exercises the path a real command takes.
+			roundTrip := func(resources string) string {
+				body := "domain: my.domain\nlayout:\n- go.kubebuilder.io/v4\nprojectName: my-project\n" +
+					"repo: myrepo\nresources:\n" + resources + "version: \"3\"\n"
+
+				var cfg Cfg
+				Expect(cfg.UnmarshalYAML([]byte(body))).To(Succeed())
+				b, err := cfg.MarshalYAML()
+				Expect(err).NotTo(HaveOccurred())
+
+				return string(b)
+			}
+
+			It("should convert a legacy controller to the controllers list", func() {
+				out := roundTrip("- controller: true\n  group: crew\n  kind: Captain\n  version: v1\n")
+
+				Expect(out).To(ContainSubstring("controllers:\n  - name: captain\n"))
+				Expect(out).NotTo(ContainSubstring("controller: true"))
+			})
+
+			It("should leave a project already using controllers byte-identical", func() {
+				// A non-default name only, so a spuriously inserted default would show up.
+				in := "- controllers:\n  - name: captain-backup\n" +
+					"  group: crew\n  kind: Captain\n  version: v1\n"
+
+				Expect(roundTrip(in)).To(Equal(roundTrip(roundTrip(in))),
+					"writing an already-migrated project must not change it")
+				Expect(roundTrip(in)).To(ContainSubstring("- name: captain-backup\n"))
+				Expect(roundTrip(in)).NotTo(ContainSubstring("- name: captain\n"))
+				Expect(roundTrip(in)).NotTo(ContainSubstring("controller:"))
+			})
+
+			It("should be idempotent, so a second write changes nothing", func() {
+				once := roundTrip("- controller: true\n  group: crew\n  kind: Captain\n  version: v1\n")
+
+				var cfg Cfg
+				Expect(cfg.UnmarshalYAML([]byte(once))).To(Succeed())
+				twice, err := cfg.MarshalYAML()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(twice)).To(Equal(once))
+			})
+
+			It("should keep the controllers list when a hand-edited file carries both", func() {
+				in := "- controller: true\n  controllers:\n  - name: captain-backup\n" +
+					"  group: crew\n  kind: Captain\n  version: v1\n"
+				out := roundTrip(in)
+
+				Expect(out).To(ContainSubstring("- name: captain-backup\n"))
+				Expect(out).To(ContainSubstring("- name: captain\n"),
+					"the legacy controller must be kept under its default name, not dropped")
+				Expect(out).NotTo(ContainSubstring("controller: true"))
+			})
+
+			It("should migrate every resource, not only the ones a command touched", func() {
+				in := "- controller: true\n  group: crew\n  kind: Captain\n  version: v1\n" +
+					"- controller: true\n  group: crew\n  kind: Sailor\n  version: v1\n" +
+					"- controllers:\n  - name: admiral\n  group: crew\n  kind: Admiral\n  version: v1\n"
+				out := roundTrip(in)
+
+				Expect(out).To(ContainSubstring("- name: captain\n"))
+				Expect(out).To(ContainSubstring("- name: sailor\n"))
+				Expect(out).To(ContainSubstring("- name: admiral\n"))
+				Expect(out).NotTo(ContainSubstring("controller: true"))
+			})
+
+			It("should omit an empty controllers list", func() {
+				cfg := Cfg{
+					Version: Version,
+					Resources: []resource.Resource{{
+						GVK:         resource.GVK{Group: "crew", Version: "v1", Kind: "Captain"},
+						Controllers: &resource.Controllers{},
+					}},
+				}
+
+				b, err := cfg.MarshalYAML()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(b)).NotTo(ContainSubstring("controllers:"))
+			})
+
+			It("should not invent a controller for a resource that has none", func() {
+				out := roundTrip("- group: crew\n  kind: Captain\n  version: v1\n")
+
+				Expect(out).NotTo(ContainSubstring("controller"))
+			})
+
+			It("should report a legacy controller through the accessors before it is written", func() {
+				var cfg Cfg
+				body := "domain: my.domain\nlayout:\n- go.kubebuilder.io/v4\nprojectName: my-project\n" +
+					"repo: myrepo\nresources:\n- controller: true\n  group: crew\n  kind: Captain\n" +
+					"  version: v1\nversion: \"3\"\n"
+				Expect(cfg.UnmarshalYAML([]byte(body))).To(Succeed())
+
+				res, err := cfg.GetResource(resource.GVK{Group: "crew", Version: "v1", Kind: "Captain"})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.HasController()).To(BeTrue())
+				Expect(res.GetControllerNames()).To(Equal([]string{"captain"}))
+			})
+		})
 
 		DescribeTable("UnmarshalYAML should succeed",
 			func(getContent func() string, getCfg func() Cfg) {

--- a/pkg/model/resource/controller.go
+++ b/pkg/model/resource/controller.go
@@ -28,7 +28,7 @@ import (
 type Controller struct {
 	// Name is the controller identifier, unique within a resource.
 	// Must be a valid DNS label (lowercase, alphanumeric, hyphens, max 63 chars).
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 // Validate checks that the Controller is valid.
@@ -54,49 +54,32 @@ func (c *Controllers) IsEmpty() bool {
 }
 
 // Validate checks that all controllers are valid and have unique names.
-// It also detects name collisions that would occur after normalization,
-// such as "captain-backup" and "captainbackup" both becoming "CaptainBackupReconciler".
+// Names generating the same reconciler struct are rejected by Resource.Validate,
+// which knows the kind those names are resolved against.
 func (c *Controllers) Validate() error {
 	if c.IsEmpty() {
 		return nil
 	}
 
 	names := make(map[string]bool)
-	normalizedNames := make(map[string]string) // Maps normalized name to original name
 
 	for _, controller := range *c {
 		if err := controller.Validate(); err != nil {
 			return err
 		}
 
-		// Check for exact duplicate names
 		if names[controller.Name] {
 			return fmt.Errorf("duplicate controller name %q", controller.Name)
 		}
 		names[controller.Name] = true
-
-		// Check for normalization collisions where different names would generate the same struct
-		normalized := normalizeControllerName(controller.Name)
-		if existingName, exists := normalizedNames[normalized]; exists {
-			return fmt.Errorf("controller name %q conflicts with %q: both normalize to %q",
-				controller.Name, existingName, normalized+"Reconciler")
-		}
-		normalizedNames[normalized] = controller.Name
 	}
 
 	return nil
 }
 
-// normalizeControllerName removes non-alphanumeric characters and converts to lowercase
-// for collision detection. This helps identify names that would generate the same struct.
-func normalizeControllerName(name string) string {
-	var result strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			result.WriteRune(r)
-		}
-	}
-	return strings.ToLower(result.String())
+// DefaultControllerName returns the controller name used when none is given.
+func DefaultControllerName(kind string) string {
+	return strings.ToLower(kind)
 }
 
 // NormalizeFileName converts a controller name to a valid Go filename.
@@ -121,10 +104,12 @@ func NormalizeReconcilerName(controllerName, kind string) string {
 	var result strings.Builder
 	for _, part := range parts {
 		if len(part) > 0 {
-			result.WriteString(strings.ToUpper(part[:1]) + part[1:])
+			result.WriteString(strings.ToUpper(part[:1]))
+			result.WriteString(part[1:])
 		}
 	}
-	return result.String() + "Reconciler"
+	result.WriteString("Reconciler")
+	return result.String()
 }
 
 // GetControllerName returns the runtime name used in Named() and error logs.

--- a/pkg/model/resource/controller_test.go
+++ b/pkg/model/resource/controller_test.go
@@ -17,376 +17,321 @@ limitations under the License.
 package resource
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-const (
-	controller1        = "controller-1"
-	controller2        = "controller-2"
-	captainBackup      = "captainbackup"
-	captainBackupKebab = "captain-backup"
-	crewGroup          = "crew"
-	captainKind        = "Captain"
-	captainsPlural     = "captains"
-	myKind             = "MyKind"
-)
+var _ = Describe("Controller", func() {
+	const (
+		controller1        = "controller-1"
+		controller2        = "controller-2"
+		captain            = "captain"
+		captainBackup      = "captainbackup"
+		captainBackupKebab = "captain-backup"
+		crewGroup          = "crew"
+		captainKind        = "Captain"
+		captainsPlural     = "captains"
+		myKind             = "MyKind"
+		myKindCtrl         = "mykind"
+	)
 
-func TestController_Validate(t *testing.T) {
-	tests := []struct {
-		name    string
-		ctrl    Controller
-		wantErr bool
-	}{
-		{
-			name:    "valid controller name",
-			ctrl:    Controller{Name: "my-controller"},
-			wantErr: false,
+	DescribeTable("Validate should succeed for valid names",
+		func(name string) {
+			Expect(Controller{Name: name}.Validate()).To(Succeed())
 		},
-		{
-			name:    "empty controller name",
-			ctrl:    Controller{Name: ""},
-			wantErr: true,
-		},
-		{
-			name:    "invalid controller name with uppercase",
-			ctrl:    Controller{Name: "MyController"},
-			wantErr: true,
-		},
-		{
-			name:    "invalid controller name with underscore",
-			ctrl:    Controller{Name: "my_controller"},
-			wantErr: true,
-		},
-		{
-			name:    "valid controller name with numbers",
-			ctrl:    Controller{Name: controller1},
-			wantErr: false,
-		},
-	}
+		Entry("a hyphenated name", "my-controller"),
+		Entry("a name with numbers", controller1),
+	)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.ctrl.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Controller.Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
+	DescribeTable("Validate should fail for invalid names",
+		func(name string) {
+			Expect(Controller{Name: name}.Validate()).NotTo(Succeed())
+		},
+		Entry("an empty name", ""),
+		Entry("a name with uppercase characters", "MyController"),
+		Entry("a name with an underscore", "my_controller"),
+	)
+
+	Context("Controllers", func() {
+		DescribeTable("Validate should succeed",
+			func(controllers *Controllers) {
+				Expect(controllers.Validate()).To(Succeed())
+			},
+			Entry("for nil controllers", nil),
+			Entry("for empty controllers", &Controllers{}),
+			Entry("for distinct names", &Controllers{{Name: controller1}, {Name: controller2}}),
+		)
+
+		DescribeTable("Validate should fail",
+			func(controllers *Controllers) {
+				Expect(controllers.Validate()).NotTo(Succeed())
+			},
+			Entry("for duplicate names", &Controllers{{Name: controller1}, {Name: controller1}}),
+			Entry("for an invalid name", &Controllers{{Name: "Controller-1"}}),
+		)
+
+		DescribeTable("HasController should report whether a name is present",
+			func(name string, expected bool) {
+				controllers := &Controllers{{Name: controller1}, {Name: controller2}}
+				Expect(controllers.HasController(name)).To(Equal(expected))
+			},
+			Entry("for the first controller", controller1, true),
+			Entry("for the second controller", controller2, true),
+			Entry("for an absent controller", "controller-3", false),
+		)
+
+		Context("AddController", func() {
+			It("should fail on nil controllers", func() {
+				var controllers *Controllers
+				Expect(controllers.AddController(controller1)).NotTo(Succeed())
+			})
+
+			It("should append valid controllers in order", func() {
+				controllers := &Controllers{}
+				Expect(controllers.AddController(controller1)).To(Succeed())
+				Expect(controllers.AddController(controller2)).To(Succeed())
+				Expect(controllers.GetControllerNames()).To(Equal([]string{controller1, controller2}))
+			})
+
+			It("should reject a duplicate controller", func() {
+				controllers := &Controllers{{Name: controller1}}
+				Expect(controllers.AddController(controller1)).NotTo(Succeed())
+				Expect(*controllers).To(HaveLen(1))
+			})
+
+			It("should reject an invalid name", func() {
+				controllers := &Controllers{}
+				Expect(controllers.AddController("Controller_1")).NotTo(Succeed())
+				Expect(*controllers).To(BeEmpty())
+			})
 		})
-	}
-}
+	})
 
-func TestControllers_Validate(t *testing.T) {
-	tests := []struct {
-		name    string
-		ctrls   *Controllers
-		wantErr bool
-	}{
-		{
-			name:    "nil controllers",
-			ctrls:   nil,
-			wantErr: false,
-		},
-		{
-			name:    "empty controllers",
-			ctrls:   &Controllers{},
-			wantErr: false,
-		},
-		{
-			name: "valid controllers",
-			ctrls: &Controllers{
-				{Name: controller1},
-				{Name: controller2},
-			},
-			wantErr: false,
-		},
-		{
-			name: "duplicate controller names",
-			ctrls: &Controllers{
-				{Name: controller1},
-				{Name: controller1},
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid controller name",
-			ctrls: &Controllers{
-				{Name: "Controller-1"},
-			},
-			wantErr: true,
-		},
-		{
-			name: "normalization collision: removes hyphens",
-			ctrls: &Controllers{
-				{Name: captainBackup},
-				{Name: captainBackupKebab},
-			},
-			wantErr: true,
-		},
-		{
-			name: "normalization collision: case insensitive",
-			ctrls: &Controllers{
-				{Name: captainBackup},
-				{Name: captainBackup}, // Will be caught as exact duplicate first
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.ctrls.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Controllers.Validate() error = %v, wantErr %v", err, tt.wantErr)
+	// Reconciler collisions need the kind, so Resource.Validate owns this check.
+	Context("Resource.Validate reconciler names", func() {
+		validate := func(kind string, names ...string) error {
+			controllers := make(Controllers, 0, len(names))
+			for _, name := range names {
+				controllers = append(controllers, Controller{Name: name})
 			}
+
+			res := Resource{
+				GVK:         GVK{Group: crewGroup, Version: "v1", Kind: kind},
+				Plural:      captainsPlural,
+				Controllers: &controllers,
+			}
+
+			return res.validateReconcilerNames()
+		}
+
+		It("should accept names differing only by a hyphen", func() {
+			// These generate CaptainbackupReconciler and CaptainBackupReconciler:
+			// distinct identifiers, not a collision.
+			Expect(validate(captainKind, captainBackup, captainBackupKebab)).To(Succeed())
 		})
-	}
-}
 
-func TestControllers_HasController(t *testing.T) {
-	ctrls := &Controllers{
-		{Name: controller1},
-		{Name: controller2},
-	}
-
-	tests := []struct {
-		name string
-		want bool
-	}{
-		{
-			name: controller1,
-			want: true,
-		},
-		{
-			name: controller2,
-			want: true,
-		},
-		{
-			name: "controller-3",
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ctrls.HasController(tt.name); got != tt.want {
-				t.Errorf("Controllers.HasController() = %v, want %v", got, tt.want)
-			}
+		It("should reject names generating the same reconciler", func() {
+			Expect(validate(captainKind, captainBackupKebab, "captain--backup")).NotTo(Succeed())
 		})
-	}
-}
 
-func TestControllers_AddController(t *testing.T) {
-	tests := []struct {
-		name    string
-		initial *Controllers
-		addName string
-		wantErr bool
-		wantLen int
-	}{
-		{
-			name:    "add to nil controllers",
-			initial: nil,
-			addName: controller1,
-			wantErr: true,
-		},
-		{
-			name:    "add valid controller",
-			initial: &Controllers{},
-			addName: controller1,
-			wantErr: false,
-			wantLen: 1,
-		},
-		{
-			name: "add duplicate controller",
-			initial: &Controllers{
-				{Name: controller1},
-			},
-			addName: controller1,
-			wantErr: true,
-			wantLen: 1,
-		},
-		{
-			name:    "add invalid controller name",
-			initial: &Controllers{},
-			addName: "Controller_1",
-			wantErr: true,
-			wantLen: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.initial.AddController(tt.addName)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Controllers.AddController() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.initial != nil && len(*tt.initial) != tt.wantLen {
-				t.Errorf("Controllers.AddController() len = %v, want %v", len(*tt.initial), tt.wantLen)
-			}
+		It("should reject a name colliding with the kind-based default", func() {
+			// myKindCtrl takes the kind-based shortcut and "my-kind" is converted to
+			// PascalCase, so both end up as MyKindReconciler.
+			Expect(validate(myKind, myKindCtrl, "my-kind")).NotTo(Succeed())
 		})
-	}
-}
 
-func TestResource_Update_WithControllers(t *testing.T) {
-	tests := []struct {
-		name    string
-		base    Resource
-		other   Resource
-		wantErr bool
-		wantLen int
-	}{
-		{
-			name: "update resource without controllers with one that has controllers",
-			base: Resource{
-				GVK: GVK{
-					Group:   crewGroup,
-					Version: "v1",
-					Kind:    captainKind,
-				},
-				Plural: captainsPlural,
-			},
-			other: Resource{
-				GVK: GVK{
-					Group:   crewGroup,
-					Version: "v1",
-					Kind:    captainKind,
-				},
-				Plural: captainsPlural,
-				Controllers: &Controllers{
-					{Name: captainBackupKebab},
-				},
-			},
-			wantErr: false,
-			wantLen: 1,
-		},
-		{
-			name: "update resource with controllers with another controller",
-			base: Resource{
-				GVK: GVK{
-					Group:   crewGroup,
-					Version: "v1",
-					Kind:    captainKind,
-				},
-				Plural: captainsPlural,
-				Controllers: &Controllers{
-					{Name: "captain"},
-				},
-			},
-			other: Resource{
-				GVK: GVK{
-					Group:   crewGroup,
-					Version: "v1",
-					Kind:    captainKind,
-				},
-				Plural: captainsPlural,
-				Controllers: &Controllers{
-					{Name: captainBackupKebab},
-				},
-			},
-			wantErr: false,
-			wantLen: 2,
-		},
-		{
-			name: "update with nil other controllers",
-			base: Resource{
-				GVK: GVK{
-					Group:   crewGroup,
-					Version: "v1",
-					Kind:    captainKind,
-				},
-				Plural: captainsPlural,
-				Controllers: &Controllers{
-					{Name: "captain"},
-				},
-			},
-			other: Resource{
-				GVK: GVK{
-					Group:   crewGroup,
-					Version: "v1",
-					Kind:    captainKind,
-				},
-				Plural: captainsPlural,
-			},
-			wantErr: false,
-			wantLen: 1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.base.Update(tt.other)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Resource.Update() error = %v, wantErr %v", err, tt.wantErr)
+		It("should surface the collision through Resource.Validate", func() {
+			res := Resource{
+				GVK:         GVK{Group: crewGroup, Version: "v1", Kind: myKind},
+				Plural:      "mykinds",
+				Controllers: &Controllers{{Name: myKindCtrl}, {Name: "my-kind"}},
 			}
-			if !tt.wantErr {
-				if tt.base.Controllers != nil {
-					if len(*tt.base.Controllers) != tt.wantLen {
-						t.Errorf("Resource.Update() controllers len = %v, want %v", len(*tt.base.Controllers), tt.wantLen)
-					}
-				} else if tt.wantLen > 0 {
-					t.Errorf("Resource.Update() controllers is nil, want %v controllers", tt.wantLen)
-				}
-			}
+			Expect(res.Validate()).NotTo(Succeed())
 		})
-	}
-}
+	})
 
-func TestResource_GetControllerNames(t *testing.T) {
-	tests := []struct {
-		name     string
-		resource Resource
-		want     []string
-	}{
-		{
-			name: "resource with new Controllers field",
-			resource: Resource{
-				GVK: GVK{Kind: myKind},
-				Controllers: &Controllers{
-					{Name: controller1},
-					{Name: controller2},
-				},
-			},
-			want: []string{controller1, controller2},
-		},
-		{
-			name: "resource with legacy Controller bool",
-			resource: Resource{
-				GVK:        GVK{Kind: myKind},
-				Controller: true,
-			},
-			want: []string{"mykind"},
-		},
-		{
-			name: "resource with no controllers",
-			resource: Resource{
-				GVK: GVK{Kind: myKind},
-			},
-			want: nil,
-		},
-		{
-			name: "resource with both fields (new takes precedence)",
-			resource: Resource{
-				GVK:        GVK{Kind: myKind},
-				Controller: true,
-				Controllers: &Controllers{
-					{Name: "custom-controller"},
-				},
-			},
-			want: []string{"custom-controller"},
-		},
-	}
+	Context("Resource.Migrate", func() {
+		It("should record a legacy controller under its default name", func() {
+			res := Resource{GVK: GVK{Kind: captainKind}, Controller: true}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.resource.GetControllerNames()
-			if len(got) != len(tt.want) {
-				t.Errorf("Resource.GetControllerNames() = %v, want %v", got, tt.want)
-				return
-			}
-			for i, name := range got {
-				if name != tt.want[i] {
-					t.Errorf("Resource.GetControllerNames()[%d] = %v, want %v", i, name, tt.want[i])
-				}
-			}
+			Expect(res.Migrate()).To(Succeed())
+			Expect(res.Controller).To(BeFalse())
+			Expect(res.GetControllerNames()).To(Equal([]string{captain}))
 		})
-	}
-}
+
+		It("should keep the default alongside names already recorded", func() {
+			res := Resource{
+				GVK:         GVK{Kind: captainKind},
+				Controller:  true,
+				Controllers: &Controllers{{Name: captainBackupKebab}},
+			}
+
+			Expect(res.Migrate()).To(Succeed())
+			Expect(res.Controller).To(BeFalse())
+			Expect(res.GetControllerNames()).To(Equal([]string{captainBackupKebab, captain}))
+		})
+
+		It("should be a no-op for a resource with no controller", func() {
+			res := Resource{GVK: GVK{Kind: captainKind}}
+
+			Expect(res.Migrate()).To(Succeed())
+			Expect(res.HasController()).To(BeFalse())
+			Expect(res.Controllers).To(BeNil())
+		})
+
+		It("should be idempotent", func() {
+			res := Resource{GVK: GVK{Kind: captainKind}, Controller: true}
+
+			Expect(res.Migrate()).To(Succeed())
+			Expect(res.Migrate()).To(Succeed())
+			Expect(res.GetControllerNames()).To(Equal([]string{captain}))
+		})
+	})
+
+	Context("Resource.Update", func() {
+		var gvk GVK
+
+		BeforeEach(func() {
+			gvk = GVK{Group: crewGroup, Version: "v1", Kind: captainKind}
+		})
+
+		It("should adopt the controllers of the other resource", func() {
+			res := Resource{GVK: gvk, Plural: captainsPlural}
+			other := Resource{
+				GVK:         gvk,
+				Plural:      captainsPlural,
+				Controllers: &Controllers{{Name: captainBackupKebab}},
+			}
+
+			Expect(res.Update(other)).To(Succeed())
+			Expect(res.GetControllerNames()).To(Equal([]string{captainBackupKebab}))
+		})
+
+		It("should merge controllers from both resources", func() {
+			res := Resource{GVK: gvk, Plural: captainsPlural, Controllers: &Controllers{{Name: captain}}}
+			other := Resource{
+				GVK:         gvk,
+				Plural:      captainsPlural,
+				Controllers: &Controllers{{Name: captainBackupKebab}},
+			}
+
+			Expect(res.Update(other)).To(Succeed())
+			Expect(res.GetControllerNames()).To(Equal([]string{captain, captainBackupKebab}))
+		})
+
+		It("should keep its controllers when the other resource has none", func() {
+			res := Resource{GVK: gvk, Plural: captainsPlural, Controllers: &Controllers{{Name: captain}}}
+			other := Resource{GVK: gvk, Plural: captainsPlural}
+
+			Expect(res.Update(other)).To(Succeed())
+			Expect(res.GetControllerNames()).To(Equal([]string{captain}))
+		})
+
+		It("should migrate a legacy controller into the controllers list", func() {
+			res := Resource{GVK: gvk, Plural: captainsPlural, Controller: true}
+			other := Resource{
+				GVK:         gvk,
+				Plural:      captainsPlural,
+				Controllers: &Controllers{{Name: captainBackupKebab}},
+			}
+
+			Expect(res.Update(other)).To(Succeed())
+			Expect(res.Controller).To(BeFalse())
+			Expect(res.GetControllerNames()).To(Equal([]string{captain, captainBackupKebab}))
+		})
+
+		It("should migrate a legacy controller coming from the other resource", func() {
+			res := Resource{GVK: gvk, Plural: captainsPlural}
+			other := Resource{GVK: gvk, Plural: captainsPlural, Controller: true}
+
+			Expect(res.Update(other)).To(Succeed())
+			Expect(res.Controller).To(BeFalse())
+			Expect(res.GetControllerNames()).To(Equal([]string{captain}))
+		})
+	})
+
+	DescribeTable("Resource.GetControllerNames",
+		func(res Resource, expected []string) {
+			Expect(res.GetControllerNames()).To(Equal(expected))
+		},
+		Entry("returns the names from the controllers list",
+			Resource{
+				GVK:         GVK{Kind: myKind},
+				Controllers: &Controllers{{Name: controller1}, {Name: controller2}},
+			},
+			[]string{controller1, controller2}),
+		Entry("returns the kind-based default for a legacy controller",
+			Resource{GVK: GVK{Kind: myKind}, Controller: true},
+			[]string{myKindCtrl}),
+		Entry("returns nil when there is no controller",
+			Resource{GVK: GVK{Kind: myKind}},
+			nil),
+		// A hand-edited file can carry both. Reporting only the list would drop the legacy
+		// controller when alpha generate replays the resource.
+		Entry("reports the legacy controller alongside the list",
+			Resource{
+				GVK:         GVK{Kind: myKind},
+				Controller:  true,
+				Controllers: &Controllers{{Name: "custom-controller"}},
+			},
+			[]string{"custom-controller", myKindCtrl}),
+		Entry("does not repeat a legacy controller already in the list",
+			Resource{
+				GVK:         GVK{Kind: myKind},
+				Controller:  true,
+				Controllers: &Controllers{{Name: myKindCtrl}},
+			},
+			[]string{myKindCtrl}),
+	)
+
+	// GetControllerNames drives the alpha generate replay, so it must report the same set
+	// that Migrate would record. A disagreement silently drops a controller on re-scaffold.
+	It("should report the same controllers that Migrate records", func() {
+		for _, res := range []Resource{
+			{GVK: GVK{Kind: captainKind}, Controller: true},
+			{GVK: GVK{Kind: captainKind}, Controllers: &Controllers{{Name: captainBackupKebab}}},
+			{GVK: GVK{Kind: captainKind}, Controller: true, Controllers: &Controllers{{Name: captainBackupKebab}}},
+			{GVK: GVK{Kind: captainKind}},
+		} {
+			before := res.GetControllerNames()
+			Expect(res.Migrate()).To(Succeed())
+			Expect(res.GetControllerNames()).To(ConsistOf(before))
+		}
+	})
+
+	DescribeTable("NormalizeReconcilerName",
+		func(controllerName, kind, expected string) {
+			Expect(NormalizeReconcilerName(controllerName, kind)).To(Equal(expected))
+		},
+		Entry("falls back to the kind when no name is given", "", captainKind, "CaptainReconciler"),
+		Entry("falls back to the kind when the name matches it", captain, captainKind, "CaptainReconciler"),
+		Entry("converts a hyphenated name to PascalCase",
+			captainBackupKebab, captainKind, "CaptainBackupReconciler"),
+	)
+
+	DescribeTable("GetControllerName",
+		func(controllerName, kind, group string, multiGroup bool, expected string) {
+			Expect(GetControllerName(controllerName, kind, group, multiGroup)).To(Equal(expected))
+		},
+		Entry("uses the lowercase kind when no name is given", "", captainKind, crewGroup, false, captain),
+		Entry("uses the given name", captainBackupKebab, captainKind, crewGroup, false, captainBackupKebab),
+		Entry("prefixes the group in multigroup projects", captain, captainKind, crewGroup, true, "crew-captain"),
+		Entry("skips the prefix when there is no group", captain, captainKind, "", true, captain),
+	)
+
+	DescribeTable("NormalizeFileName",
+		func(controllerName, expected string) {
+			Expect(NormalizeFileName(controllerName)).To(Equal(expected))
+		},
+		Entry("leaves a plain name untouched", captain, captain),
+		Entry("replaces hyphens with underscores", captainBackupKebab, "captain_backup"),
+	)
+
+	DescribeTable("DefaultControllerName",
+		func(kind, expected string) {
+			Expect(DefaultControllerName(kind)).To(Equal(expected))
+		},
+		Entry("lowercases a single-word kind", captainKind, captain),
+		Entry("lowercases a multi-word kind", myKind, myKindCtrl),
+	)
+})

--- a/pkg/model/resource/resource.go
+++ b/pkg/model/resource/resource.go
@@ -38,8 +38,11 @@ type Resource struct {
 	// API holds the information related to the resource API.
 	API *API `json:"api,omitempty"`
 
-	// Controller specifies if a controller has been scaffolded (legacy, deprecated).
-	// Deprecated: Use Controllers for multiple controller support.
+	// Controller specifies if a controller has been scaffolded.
+	// It cannot be removed while config v3 is the current version: PROJECT files written
+	// before Controllers existed still carry it, and dropping it would stop them parsing.
+	//
+	// Deprecated: use Controllers. This field reads false once a project is migrated.
 	Controller bool `json:"controller,omitempty"`
 
 	// Controllers holds named controllers for this resource.
@@ -114,28 +117,79 @@ func (r Resource) Validate() error {
 	}
 
 	// Validate the Controllers
-	if r.Controllers != nil && !r.Controllers.IsEmpty() {
-		if err := r.Controllers.Validate(); err != nil {
-			return fmt.Errorf("invalid Controllers: %w", err)
-		}
+	if err := r.Controllers.Validate(); err != nil {
+		return fmt.Errorf("invalid Controllers: %w", err)
+	}
+	if err := r.validateReconcilerNames(); err != nil {
+		return fmt.Errorf("invalid Controllers: %w", err)
 	}
 
 	return nil
 }
 
-// Normalize handles the edge case where both controller: true and controllers: are set.
-// This can only occur if someone manually edits the PROJECT file.
-// The new controllers array format takes precedence, and the legacy flag is cleared.
-func (r *Resource) Normalize() {
-	if r == nil {
-		return
+// validateReconcilerNames rejects controllers whose names generate the same reconciler
+// struct, such as "captain-backup" and "captain--backup". A name matching the lowercase
+// kind resolves to {Kind}Reconciler, so the kind is needed to compare them.
+func (r Resource) validateReconcilerNames() error {
+	if r.Controllers.IsEmpty() {
+		return nil
 	}
 
-	// If both controller: true and controllers: are set (manual edit),
-	// keep the explicit controllers array and clear the legacy flag
-	if r.Controller && r.Controllers != nil && !r.Controllers.IsEmpty() {
-		r.Controller = false
+	reconcilers := make(map[string]string, len(*r.Controllers))
+	for _, controller := range *r.Controllers {
+		reconciler := NormalizeReconcilerName(controller.Name, r.Kind)
+		if existing, found := reconcilers[reconciler]; found {
+			return fmt.Errorf("controller name %q conflicts with %q: both generate %s",
+				controller.Name, existing, reconciler)
+		}
+		reconcilers[reconciler] = controller.Name
 	}
+
+	return nil
+}
+
+// Migrate rewrites deprecated fields into the format Kubebuilder currently writes.
+// Deprecated fields are read so that existing PROJECT files keep working, but they are
+// never written back, so this runs whenever the PROJECT file is written. Add a call here
+// for each new deprecation so a project is migrated in one place.
+func (r *Resource) Migrate() error {
+	if r == nil {
+		return nil
+	}
+
+	return r.migrateControllers()
+}
+
+// Normalize resolves a resource carrying both the legacy controller field and Controllers.
+// It now delegates to Migrate, so it also converts a resource carrying only the legacy
+// field, where it used to do nothing, and it records that controller in Controllers rather
+// than discarding it.
+//
+// Deprecated: use Migrate, which reports failures.
+func (r *Resource) Normalize() {
+	_ = r.Migrate()
+}
+
+// migrateControllers records a legacy controller under its default kind-based name.
+func (r *Resource) migrateControllers() error {
+	if !r.Controller {
+		return nil
+	}
+
+	if r.Controllers == nil {
+		r.Controllers = &Controllers{}
+	}
+
+	// A hand-edited file can carry both fields, so the default name may already be recorded.
+	name := DefaultControllerName(r.Kind)
+	if !r.Controllers.HasController(name) {
+		if err := r.Controllers.AddController(name); err != nil {
+			return fmt.Errorf("cannot migrate controller of %s: %w", r.Kind, err)
+		}
+	}
+	r.Controller = false
+
+	return nil
 }
 
 // PackageName returns a name valid to be used for Go packages.
@@ -162,17 +216,9 @@ func (r Resource) HasAPI() bool {
 }
 
 // HasController returns true if the resource has at least one associated controller.
-// It checks both the legacy Controller bool field and the new Controllers field.
+// The legacy Controller field is still honoured so that existing PROJECT files work.
 func (r Resource) HasController() bool {
-	// Check legacy field first for backward compatibility
-	if r.Controller {
-		return true
-	}
-	// Check new Controllers field
-	if r.Controllers != nil && !r.Controllers.IsEmpty() {
-		return true
-	}
-	return false
+	return r.Controller || !r.Controllers.IsEmpty()
 }
 
 // HasDefaultingWebhook returns true if the resource has an associated defaulting webhook.
@@ -201,21 +247,18 @@ func (r Resource) IsRegularPlural() bool {
 }
 
 // GetControllerNames returns the names of all controllers for this resource.
-// For resources using the new Controllers field, it returns the actual controller names.
-// For resources using the legacy Controller bool field, it returns a default name (lowercase kind).
+// A legacy Controller bool is reported under its default kind-based name.
 // Returns nil if the resource has no controllers.
 func (r Resource) GetControllerNames() []string {
-	// New format: return explicit controller names
-	if r.Controllers != nil && !r.Controllers.IsEmpty() {
-		return r.Controllers.GetControllerNames()
+	names := r.Controllers.GetControllerNames()
+
+	// A hand-edited file can carry both fields. Report the legacy controller too, so this
+	// agrees with Migrate and re-scaffolding cannot drop it.
+	if name := DefaultControllerName(r.Kind); r.Controller && !r.Controllers.HasController(name) {
+		names = append(names, name)
 	}
 
-	// Legacy format: generate default name from kind
-	if r.Controller {
-		return []string{strings.ToLower(r.Kind)}
-	}
-
-	return nil
+	return names
 }
 
 // Copy returns a deep copy of the Resource that can be safely modified without affecting the original.
@@ -270,35 +313,25 @@ func (r *Resource) Update(other Resource) error {
 		return err
 	}
 
-	// Update controllers
-	if other.Controllers != nil && !other.Controllers.IsEmpty() {
-		// Migrate legacy controller: true to the new controllers array format
-		if r.Controller {
-			if r.Controllers == nil {
-				r.Controllers = &Controllers{}
-			}
-			// Add a default controller with a kind-based name
-			defaultName := strings.ToLower(r.Kind)
-			if !r.Controllers.HasController(defaultName) {
-				_ = r.Controllers.AddController(defaultName)
-			}
-		}
-
-		// Initialize controllers array if not yet created
+	// Update controllers.
+	if err := r.Migrate(); err != nil {
+		return err
+	}
+	if other.Controller || !other.Controllers.IsEmpty() {
 		if r.Controllers == nil {
 			r.Controllers = &Controllers{}
 		}
-
-		// Merge controllers from the other resource
+		if other.Controller {
+			name := DefaultControllerName(r.Kind)
+			if !r.Controllers.HasController(name) {
+				if err := r.Controllers.AddController(name); err != nil {
+					return fmt.Errorf("cannot add controller of %s: %w", r.Kind, err)
+				}
+			}
+		}
 		if err := r.Controllers.Update(other.Controllers); err != nil {
 			return err
 		}
-
-		// Clear the legacy flag now that we're using the new format
-		r.Controller = false
-	} else {
-		// Only update the legacy field if not using the new format
-		r.Controller = r.Controller || other.Controller
 	}
 
 	// Update Webhooks.

--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -471,17 +471,21 @@ var _ = Describe("Resource", func() {
 		})
 
 		Context("Controller", func() {
-			It("should set the controller flag if provided and not previously set", func() {
+			// The legacy Controller flag is read but never written back: Update migrates
+			// it into the Controllers list so a PROJECT entry never holds both.
+			It("should record the controller if provided and not previously set", func() {
 				r = Resource{GVK: gvk}
 				other = Resource{
 					GVK:        gvk,
 					Controller: true,
 				}
 				Expect(r.Update(other)).To(Succeed())
-				Expect(r.Controller).To(BeTrue())
+				Expect(r.HasController()).To(BeTrue())
+				Expect(r.Controller).To(BeFalse())
+				Expect(r.GetControllerNames()).To(Equal([]string{strings.ToLower(kind)}))
 			})
 
-			It("should keep the controller flag if previously set", func() {
+			It("should keep the controller if previously set", func() {
 				r = Resource{
 					GVK:        gvk,
 					Controller: true,
@@ -490,7 +494,8 @@ var _ = Describe("Resource", func() {
 				By("not providing it")
 				other = Resource{GVK: gvk}
 				Expect(r.Update(other)).To(Succeed())
-				Expect(r.Controller).To(BeTrue())
+				Expect(r.HasController()).To(BeTrue())
+				Expect(r.GetControllerNames()).To(Equal([]string{strings.ToLower(kind)}))
 
 				By("providing it")
 				other = Resource{
@@ -498,7 +503,9 @@ var _ = Describe("Resource", func() {
 					Controller: true,
 				}
 				Expect(r.Update(other)).To(Succeed())
-				Expect(r.Controller).To(BeTrue())
+				Expect(r.HasController()).To(BeTrue())
+				Expect(r.Controller).To(BeFalse())
+				Expect(r.GetControllerNames()).To(Equal([]string{strings.ToLower(kind)}))
 			})
 
 			It("should not set the controller flag if not provided and not previously set", func() {

--- a/pkg/plugins/golang/options.go
+++ b/pkg/plugins/golang/options.go
@@ -19,7 +19,6 @@ package golang
 import (
 	log "log/slog"
 	"path"
-	"strings"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
@@ -184,36 +183,27 @@ func (opts Options) UpdateResource(res *resource.Resource, c config.Config) {
 	}
 }
 
-// updateControllers applies controller-related options to the resource.
-// It handles both legacy (--controller) and new (--controller-name) controller creation.
+// updateControllers records the controller on the resource. Controllers are always
+// stored in the Controllers list; the legacy Controller bool is never written back.
+// The name is rejected earlier by createAPISubcommand.validateController, so a failure here
+// means a caller built the options directly. UpdateResource has no error to return, so it is
+// logged: the resource then records no controller and nothing is scaffolded for it.
 func (opts Options) updateControllers(res *resource.Resource) {
-	if opts.ControllerName == "" {
-		// No controller name specified: use legacy mode
-		if res.Controllers == nil || res.Controllers.IsEmpty() {
-			res.Controller = true
-		} else {
-			// Warn when trying to use legacy mode on a resource with named controllers
-			log.Warn("resource already has named controllers; use --controller-name to add another controller")
-		}
-		return
+	if err := res.Migrate(); err != nil {
+		log.Error("could not migrate resource", "kind", res.Kind, "error", err)
 	}
 
-	// Controller name specified: migrate from legacy format if needed
-	if res.Controller {
-		if res.Controllers == nil {
-			res.Controllers = &resource.Controllers{}
-		}
-		// Convert the legacy controller: true to a named controller
-		defaultName := strings.ToLower(res.Kind)
-		_ = res.Controllers.AddController(defaultName)
-		res.Controller = false
-	}
-
-	// Initialize controllers array if not yet created
 	if res.Controllers == nil {
 		res.Controllers = &resource.Controllers{}
 	}
 
-	// Add the new named controller (AddController validates and checks for duplicates)
-	_ = res.Controllers.AddController(opts.ControllerName)
+	name := opts.ControllerName
+	if name == "" {
+		name = resource.DefaultControllerName(res.Kind)
+	}
+	if !res.Controllers.HasController(name) {
+		if err := res.Controllers.AddController(name); err != nil {
+			log.Error("could not record controller", "name", name, "kind", res.Kind, "error", err)
+		}
+	}
 }

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -30,11 +30,13 @@ import (
 var _ = Describe("Options", func() {
 	Context("UpdateResource", func() {
 		const (
-			group   = "crew"
-			domain  = "test.io"
-			version = "v1"
-			kind    = "FirstMate"
-			plural  = "firstmates"
+			group         = "crew"
+			domain        = "test.io"
+			version       = "v1"
+			kind          = "FirstMate"
+			plural        = "firstmates"
+			controller    = "firstmate"
+			backupControl = "firstmate-backup"
 		)
 
 		var (
@@ -96,7 +98,9 @@ var _ = Describe("Options", func() {
 					} else {
 						Expect(res.API.IsEmpty()).To(BeTrue())
 					}
-					Expect(res.Controller).To(Equal(options.DoController))
+					// Controllers are always recorded in the list; the legacy flag is never written.
+					Expect(res.Controller).To(BeFalse()) //nolint:staticcheck // asserting it stays unwritten
+					Expect(res.HasController()).To(Equal(options.DoController))
 					Expect(res.Webhooks).NotTo(BeNil())
 					if options.DoDefaulting || options.DoValidation || options.DoConversion {
 						Expect(res.Webhooks.Defaulting).To(Equal(options.DoDefaulting))
@@ -126,6 +130,53 @@ var _ = Describe("Options", func() {
 			Entry("when updating the API with setting webhooks params",
 				Options{DoAPI: true, DoDefaulting: true, DoValidation: true, DoConversion: true}),
 		)
+
+		Context("recording controllers", func() {
+			var res resource.Resource
+
+			BeforeEach(func() {
+				res = resource.Resource{
+					GVK:      gvk,
+					Plural:   plural,
+					API:      &resource.API{},
+					Webhooks: &resource.Webhooks{},
+				}
+			})
+
+			It("should record the default kind-based name when none is given", func() {
+				Options{DoController: true}.UpdateResource(&res, cfg)
+
+				Expect(res.GetControllerNames()).To(Equal([]string{controller}))
+			})
+
+			It("should record the given controller name", func() {
+				Options{DoController: true, ControllerName: backupControl}.UpdateResource(&res, cfg)
+
+				Expect(res.GetControllerNames()).To(Equal([]string{backupControl}))
+			})
+
+			It("should carry a legacy controller into the list before adding a new one", func() {
+				res.Controller = true //nolint:staticcheck // simulating a project read from an old PROJECT file
+
+				Options{DoController: true, ControllerName: backupControl}.UpdateResource(&res, cfg)
+
+				Expect(res.Controller).To(BeFalse()) //nolint:staticcheck // asserting it stays unwritten
+				Expect(res.GetControllerNames()).To(Equal([]string{controller, backupControl}))
+			})
+
+			It("should not duplicate a controller that is already recorded", func() {
+				Options{DoController: true}.UpdateResource(&res, cfg)
+				Options{DoController: true}.UpdateResource(&res, cfg)
+
+				Expect(res.GetControllerNames()).To(Equal([]string{controller}))
+			})
+
+			It("should record nothing when no controller is requested", func() {
+				Options{}.UpdateResource(&res, cfg)
+
+				Expect(res.HasController()).To(BeFalse())
+			})
+		})
 
 		It("should retain path and external flag when ExternalAPIPath is not provided but resource is already external",
 			func() {

--- a/pkg/plugins/golang/v4/api.go
+++ b/pkg/plugins/golang/v4/api.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	log "log/slog"
 	"os"
-	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -178,17 +177,23 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 		return errors.New("'--ssa' can only be used when creating an API resource ('--resource=true')")
 	}
 
+	// Check the requested API and controller against the project before building the
+	// resource, so nothing is recorded on it when the command is going to fail.
+	if err := p.validateAPI(); err != nil {
+		return err
+	}
+	if err := p.validateController(); err != nil {
+		return err
+	}
+
 	p.options.UpdateResource(p.resource, p.config)
 
+	// Now that the resource is complete, check it as a whole.
 	if err := p.resource.Validate(); err != nil {
 		return fmt.Errorf("error validating resource: %w", err)
 	}
 
-	if err := p.validateAPI(); err != nil {
-		return err
-	}
-
-	return p.validateController()
+	return nil
 }
 
 func (p *createAPISubcommand) validateAPI() error {
@@ -217,78 +222,112 @@ func (p *createAPISubcommand) validateController() error {
 		return nil
 	}
 
+	// Reject the name here, while the command can still fail. Later the resource simply
+	// records no controller, and the scaffold would silently produce nothing.
+	if p.options.ControllerName != "" {
+		if err := (resource.Controller{Name: p.options.ControllerName}).Validate(); err != nil {
+			return fmt.Errorf("invalid '--controller-name': %w", err)
+		}
+	}
+
+	if err := p.validateControllerAcrossResources(); err != nil {
+		return err
+	}
+
 	existingRes, err := p.config.GetResource(p.resource.GVK)
 	if err != nil {
 		// Resource does not exist yet, no validation needed
 		return nil
 	}
 
-	// Require --controller-name when adding a controller to a resource that already has controllers.
-	// Exception: if --resource=true (creating/recreating API), allow --controller=true without
-	// a name for backward compatibility.
-	if p.options.ControllerName == "" && !p.options.DoAPI &&
-		existingRes.Controllers != nil && !existingRes.Controllers.IsEmpty() {
+	// Covers both the controllers list and a legacy controller: true entry.
+	existing := existingRes.GetControllerNames()
+	if len(existing) == 0 {
+		return nil
+	}
+
+	if p.options.ControllerName == "" {
+		// --resource=true is recreating the API, so keep allowing it without a name.
+		if p.options.DoAPI {
+			return nil
+		}
+		// Re-scaffolding the single default controller is unambiguous.
+		if len(existing) == 1 && existing[0] == resource.DefaultControllerName(p.resource.Kind) {
+			return nil
+		}
 		return errors.New(
 			"resource already has controllers defined; please specify '--controller-name' " +
 				"to add another controller, or use '--controller=false' to skip controller scaffolding",
 		)
 	}
 
-	// No controller name specified: using legacy mode, no further validation needed
-	if p.options.ControllerName == "" {
-		return nil
-	}
-
-	// Check that the controller name does not already exist
-	if existingRes.Controllers != nil && existingRes.Controllers.HasController(p.options.ControllerName) {
-		return fmt.Errorf(
-			"controller with name %q already exists for resource %s/%s/%s",
-			p.options.ControllerName,
-			p.resource.Group,
-			p.resource.Version,
-			p.resource.Kind,
-		)
-	}
-
-	// Check for name collisions after normalization (e.g., "foo-bar" vs "foobar")
-	if existingRes.Controllers != nil {
-		newNormalized := normalizeForCollisionCheck(p.options.ControllerName)
-		for _, existing := range *existingRes.Controllers {
-			if newNormalized == normalizeForCollisionCheck(existing.Name) {
-				return fmt.Errorf(
-					"controller name %q conflicts with existing controller %q: "+
-						"both would generate the same reconciler struct name",
-					p.options.ControllerName,
-					existing.Name,
-				)
-			}
+	newReconciler := resource.NormalizeReconcilerName(p.options.ControllerName, p.resource.Kind)
+	for _, name := range existing {
+		if name == p.options.ControllerName {
+			return fmt.Errorf(
+				"controller with name %q already exists for resource %s/%s/%s",
+				p.options.ControllerName,
+				p.resource.Group,
+				p.resource.Version,
+				p.resource.Kind,
+			)
 		}
-	}
 
-	// Also check legacy controller: true case
-	if existingRes.Controller && p.options.ControllerName == strings.ToLower(p.resource.Kind) {
-		return fmt.Errorf(
-			"controller with name %q already exists for resource %s/%s/%s",
-			p.options.ControllerName,
-			p.resource.Group,
-			p.resource.Version,
-			p.resource.Kind,
-		)
+		if resource.NormalizeReconcilerName(name, p.resource.Kind) == newReconciler {
+			return fmt.Errorf(
+				"controller name %q conflicts with existing controller %q: both generate %s",
+				p.options.ControllerName,
+				name,
+				newReconciler,
+			)
+		}
 	}
 
 	return nil
 }
 
-// normalizeForCollisionCheck normalizes a controller name to detect potential collisions.
-// Different names that normalize to the same value would generate conflicting code.
-func normalizeForCollisionCheck(name string) string {
-	var result strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			result.WriteRune(r)
+// validateControllerAcrossResources rejects a controller that would generate the same
+// reconciler as a controller of another resource scaffolded into the same package, which
+// would collide on both the struct name and the file name. The default kind-based name is
+// checked too: another version of the same kind resolves to the same reconciler.
+func (p *createAPISubcommand) validateControllerAcrossResources() error {
+	resources, err := p.config.GetResources()
+	if err != nil {
+		return nil
+	}
+
+	newName := p.options.ControllerName
+	if newName == "" {
+		newName = resource.DefaultControllerName(p.resource.Kind)
+	}
+	newReconciler := resource.NormalizeReconcilerName(newName, p.resource.Kind)
+
+	for _, res := range resources {
+		if res.IsEqualTo(p.resource.GVK) || !p.sharesControllerPackage(res) {
+			continue
+		}
+
+		for _, name := range res.GetControllerNames() {
+			if resource.NormalizeReconcilerName(name, res.Kind) != newReconciler {
+				continue
+			}
+
+			return fmt.Errorf(
+				"controller %q conflicts with controller %q of %s/%s/%s: "+
+					"both generate %s in the same package; use '--controller-name' to pick "+
+					"another name, or '--controller=false' if that controller already reconciles this resource",
+				newName, name, res.Group, res.Version, res.Kind, newReconciler,
+			)
 		}
 	}
-	return strings.ToLower(result.String())
+
+	return nil
+}
+
+// sharesControllerPackage reports whether both resources scaffold their controllers into the
+// same directory. Only multigroup projects split them, and then only by group.
+func (p *createAPISubcommand) sharesControllerPackage(other resource.Resource) bool {
+	return !p.config.IsMultiGroup() || p.resource.Group == other.Group
 }
 
 func (p *createAPISubcommand) PreScaffold(machinery.Filesystem) error {

--- a/pkg/plugins/golang/v4/api_test.go
+++ b/pkg/plugins/golang/v4/api_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v4
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
@@ -328,4 +330,204 @@ var _ = Describe("createAPISubcommand", func() {
 
 		Expect(subCmd.InjectResource(res)).To(Succeed())
 	})
+})
+
+var _ = Describe("validateController", func() {
+	const (
+		captainCtrl   = "captain"
+		captainBackup = "captain-backup"
+	)
+
+	var (
+		cfg config.Config
+		gvk resource.GVK
+	)
+
+	BeforeEach(func() {
+		cfg = cfgv3.New()
+		Expect(cfg.SetRepository("test")).To(Succeed())
+		gvk = resource.GVK{Group: crewGroup, Domain: testIO, Version: "v1", Kind: captainKind}
+	})
+
+	// stored puts a resource carrying the given controllers into the config, the way a
+	// PROJECT file on disk would present it.
+	stored := func(controllers *resource.Controllers, legacy bool) {
+		res := resource.Resource{GVK: gvk, Plural: captains, Controllers: controllers}
+		res.Controller = legacy //nolint:staticcheck // simulating an unmigrated PROJECT file
+		Expect(cfg.AddResource(res)).To(Succeed())
+	}
+
+	subcommand := func(name string, doAPI bool) *createAPISubcommand {
+		return &createAPISubcommand{
+			config:   cfg,
+			resource: &resource.Resource{GVK: gvk, Plural: captains},
+			options:  &goPlugin.Options{DoController: true, ControllerName: name, DoAPI: doAPI},
+		}
+	}
+
+	It("should skip validation when no controller is requested", func() {
+		stored(&resource.Controllers{{Name: captainCtrl}}, false)
+		p := subcommand("", false)
+		p.options.DoController = false
+
+		Expect(p.validateController()).To(Succeed())
+	})
+
+	It("should reject a name that is not a valid DNS label", func() {
+		Expect(subcommand("Not_A_Label", false).validateController()).NotTo(Succeed())
+	})
+
+	It("should accept any name when the resource does not exist yet", func() {
+		Expect(subcommand(captainBackup, false).validateController()).To(Succeed())
+	})
+
+	It("should accept a new name on a resource that already has controllers", func() {
+		stored(&resource.Controllers{{Name: captainCtrl}}, false)
+
+		Expect(subcommand(captainBackup, false).validateController()).To(Succeed())
+	})
+
+	It("should reject a name already recorded", func() {
+		stored(&resource.Controllers{{Name: captainCtrl}}, false)
+
+		Expect(subcommand(captainCtrl, false).validateController()).NotTo(Succeed())
+	})
+
+	It("should reject a name already recorded through the legacy field", func() {
+		stored(nil, true)
+
+		Expect(subcommand(captainCtrl, false).validateController()).NotTo(Succeed())
+	})
+
+	It("should reject a name generating an existing reconciler", func() {
+		stored(&resource.Controllers{{Name: captainBackup}}, false)
+
+		Expect(subcommand("captain--backup", false).validateController()).NotTo(Succeed())
+	})
+
+	It("should allow re-scaffolding the single default controller without a name", func() {
+		stored(&resource.Controllers{{Name: captainCtrl}}, false)
+
+		Expect(subcommand("", false).validateController()).To(Succeed())
+	})
+
+	It("should require a name when the resource has several controllers", func() {
+		stored(&resource.Controllers{{Name: captainCtrl}, {Name: captainBackup}}, false)
+
+		Expect(subcommand("", false).validateController()).NotTo(Succeed())
+	})
+
+	It("should require a name when the only controller is not the default", func() {
+		stored(&resource.Controllers{{Name: captainBackup}}, false)
+
+		Expect(subcommand("", false).validateController()).NotTo(Succeed())
+	})
+
+	It("should allow omitting the name while recreating the API", func() {
+		stored(&resource.Controllers{{Name: captainCtrl}, {Name: captainBackup}}, false)
+
+		Expect(subcommand("", true).validateController()).To(Succeed())
+	})
+})
+
+var _ = Describe("validateController across resources", func() {
+	const (
+		admiralCtrl   = "admiral"
+		admiralKind   = "Admiral"
+		admiralPlural = "admirals"
+	)
+
+	var (
+		cfg        config.Config
+		captainGVK resource.GVK
+	)
+
+	BeforeEach(func() {
+		cfg = cfgv3.New()
+		Expect(cfg.SetRepository("test")).To(Succeed())
+		captainGVK = resource.GVK{Group: crewGroup, Domain: testIO, Version: "v1", Kind: captainKind}
+
+		// Admiral already owns AdmiralReconciler under its default controller name.
+		Expect(cfg.AddResource(resource.Resource{
+			GVK:         resource.GVK{Group: crewGroup, Domain: testIO, Version: "v1", Kind: admiralKind},
+			Plural:      admiralPlural,
+			Controllers: &resource.Controllers{{Name: admiralCtrl}},
+		})).To(Succeed())
+	})
+
+	subcommand := func(name string) *createAPISubcommand {
+		return &createAPISubcommand{
+			config:   cfg,
+			resource: &resource.Resource{GVK: captainGVK, Plural: captains},
+			options:  &goPlugin.Options{DoController: true, ControllerName: name},
+		}
+	}
+
+	It("should reject a name generating another resource's reconciler", func() {
+		err := subcommand(admiralCtrl).validateController()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("AdmiralReconciler"))
+	})
+
+	It("should accept a name that does not collide", func() {
+		Expect(subcommand("captain-backup").validateController()).To(Succeed())
+	})
+
+	// A second version of an existing kind resolves to the same default controller name,
+	// so it collides even though no --controller-name was given.
+	It("should reject the default name when another version of the kind already has it", func() {
+		p := subcommand("")
+		p.resource = &resource.Resource{
+			GVK:    resource.GVK{Group: crewGroup, Domain: testIO, Version: "v2", Kind: admiralKind},
+			Plural: admiralPlural,
+		}
+
+		err := p.validateController()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("AdmiralReconciler"))
+	})
+
+	It("should accept a second version of a kind that names its controller", func() {
+		p := subcommand("admiral-v2")
+		p.resource = &resource.Resource{
+			GVK:    resource.GVK{Group: crewGroup, Domain: testIO, Version: "v2", Kind: admiralKind},
+			Plural: admiralPlural,
+		}
+
+		Expect(p.validateController()).To(Succeed())
+	})
+
+	It("should allow the same name in another group of a multigroup project", func() {
+		Expect(cfg.SetMultiGroup()).To(Succeed())
+		p := subcommand(admiralCtrl)
+		p.resource.Group = shipGroup
+
+		Expect(p.validateController()).To(Succeed())
+	})
+
+	It("should still reject it within the same group of a multigroup project", func() {
+		Expect(cfg.SetMultiGroup()).To(Succeed())
+
+		Expect(subcommand(admiralCtrl).validateController()).NotTo(Succeed())
+	})
+})
+
+var _ = Describe("default controller name", func() {
+	// Migrate derives the default name with strings.ToLower(Kind) and Controller.Validate
+	// requires a DNS-1035 label. GVK.Validate applies the same rule to the kind, so any
+	// resource kubebuilder accepts can always be migrated.
+	DescribeTable("should be valid for every kind GVK.Validate accepts",
+		func(kind string) {
+			gvk := resource.GVK{Group: crewGroup, Domain: testIO, Version: "v1", Kind: kind}
+			Expect(gvk.Validate()).To(Succeed())
+
+			name := resource.DefaultControllerName(kind)
+			Expect(resource.Controller{Name: name}.Validate()).To(Succeed())
+		},
+		Entry("a short kind", captainKind),
+		Entry("a kind with digits", "Captain2"),
+		Entry("a kind at the 63 character limit", "C"+strings.Repeat("a", 62)),
+	)
 })

--- a/pkg/plugins/golang/v4/scaffolds/api.go
+++ b/pkg/plugins/golang/v4/scaffolds/api.go
@@ -129,24 +129,12 @@ func (s *apiScaffolder) Scaffold() error {
 	}
 
 	if doController {
-		// Get the controller name to scaffold
-		// If using the new Controllers field, get the last added controller name
-		// Otherwise, use empty string to generate default name
-		controllerName := ""
-		if s.resource.Controllers != nil && !s.resource.Controllers.IsEmpty() {
-			names := s.resource.Controllers.GetControllerNames()
-			if len(names) > 0 {
-				// Use the last controller name (the one just added)
-				controllerName = names[len(names)-1]
-			}
-		}
-
 		if err := scaffold.Execute(
 			&controllers.SuiteTest{Force: s.force},
 			&controllers.Controller{
 				ControllerRuntimeVersion: ControllerRuntimeVersion,
 				Force:                    s.force,
-				ControllerName:           controllerName,
+				ControllerName:           s.controllerName(),
 			},
 			&controllers.ControllerTest{Force: s.force, DoAPI: doAPI},
 		); err != nil {
@@ -158,21 +146,24 @@ func (s *apiScaffolder) Scaffold() error {
 		&cmd.MainUpdater{
 			WireResource:   doAPI,
 			WireController: doController,
-			ControllerName: func() string {
-				if s.resource.Controllers != nil && !s.resource.Controllers.IsEmpty() {
-					names := s.resource.Controllers.GetControllerNames()
-					if len(names) > 0 {
-						return names[len(names)-1]
-					}
-				}
-				return ""
-			}(),
+			ControllerName: s.controllerName(),
 		},
 	); err != nil {
 		return fmt.Errorf("error updating cmd/main.go: %w", err)
 	}
 
 	return nil
+}
+
+// controllerName returns the controller this invocation scaffolds. The resource is
+// built for a single create api call, so it carries exactly the controller being added.
+func (s *apiScaffolder) controllerName() string {
+	names := s.resource.GetControllerNames()
+	if len(names) == 0 {
+		return ""
+	}
+
+	return names[0]
 }
 
 // apiPackageDir returns the directory of the resource group/version package.

--- a/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
@@ -145,7 +145,8 @@ var _ = Describe("Server-Side Apply (--ssa) Scaffolding", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(projectContent)).To(ContainSubstring("ssa: true"),
 			"adding the controller must not drop the ssa flag from the PROJECT file")
-		Expect(string(projectContent)).To(ContainSubstring("controller: true"))
+		Expect(string(projectContent)).To(ContainSubstring("- name: admiral"))
+		Expect(string(projectContent)).NotTo(ContainSubstring("controller: true"))
 	})
 
 	It("should complete 'create api --ssa' when groupversion_info.go was customized", func() {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
@@ -183,6 +183,8 @@ func (f *MainUpdater) GetCodeFragments() machinery.CodeFragmentsMap {
 	setup := make([]string, 0)
 	if f.WireController {
 		reconcilerName := f.ReconcilerName()
+		// Matches the Named() value so setup errors correlate with controller-runtime's
+		// own logs and metrics, and stays unique when a kind repeats across groups.
 		controllerName := resource.GetControllerName(f.ControllerName, f.Resource.Kind, f.Resource.Group, f.MultiGroup)
 
 		if !f.MultiGroup || f.Resource.Group == "" {

--- a/test/testdata/generate.sh
+++ b/test/testdata/generate.sh
@@ -38,9 +38,12 @@ function scaffold_test_project {
 
   if [ $project == "project-v4" ] ; then
     header_text 'Creating APIs ...'
-    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false --controller-name=captain
+    # Captain covers both ways of naming a controller. Without --controller-name the
+    # controller is recorded under the default name, the lowercase kind: `captain`.
+    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false
     $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false --force
-    # Create a second controller for the Captain resource to test multiple controllers per API
+    # A second controller for the same API. --controller-name gives it its own name,
+    # reconciler struct and file, so one GVK ends up with two controllers.
     $kb create api --group crew --version v1 --kind Captain --controller=true --resource=false --make=false --controller-name=captain-backup
     $kb create webhook --group crew --version v1 --kind Captain --defaulting --make=false
     $kb create webhook --group crew --version v1 --kind Captain --programmatic-validation --make=false
@@ -75,8 +78,11 @@ function scaffold_test_project {
 
   if [[ $project =~ multigroup ]]; then
     header_text 'Creating APIs ...'
-    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false --controller-name=captain
-    # Create a second controller for the Captain resource to test multiple controllers per API
+    # Captain covers both ways of naming a controller. Without --controller-name the
+    # controller is recorded under the default name, the lowercase kind: `captain`.
+    $kb create api --group crew --version v1 --kind Captain --controller=true --resource=true --make=false
+    # A second controller for the same API. In a multigroup project the group is
+    # prefixed in Named(), so these become `crew-captain` and `crew-captain-backup`.
     $kb create api --group crew --version v1 --kind Captain --controller=true --resource=false --make=false --controller-name=captain-backup
     # Test incremental webhook additions
     $kb create webhook --group crew --version v1 --kind Captain --defaulting --make=false

--- a/testdata/project-v4-multigroup/PROJECT
+++ b/testdata/project-v4-multigroup/PROJECT
@@ -47,7 +47,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: frigate
   domain: testproject.org
   group: ship
   kind: Frigate
@@ -55,7 +56,8 @@ resources:
   version: v1beta1
 - api:
     crdVersion: v1
-  controller: true
+  controllers:
+  - name: destroyer
   domain: testproject.org
   group: ship
   kind: Destroyer
@@ -66,7 +68,8 @@ resources:
     webhookVersion: v1
 - api:
     crdVersion: v1
-  controller: true
+  controllers:
+  - name: cruiser
   domain: testproject.org
   group: ship
   kind: Cruiser
@@ -78,7 +81,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: kraken
   domain: testproject.org
   group: sea-creatures
   kind: Kraken
@@ -87,7 +91,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: leviathan
   domain: testproject.org
   group: sea-creatures
   kind: Leviathan
@@ -96,13 +101,15 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: healthcheckpolicy
   domain: testproject.org
   group: foo.policy
   kind: HealthCheckPolicy
   path: sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/foo.policy/v1
   version: v1
-- controller: true
+- controllers:
+  - name: deployment
   core: true
   group: apps
   kind: Deployment
@@ -115,7 +122,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: bar
   domain: testproject.org
   group: foo
   kind: Bar
@@ -124,13 +132,15 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: bar
   domain: testproject.org
   group: fiz
   kind: Bar
   path: sigs.k8s.io/kubebuilder/testdata/project-v4-multigroup/api/fiz/v1
   version: v1
-- controller: true
+- controllers:
+  - name: certificate
   domain: io
   external: true
   group: cert-manager
@@ -160,7 +170,8 @@ resources:
     crdVersion: v1
     namespaced: true
     ssa: true
-  controller: true
+  controllers:
+  - name: prawn
   domain: testproject.org
   group: sea-creatures
   kind: Prawn
@@ -169,7 +180,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: memcached
   domain: testproject.org
   group: example.com
   kind: Memcached
@@ -181,7 +193,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: busybox
   domain: testproject.org
   group: example.com
   kind: Busybox
@@ -190,7 +203,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: wordpress
   domain: testproject.org
   group: example.com
   kind: Wordpress

--- a/testdata/project-v4-with-plugins/PROJECT
+++ b/testdata/project-v4-with-plugins/PROJECT
@@ -36,7 +36,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: memcached
   domain: testproject.org
   group: example.com
   kind: Memcached
@@ -48,7 +49,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: busybox
   domain: testproject.org
   group: example.com
   kind: Busybox
@@ -57,7 +59,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: wordpress
   domain: testproject.org
   group: example.com
   kind: Wordpress

--- a/testdata/project-v4/PROJECT
+++ b/testdata/project-v4/PROJECT
@@ -27,7 +27,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: firstmate
   domain: testproject.org
   group: crew
   kind: FirstMate
@@ -49,7 +50,8 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
-  controller: true
+  controllers:
+  - name: sailor
   domain: testproject.org
   group: crew
   kind: Sailor
@@ -63,7 +65,8 @@ resources:
     webhookVersion: v1
 - api:
     crdVersion: v1
-  controller: true
+  controllers:
+  - name: admiral
   domain: testproject.org
   group: crew
   kind: Admiral
@@ -75,7 +78,8 @@ resources:
     validation: true
     validationPath: /custom-validate-admiral
     webhookVersion: v1
-- controller: true
+- controllers:
+  - name: certificate
   domain: io
   external: true
   group: cert-manager
@@ -114,7 +118,8 @@ resources:
     crdVersion: v1
     namespaced: true
     ssa: true
-  controller: true
+  controllers:
+  - name: navigator
   domain: testproject.org
   group: crew
   kind: Navigator


### PR DESCRIPTION
This is a follow-up to the multiple-controller support introduced in v4.14.0.

That release continued writing the legacy `controller: true` field and converted between the legacy and new formats in several places, including during unmarshalling. As a result, reading a `PROJECT` file could modify its in-memory representation.

`controllers` is now the only format Kubebuilder writes. The legacy `controller` field is still read, so existing projects continue to work, but it is never written back.

Migration is centralized in `Resource.Migrate()` and called from `Cfg.MarshalYAML()`. Therefore, any command that writes the `PROJECT` file migrates every resource, while reading the file never modifies it.

**No user action is required. The next command that writes the `PROJECT` file automatically converts:**

```diff
- controller: true
+ controllers:
+ - name: captain
```

Only the `PROJECT` file changes. Reconciler struct names, controller file names, and `Named()` behavior remain unchanged.

## Compatibility

There are no breaking changes for existing Kubebuilder projects.

The Go API changes are additive only:

* Adds `DefaultControllerName`.
* Adds `Resource.Migrate()`.
* Keeps `Resource.Normalize()` as a deprecated wrapper that delegates to `Migrate()`.

The `PROJECT` configuration version remains `3`.

- ⚠️  Read `resources[].controllers` instead of `resources[].controller`. Plugins that continue reading the legacy key will receive a missing key rather than an error.
- Use HasController() or GetControllerNames() — both read the legacy field and Controllers, so they are correct before and after migration. Code reading the Resource.Controller field directly will see false once a project is migrated; staticcheck flags it.


**Motivation**
- Address the normalization without breaking changes
- Aiming easy maintainability long term 
- Follow k8s convetions for names
- Ensure that controllers config schema can grow if needed. 