### PR TITLE
🐛 (CLI) only read PROJECT for commands that consume it

### DIFF
--- a/internal/cli/alpha/internal/common/common.go
+++ b/internal/cli/alpha/internal/common/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -27,7 +28,7 @@ import (
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 )
 
-// LoadProjectConfig load the project config.
+// LoadProjectConfig loads the project configuration.
 func LoadProjectConfig(inputDir string) (store.Store, error) {
 	projectConfig := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
 	if err := projectConfig.LoadFrom(fmt.Sprintf("%s/%s", inputDir, yaml.DefaultPath)); err != nil {
@@ -36,7 +37,7 @@ func LoadProjectConfig(inputDir string) (store.Store, error) {
 	return projectConfig, nil
 }
 
-// GetInputPath will return the input path for the project.
+// GetInputPath returns the input path for the project.
 func GetInputPath(inputPath string) (string, error) {
 	if inputPath == "" {
 		cwd, err := os.Getwd()
@@ -46,8 +47,11 @@ func GetInputPath(inputPath string) (string, error) {
 		inputPath = cwd
 	}
 	projectPath := fmt.Sprintf("%s/%s", inputPath, yaml.DefaultPath)
-	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+	// The link is not followed, so that loading the project reports a link with a missing target.
+	if _, err := os.Lstat(projectPath); errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("project path %q does not exist: %w", projectPath, err)
+	} else if err != nil {
+		return "", fmt.Errorf("failed to check project path %q: %w", projectPath, err)
 	}
 	return inputPath, nil
 }

--- a/internal/cli/alpha/internal/common/common_test.go
+++ b/internal/cli/alpha/internal/common/common_test.go
@@ -21,6 +21,7 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -81,6 +82,28 @@ var _ = Describe("LoadProjectConfig", func() {
 			_, err := LoadProjectConfig(kbc.Dir)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to load PROJECT file"))
+		})
+	})
+
+	Context("when PROJECT is not a regular file", func() {
+		It("should report a directory instead of a missing file", func() {
+			Expect(os.Mkdir(projectFile, 0o755)).To(Succeed())
+
+			_, err := LoadProjectConfig(kbc.Dir)
+			Expect(err).To(MatchError(ContainSubstring("is a directory")))
+			Expect(err).NotTo(MatchError(ContainSubstring("does not exist")))
+		})
+
+		It("should report a dangling symbolic link instead of a missing file", func() {
+			if runtime.GOOS == "windows" {
+				Skip("symlink creation requires elevated privileges on Windows")
+			}
+			target := filepath.Join(kbc.Dir, "stolen.yaml")
+			Expect(os.Symlink(target, projectFile)).To(Succeed())
+
+			_, err := LoadProjectConfig(kbc.Dir)
+			Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+			Expect(target).NotTo(BeAnExistingFile())
 		})
 	})
 })
@@ -149,6 +172,19 @@ var _ = Describe("GetInputPath", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(inputPath).To(Equal(""))
 			Expect(err.Error()).To(ContainSubstring("does not exist"))
+		})
+	})
+
+	Context("when PROJECT is a dangling symbolic link", func() {
+		It("should accept the path so that loading it reports the link", func() {
+			if runtime.GOOS == "windows" {
+				Skip("symlink creation requires elevated privileges on Windows")
+			}
+			Expect(os.Symlink(filepath.Join(kbc.Dir, "stolen.yaml"), projectFile)).To(Succeed())
+
+			inputPath, err := GetInputPath(kbc.Dir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(inputPath).To(Equal(kbc.Dir))
 		})
 	})
 })

--- a/internal/cli/alpha/internal/update.go
+++ b/internal/cli/alpha/internal/update.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	log "log/slog"
@@ -443,15 +444,15 @@ func (opts *Update) Validate() error {
 	return nil
 }
 
-// Load the PROJECT configuration file to get the current CLI version
+// loadConfigFile loads the PROJECT configuration file to get the current CLI version.
 func (opts *Update) loadConfigFile() (store.Store, error) {
 	projectConfigFile := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
 	// TODO: assess if DefaultPath could be renamed to a more self-descriptive name
 	if err := projectConfigFile.LoadFrom(yaml.DefaultPath); err != nil {
-		if _, statErr := os.Stat(yaml.DefaultPath); os.IsNotExist(statErr) {
+		if errors.Is(err, os.ErrNotExist) {
 			return projectConfigFile, fmt.Errorf("no PROJECT file found. Make sure you're in the project root directory")
 		}
-		return projectConfigFile, fmt.Errorf("fail to load the PROJECT file: %w", err)
+		return projectConfigFile, fmt.Errorf("failed to load the PROJECT file: %w", err)
 	}
 	return projectConfigFile, nil
 }

--- a/internal/cli/alpha/internal/update_test.go
+++ b/internal/cli/alpha/internal/update_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
+)
+
+var _ = Describe("Update.loadConfigFile", func() {
+	var opts Update
+
+	BeforeEach(func() {
+		opts = Update{}
+
+		originalDir, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Chdir(GinkgoT().TempDir())).To(Succeed())
+		DeferCleanup(func() { Expect(os.Chdir(originalDir)).To(Succeed()) })
+	})
+
+	It("should load an existing PROJECT file", func() {
+		Expect(os.WriteFile(yaml.DefaultPath, []byte("version: \"3\"\n"), 0o644)).To(Succeed())
+
+		_, err := opts.loadConfigFile()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should report a missing PROJECT file", func() {
+		_, err := opts.loadConfigFile()
+		Expect(err).To(MatchError(ContainSubstring("no PROJECT file found")))
+	})
+
+	It("should report what occupies the path when PROJECT is a directory", func() {
+		Expect(os.Mkdir(yaml.DefaultPath, 0o755)).To(Succeed())
+
+		_, err := opts.loadConfigFile()
+		Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a directory`)))
+	})
+
+	It("should report a dangling symbolic link as a link and not as a missing file", func() {
+		if runtime.GOOS == "windows" {
+			Skip("symlink creation requires elevated privileges on Windows")
+		}
+		target := filepath.Join(GinkgoT().TempDir(), "stolen.yaml")
+		Expect(os.Symlink(target, yaml.DefaultPath)).To(Succeed())
+
+		_, err := opts.loadConfigFile()
+		Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a symbolic link`)))
+		Expect(target).NotTo(BeAnExistingFile())
+	})
+
+	It("should load a PROJECT file through a symbolic link to a regular file", func() {
+		if runtime.GOOS == "windows" {
+			Skip("symlink creation requires elevated privileges on Windows")
+		}
+		target := filepath.Join(GinkgoT().TempDir(), "project.yaml")
+		Expect(os.WriteFile(target, []byte("version: \"3\"\n"), 0o644)).To(Succeed())
+		Expect(os.Symlink(target, yaml.DefaultPath)).To(Succeed())
+
+		_, err := opts.loadConfigFile()
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -43,6 +43,7 @@ const (
 	pluginsFlagArg     = "--plugins"
 	projectVersionFlag = "project-version"
 	helpFlagArg        = "--help"
+	helpShorthandArg   = "-h"
 	shellZsh           = "zsh"
 
 	kubebuilderCommandName          = "kubebuilder"
@@ -51,7 +52,9 @@ const (
 	kubebuilderSubcommandVersion    = "version"
 	kubebuilderSubcommandCompletion = "completion"
 	pluginGoKubebuilderV4           = "go.kubebuilder.io/v4"
+	pluginGoKubebuilderV3           = "go.kubebuilder.io/v3"
 	pluginGoKubebuilderV2           = "go.kubebuilder.io/v2"
+	generateSubcommand              = "generate"
 
 	pluginsFlagDescription = "Comma-separated list of plugin keys to use. " +
 		"If unset, Kubebuilder uses the plugin chain from PROJECT or the CLI default"
@@ -83,6 +86,8 @@ type CLI struct {
 	extraAlphaCommands []*cobra.Command
 	// Whether to add a completion command to the CLI.
 	completionCommand bool
+	// args contains the command-line arguments used to resolve the project configuration and plugin chain.
+	args []string
 
 	/* Internal fields */
 
@@ -90,6 +95,12 @@ type CLI struct {
 	pluginKeys []string
 	// Project version to scaffold.
 	projectVersion config.Version
+	// configErr stores an error found while resolving the project configuration or plugin chain.
+	configErr error
+	// flagErr stores an error found while reading the command line.
+	flagErr error
+	// configSkipped reports whether the project configuration was left unread.
+	configSkipped bool
 
 	// A filtered set of plugins that should be used by command constructors.
 	resolvedPlugins []plugin.Plugin
@@ -105,10 +116,9 @@ type CLI struct {
 //
 // It follows the functional options pattern in order to customize the resulting CLI.
 //
-// It returns an error if any of the provided options fails. As some processing needs
-// to be done, execution errors may be found here. Instead of returning an error, this
-// function will return a valid CLI that errors in Run so that help is provided to the
-// user.
+// It returns an error if any of the provided options fails. A project configuration that cannot be
+// read is not an error here. The command tree is still built, and the failure is reported when
+// running a command that consumes the configuration.
 func New(options ...Option) (*CLI, error) {
 	// Create the CLI.
 	c, err := newCLI(options...)
@@ -117,10 +127,7 @@ func New(options ...Option) (*CLI, error) {
 	}
 
 	// Build the cmd tree.
-	if err := c.buildCmd(); err != nil {
-		c.cmd.RunE = errCmdFunc(err)
-		return c, nil
-	}
+	c.buildCmd()
 
 	// Add extra commands injected by options.
 	if err := c.addExtraCommands(); err != nil {
@@ -149,6 +156,7 @@ func newCLI(options ...Option) (*CLI, error) {
 		plugins:        make(map[string]plugin.Plugin),
 		defaultPlugins: make(map[config.Version][]string),
 		fs:             machinery.Filesystem{FS: afero.NewOsFs()},
+		args:           defaultArgs(),
 	}
 
 	// Apply provided options.
@@ -161,57 +169,147 @@ func newCLI(options ...Option) (*CLI, error) {
 	return c, nil
 }
 
+// defaultArgs returns the command-line arguments of the running program without its name.
+func defaultArgs() []string {
+	if len(os.Args) < 2 {
+		return nil
+	}
+
+	return os.Args[1:]
+}
+
 // buildCmd creates the underlying cobra command and stores it internally.
-func (c *CLI) buildCmd() error {
+func (c *CLI) buildCmd() {
 	c.cmd = c.newRootCmd()
 
+	c.configSkipped = isSubcommandWithoutConfig(c.args)
+
+	if err := c.resolveInfo(!c.configSkipped); err != nil {
+		// Cobra has not parsed the command line yet, so the command that will run is unknown.
+		// Keep a working command tree and let the root hook raise this where it matters.
+		var parseErr flagError
+		if errors.As(err, &parseErr) {
+			c.flagErr = err
+		} else {
+			c.configErr = err
+		}
+		c.resolveWithoutConfig()
+	}
+
+	c.addSubcommands()
+}
+
+// resolveInfo obtains the project version and the plugin keys, and resolves the plugin chain.
+func (c *CLI) resolveInfo(readConfig bool) error {
 	var uve config.UnsupportedVersionError
 
 	// Get project version and plugin keys.
-	switch err := c.getInfo(); {
+	switch err := c.getInfo(readConfig); {
 	case err == nil:
 	case errors.As(err, &uve) && uve.Version.Compare(config.Version{Number: 3, Stage: stage.Alpha}) == 0:
-		// Check if the corresponding stable version exists, set c.projectVersion and break
+		// Use the stable project version when it is registered.
 		stableVersion := config.Version{
 			Number: uve.Version.Number,
 		}
-		if config.IsRegistered(stableVersion) {
-			// Use the stableVersion
-			c.projectVersion = stableVersion
-		} else {
+		if !config.IsRegistered(stableVersion) {
 			// stable version not registered, let's bail out
 			return err
 		}
+		c.projectVersion = stableVersion
 	default:
 		return err
 	}
 
 	// Resolve plugins for project version and plugin keys.
-	if err := c.resolvePlugins(); err != nil {
-		if !shouldIgnoreConfigLoadError(os.Args[1:]) {
-			return err
-		}
+	return c.resolvePlugins()
+}
+
+// resolveSkippedConfig reads the project configuration that was left unread while the command tree
+// was built. The tree cannot be built again, so a plugin chain that differs from the one it was
+// built with is reported as an error instead of scaffolding with the wrong plugins.
+func (c *CLI) resolveSkippedConfig() error {
+	builtWith := slices.Clone(c.pluginKeys)
+	builtForVersion := c.projectVersion
+	c.forgetPluginChain()
+
+	if err := c.resolveInfo(true); err != nil {
+		return err
 	}
 
-	// Add the subcommands
-	c.addSubcommands()
+	if !slices.Equal(c.pluginKeys, builtWith) || c.projectVersion.Compare(builtForVersion) != 0 {
+		return fmt.Errorf("the command tree was built for the plugin chain %q but the project requires %q: "+
+			"run the program with the arguments of the command that Command().SetArgs runs",
+			strings.Join(builtWith, ","), strings.Join(c.pluginKeys, ","))
+	}
 
 	return nil
 }
 
-// getInfo obtains the plugin keys and project version resolving conflicts between the project config file and flags.
-func (c *CLI) getInfo() error {
-	// Get plugin keys and project version from project configuration file
-	// We discard the error if file doesn't exist because not being able to read a project configuration
-	// file is not fatal for some commands. The ones that require it need to check its existence later.
-	hasConfigFile := true
-	if err := c.getInfoFromConfigFile(); errors.Is(err, os.ErrNotExist) {
-		hasConfigFile = false
-	} else if err != nil {
-		if shouldIgnoreConfigLoadError(os.Args[1:]) {
-			hasConfigFile = false
-		} else {
+// resolveWithoutConfig builds a fallback plugin chain without reading the project configuration.
+// It uses valid flag values when possible and otherwise uses the CLI defaults.
+func (c *CLI) resolveWithoutConfig() {
+	const withFlags, withoutFlags = true, false
+
+	if c.resolveDefaultPlugins(withFlags) == nil {
+		return
+	}
+
+	_ = c.resolveDefaultPlugins(withoutFlags)
+}
+
+// resolveDefaultPlugins resolves the plugin chain from the CLI defaults, optionally letting the
+// flags override them. The chain resolved so far is discarded first, so a failed attempt leaves
+// nothing behind for the next one.
+func (c *CLI) resolveDefaultPlugins(withFlags bool) error {
+	c.forgetPluginChain()
+
+	if withFlags {
+		if err := c.getInfoFromFlags(false); err != nil {
 			return err
+		}
+	}
+	c.getInfoFromDefaults()
+
+	if err := c.resolvePlugins(); err != nil {
+		c.resolvedPlugins = nil
+		return err
+	}
+
+	return nil
+}
+
+// forgetPluginChain clears the selected plugin keys, project version, and resolved plugins.
+func (c *CLI) forgetPluginChain() {
+	c.pluginKeys = nil
+	c.projectVersion = config.Version{}
+	c.resolvedPlugins = nil
+}
+
+// flagError stores a command-line parsing error.
+type flagError struct{ err error }
+
+// Error returns the command-line parsing error as a string.
+func (e flagError) Error() string { return e.err.Error() }
+
+// Unwrap returns the command-line parsing error for errors.Is and errors.As.
+func (e flagError) Unwrap() error { return e.err }
+
+// getInfo obtains the plugin keys and project version while resolving conflicts between the project
+// configuration and flags.
+func (c *CLI) getInfo(readConfig bool) error {
+	// A missing PROJECT file is not an error here. Commands that require it check for it later.
+	hasConfigFile := readConfig
+	var configErr error
+	if readConfig {
+		switch err := c.getInfoFromConfigFile(); {
+		case err == nil:
+		case errors.Is(err, os.ErrNotExist):
+			hasConfigFile = false
+		default:
+			// The flags are still read, so that a malformed command line is reported instead of a
+			// configuration the command may not even consume.
+			configErr = err
+			hasConfigFile = false
 		}
 	}
 
@@ -220,7 +318,10 @@ func (c *CLI) getInfo() error {
 
 	// Get project version and plugin info from flags
 	if err := c.getInfoFromFlags(hasConfigFile); err != nil {
-		return err
+		return flagError{err}
+	}
+	if configErr != nil {
+		return configErr
 	}
 
 	// Get project version and plugin info from defaults
@@ -243,10 +344,13 @@ func (c *CLI) getInfoFromConfigFile() error {
 	// before the CLI tries to load it. This avoids errors during config loading
 	// and lets users migrate their project layout from go/v3 to go/v4.
 
-	if isAlphaGenerateCommand(os.Args[1:]) {
-		// Patch raw file bytes before unmarshalling
-		if err := patchProjectFileInMemoryIfNeeded(c.fs.FS, yamlstore.DefaultPath); err != nil {
-			return err
+	if isAlphaGenerateCommand(c.args) {
+		// Only a regular file can be patched. Anything else at the path is classified and reported
+		// by Load, and a named pipe must never be opened: reading it blocks until something writes.
+		if isRegularPathNoFollow(c.fs.FS, yamlstore.DefaultPath) {
+			if err := patchProjectFileInMemoryIfNeeded(c.fs.FS, yamlstore.DefaultPath); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -255,6 +359,18 @@ func (c *CLI) getInfoFromConfigFile() error {
 	}
 
 	return c.getInfoFromConfig(cfg.Config())
+}
+
+// isRegularPathNoFollow reports whether path is a regular file without following a final symbolic
+// link. If the filesystem cannot make that distinction, it is not safe to patch the path.
+func isRegularPathNoFollow(fs afero.Fs, path string) bool {
+	lstater, ok := fs.(afero.Lstater)
+	if !ok {
+		return false
+	}
+
+	info, _, err := lstater.LstatIfPossible(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 // positionalArgs returns arguments that are not flags or flag values.
@@ -286,13 +402,15 @@ func positionalArgs(args []string) []string {
 func hasOnlyRootFlags(args []string) bool {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
-		case pluginsFlagArg, "--" + projectVersionFlag:
+		case pluginsFlagArg, "--" + projectVersionFlag, helpFlagArg, helpShorthandArg:
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				i++
 			}
 		default:
 			if strings.HasPrefix(args[i], pluginsFlagArg+"=") ||
-				strings.HasPrefix(args[i], "--"+projectVersionFlag+"=") {
+				strings.HasPrefix(args[i], "--"+projectVersionFlag+"=") ||
+				strings.HasPrefix(args[i], helpFlagArg+"=") ||
+				strings.HasPrefix(args[i], helpShorthandArg+"=") {
 				continue
 			}
 			return false
@@ -302,14 +420,13 @@ func hasOnlyRootFlags(args []string) bool {
 	return true
 }
 
-// isAlphaGenerateCommand checks if the command invocation is `kubebuilder alpha generate`
-// by scanning os.Args (excluding global flags). It returns true if "alpha" is followed by "generate".
+// isAlphaGenerateCommand reports whether args invoke `kubebuilder alpha generate`.
 func isAlphaGenerateCommand(args []string) bool {
 	positional := positionalArgs(args)
 
 	// Check for `alpha generate` in positional arguments
 	for i := 0; i < len(positional)-1; i++ {
-		if positional[i] == "alpha" && positional[i+1] == "generate" {
+		if positional[i] == alphaCommand && positional[i+1] == generateSubcommand {
 			return true
 		}
 	}
@@ -317,30 +434,51 @@ func isAlphaGenerateCommand(args []string) bool {
 	return false
 }
 
-// shouldIgnoreConfigLoadError returns true for commands that do not require a valid PROJECT file.
-// This keeps context-free commands like help, version, and completion working from arbitrary directories.
-func shouldIgnoreConfigLoadError(args []string) bool {
-	if slices.ContainsFunc(args, isHelpFlag) {
-		return true
-	}
+// subcommandsWithoutConfig are the subcommands that run without a project configuration file.
+var subcommandsWithoutConfig = []string{
+	kubebuilderSubcommandHelp,
+	kubebuilderSubcommandVersion,
+	kubebuilderSubcommandCompletion,
+	cobra.ShellCompRequestCmd,
+	cobra.ShellCompNoDescRequestCmd,
+}
 
+// isSubcommandWithoutConfig returns true for invocations that do not need the PROJECT file to build
+// their command tree.
+func isSubcommandWithoutConfig(args []string) bool {
 	positional := positionalArgs(args)
 	// With no subcommand, Cobra displays root help. Configuration is not required.
 	if len(positional) == 0 {
 		return len(args) == 0 || hasOnlyRootFlags(args)
 	}
 
-	return positional[0] == kubebuilderSubcommandHelp ||
-		positional[0] == kubebuilderSubcommandVersion ||
-		positional[0] == kubebuilderSubcommandCompletion
+	// The help command consumes the remaining arguments as the command whose help is requested.
+	// A plugin-backed command needs the project chain to build accurate help, while help for a
+	// context-free command does not.
+	if positional[0] == kubebuilderSubcommandHelp {
+		return len(positional) == 1 || isSubcommandPathWithoutConfig(positional[1:])
+	}
+
+	return isSubcommandPathWithoutConfig(positional)
 }
 
-// patchProjectFileInMemoryIfNeeded updates deprecated plugin keys in the PROJECT file in place,
-// so that users can run `kubebuilder alpha generate` even with older plugin layouts.
+// isSubcommandPathWithoutConfig returns true for a subcommand path that never consumes the PROJECT
+// file. The path holds the subcommand names leading to the command, such as "alpha" and "generate".
+// The root command displays help, so it does not require the configuration either.
+func isSubcommandPathWithoutConfig(path []string) bool {
+	if len(path) == 0 {
+		return true
+	}
+
+	return slices.Contains(subcommandsWithoutConfig, path[0])
+}
+
+// patchProjectFileInMemoryIfNeeded updates deprecated plugin keys before the PROJECT file is loaded,
+// so that users can run `kubebuilder alpha generate` with older plugin layouts.
 //
 // See: https://github.com/kubernetes-sigs/kubebuilder/issues/4433
 //
-// This ensures the CLI can successfully load the config without failing on unsupported plugin versions.
+// This lets the CLI load the PROJECT file without failing on unsupported plugin versions.
 func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 	type pluginReplacement struct {
 		Old string
@@ -349,8 +487,8 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 
 	replacements := []pluginReplacement{
 		{pluginGoKubebuilderV2, pluginGoKubebuilderV4},
-		{"go.kubebuilder.io/v3", pluginGoKubebuilderV4},
-		{"go.kubebuilder.io/v3-alpha", pluginGoKubebuilderV4},
+		{pluginGoKubebuilderV3, pluginGoKubebuilderV4},
+		{pluginGoKubebuilderV3 + "-alpha", pluginGoKubebuilderV4},
 	}
 
 	content, err := afero.ReadFile(fs, path)
@@ -382,7 +520,7 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 	return nil
 }
 
-// getInfoFromConfig obtains the project version and plugin keys from the project config.
+// getInfoFromConfig obtains the project version and plugin keys from the project configuration.
 // It is extracted from getInfoFromConfigFile for testing purposes.
 func (c *CLI) getInfoFromConfig(projectConfig config.Config) error {
 	c.pluginKeys = projectConfig.GetPluginChain()
@@ -401,9 +539,9 @@ func (c *CLI) getInfoFromConfig(projectConfig config.Config) error {
 func (c *CLI) getInfoFromFlags(hasConfigFile bool) error {
 	// Check if --plugins is followed by --help or -h to avoid parsing help as a plugin value
 	// This fixes: kubebuilder init --plugins --help
-	for i := 0; i < len(os.Args)-1; i++ {
-		if os.Args[i] == pluginsFlagArg || os.Args[i] == pluginsFlagArg+"=" {
-			nextArg := os.Args[i+1]
+	for i := 0; i < len(c.args)-1; i++ {
+		if c.args[i] == pluginsFlagArg || c.args[i] == pluginsFlagArg+"=" {
+			nextArg := c.args[i+1]
 			if isHelpFlag(nextArg) {
 				// Help was requested, return early to let Cobra handle it
 				return nil
@@ -414,8 +552,10 @@ func (c *CLI) getInfoFromFlags(hasConfigFile bool) error {
 	// Partially parse the command line arguments
 	fs := pflag.NewFlagSet("base", pflag.ContinueOnError)
 
-	// Load the base command global flags
-	fs.AddFlagSet(c.cmd.PersistentFlags())
+	// The global flags are declared again instead of taken from the root command, which holds the
+	// values Cobra parses. A shared value appends what it already holds, so reading the arguments
+	// more than once would grow the plugin chain.
+	fs.StringSlice(pluginsFlag, nil, pluginsFlagDescription)
 
 	// If we were unable to load the project configuration, we should also accept the project version flag
 	var projectVersionStr string
@@ -431,7 +571,7 @@ func (c *CLI) getInfoFromFlags(hasConfigFile bool) error {
 	fs.ParseErrorsAllowlist = pflag.ParseErrorsAllowlist{UnknownFlags: true}
 
 	// Parse the arguments
-	if err := fs.Parse(os.Args[1:]); err != nil {
+	if err := fs.Parse(c.args); err != nil {
 		return fmt.Errorf("could not parse flags: %w", err)
 	}
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -17,23 +17,37 @@ limitations under the License.
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	yamlstore "sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
 	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
 	"sigs.k8s.io/kubebuilder/v4/pkg/model/stage"
 	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
 	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
+)
+
+const (
+	createSubcommand  = "create"
+	apiSubcommand     = "api"
+	webhookSubcommand = "webhook"
+	editSubcommand    = "edit"
+	kindFlagArg       = "--kind"
+	kindValue         = "Captain"
 )
 
 func makeMockPluginsFor(projectVersion config.Version, pluginKeys ...string) []plugin.Plugin {
@@ -69,6 +83,14 @@ func setPluginsFlag(value string) {
 	setFlag(pluginsFlag, value)
 }
 
+// parseFlagsFromArgs resolves the flags of the CLI from the arguments of the running program, the
+// way New does when it builds the CLI.
+func parseFlagsFromArgs(c *CLI) error {
+	c.args = defaultArgs()
+
+	return c.getInfoFromFlags(false)
+}
+
 func hasSubCommand(cmd *cobra.Command, name string) bool {
 	for _, subcommand := range cmd.Commands() {
 		if subcommand.Name() == name {
@@ -78,12 +100,251 @@ func hasSubCommand(cmd *cobra.Command, name string) bool {
 	return false
 }
 
-func filesystemWithInvalidProjectPath() machinery.Filesystem {
-	fs := machinery.Filesystem{FS: afero.NewBasePathFs(afero.NewOsFs(), GinkgoT().TempDir())}
-	Expect(fs.FS.Mkdir("PROJECT", machinery.DefaultDirectoryPermission)).To(Succeed())
+// filesystemWithUnloadableProject returns a filesystem holding a PROJECT file that cannot be loaded
+// because its version is not supported.
+func filesystemWithUnloadableProject() machinery.Filesystem {
+	return filesystemWithProject(`version: "1"
+`)
+}
+
+// filesystemWithInvalidProject returns a filesystem holding a PROJECT file that is not valid YAML.
+func filesystemWithInvalidProject() machinery.Filesystem {
+	return filesystemWithProject(`{ version: "3"
+`)
+}
+
+// filesystemWithUnresolvableProject returns a filesystem holding a valid PROJECT file whose plugin
+// chain cannot be resolved.
+func filesystemWithUnresolvableProject() machinery.Filesystem {
+	return filesystemWithProject(`domain: example.com
+layout:
+- gone.example.com/v1
+projectName: test
+version: "3"
+`)
+}
+
+// filesystemWithProjectChainProject returns a filesystem holding a valid PROJECT file whose plugin
+// chain names a registered plugin that is not one of the CLI defaults.
+func filesystemWithProjectChainProject() machinery.Filesystem {
+	return filesystemWithProject(`domain: example.com
+layout:
+- ` + projectChainPluginKey + `
+projectName: test
+version: "3"
+`)
+}
+
+// filesystemWithResolvableProject returns a filesystem holding a valid PROJECT file whose plugin
+// chain resolves to the go/v4 plugin.
+func filesystemWithResolvableProject() machinery.Filesystem {
+	return filesystemWithProject(`domain: example.com
+layout:
+- base.go.kubebuilder.io/v4
+projectName: test
+version: "3"
+`)
+}
+
+// filesystemWithProject returns a temporary filesystem containing the given PROJECT content.
+func filesystemWithProject(content string) machinery.Filesystem {
+	GinkgoHelper()
+
+	fs := filesystemWithoutProject()
+	Expect(afero.WriteFile(fs.FS, yamlstore.DefaultPath, []byte(content), machinery.DefaultFilePermission)).To(Succeed())
 
 	return fs
 }
+
+// filesystemWithoutProject returns an empty temporary filesystem.
+func filesystemWithoutProject() machinery.Filesystem {
+	return machinery.Filesystem{FS: afero.NewBasePathFs(afero.NewOsFs(), GinkgoT().TempDir())}
+}
+
+func filesystemWithInvalidProjectPath() machinery.Filesystem {
+	fs := filesystemWithoutProject()
+	Expect(fs.FS.Mkdir(yamlstore.DefaultPath, machinery.DefaultDirectoryPermission)).To(Succeed())
+
+	return fs
+}
+
+// filesystemWithNonRegularProject returns a filesystem where PROJECT is not a regular file, which
+// must never be opened.
+func filesystemWithNonRegularProject() machinery.Filesystem {
+	return machinery.Filesystem{FS: &nonRegularProjectFs{Fs: filesystemWithResolvableProject().FS}}
+}
+
+// filesystemWithPopulatedProjectDirectory returns a filesystem where PROJECT is a directory that
+// holds a file.
+func filesystemWithPopulatedProjectDirectory() machinery.Filesystem {
+	GinkgoHelper()
+
+	fs := filesystemWithProjectDirectory()
+	Expect(afero.WriteFile(fs.FS, filepath.Join(yamlstore.DefaultPath, "inner.yaml"),
+		[]byte(`version: "3"`), machinery.DefaultFilePermission)).To(Succeed())
+
+	return fs
+}
+
+// filesystemWithProjectDirectory returns a filesystem where PROJECT is a directory, which holds no
+// configuration and must be handled as a project that was never initialized.
+func filesystemWithProjectDirectory() machinery.Filesystem {
+	GinkgoHelper()
+
+	fs := filesystemWithoutProject()
+	Expect(fs.FS.Mkdir(yamlstore.DefaultPath, machinery.DefaultDirectoryPermission)).To(Succeed())
+
+	return fs
+}
+
+// filesystemWithDanglingProjectSymlink returns a filesystem where PROJECT is a symbolic link whose
+// target does not exist, along with the path that the link points to.
+func filesystemWithDanglingProjectSymlink() (machinery.Filesystem, string) {
+	GinkgoHelper()
+
+	dir := GinkgoT().TempDir()
+	target := filepath.Join(dir, "stolen.yaml")
+	Expect(os.Symlink(target, filepath.Join(dir, yamlstore.DefaultPath))).To(Succeed())
+
+	return machinery.Filesystem{FS: afero.NewBasePathFs(afero.NewOsFs(), dir)}, target
+}
+
+// skipWithoutSymlinks skips the test where creating a symbolic link needs extra privileges.
+func skipWithoutSymlinks() {
+	GinkgoHelper()
+
+	if runtime.GOOS == "windows" {
+		Skip("symlink creation requires elevated privileges on Windows")
+	}
+}
+
+// expectNothingScaffolded asserts that the filesystem holds nothing besides the PROJECT path.
+func expectNothingScaffolded(fs machinery.Filesystem) {
+	GinkgoHelper()
+
+	entries, err := afero.ReadDir(fs.FS, ".")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(entries).To(HaveLen(1))
+	Expect(entries[0].Name()).To(Equal(yamlstore.DefaultPath))
+}
+
+// projectReadCountingFs counts how many times the project configuration file is opened.
+type projectReadCountingFs struct {
+	afero.Fs
+	reads int
+}
+
+// Open counts PROJECT reads before delegating to the wrapped filesystem.
+func (f *projectReadCountingFs) Open(name string) (afero.File, error) {
+	if name == yamlstore.DefaultPath {
+		f.reads++
+	}
+
+	file, err := f.Fs.Open(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %q: %w", name, err)
+	}
+
+	return file, nil
+}
+
+// nonRegularProjectFileInfo reports a named pipe mode on top of the wrapped FileInfo.
+type nonRegularProjectFileInfo struct{ os.FileInfo }
+
+// Mode adds a named-pipe mode to the wrapped file information.
+func (i nonRegularProjectFileInfo) Mode() os.FileMode { return i.FileInfo.Mode() | os.ModeNamedPipe }
+
+// nonRegularProjectFs makes the project configuration file look like a named pipe.
+type nonRegularProjectFs struct {
+	afero.Fs
+}
+
+// Stat reports PROJECT as a named pipe while preserving the wrapped filesystem behavior.
+func (f *nonRegularProjectFs) Stat(name string) (os.FileInfo, error) {
+	info, err := f.Fs.Stat(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %q: %w", name, err)
+	}
+	if name == yamlstore.DefaultPath {
+		info = nonRegularProjectFileInfo{info}
+	}
+
+	return info, nil
+}
+
+// executeCLI builds a CLI over the given filesystem and runs it with the given arguments, as the
+// binary does when invoked from a project directory.
+func executeCLI(filesystem machinery.Filesystem, args ...string) error {
+	_, err := runCLI(filesystem, args, args)
+
+	return err
+}
+
+// executeEmbeddedCLI builds a CLI while the program was invoked with programArgs, and runs it with
+// commandArgs, as an embedded CLI driven by Command().SetArgs does.
+func executeEmbeddedCLI(
+	filesystem machinery.Filesystem,
+	programArgs, commandArgs []string,
+	options ...Option,
+) error {
+	_, err := runCLI(filesystem, programArgs, commandArgs, options...)
+
+	return err
+}
+
+// completeCLI runs the hidden command that Cobra uses to complete a command line, and returns what
+// it offers.
+func completeCLI(filesystem machinery.Filesystem, args ...string) (string, error) {
+	completionArgs := append([]string{cobra.ShellCompRequestCmd}, args...)
+
+	return runCLI(filesystem, completionArgs, completionArgs)
+}
+
+// runCLI builds a CLI while the program was invoked with programArgs, runs it with commandArgs, and
+// returns what the command wrote.
+func runCLI(
+	filesystem machinery.Filesystem,
+	programArgs, commandArgs []string,
+	options ...Option,
+) (string, error) {
+	GinkgoHelper()
+
+	originalArgs := os.Args
+	DeferCleanup(func() { os.Args = originalArgs })
+	os.Args = append([]string{kubebuilderCommandName}, programArgs...)
+
+	testProjectVersion := config.Version{Number: 3}
+	c, err := New(append([]Option{
+		WithPlugins(&golangv4.Plugin{}),
+		WithDefaultPlugins(testProjectVersion, &golangv4.Plugin{}),
+		WithDefaultProjectVersion(testProjectVersion),
+		WithVersion("version string"),
+		WithCompletion(),
+		WithFilesystem(filesystem),
+	}, options...)...)
+	Expect(err).NotTo(HaveOccurred())
+
+	var out bytes.Buffer
+	c.cmd.SetOut(&out)
+	// Cobra falls back to the arguments of the running program when they are set to nil.
+	if commandArgs == nil {
+		commandArgs = []string{}
+	}
+	c.cmd.SetArgs(commandArgs)
+
+	if err := c.cmd.Execute(); err != nil {
+		return out.String(), fmt.Errorf("failed to execute the command: %w", err)
+	}
+
+	return out.String(), nil
+}
+
+const (
+	projectChainPluginName  = "mock.example.com"
+	projectChainPluginKey   = projectChainPluginName + "/v1"
+	projectChainFlag        = "mock-only"
+	projectChainDescription = "Scaffold with the plugin the project asks for"
+)
 
 type pluginChainCapturingSubcommand struct {
 	pluginChain []string
@@ -113,6 +374,16 @@ func newTestCreateAPIPlugin(name string, version plugin.Version) testCreateAPIPl
 	}
 }
 
+// newDescribedCreateAPIPlugin returns a plugin whose create api subcommand brings a description and
+// a flag of its own, so that the help output tells which plugin chain built it.
+func newDescribedCreateAPIPlugin() testCreateAPIPlugin {
+	p := newTestCreateAPIPlugin(projectChainPluginName, plugin.Version{Number: 1})
+	p.subcommand.description = projectChainDescription
+	p.subcommand.flagName = projectChainFlag
+
+	return p
+}
+
 func (p testCreateAPIPlugin) Name() string                               { return p.name }
 func (p testCreateAPIPlugin) Version() plugin.Version                    { return p.version }
 func (p testCreateAPIPlugin) SupportedProjectVersions() []config.Version { return p.projectVers }
@@ -120,13 +391,31 @@ func (p testCreateAPIPlugin) GetCreateAPISubcommand() plugin.CreateAPISubcommand
 	return p.subcommand
 }
 
-type testCreateAPISubcommand struct{}
+type testCreateAPISubcommand struct {
+	description string
+	flagName    string
+	scaffolded  bool
+}
+
+func (s *testCreateAPISubcommand) UpdateMetadata(_ plugin.CLIMetadata, meta *plugin.SubcommandMetadata) {
+	if s.description != "" {
+		meta.Description = s.description
+	}
+}
+
+func (s *testCreateAPISubcommand) BindFlags(fs *pflag.FlagSet) {
+	if s.flagName != "" {
+		fs.Bool(s.flagName, false, "flag of the plugin the project asks for")
+	}
+}
 
 func (s *testCreateAPISubcommand) InjectResource(*resource.Resource) error {
 	return nil
 }
 
 func (s *testCreateAPISubcommand) Scaffold(machinery.Filesystem) error {
+	s.scaffolded = true
+
 	return nil
 }
 
@@ -269,28 +558,31 @@ plugins:
 
 			_, err = f.WriteString(projectFile)
 			Expect(err).To(Not(HaveOccurred()))
+
+			// A subcommand that consumes the configuration, so that the file is read.
+			c.args = []string{kubebuilderSubcommandInit}
 		})
 
 		When("reading a 3-alpha config", func() {
 			It("should succeed and set the projectVersion", func() {
-				err := c.buildCmd()
-				Expect(err).To(Not(HaveOccurred()))
+				c.buildCmd()
+				Expect(c.configErr).NotTo(HaveOccurred())
 				Expect(c.projectVersion.Compare(
 					config.Version{
 						Number: 3,
 						Stage:  stage.Stable,
 					})).To(Equal(0))
 			})
-			It("should fail when stable is not registered ", func() {
+			It("should fail when stable is not registered", func() {
 				// overwrite project file with fake 4-alpha
 				f, err := c.fs.FS.OpenFile("PROJECT", os.O_WRONLY, 0)
 				Expect(err).To(Not(HaveOccurred()))
 				_, err = f.WriteString(strings.ReplaceAll(projectFile, "3-alpha", "4-alpha"))
 				Expect(err).To(Not(HaveOccurred()))
 
-				// buildCmd should return an error
-				err = c.buildCmd()
-				Expect(err).To(HaveOccurred())
+				c.buildCmd()
+				Expect(c.configErr).To(HaveOccurred())
+				Expect(c.cmd.Commands()).NotTo(BeEmpty())
 			})
 		})
 	})
@@ -349,7 +641,7 @@ plugins:
 
 		When("no flag is set", func() {
 			It("should succeed", func() {
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(BeEmpty())
 				Expect(c.projectVersion.Compare(config.Version{})).To(Equal(0))
 			})
@@ -360,7 +652,7 @@ plugins:
 				pluginKeys := []string{pluginGoV1}
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal(pluginKeys))
 				Expect(c.projectVersion.Compare(config.Version{})).To(Equal(0))
 			})
@@ -369,7 +661,7 @@ plugins:
 				pluginKeys := []string{pluginGoV1, pluginExampleV2, pluginTestV1}
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal(pluginKeys))
 				Expect(c.projectVersion.Compare(config.Version{})).To(Equal(0))
 			})
@@ -378,7 +670,7 @@ plugins:
 				pluginKeys := []string{pluginGoV1, pluginExampleV2, pluginTestV1}
 				setPluginsFlag(strings.Join(pluginKeys, ", "))
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal(pluginKeys))
 				Expect(c.projectVersion.Compare(config.Version{})).To(Equal(0))
 			})
@@ -386,7 +678,7 @@ plugins:
 			It("should fail for an invalid plugin key", func() {
 				setPluginsFlag("_/v1")
 
-				Expect(c.getInfoFromFlags(false)).NotTo(Succeed())
+				Expect(parseFlagsFromArgs(c)).NotTo(Succeed())
 			})
 		})
 
@@ -394,7 +686,7 @@ plugins:
 			It("should succeed", func() {
 				setProjectVersionFlag(projectVersion.String())
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(BeEmpty())
 				Expect(c.projectVersion.Compare(projectVersion)).To(Equal(0))
 			})
@@ -402,7 +694,7 @@ plugins:
 			It("should fail for an invalid project version", func() {
 				setProjectVersionFlag("v_1")
 
-				Expect(c.getInfoFromFlags(false)).NotTo(Succeed())
+				Expect(parseFlagsFromArgs(c)).NotTo(Succeed())
 			})
 		})
 
@@ -412,7 +704,7 @@ plugins:
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 				setProjectVersionFlag(projectVersion.String())
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal(pluginKeys))
 				Expect(c.projectVersion.Compare(projectVersion)).To(Equal(0))
 			})
@@ -422,7 +714,7 @@ plugins:
 				setPluginsFlag(strings.Join(pluginKeys, ","))
 				setProjectVersionFlag(projectVersion.String())
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal(pluginKeys))
 				Expect(c.projectVersion.Compare(projectVersion)).To(Equal(0))
 			})
@@ -432,7 +724,7 @@ plugins:
 				setPluginsFlag(strings.Join(pluginKeys, ", "))
 				setProjectVersionFlag(projectVersion.String())
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal(pluginKeys))
 				Expect(c.projectVersion.Compare(projectVersion)).To(Equal(0))
 			})
@@ -442,14 +734,14 @@ plugins:
 			It("should succeed", func() {
 				setFlag("extra-flag", "extra-value")
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 			})
 
 			// `--help` is not captured by the allowlist, so we need to special case it
 			It("should not fail for `--help`", func() {
 				setBoolFlag("help")
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 			})
 
 			// When --plugins is followed by --help, --help is consumed as plugin value
@@ -457,7 +749,7 @@ plugins:
 			It("should not fail when `--plugins --help` is used together", func() {
 				os.Args = append(os.Args, "edit", pluginsFlagArg, "--help")
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(BeEmpty())
 			})
 
@@ -465,21 +757,21 @@ plugins:
 			It("should not fail when `--plugins -h` is used together", func() {
 				os.Args = append(os.Args, "edit", pluginsFlagArg, "-h")
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(BeEmpty())
 			})
 
 			It("should keep the plugin key when `--plugins=<value> --help` is used together", func() {
 				os.Args = append(os.Args, "edit", pluginsFlagArg+"="+pluginGoV1, "--help")
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal([]string{pluginGoV1}))
 			})
 
 			It("should keep the plugin key when `--plugins=<value> -h` is used together", func() {
 				os.Args = append(os.Args, "edit", pluginsFlagArg+"="+pluginGoV1, "-h")
 
-				Expect(c.getInfoFromFlags(false)).To(Succeed())
+				Expect(parseFlagsFromArgs(c)).To(Succeed())
 				Expect(c.pluginKeys).To(Equal([]string{pluginGoV1}))
 			})
 		})
@@ -778,6 +1070,31 @@ plugins:
 				Expect(c.cmd.Execute()).To(MatchError("help displayed"))
 			})
 
+			It("should read a loadable PROJECT file so help reflects the project's plugin chain", func() {
+				fs := &projectReadCountingFs{Fs: filesystemWithResolvableProject().FS}
+
+				Expect(executeCLI(machinery.Filesystem{FS: fs},
+					createSubcommand, apiSubcommand, helpFlagArg)).To(Succeed())
+				Expect(fs.reads).NotTo(BeZero())
+			})
+
+			DescribeTable("should display help when it is passed as a plugins value",
+				func(filesystem func() machinery.Filesystem) {
+					err = executeCLI(filesystem(), createSubcommand, apiSubcommand,
+						pluginsFlagArg+"="+kubebuilderSubcommandHelp)
+					Expect(err).To(MatchError(errHelpDisplayed))
+				},
+				Entry("when the PROJECT file is missing", filesystemWithoutProject),
+				Entry("when PROJECT is a directory", filesystemWithProjectDirectory),
+				Entry("when the PROJECT file cannot be loaded", filesystemWithUnloadableProject),
+			)
+
+			It("should return a configuration error for commands requiring a project", func() {
+				err = executeCLI(filesystemWithUnloadableProject(),
+					createSubcommand, apiSubcommand, kindFlagArg, kubebuilderSubcommandHelp)
+				Expect(err).To(MatchError(ContainSubstring("version 1 is not supported")))
+			})
+
 			It("should ignore an invalid PROJECT path for the help subcommand", func() {
 				args := os.Args
 				defer func() {
@@ -865,18 +1182,15 @@ plugins:
 				Expect(c.cmd.Execute()).To(Succeed())
 			})
 
-			It("should return a configuration error for commands requiring a project", func() {
-				const (
-					createSubcommand = "create"
-					apiSubcommand    = "api"
-					kindFlagArg      = "--kind"
-				)
-
+			It("should report the current PROJECT path error for commands requiring a project", func() {
 				args := os.Args
 				defer func() {
 					os.Args = args
 				}()
-				os.Args = []string{kubebuilderCommandName, createSubcommand, apiSubcommand, kindFlagArg, kubebuilderSubcommandHelp}
+				os.Args = []string{
+					kubebuilderCommandName, createSubcommand, apiSubcommand,
+					kindFlagArg, kubebuilderSubcommandHelp,
+				}
 
 				fs := filesystemWithInvalidProjectPath()
 
@@ -888,7 +1202,328 @@ plugins:
 				Expect(err).NotTo(HaveOccurred())
 
 				c.cmd.SetArgs([]string{createSubcommand, apiSubcommand, kindFlagArg, kubebuilderSubcommandHelp})
-				Expect(c.cmd.Execute()).To(MatchError(ContainSubstring("failed to read \"PROJECT\" file")))
+				Expect(c.cmd.Execute()).To(MatchError(ContainSubstring(`"PROJECT" is a directory`)))
+			})
+		})
+
+		When("a flag value is spelled as a help flag", func() {
+			// A flag value is data, so it must not become a help request that hides the plugin resolution error.
+			DescribeTable("should report the plugin resolution error",
+				func(flagArg string) {
+					err = executeCLI(filesystemWithUnresolvableProject(),
+						createSubcommand, apiSubcommand, flagArg, kubebuilderSubcommandHelp)
+					Expect(err).To(MatchError(ContainSubstring(
+						`no plugin could be resolved with key "gone.example.com/v1"`)))
+				},
+				Entry("for --kind", kindFlagArg),
+				Entry("for --group", "--group"),
+				Entry("for --version", "--version"),
+			)
+		})
+
+		When("PROJECT is a directory", func() {
+			It("should report what occupies the path instead of reading the configuration", func() {
+				err = executeCLI(filesystemWithProjectDirectory(),
+					createSubcommand, apiSubcommand, kindFlagArg, kindValue)
+				Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a directory`)))
+			})
+
+			It("should refuse to initialize the project without scaffolding anything", func() {
+				fs := filesystemWithProjectDirectory()
+
+				err = executeCLI(fs, kubebuilderSubcommandInit)
+				Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a directory`)))
+				Expect(err).NotTo(MatchError(ContainSubstring("already initialized")))
+				expectNothingScaffolded(fs)
+			})
+		})
+
+		When("PROJECT is a symbolic link with a missing target", func() {
+			It("should refuse to initialize without creating the target or scaffolding anything", func() {
+				skipWithoutSymlinks()
+				fs, target := filesystemWithDanglingProjectSymlink()
+
+				err = executeCLI(fs, kubebuilderSubcommandInit)
+				Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a symbolic link`)))
+				Expect(target).NotTo(BeAnExistingFile())
+				expectNothingScaffolded(fs)
+			})
+
+			It("should report the link instead of reading the configuration", func() {
+				skipWithoutSymlinks()
+				fs, target := filesystemWithDanglingProjectSymlink()
+
+				err = executeCLI(fs, createSubcommand, apiSubcommand, kindFlagArg, kindValue)
+				Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a symbolic link`)))
+				Expect(target).NotTo(BeAnExistingFile())
+			})
+		})
+
+		When("the PROJECT file names a registered plugin chain that is not the default", func() {
+			var projectPlugin testCreateAPIPlugin
+			var createAPIArgs []string
+
+			BeforeEach(func() {
+				projectPlugin = newDescribedCreateAPIPlugin()
+				createAPIArgs = []string{
+					createSubcommand, apiSubcommand,
+					"--group", "crew", "--version", "v1", kindFlagArg, kindValue,
+				}
+			})
+
+			It("should build the help of a subcommand from that chain", func() {
+				args := []string{createSubcommand, apiSubcommand, helpFlagArg}
+
+				out, helpErr := runCLI(filesystemWithProjectChainProject(), args, args, WithPlugins(projectPlugin))
+				Expect(helpErr).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring(projectChainDescription))
+				Expect(out).To(ContainSubstring("--" + projectChainFlag))
+				// A flag of the default plugin, which the project does not ask for.
+				Expect(out).NotTo(ContainSubstring("--controller"))
+			})
+
+			It("should build help requested through the help subcommand from that chain", func() {
+				args := []string{kubebuilderSubcommandHelp, createSubcommand, apiSubcommand}
+
+				out, helpErr := runCLI(filesystemWithProjectChainProject(), args, args, WithPlugins(projectPlugin))
+				Expect(helpErr).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring(projectChainDescription))
+				Expect(out).To(ContainSubstring("--" + projectChainFlag))
+				Expect(out).NotTo(ContainSubstring("--controller"))
+			})
+
+			It("should scaffold with that chain", func() {
+				_, runErr := runCLI(filesystemWithProjectChainProject(), createAPIArgs, createAPIArgs,
+					WithPlugins(projectPlugin))
+				Expect(runErr).NotTo(HaveOccurred())
+				Expect(projectPlugin.subcommand.scaffolded).To(BeTrue())
+			})
+
+			It("should fall back to the default plugins only when the configuration cannot be loaded", func() {
+				args := []string{createSubcommand, apiSubcommand, helpFlagArg}
+
+				out, helpErr := runCLI(filesystemWithInvalidProject(), args, args, WithPlugins(projectPlugin))
+				Expect(helpErr).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring("--controller"))
+				Expect(out).NotTo(ContainSubstring("--" + projectChainFlag))
+			})
+		})
+
+		When("the PROJECT file names a plugin layout that is no longer supported", func() {
+			var filesystem machinery.Filesystem
+
+			BeforeEach(func() {
+				filesystem = filesystemWithProject(`domain: example.com
+layout:
+- go.kubebuilder.io/v3
+projectName: test
+version: "3"
+`)
+			})
+
+			It("should patch the layout so that alpha generate can read it", func() {
+				// The command scaffolds from the working directory, so only the read matters here.
+				_ = executeCLI(filesystem, alphaCommand, generateSubcommand)
+
+				content, readErr := afero.ReadFile(filesystem.FS, yamlstore.DefaultPath)
+				Expect(readErr).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring(pluginGoKubebuilderV4))
+				Expect(string(content)).NotTo(ContainSubstring(pluginGoKubebuilderV3))
+			})
+
+			It("should leave the layout alone for any other command", func() {
+				err = executeCLI(filesystem, createSubcommand, apiSubcommand, kindFlagArg, kindValue)
+				Expect(err).To(MatchError(ContainSubstring(pluginGoKubebuilderV3)))
+
+				content, readErr := afero.ReadFile(filesystem.FS, yamlstore.DefaultPath)
+				Expect(readErr).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring(pluginGoKubebuilderV3))
+			})
+
+			It("should not patch through a symbolic link", func() {
+				skipWithoutSymlinks()
+				dir := GinkgoT().TempDir()
+				target := filepath.Join(dir, "project.yaml")
+				link := filepath.Join(dir, yamlstore.DefaultPath)
+				oldProject := []byte(`domain: example.com
+layout:
+- go.kubebuilder.io/v3
+projectName: test
+version: "3"
+`)
+				Expect(os.WriteFile(target, oldProject, 0o644)).To(Succeed())
+				Expect(os.Symlink(target, link)).To(Succeed())
+
+				filesystem := machinery.Filesystem{FS: afero.NewBasePathFs(afero.NewOsFs(), dir)}
+				err = executeCLI(filesystem, alphaCommand, generateSubcommand)
+				Expect(err).To(MatchError(ContainSubstring(pluginGoKubebuilderV3)))
+
+				content, readErr := os.ReadFile(target)
+				Expect(readErr).NotTo(HaveOccurred())
+				Expect(content).To(Equal(oldProject))
+			})
+		})
+
+		When("PROJECT is not a regular file", func() {
+			It("should not read it while patching the plugin layout for alpha generate", func() {
+				// Patching reads raw bytes, and opening a named pipe blocks until something writes.
+				fs := &projectReadCountingFs{Fs: &nonRegularProjectFs{Fs: filesystemWithResolvableProject().FS}}
+
+				err = executeCLI(machinery.Filesystem{FS: fs}, alphaCommand, "generate")
+				Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is not a regular file`)))
+				Expect(fs.reads).To(BeZero())
+			})
+		})
+
+		When("the command line is malformed", func() {
+			DescribeTable("should report an invalid project version flag without a subcommand",
+				func(filesystem func() machinery.Filesystem) {
+					err = executeCLI(filesystem(), "--"+projectVersionFlag, "not-a-version")
+					Expect(err).To(MatchError(ContainSubstring("invalid project version flag")))
+				},
+				Entry("when the PROJECT file is missing", filesystemWithoutProject),
+				Entry("when PROJECT is a directory", filesystemWithProjectDirectory),
+				Entry("when the PROJECT file is not valid YAML", filesystemWithInvalidProject),
+			)
+
+			It("should report an invalid plugin key without a subcommand", func() {
+				err = executeCLI(filesystemWithoutProject(), pluginsFlagArg, "//")
+				Expect(err).To(MatchError(ContainSubstring("invalid plugin")))
+			})
+
+			DescribeTable("should report it for a subcommand that runs without the configuration",
+				func(command ...string) {
+					err = executeCLI(filesystemWithProjectDirectory(), append(command, pluginsFlagArg, "//")...)
+					Expect(err).To(MatchError(ContainSubstring("invalid plugin")))
+				},
+				Entry("for the version subcommand", kubebuilderSubcommandVersion),
+				Entry("for the help subcommand", kubebuilderSubcommandHelp),
+				Entry("for the completion subcommand", kubebuilderSubcommandCompletion, shellZsh),
+			)
+		})
+
+		When("completing a command line", func() {
+			It("should offer the subcommands of the project", func() {
+				completions, completeErr := completeCLI(filesystemWithResolvableProject(), createSubcommand, "")
+				Expect(completeErr).NotTo(HaveOccurred())
+				Expect(completions).To(ContainSubstring(apiSubcommand))
+				Expect(completions).To(ContainSubstring(webhookSubcommand))
+			})
+
+			It("should offer the flags of a subcommand", func() {
+				completions, completeErr := completeCLI(filesystemWithResolvableProject(),
+					createSubcommand, apiSubcommand, "--")
+				Expect(completeErr).NotTo(HaveOccurred())
+				Expect(completions).To(ContainSubstring(kindFlagArg))
+			})
+
+			It("should still offer completions when the PROJECT file cannot be read", func() {
+				completions, completeErr := completeCLI(filesystemWithProjectDirectory(), createSubcommand, "")
+				Expect(completeErr).NotTo(HaveOccurred())
+				Expect(completions).To(ContainSubstring(apiSubcommand))
+			})
+		})
+
+		DescribeTable("should report what occupies the configuration path",
+			func(filesystem func() machinery.Filesystem, occupant string, command []string) {
+				fs := filesystem()
+
+				err = executeCLI(fs, command...)
+				Expect(err).To(MatchError(ContainSubstring(occupant)))
+				Expect(err).NotTo(MatchError(ContainSubstring("initialized")))
+				expectNothingScaffolded(fs)
+			},
+			Entry("for init when PROJECT is a directory", filesystemWithProjectDirectory,
+				`"PROJECT" is a directory`, []string{kubebuilderSubcommandInit}),
+			Entry("for edit when PROJECT is a directory", filesystemWithProjectDirectory,
+				`"PROJECT" is a directory`, []string{editSubcommand}),
+			Entry("for create api when PROJECT is a directory", filesystemWithProjectDirectory,
+				`"PROJECT" is a directory`, []string{createSubcommand, apiSubcommand, kindFlagArg, kindValue}),
+			Entry("for create webhook when PROJECT is a directory", filesystemWithProjectDirectory,
+				`"PROJECT" is a directory`,
+				[]string{createSubcommand, webhookSubcommand, kindFlagArg, kindValue, "--defaulting"}),
+			Entry("for alpha generate when PROJECT is a directory", filesystemWithProjectDirectory,
+				`"PROJECT" is a directory`, []string{alphaCommand, generateSubcommand}),
+			Entry("for init when PROJECT is not a regular file", filesystemWithNonRegularProject,
+				`"PROJECT" is not a regular file`, []string{kubebuilderSubcommandInit}),
+			Entry("for edit when PROJECT is not a regular file", filesystemWithNonRegularProject,
+				`"PROJECT" is not a regular file`, []string{editSubcommand}),
+			Entry("for alpha generate when PROJECT is not a regular file", filesystemWithNonRegularProject,
+				`"PROJECT" is not a regular file`, []string{alphaCommand, generateSubcommand}),
+		)
+
+		When("no PROJECT file exists", func() {
+			DescribeTable("should ask for an initialized project without scaffolding anything",
+				func(args ...string) {
+					fs := filesystemWithoutProject()
+
+					err = executeCLI(fs, args...)
+					Expect(err).To(MatchError(ContainSubstring("project must be initialized")))
+
+					entries, readErr := afero.ReadDir(fs.FS, ".")
+					Expect(readErr).NotTo(HaveOccurred())
+					Expect(entries).To(BeEmpty())
+				},
+				Entry("for create api", createSubcommand, apiSubcommand, kindFlagArg, kindValue),
+				Entry("for create webhook", createSubcommand, webhookSubcommand, kindFlagArg, kindValue, "--defaulting"),
+				Entry("for edit", editSubcommand),
+			)
+		})
+
+		When("initializing a project", func() {
+			It("should refuse as already initialized when a valid PROJECT file exists", func() {
+				fs := filesystemWithResolvableProject()
+
+				err = executeCLI(fs, kubebuilderSubcommandInit)
+				Expect(err).To(MatchError(ContainSubstring("already initialized")))
+				expectNothingScaffolded(fs)
+			})
+
+			It("should stop at startup without scaffolding when the PROJECT file cannot be loaded", func() {
+				fs := filesystemWithUnloadableProject()
+
+				err = executeCLI(fs, kubebuilderSubcommandInit)
+				Expect(err).To(MatchError(ContainSubstring("version 1 is not supported")))
+				expectNothingScaffolded(fs)
+			})
+		})
+
+		When("the plugin chain comes from a flag", func() {
+			It("should keep it as it was given however often the arguments are read", func() {
+				// Resolving the chain again must not grow it: the CLI reads the arguments once
+				// while it builds the command tree and again when it falls back to the defaults.
+				fs := filesystemWithProjectDirectory()
+
+				pluginKey := plugin.KeyFor(&golangv4.Plugin{})
+
+				originalArgs := os.Args
+				DeferCleanup(func() { os.Args = originalArgs })
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandInit, pluginsFlagArg, pluginKey}
+
+				c, err = New(
+					WithPlugins(&golangv4.Plugin{}),
+					WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+					WithDefaultProjectVersion(projectVersion),
+					WithFilesystem(fs),
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c.pluginKeys).To(ConsistOf(pluginKey))
+				Expect(c.resolvedPlugins).To(HaveLen(1))
+			})
+		})
+
+		When("help was displayed", func() {
+			It("should exit without an error", func() {
+				originalArgs := os.Args
+				DeferCleanup(func() { os.Args = originalArgs })
+				os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandInit, pluginsFlagArg, helpFlagArg}
+
+				c, err = New(WithPlugins(&golangv4.Plugin{}), WithDefaultPlugins(projectVersion, &golangv4.Plugin{}))
+				Expect(err).NotTo(HaveOccurred())
+				c.cmd.SetOut(io.Discard)
+				c.cmd.SetArgs([]string{kubebuilderSubcommandInit, pluginsFlagArg, helpFlagArg})
+
+				Expect(c.Run()).To(Succeed())
 			})
 		})
 
@@ -1018,4 +1653,257 @@ plugins:
 			})
 		})
 	})
+})
+
+var _ = Describe("isSubcommandWithoutConfig", func() {
+	DescribeTable("should not read the project configuration",
+		func(args ...string) {
+			Expect(isSubcommandWithoutConfig(args)).To(BeTrue())
+		},
+		Entry("without arguments"),
+		Entry("with root flags only", pluginsFlagArg, pluginGoKubebuilderV4),
+		Entry("for help without a target", kubebuilderSubcommandHelp),
+		Entry("for the version subcommand", kubebuilderSubcommandVersion),
+		Entry("for the completion subcommand", kubebuilderSubcommandCompletion, shellZsh),
+		Entry("for help on the version subcommand", kubebuilderSubcommandHelp, kubebuilderSubcommandVersion),
+		Entry("for help on the completion subcommand", kubebuilderSubcommandHelp, kubebuilderSubcommandCompletion),
+	)
+
+	DescribeTable("should read the project configuration",
+		func(args ...string) {
+			Expect(isSubcommandWithoutConfig(args)).To(BeFalse())
+		},
+		Entry("with help as a flag value", createSubcommand, apiSubcommand, kindFlagArg, kubebuilderSubcommandHelp),
+		Entry("with help as a flag value in the equals form", createSubcommand, apiSubcommand,
+			kindFlagArg+"="+kubebuilderSubcommandHelp),
+		Entry("with help as an argument of another subcommand", createSubcommand, apiSubcommand, kubebuilderSubcommandHelp),
+		// Help output describes the plugin chain of the project, so the configuration is read.
+		Entry("with the help flag of a subcommand", kubebuilderSubcommandInit, helpFlagArg),
+		Entry("with a dangling plugins flag", kubebuilderSubcommandInit, pluginsFlagArg),
+		Entry("for a subcommand that requires a project", kubebuilderSubcommandInit),
+		Entry("for a subcommand added to the CLI", "docs"),
+	)
+})
+
+var _ = Describe("isHelpFlag", func() {
+	DescribeTable("should recognize a request for help",
+		func(arg string) {
+			Expect(isHelpFlag(arg)).To(BeTrue())
+		},
+		Entry("for the help flag", helpFlagArg),
+		Entry("for the help shorthand", helpShorthandArg),
+		Entry("for the help flag set to a value", helpFlagArg+"=true"),
+		Entry("for the help shorthand set to a value", helpShorthandArg+"=true"),
+		Entry("for the bare help word", kubebuilderSubcommandHelp),
+	)
+
+	DescribeTable("should not recognize a request for help",
+		func(arg string) {
+			Expect(isHelpFlag(arg)).To(BeFalse())
+		},
+		Entry("for the help flag explicitly set to false", helpFlagArg+"=false"),
+		Entry("for the help shorthand explicitly set to false", helpShorthandArg+"=false"),
+		Entry("for a non boolean value", helpFlagArg+"=please"),
+		Entry("for a plugin key", pluginGoKubebuilderV4),
+		Entry("for another flag", pluginsFlagArg),
+	)
+})
+
+type describedFilesystem struct {
+	description string
+	build       func() machinery.Filesystem
+}
+
+type describedCommand struct {
+	description string
+	args        []string
+}
+
+// brokenProjectStates are the project states that must not stop a command that does not consume the
+// project configuration.
+var brokenProjectStates = []describedFilesystem{
+	{"the PROJECT file is missing", filesystemWithoutProject},
+	{"the PROJECT file is not valid YAML", filesystemWithInvalidProject},
+	{"the PROJECT project version is not supported", filesystemWithUnloadableProject},
+	{"the PROJECT plugin chain cannot be resolved", filesystemWithUnresolvableProject},
+	{"PROJECT is a directory", filesystemWithProjectDirectory},
+	{"PROJECT is a directory holding a file", filesystemWithPopulatedProjectDirectory},
+	{"PROJECT is not a regular file", filesystemWithNonRegularProject},
+}
+
+// configFreeCommands are the commands that do not consume the project configuration.
+var configFreeCommands = []describedCommand{
+	{"the root command", nil},
+	{"the version subcommand", []string{kubebuilderSubcommandVersion}},
+	{"the help subcommand", []string{kubebuilderSubcommandHelp}},
+	{"help on the help subcommand", []string{kubebuilderSubcommandHelp, kubebuilderSubcommandHelp}},
+	{"the completion subcommand", []string{kubebuilderSubcommandCompletion, shellZsh}},
+	{"the bash completion subcommand", []string{kubebuilderSubcommandCompletion, "bash"}},
+	{"the fish completion subcommand", []string{kubebuilderSubcommandCompletion, "fish"}},
+	{"the powershell completion subcommand", []string{kubebuilderSubcommandCompletion, "powershell"}},
+	{"the bare completion subcommand", []string{kubebuilderSubcommandCompletion}},
+	{"help on the completion subcommand", []string{kubebuilderSubcommandHelp, kubebuilderSubcommandCompletion}},
+	{"version help", []string{kubebuilderSubcommandVersion, helpFlagArg}},
+	{"version help shorthand", []string{kubebuilderSubcommandVersion, helpShorthandArg}},
+	{"version help set to true", []string{kubebuilderSubcommandVersion, helpFlagArg + "=true"}},
+	{"version help shorthand set to true", []string{kubebuilderSubcommandVersion, helpShorthandArg + "=true"}},
+	{"completion help", []string{kubebuilderSubcommandCompletion, helpFlagArg}},
+	{"completion help shorthand", []string{kubebuilderSubcommandCompletion, helpShorthandArg}},
+	{"completion help set to true", []string{kubebuilderSubcommandCompletion, helpFlagArg + "=true"}},
+	{"completion help shorthand set to true", []string{kubebuilderSubcommandCompletion, helpShorthandArg + "=true"}},
+	{"the help flag of a subcommand", []string{kubebuilderSubcommandInit, helpFlagArg}},
+	{"the help shorthand of a subcommand", []string{kubebuilderSubcommandInit, helpShorthandArg}},
+	{"the help flag of a subcommand set to a value", []string{kubebuilderSubcommandInit, helpFlagArg + "=true"}},
+	{"the help shorthand of a subcommand set to a value", []string{kubebuilderSubcommandInit, helpShorthandArg + "=true"}},
+	{"help for the version subcommand", []string{kubebuilderSubcommandHelp, kubebuilderSubcommandVersion}},
+	{"the help flag of the root command", []string{helpFlagArg}},
+	{"the help shorthand of the root command", []string{helpShorthandArg}},
+	{"the help flag of the root command set to a value", []string{helpFlagArg + "=true"}},
+	{"the help shorthand of the root command set to a value", []string{helpShorthandArg + "=true"}},
+	{"root flags without a subcommand", []string{pluginsFlagArg, pluginGoKubebuilderV4}},
+	{"root flags without a subcommand in the equals form", []string{pluginsFlagArg + "=" + pluginGoKubebuilderV4}},
+	{"the bare create command", []string{createSubcommand}},
+	{"the bare alpha command", []string{alphaCommand}},
+	{"a completion request", []string{cobra.ShellCompRequestCmd, createSubcommand, ""}},
+	{"a completion request for a command group", []string{cobra.ShellCompRequestCmd, alphaCommand, ""}},
+}
+
+func configFreeCommandEntries() []TableEntry {
+	entries := make([]TableEntry, 0, len(brokenProjectStates)*len(configFreeCommands))
+	for _, state := range brokenProjectStates {
+		for _, command := range configFreeCommands {
+			entries = append(entries,
+				Entry(fmt.Sprintf("%s when %s", command.description, state.description), state.build, command.args))
+		}
+	}
+
+	return entries
+}
+
+var _ = Describe("commands that do not consume the project configuration", func() {
+	DescribeTable("should run",
+		func(filesystem func() machinery.Filesystem, args []string) {
+			Expect(executeCLI(filesystem(), args...)).To(Succeed())
+		},
+		configFreeCommandEntries(),
+	)
+
+	It("should not read the PROJECT file", func() {
+		fs := &projectReadCountingFs{Fs: filesystemWithUnresolvableProject().FS}
+
+		Expect(executeCLI(machinery.Filesystem{FS: fs}, kubebuilderSubcommandVersion)).To(Succeed())
+		Expect(fs.reads).To(BeZero())
+	})
+
+	DescribeTable("should not read the PROJECT file for root help or completion",
+		func(args ...string) {
+			fs := &projectReadCountingFs{Fs: filesystemWithUnresolvableProject().FS}
+
+			Expect(executeCLI(machinery.Filesystem{FS: fs}, args...)).To(Succeed())
+			Expect(fs.reads).To(BeZero())
+		},
+		Entry("for root help", helpFlagArg),
+		Entry("for root help shorthand", helpShorthandArg),
+		Entry("for a shell completion request", cobra.ShellCompRequestCmd, createSubcommand, ""),
+		Entry("for a shell completion request without descriptions", cobra.ShellCompNoDescRequestCmd,
+			createSubcommand, ""),
+	)
+})
+
+// An embedded CLI is built before the caller chooses the command with Command().SetArgs, so the
+// arguments of the running program say nothing about the command that will run.
+var _ = Describe("commands driven by Command().SetArgs", func() {
+	// The arguments of the running program, which name a command that consumes the configuration.
+	var programArgs []string
+
+	BeforeEach(func() {
+		programArgs = []string{createSubcommand, apiSubcommand, kindFlagArg, kindValue}
+	})
+
+	DescribeTable("should run",
+		func(filesystem func() machinery.Filesystem, args []string) {
+			Expect(executeEmbeddedCLI(filesystem(), programArgs, args)).To(Succeed())
+		},
+		configFreeCommandEntries(),
+	)
+
+	It("should report the failure for a command added to the CLI", func() {
+		const docsSubcommand = "docs"
+		docs := &cobra.Command{Use: docsSubcommand, RunE: func(*cobra.Command, []string) error { return nil }}
+
+		err := executeEmbeddedCLI(filesystemWithInvalidProject(), programArgs, []string{docsSubcommand},
+			WithExtraCommands(docs))
+		Expect(err).To(MatchError(ContainSubstring("failed to determine config version")))
+	})
+
+	DescribeTable("should report the failure for a command that consumes the configuration",
+		func(filesystem func() machinery.Filesystem, expected string) {
+			err := executeEmbeddedCLI(filesystem(), []string{kubebuilderSubcommandVersion},
+				[]string{createSubcommand, apiSubcommand, kindFlagArg, kindValue})
+			Expect(err).To(MatchError(ContainSubstring(expected)))
+		},
+		Entry("when the PROJECT file is not valid YAML",
+			filesystemWithInvalidProject, "failed to determine config version"),
+		Entry("when the PROJECT project version is not supported",
+			filesystemWithUnloadableProject, "version 1 is not supported"),
+		Entry("when the PROJECT plugin chain cannot be resolved",
+			filesystemWithUnresolvableProject, `no plugin could be resolved with key "gone.example.com/v1"`),
+	)
+
+	It("should refuse to scaffold with a plugin chain the command tree was not built for", func() {
+		// The command tree was built for the CLI defaults, so the plugins the project asks for
+		// cannot be honored anymore.
+		extraPlugin := newTestCreateAPIPlugin(projectChainPluginName, plugin.Version{Number: 1})
+
+		err := executeEmbeddedCLI(filesystemWithResolvableProject(),
+			[]string{kubebuilderSubcommandVersion},
+			[]string{createSubcommand, apiSubcommand, kindFlagArg, kindValue},
+			WithPlugins(extraPlugin),
+			WithDefaultPlugins(config.Version{Number: 3}, extraPlugin),
+		)
+		Expect(err).To(MatchError(ContainSubstring("the command tree was built for the plugin chain")))
+	})
+
+	It("should read the skipped configuration when the command tree was built for its plugin chain", func() {
+		fs := &projectReadCountingFs{Fs: filesystemWithResolvableProject().FS}
+
+		// The command reaches the plugins of the project, so it stops at the missing scaffold and
+		// not at the plugin chain.
+		err := executeEmbeddedCLI(machinery.Filesystem{FS: fs},
+			[]string{kubebuilderSubcommandVersion}, []string{editSubcommand})
+		Expect(err).To(MatchError(ContainSubstring("failed to edit scaffold")))
+		Expect(err).NotTo(MatchError(ContainSubstring("the command tree was built for the plugin chain")))
+		Expect(fs.reads).NotTo(BeZero())
+	})
+})
+
+var _ = Describe("help requested through the plugins flag", func() {
+	DescribeTable("should exit successfully through the binary workflow",
+		func(args []string) {
+			originalArgs := os.Args
+			DeferCleanup(func() { os.Args = originalArgs })
+			os.Args = append([]string{kubebuilderCommandName}, args...)
+
+			c, err := New(
+				WithPlugins(&golangv4.Plugin{}),
+				WithDefaultPlugins(config.Version{Number: 3}, &golangv4.Plugin{}),
+				WithVersion("version string"),
+				WithFilesystem(filesystemWithInvalidProjectPath()),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			c.cmd.SetOut(io.Discard)
+			c.cmd.SetArgs(args)
+			Expect(c.Run()).To(Succeed())
+		},
+		Entry("for --plugins --help", []string{kubebuilderSubcommandInit, pluginsFlagArg, helpFlagArg}),
+		Entry("for --plugins -h", []string{kubebuilderSubcommandInit, pluginsFlagArg, helpShorthandArg}),
+		Entry("for --plugins help", []string{kubebuilderSubcommandInit, pluginsFlagArg, kubebuilderSubcommandHelp}),
+		Entry("for --plugins=<plugin> --help", []string{
+			kubebuilderSubcommandInit, pluginsFlagArg + "=" + pluginGoKubebuilderV4, helpFlagArg,
+		}),
+		Entry("for --plugins=<plugin> -h", []string{
+			kubebuilderSubcommandInit, pluginsFlagArg + "=" + pluginGoKubebuilderV4, helpShorthandArg,
+		}),
+	)
 })

--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -148,7 +148,7 @@ func (c *CLI) applySubcommandHooks(
 		}
 	}
 
-	showPluginPrefix := c.shouldShowPluginPrefix(os.Args)
+	showPluginPrefix := c.shouldShowPluginPrefix(c.args)
 	result, err := initializationHooks(cmd, subcommands, c.metadata(), showPluginPrefix)
 	if err != nil {
 		cmdErr(cmd, err)
@@ -469,7 +469,7 @@ func (factory *executionHooksFactory) preRunEFunc(
 			}
 		} else {
 			// Load the project configuration.
-			if err := factory.store.Load(); os.IsNotExist(err) {
+			if err := factory.store.Load(); errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("%s: failed to find configuration file, project must be initialized",
 					factory.errorMessage)
 			} else if err != nil {

--- a/pkg/cli/cmd_helpers_test.go
+++ b/pkg/cli/cmd_helpers_test.go
@@ -139,7 +139,7 @@ var _ = Describe("cmd_helpers", func() {
 		It("should return false if neither --plugins flag nor external plugin is used", func() {
 			c := &CLI{resolvedPlugins: []plugin.Plugin{mockPlugin{}}}
 			Expect(c.shouldShowPluginPrefix([]string{
-				kubebuilderCommandName, kubebuilderSubcommandInit, "--domain", "my-test.example.com",
+				kubebuilderCommandName, kubebuilderSubcommandInit, domainFlagArg, "my-test.example.com",
 			})).To(BeFalse())
 		})
 	})

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -793,6 +793,29 @@ var _ = Describe("CLI options", func() {
 		})
 	})
 
+	Context("arguments", func() {
+		It("should use the arguments of the running program", func() {
+			originalArgs := os.Args
+			DeferCleanup(func() { os.Args = originalArgs })
+			os.Args = []string{kubebuilderCommandName, kubebuilderSubcommandInit, domainFlagArg, "example.com"}
+
+			c, err = newCLI()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c).NotTo(BeNil())
+			Expect(c.args).To(Equal([]string{kubebuilderSubcommandInit, domainFlagArg, "example.com"}))
+		})
+
+		It("should be empty when the program takes no arguments", func() {
+			originalArgs := os.Args
+			DeferCleanup(func() { os.Args = originalArgs })
+			os.Args = []string{kubebuilderCommandName}
+
+			c, err = newCLI()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.args).To(BeEmpty())
+		})
+	})
+
 	Context("WithFilesystem", func() {
 		When("providing a valid filesystem", func() {
 			It("should use the provided filesystem", func() {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -33,9 +34,46 @@ var (
 	errHelpDisplayed = errors.New("help displayed")
 )
 
-// isHelpFlag checks if the given string is a help flag
+// isHelpFlagArg reports whether the given command-line argument is a help flag.
+func isHelpFlagArg(arg string) bool {
+	if arg == helpFlagArg || arg == helpShorthandArg {
+		return true
+	}
+
+	value, found := strings.CutPrefix(arg, helpFlagArg+"=")
+	if !found {
+		value, found = strings.CutPrefix(arg, helpShorthandArg+"=")
+	}
+	if !found {
+		return false
+	}
+
+	help, err := strconv.ParseBool(value)
+	return err == nil && help
+}
+
+// isHelpFlag reports whether the given string asks for help. It also accepts the bare word "help", so use
+// it only for values that cannot hold data, such as a plugin key.
 func isHelpFlag(s string) bool {
-	return s == helpFlagArg || s == "-h" || s == kubebuilderSubcommandHelp
+	return isHelpFlagArg(s) || s == kubebuilderSubcommandHelp
+}
+
+// isCompletionRequest reports whether the command is the hidden one Cobra runs to complete a command
+// line. Completions are offered with whatever the command tree holds, so they never fail on the
+// project configuration.
+func isCompletionRequest(cmd *cobra.Command) bool {
+	return cmd.Name() == cobra.ShellCompRequestCmd || cmd.Name() == cobra.ShellCompNoDescRequestCmd
+}
+
+// subcommandPath returns the subcommand names leading from the root command to cmd.
+func subcommandPath(cmd *cobra.Command) []string {
+	var path []string
+	for current := cmd; current.HasParent(); current = current.Parent() {
+		path = append(path, current.Name())
+	}
+	slices.Reverse(path)
+
+	return path
 }
 
 // getShortKey converts a full plugin key to a short display key
@@ -74,7 +112,8 @@ func getPluginDescription(_ string) string {
 	return "External or custom plugin"
 }
 
-func (c CLI) newRootCmd() *cobra.Command {
+// newRootCmd creates the root Cobra command for the CLI.
+func (c *CLI) newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     c.commandName,
 		Long:    c.description,
@@ -97,6 +136,27 @@ func (c CLI) newRootCmd() *cobra.Command {
 					}
 				}
 			}
+
+			if isCompletionRequest(cmd) {
+				return nil
+			}
+			// A malformed command line is reported for normal commands. Completion requests are
+			// intentionally allowed to inspect partial input.
+			if c.flagErr != nil {
+				return c.flagErr
+			}
+
+			// Cobra resolved the command, so it is now known whether it consumes the configuration.
+			if isSubcommandPathWithoutConfig(subcommandPath(cmd)) {
+				return nil
+			}
+			if c.configErr != nil {
+				return c.configErr
+			}
+			if c.configSkipped {
+				return c.resolveSkippedConfig()
+			}
+
 			return nil
 		},
 	}
@@ -107,7 +167,7 @@ func (c CLI) newRootCmd() *cobra.Command {
 	// Register --project-version on the root command so that it shows up in help.
 	cmd.Flags().String(projectVersionFlag, c.defaultProjectVersion.String(), projectVersionFlagDescription)
 
-	// As the root command will be used to shot the help message under some error conditions,
+	// As the root command will be used to show the help message under some error conditions,
 	// like during plugin resolving, we need to allow unknown flags to prevent parsing errors.
 	cmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
 

--- a/pkg/config/store/yaml/store.go
+++ b/pkg/config/store/yaml/store.go
@@ -17,7 +17,9 @@ limitations under the License.
 package yaml
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/afero"
@@ -77,9 +79,127 @@ type versionedConfig struct {
 	Version config.Version `json:"version"`
 }
 
+// pathClass describes what is at a path.
+type pathClass int
+
+const (
+	pathMissing pathClass = iota
+	pathRegularFile
+	pathDirectory
+	pathIrregularFile
+	pathSymbolicLink
+)
+
+// String returns a human-readable description of the path class.
+func (c pathClass) String() string {
+	switch c {
+	case pathRegularFile:
+		return "a regular file"
+	case pathDirectory:
+		return "a directory"
+	case pathSymbolicLink:
+		return "a symbolic link"
+	case pathIrregularFile:
+		return "not a regular file"
+	default:
+		return ""
+	}
+}
+
+// classify reports what is at the path after following a final symbolic link.
+func classify(fs afero.Fs, path string) (pathClass, error) {
+	info, err := fs.Stat(path)
+
+	return classifyInfo(path, info, err)
+}
+
+// classifyNoFollow reports a final symbolic link without following it when the filesystem supports
+// Lstat. This lets callers distinguish a link with a missing target from a missing path.
+func classifyNoFollow(fs afero.Fs, path string) (pathClass, error) {
+	lstater, ok := fs.(afero.Lstater)
+	if !ok {
+		return classify(fs, path)
+	}
+
+	info, _, err := lstater.LstatIfPossible(path)
+
+	return classifyInfo(path, info, err)
+}
+
+// classifyInfo maps file information and a stat error to a path class.
+func classifyInfo(path string, info os.FileInfo, err error) (pathClass, error) {
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return pathMissing, nil
+	case err != nil:
+		return pathMissing, fmt.Errorf("failed to check %q: %w", path, err)
+	case info.Mode()&os.ModeSymlink != 0:
+		return pathSymbolicLink, nil
+	case info.Mode().IsRegular():
+		return pathRegularFile, nil
+	case info.IsDir():
+		return pathDirectory, nil
+	default:
+		return pathIrregularFile, nil
+	}
+}
+
+// checkReadable returns an error when the path cannot be read as a configuration file. It reports
+// os.ErrNotExist only when nothing is at the path, so that callers can tell a project that was
+// never initialized from one whose configuration path holds something else.
+func checkReadable(fs afero.Fs, path string) error {
+	// The link is followed, so a link to a configuration file is read as one.
+	class, err := classify(fs, path)
+	if err != nil {
+		return err
+	}
+
+	if class == pathMissing {
+		// A link with a missing target also reads as missing, so report the link instead.
+		linkClass, linkErr := classifyNoFollow(fs, path)
+		if linkErr != nil || linkClass != pathSymbolicLink {
+			return fmt.Errorf("failed to read %q file: %w", path, os.ErrNotExist)
+		}
+		class = linkClass
+	}
+
+	if class != pathRegularFile {
+		return fmt.Errorf("%q is %s", path, class)
+	}
+
+	return nil
+}
+
+// checkSavePath verifies that the path can be used to save a configuration. It accepts a missing
+// path for a new configuration and a regular file for an update. Other path types are rejected
+// when the filesystem can identify them.
+func checkSavePath(fs afero.Fs, path string, mustNotExist bool) error {
+	class, err := classifyNoFollow(fs, path)
+	if err != nil {
+		return err
+	}
+
+	switch class {
+	case pathRegularFile:
+		if mustNotExist {
+			return fmt.Errorf("configuration already exists in %q", path)
+		}
+		return nil
+	case pathSymbolicLink, pathDirectory, pathIrregularFile:
+		return fmt.Errorf("cannot save configuration to %q: path is %s", path, class)
+	default:
+		return nil
+	}
+}
+
 // LoadFrom implements store.Store interface
 func (s *yamlStore) LoadFrom(path string) error {
 	s.mustNotExist = false
+
+	// Only a regular file can carry configuration data.
+	if err := checkReadable(s.fs, path); err != nil {
+		return store.LoadError{Err: err}
+	}
 
 	// Read the file
 	in, err := afero.ReadFile(s.fs, path)
@@ -121,17 +241,10 @@ func (s yamlStore) SaveTo(path string) error {
 		return store.SaveError{Err: fmt.Errorf("undefined config, use one of the initializers: New, Load, LoadFrom")}
 	}
 
-	// If it is a new configuration, the path should not exist yet
-	if s.mustNotExist {
-		// Check that the file doesn't exist
-		_, err := s.fs.Stat(path)
-		if err == nil || os.IsExist(err) {
-			// File already exists
-			return store.SaveError{Err: fmt.Errorf("configuration already exists in %q", path)}
-		} else if !os.IsNotExist(err) {
-			// Error occurred while checking file existence
-			return store.SaveError{Err: fmt.Errorf("failed to check for file prior existence: %w", err)}
-		}
+	// Only a missing path or a regular file can be used for saving. New configurations require
+	// the path to be missing, while existing configurations may update a regular file.
+	if err := checkSavePath(s.fs, path, s.mustNotExist); err != nil {
+		return store.SaveError{Err: err}
 	}
 
 	// Marshall into YAML
@@ -144,12 +257,42 @@ func (s yamlStore) SaveTo(path string) error {
 	content = append([]byte(commentStr), content...)
 
 	// Write the marshalled configuration
-	err = afero.WriteFile(s.fs, path, content, machinery.DefaultFilePermission)
-	if err != nil {
-		return store.SaveError{Err: fmt.Errorf("failed to save configuration to %q: %w", path, err)}
+	// afero.WriteFile uses O_CREATE|O_TRUNC, so it is appropriate when updating an existing regular
+	// file. New configurations need O_EXCL, which afero.WriteFile does not expose, to prevent an
+	// existing path from being overwritten after the path check.
+	var writeErr error
+	if s.mustNotExist {
+		writeErr = s.writeNew(path, content)
+	} else {
+		writeErr = afero.WriteFile(s.fs, path, content, machinery.DefaultFilePermission)
+	}
+	if writeErr != nil {
+		return store.SaveError{Err: fmt.Errorf("failed to save configuration to %q: %w", path, writeErr)}
 	}
 
 	return nil
+}
+
+// writeNew creates a configuration only if the path is still unused. If kubebuilder init sees no
+// PROJECT and another process creates PROJECT before the write—for example, a symbolic link to
+// /tmp/important.yaml—O_EXCL makes the write fail instead of overwriting that file or following
+// the link.
+func (s yamlStore) writeNew(path string, content []byte) error {
+	file, err := s.fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, machinery.DefaultFilePermission)
+	if err != nil {
+		return fmt.Errorf("failed to open the file: %w", err)
+	}
+
+	n, err := file.Write(content)
+	if err == nil && n != len(content) {
+		err = io.ErrShortWrite
+	}
+
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+
+	return err
 }
 
 // Config implements store.Store interface

--- a/pkg/config/store/yaml/store_test.go
+++ b/pkg/config/store/yaml/store_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,6 +37,17 @@ import (
 func TestConfigStoreYaml(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Store YAML Suite")
+}
+
+// missingConfigError is the error the store reports when nothing is at the path.
+func missingConfigError(path string) error {
+	return store.LoadError{Err: fmt.Errorf("failed to read %q file: %w", path, os.ErrNotExist)}
+}
+
+// occupiedConfigError is the error the store reports when the path holds no configuration because
+// something else is at it.
+func occupiedConfigError(path, description string) error {
+	return store.LoadError{Err: fmt.Errorf("%q is %s", path, description)}
 }
 
 var _ = Describe("New", func() {
@@ -75,6 +88,13 @@ layout: ""
 		It("should fail for an unregistered config version", func() {
 			Expect(s.New(config.Version{})).NotTo(Succeed())
 		})
+
+		It("should require the configuration not to exist yet when saving it", func() {
+			Expect(s.New(cfgv3.Version)).To(Succeed())
+			Expect(afero.WriteFile(s.fs, DefaultPath, []byte(v3File), os.ModePerm)).To(Succeed())
+
+			Expect(s.Save()).To(MatchError(ContainSubstring("configuration already exists")))
+		})
 	})
 
 	Context("Load", func() {
@@ -91,13 +111,24 @@ layout: ""
 		It("should fail if no file exists at the default path", func() {
 			err := s.Load()
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(store.LoadError{
-				Err: fmt.Errorf("failed to read %q file: %w", DefaultPath, &os.PathError{
-					Err:  os.ErrNotExist,
-					Path: DefaultPath,
-					Op:   "open",
-				}),
-			}))
+			Expect(err).To(MatchError(missingConfigError(DefaultPath)))
+			Expect(err).To(MatchError(os.ErrNotExist))
+		})
+
+		It("should report a directory at the default path instead of a missing file", func() {
+			Expect(s.fs.MkdirAll(DefaultPath, os.ModePerm)).To(Succeed())
+
+			err := s.Load()
+			Expect(err).To(MatchError(occupiedConfigError(DefaultPath, "a directory")))
+			Expect(err).NotTo(MatchError(os.ErrNotExist))
+		})
+
+		It("should ignore directories named as the config file elsewhere in the project", func() {
+			Expect(s.fs.MkdirAll(filepath.Join("docs", DefaultPath), os.ModePerm)).To(Succeed())
+			Expect(afero.WriteFile(s.fs, DefaultPath, []byte(commentStr+v3File), os.ModePerm)).To(Succeed())
+
+			Expect(s.Load()).To(Succeed())
+			Expect(s.Config().GetVersion().Compare(cfgv3.Version)).To(Equal(0))
 		})
 
 		It("should fail if unable to identify the version of the file at the default path", func() {
@@ -158,13 +189,46 @@ layout: ""
 		It("should fail if no file exists at the specified path", func() {
 			err := s.LoadFrom(path)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(store.LoadError{
-				Err: fmt.Errorf("failed to read %q file: %w", path, &os.PathError{
-					Err:  os.ErrNotExist,
-					Path: path,
-					Op:   "open",
-				}),
-			}))
+			Expect(err).To(MatchError(missingConfigError(path)))
+			Expect(err).To(MatchError(os.ErrNotExist))
+		})
+
+		It("should report a directory at the specified path instead of a missing file", func() {
+			Expect(s.fs.MkdirAll(path, os.ModePerm)).To(Succeed())
+
+			err := s.LoadFrom(path)
+			Expect(err).To(MatchError(occupiedConfigError(path, "a directory")))
+			Expect(err).NotTo(MatchError(os.ErrNotExist))
+		})
+
+		It("should never read a non-regular file at the specified path", func() {
+			Expect(afero.WriteFile(s.fs, path, []byte(commentStr+v3File), os.ModePerm)).To(Succeed())
+			fs := &nonRegularFs{Fs: s.fs, path: path}
+			s.fs = fs
+
+			err := s.LoadFrom(path)
+			Expect(err).To(MatchError(occupiedConfigError(path, "not a regular file")))
+			Expect(fs.reads).To(BeZero())
+		})
+
+		It("should load the Config through a symlink to a regular file", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
+			Expect(os.WriteFile(target, []byte(commentStr+v3File), 0o644)).To(Succeed())
+			s.fs = afero.NewOsFs()
+
+			Expect(s.LoadFrom(link)).To(Succeed())
+			Expect(s.Config().GetVersion().Compare(cfgv3.Version)).To(Equal(0))
+		})
+
+		It("should report a dangling symbolic link instead of a missing file", func() {
+			skipWithoutSymlinks()
+			link, _ := danglingSymlink()
+			s.fs = afero.NewOsFs()
+
+			err := s.LoadFrom(link)
+			Expect(err).To(MatchError(occupiedConfigError(link, "a symbolic link")))
+			Expect(err).NotTo(MatchError(os.ErrNotExist))
 		})
 
 		It("should fail if unable to identify the version of the file at the specified path", func() {
@@ -290,5 +354,203 @@ layout: ""
 				Err: fmt.Errorf("configuration already exists in %q", path),
 			}))
 		})
+
+		It("should fail if a directory exists at the target path", func() {
+			s.cfg = cfgv3.New()
+			s.mustNotExist = true
+			Expect(s.fs.MkdirAll(path, os.ModePerm)).To(Succeed())
+
+			Expect(s.SaveTo(path)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("cannot save configuration to %q: path is a directory", path),
+			}))
+		})
+
+		It("should fail if a non-regular file exists at the target path", func() {
+			s.cfg = cfgv3.New()
+			s.mustNotExist = true
+			Expect(afero.WriteFile(s.fs, path, []byte(v3File), os.ModePerm)).To(Succeed())
+			s.fs = &nonRegularFs{Fs: s.fs, path: path}
+
+			Expect(s.SaveTo(path)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("cannot save configuration to %q: path is not a regular file", path),
+			}))
+		})
+
+		It("should fail without creating the target if the target path is a dangling symbolic link", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
+
+			s.fs = afero.NewOsFs()
+			s.cfg = cfgv3.New()
+			s.mustNotExist = true
+
+			Expect(s.SaveTo(link)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("cannot save configuration to %q: path is a symbolic link", link),
+			}))
+			Expect(target).NotTo(BeAnExistingFile())
+		})
+
+		It("should fail without creating the target of a dangling symbolic link the filesystem "+
+			"cannot tell apart", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
+
+			// A filesystem that is not an afero.Lstater cannot report the link, so the write itself
+			// has to refuse the path.
+			s.fs = &opaqueFs{Fs: afero.NewOsFs()}
+			s.cfg = cfgv3.New()
+			s.mustNotExist = true
+
+			Expect(s.SaveTo(link)).NotTo(Succeed())
+			Expect(target).NotTo(BeAnExistingFile())
+		})
+
+		It("should reject a symbolic link when updating an existing configuration", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
+			existingContent := []byte(commentStr + v3File)
+			Expect(os.WriteFile(target, existingContent, 0o644)).To(Succeed())
+
+			s.fs = afero.NewOsFs()
+			s.cfg = cfgv3.New()
+			s.mustNotExist = false
+
+			Expect(s.SaveTo(link)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("cannot save configuration to %q: path is a symbolic link", link),
+			}))
+			Expect(target).To(BeAnExistingFile())
+			content, err := os.ReadFile(target)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal(existingContent))
+
+			info, err := os.Lstat(link)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode() & os.ModeSymlink).NotTo(BeZero())
+		})
+	})
+
+	Context("when the path cannot be checked", func() {
+		var statErr error
+
+		BeforeEach(func() {
+			statErr = errors.New("permission denied")
+			s.fs = &failingStatFs{Fs: s.fs, path: path, err: statErr}
+		})
+
+		It("should fail to load the Config", func() {
+			Expect(s.LoadFrom(path)).To(MatchError(store.LoadError{
+				Err: fmt.Errorf("failed to check %q: %w", path, statErr),
+			}))
+		})
+
+		It("should fail to save a new Config", func() {
+			s.cfg = cfgv3.New()
+			s.mustNotExist = true
+
+			Expect(s.SaveTo(path)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("failed to check %q: %w", path, statErr),
+			}))
+		})
 	})
 })
+
+var _ = Describe("pathClass", func() {
+	DescribeTable("should describe what occupies the path",
+		func(class pathClass, description string) {
+			Expect(class.String()).To(Equal(description))
+		},
+		Entry("for a regular file", pathRegularFile, "a regular file"),
+		Entry("for a directory", pathDirectory, "a directory"),
+		Entry("for a symbolic link", pathSymbolicLink, "a symbolic link"),
+		Entry("for any other file", pathIrregularFile, "not a regular file"),
+		Entry("for a path where nothing is", pathMissing, ""),
+		Entry("for an unknown class", pathClass(-1), ""),
+	)
+})
+
+// skipWithoutSymlinks skips the test where creating a symbolic link needs extra privileges.
+func skipWithoutSymlinks() {
+	GinkgoHelper()
+
+	if runtime.GOOS == "windows" {
+		Skip("symlink creation requires elevated privileges on Windows")
+	}
+}
+
+// danglingSymlink creates a symbolic link whose target does not exist, and returns both paths.
+func danglingSymlink() (link, target string) {
+	GinkgoHelper()
+
+	dir := GinkgoT().TempDir()
+	link = filepath.Join(dir, DefaultPath)
+	target = filepath.Join(dir, "stolen.yaml")
+	Expect(os.Symlink(target, link)).To(Succeed())
+
+	return link, target
+}
+
+// opaqueFs hides the optional interfaces of the wrapped filesystem, such as afero.Lstater.
+type opaqueFs struct {
+	afero.Fs
+}
+
+// nonRegularFileInfo reports a device file mode on top of the wrapped FileInfo.
+type nonRegularFileInfo struct{ os.FileInfo }
+
+// Mode adds a device-file mode to the wrapped file information.
+func (i nonRegularFileInfo) Mode() os.FileMode { return i.FileInfo.Mode() | os.ModeDevice }
+
+// nonRegularFs makes path look like a non-regular file and counts how many times it is opened.
+type nonRegularFs struct {
+	afero.Fs
+	path  string
+	reads int
+}
+
+// Stat reports the configured path as a non-regular file.
+func (f *nonRegularFs) Stat(name string) (os.FileInfo, error) {
+	info, err := f.Fs.Stat(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %q: %w", name, err)
+	}
+	if name == f.path {
+		info = nonRegularFileInfo{info}
+	}
+
+	return info, nil
+}
+
+// failingStatFs fails to stat the given path.
+type failingStatFs struct {
+	afero.Fs
+	path string
+	err  error
+}
+
+// Stat returns the configured error for the target path.
+func (f *failingStatFs) Stat(name string) (os.FileInfo, error) {
+	if name == f.path {
+		return nil, f.err
+	}
+
+	info, err := f.Fs.Stat(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %q: %w", name, err)
+	}
+
+	return info, nil
+}
+
+// Open counts reads of the configured path before delegating to the wrapped filesystem.
+func (f *nonRegularFs) Open(name string) (afero.File, error) {
+	if name == f.path {
+		f.reads++
+	}
+
+	file, err := f.Fs.Open(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %q: %w", name, err)
+	}
+
+	return file, nil
+}

--- a/pkg/config/store/yaml/store_unix_test.go
+++ b/pkg/config/store/yaml/store_unix_test.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yaml
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+)
+
+// A named pipe blocks the reader until something writes to it, so a store that opens one never
+// returns. These specs hang instead of failing when that happens.
+var _ = Describe("yamlStore with a named pipe", func() {
+	var s *yamlStore
+	var path string
+
+	BeforeEach(func() {
+		s = New(machinery.Filesystem{FS: afero.NewOsFs()}).(*yamlStore)
+		path = filepath.Join(GinkgoT().TempDir(), DefaultPath)
+		Expect(syscall.Mkfifo(path, 0o600)).To(Succeed())
+	})
+
+	It("should report the pipe instead of reading it", func() {
+		err := s.LoadFrom(path)
+		Expect(err).To(MatchError(occupiedConfigError(path, "not a regular file")))
+		Expect(err).NotTo(MatchError(os.ErrNotExist))
+	})
+
+	It("should refuse to save a new configuration to it", func() {
+		s.cfg = cfgv3.New()
+		s.mustNotExist = true
+
+		Expect(s.SaveTo(path)).NotTo(Succeed())
+	})
+
+	It("should refuse to update a configuration at it", func() {
+		s.cfg = cfgv3.New()
+
+		Expect(s.SaveTo(path)).NotTo(Succeed())
+	})
+})

--- a/pkg/plugins/golang/v4/init.go
+++ b/pkg/plugins/golang/v4/init.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v4
 
 import (
+	"errors"
 	"fmt"
 	log "log/slog"
 	"os"
@@ -257,6 +258,18 @@ func (p *initSubcommand) PostScaffold() error {
 	return nil
 }
 
+// describeMode returns a human-readable description of a file mode.
+func describeMode(mode os.FileMode) string {
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return "a symbolic link"
+	case mode.IsDir():
+		return "a directory"
+	default:
+		return "not a regular file"
+	}
+}
+
 // checkDir checks the target directory before scaffolding:
 // 1. Returns error if key kubebuilder files already exist (prevents re-initialization)
 // 2. Warns if directory is not empty (but allows scaffolding to continue)
@@ -273,9 +286,17 @@ func checkDir() error {
 		filepath.Join("cmd", "main.go"), // Controller manager entry point
 	}
 
-	// Check for existing scaffolded files
+	// The link is not followed, so that scaffolding never writes through it.
 	for _, file := range scaffoldedFiles {
-		if _, err := os.Stat(file); err == nil {
+		info, err := os.Lstat(file)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+		case err != nil:
+			return fmt.Errorf("failed to check %q: %w", file, err)
+		case !info.Mode().IsRegular():
+			return fmt.Errorf("cannot scaffold: %q is %s. "+
+				"Please run this command in a new directory or remove it", file, describeMode(info.Mode()))
+		default:
 			return fmt.Errorf("target directory is already initialized. "+
 				"Found existing kubebuilder file %q. "+
 				"Please run this command in a new directory or remove existing scaffolded files", file)

--- a/pkg/plugins/golang/v4/init_test.go
+++ b/pkg/plugins/golang/v4/init_test.go
@@ -19,6 +19,7 @@ package v4
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,6 +33,18 @@ import (
 )
 
 const testRepo = "github.com/example/test"
+
+var _ = Describe("describeMode", func() {
+	DescribeTable("should describe what the file mode stands for",
+		func(mode os.FileMode, description string) {
+			Expect(describeMode(mode)).To(Equal(description))
+		},
+		Entry("for a symbolic link", os.ModeSymlink, "a symbolic link"),
+		Entry("for a directory", os.ModeDir, "a directory"),
+		Entry("for a named pipe", os.ModeNamedPipe, "not a regular file"),
+		Entry("for a socket", os.ModeSocket, "not a regular file"),
+	)
+})
 
 var _ = Describe("initSubcommand", func() {
 	var (
@@ -173,6 +186,73 @@ var _ = Describe("initSubcommand", func() {
 			err = checkDir()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("already initialized"))
+		})
+
+		It("should fail when PROJECT exists even if it cannot be parsed", func() {
+			err := os.WriteFile("PROJECT", []byte("{{ not a valid config"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = checkDir()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already initialized"))
+		})
+
+		It("should fail without claiming initialization when PROJECT is a directory", func() {
+			err := os.Mkdir("PROJECT", 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = checkDir()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`"PROJECT" is a directory`))
+			Expect(err.Error()).NotTo(ContainSubstring("already initialized"))
+		})
+
+		It("should fail without following a symbolic link", func() {
+			if runtime.GOOS == "windows" {
+				Skip("symlink creation requires elevated privileges on Windows")
+			}
+
+			target := filepath.Join(GinkgoT().TempDir(), "stolen.txt")
+			Expect(os.Symlink(target, "Makefile")).To(Succeed())
+
+			err := checkDir()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`"Makefile" is a symbolic link`))
+			Expect(err.Error()).NotTo(ContainSubstring("already initialized"))
+			Expect(target).NotTo(BeAnExistingFile())
+		})
+
+		It("should fail without claiming initialization when Makefile is a directory", func() {
+			err := os.Mkdir("Makefile", 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = checkDir()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`"Makefile" is a directory`))
+			Expect(err.Error()).NotTo(ContainSubstring("already initialized"))
+		})
+
+		It("should fail without claiming initialization when cmd/main.go is a directory", func() {
+			err := os.MkdirAll(filepath.Join("cmd", "main.go"), 0o755)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = checkDir()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is a directory"))
+			Expect(err.Error()).NotTo(ContainSubstring("already initialized"))
+		})
+
+		It("should surface stat errors instead of scaffolding over them", func() {
+			if runtime.GOOS == "windows" {
+				Skip("Windows reports a file blocking the parent path as not-exist")
+			}
+
+			err := os.WriteFile("cmd", []byte("not a directory"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = checkDir()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`failed to check "cmd/main.go"`))
 		})
 
 		It("should fail when cmd/main.go exists", func() {


### PR DESCRIPTION
Follow-up of #5845. Fixes #5935.

### Problem

#5845 made config load errors non-fatal for `version`, `help` and `completion`.
It scanned the arguments for the word `help`, which also matches a flag value.

In a project whose PROJECT plugin chain cannot be resolved:

```sh
$ kubebuilder create api --group crew --version v1 --kind Captain
Error: no plugin could be resolved with key "groject version "3"

$ kubebuilder create api --kind help
Error: unknown flag: --kind
```

The second call looked like a help request. The PROJECT error was skipped, the
plugin chain stayed unresolved, and Cobra reporor.

Solution

- A flag value is data. Only --help, --help= flags. The bare word help counts only as a --plugins value.
- Commands that do not consume PROJECT no longd of reading it and ignoring the error.
- The list of these commands is a single variaed with one entry, and CLIs built on Kubebuilder, such as operator-sdk, extend it with the new WithSubcommandsWithoutConfig option. Nted, for example alpha generate.
- PROJECT is a file. A directory named PROJECT. so it is handled as a project that was never initialized.


Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5935

c/c @immanuwell