### PR TITLE
🌱added unit tests for the per-API ssa field

### DIFF
--- a/pkg/model/resource/api_test.go
+++ b/pkg/model/resource/api_test.go
@@ -44,14 +44,17 @@ var _ = Describe("API", func() {
 			Expect(api.Update(nil)).To(Succeed())
 			Expect(api.CRDVersion).To(Equal(""))
 			Expect(api.Namespaced).To(BeFalse())
+			Expect(api.SSA).To(BeFalse())
 
 			api = API{
 				CRDVersion: v1,
 				Namespaced: true,
+				SSA:        true,
 			}
 			Expect(api.Update(nil)).To(Succeed())
 			Expect(api.CRDVersion).To(Equal(v1))
 			Expect(api.Namespaced).To(BeTrue())
+			Expect(api.SSA).To(BeTrue())
 		})
 
 		Context("CRD version", func() {
@@ -112,6 +115,36 @@ var _ = Describe("API", func() {
 				Expect(api.Namespaced).To(BeFalse())
 			})
 		})
+
+		Context("SSA", func() {
+			It("should enable SSA if provided and not previously set", func() {
+				api = API{}
+				other = API{SSA: true}
+				Expect(api.Update(&other)).To(Succeed())
+				Expect(api.SSA).To(BeTrue())
+			})
+
+			It("should keep SSA enabled if previously set", func() {
+				api = API{SSA: true}
+
+				By("not providing it")
+				other = API{}
+				Expect(api.Update(&other)).To(Succeed())
+				Expect(api.SSA).To(BeTrue())
+
+				By("providing it")
+				other = API{SSA: true}
+				Expect(api.Update(&other)).To(Succeed())
+				Expect(api.SSA).To(BeTrue())
+			})
+
+			It("should not enable SSA if not provided and not previously set", func() {
+				api = API{}
+				other = API{}
+				Expect(api.Update(&other)).To(Succeed())
+				Expect(api.SSA).To(BeFalse())
+			})
+		})
 	})
 
 	Context("IsEmpty", func() {
@@ -119,6 +152,7 @@ var _ = Describe("API", func() {
 			none       API
 			cluster    API
 			namespaced API
+			ssa        API
 		)
 
 		BeforeEach(func() {
@@ -129,6 +163,9 @@ var _ = Describe("API", func() {
 			namespaced = API{
 				CRDVersion: v1,
 				Namespaced: true,
+			}
+			ssa = API{
+				SSA: true,
 			}
 		})
 
@@ -142,6 +179,7 @@ var _ = Describe("API", func() {
 			},
 			Entry("cluster-scope", func() API { return cluster }),
 			Entry("namespace-scope", func() API { return namespaced }),
+			Entry("ssa-only", func() API { return ssa }),
 		)
 	})
 })

--- a/pkg/plugins/golang/options_test.go
+++ b/pkg/plugins/golang/options_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Options", func() {
 					Expect(res.API).NotTo(BeNil())
 					if options.DoAPI {
 						Expect(res.API.Namespaced).To(Equal(options.Namespaced))
+						Expect(res.API.SSA).To(Equal(options.SSA))
 						Expect(res.API.IsEmpty()).To(BeFalse())
 					} else {
 						Expect(res.API.IsEmpty()).To(BeTrue())
@@ -125,6 +126,7 @@ var _ = Describe("Options", func() {
 				Options{ExternalAPIPath: "github.com/example/external/api/v1", ExternalAPIDomain: "test.io"}),
 			Entry("when updating the API with setting webhooks params",
 				Options{DoAPI: true, DoDefaulting: true, DoValidation: true, DoConversion: true}),
+			Entry("when updating the API with SSA enabled", Options{DoAPI: true, SSA: true}),
 		)
 
 		It("should retain path and external flag when ExternalAPIPath is not provided but resource is already external",


### PR DESCRIPTION
## Description

The SSA field on the resource API model had no test coverage. This adds unit tests for it in the two places that touch it:

- `pkg/model/resource/api_test.go`
- `API.Update` merge: enables SSA when the other side sets it, keeps it when already set and the other side doesn't, and leaves it off when neither does.
- `API.Update(nil)`: the SSA value survives a nil update.
- `API.IsEmpty`: an API holding only `SSA: true` is reported non-empty.
- `pkg/plugins/golang/options_test.go`
- `Options.UpdateResource`: `Options{DoAPI: true, SSA: true}` reaches the resource with SSA enabled.

No production code changes - tests only.

## Motivation

`pkg/model/resource/api.go` gained the SSA field, its merge in `API.Update`, and its use in `API.IsEmpty`, but none of it was covered by tests. This locks in the current behaviour and guards against regressions.

Fixes #5937
