### PR TITLE
🐛 (helm/v2-alpha): map --metrics-secure to the metrics.secure value

### DIFF
--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment.go
@@ -455,6 +455,11 @@ func extractContainerArgs(container map[string]any, config map[string]any) {
 			strings.Contains(strArg, "--metrics-cert-path") {
 			continue
 		}
+		// The chart renders this arg from .Values.metrics.secure, so keeping it
+		// here as well would let the two disagree. The arg itself is filtered out.
+		if _, ok := ExtractMetricsSecureFromArg(strArg); ok {
+			continue
+		}
 		filteredArgs = append(filteredArgs, strArg)
 	}
 
@@ -480,6 +485,28 @@ func ExtractPortFromArg(arg string) int {
 		return 0
 	}
 	return port
+}
+
+// ExtractMetricsSecureFromArg extracts the value of a "--metrics-secure" argument.
+// A bare "--metrics-secure" means true, as for any boolean flag. The second return
+// value is false when arg is a different flag or carries a non-boolean value.
+func ExtractMetricsSecureFromArg(arg string) (bool, bool) {
+	const flagName = "--metrics-secure"
+
+	if arg == flagName {
+		return true, true
+	}
+
+	value, ok := strings.CutPrefix(arg, flagName+"=")
+	if !ok {
+		return false, false
+	}
+
+	secure, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, false
+	}
+	return secure, true
 }
 
 func extractContainerPorts(container map[string]any, config map[string]any) {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/deployment_test.go
@@ -417,6 +417,35 @@ var _ = Describe("DeploymentExtractor", func() {
 		)
 	})
 
+	Describe("ExtractMetricsSecureFromArg", func() {
+		DescribeTable("recognized forms",
+			func(arg string, expected bool) {
+				secure, found := ExtractMetricsSecureFromArg(arg)
+
+				Expect(found).To(BeTrue())
+				Expect(secure).To(Equal(expected))
+			},
+			Entry("explicit false", "--metrics-secure=false", false),
+			Entry("explicit true", "--metrics-secure=true", true),
+			Entry("bare flag", "--metrics-secure", true),
+			Entry("uppercase false", "--metrics-secure=FALSE", false),
+			Entry("numeric false", "--metrics-secure=0", false),
+			Entry("numeric true", "--metrics-secure=1", true),
+		)
+
+		DescribeTable("unrecognized forms",
+			func(arg string) {
+				_, found := ExtractMetricsSecureFromArg(arg)
+
+				Expect(found).To(BeFalse())
+			},
+			Entry("another flag", "--metrics-bind-address=:8443"),
+			Entry("prefix of another flag", "--metrics-secure-extra=false"),
+			Entry("non-boolean value", "--metrics-secure=maybe"),
+			Entry("empty value", "--metrics-secure="),
+		)
+	})
+
 	Describe("Webhook port extraction", func() {
 		It("should extract webhook port from --webhook-port argument in deployment args", func() {
 			deployment := makeDeployment(deploymentOpts{

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features.go
@@ -42,6 +42,7 @@ type FeatureSet struct {
 	WebhookPort             int
 	MetricsPort             int
 	HealthProbePort         int
+	MetricsSecure           *bool // nil when the manager does not set --metrics-secure
 	RoleNamespaces          map[string]string
 }
 
@@ -111,6 +112,13 @@ func (f *FeaturesExtractor) DetectFeatures(resources *ResourceSet, namePrefix, m
 	if resources.Deployment != nil {
 		if port := extractHealthProbePortFromDeployment(resources.Deployment); port > 0 {
 			features.HealthProbePort = port
+		}
+	}
+
+	// Whether metrics are served over HTTPS is defined on the manager container's --metrics-secure arg.
+	if resources.Deployment != nil {
+		if secure, found := extractMetricsSecureFromDeployment(resources.Deployment); found {
+			features.MetricsSecure = &secure
 		}
 	}
 
@@ -258,4 +266,40 @@ func extractHealthProbePortFromDeployment(deployment *unstructured.Unstructured)
 	}
 
 	return 0
+}
+
+// extractMetricsSecureFromDeployment extracts whether metrics are served over
+// HTTPS from the manager container's --metrics-secure argument. The second
+// return value reports whether the argument is set.
+func extractMetricsSecureFromDeployment(deployment *unstructured.Unstructured) (bool, bool) {
+	specMap := extractDeploymentSpec(deployment)
+	if specMap == nil {
+		return false, false
+	}
+	container := findManagerContainer(deployment, specMap)
+	if container == nil {
+		return false, false
+	}
+
+	argsField, found, err := unstructured.NestedFieldNoCopy(container, "args")
+	if !found || err != nil {
+		return false, false
+	}
+
+	argsList, ok := argsField.([]any)
+	if !ok {
+		return false, false
+	}
+
+	for _, a := range argsList {
+		strArg, ok := a.(string)
+		if !ok {
+			continue
+		}
+		if secure, ok := ExtractMetricsSecureFromArg(strArg); ok {
+			return secure, true
+		}
+	}
+
+	return false, false
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/extractor/features_test.go
@@ -143,4 +143,72 @@ var _ = Describe("FeaturesExtractor", func() {
 			Expect(features.HealthProbePort).To(Equal(9091))
 		})
 	})
+
+	Describe("DetectFeatures metrics secure", func() {
+		It("should leave the value unset when the arg is absent", func() {
+			features := detect(deploymentWithManagerArgs("--leader-elect"))
+
+			Expect(features.MetricsSecure).To(BeNil())
+		})
+
+		It("should leave the value unset when there is no deployment", func() {
+			features := detect(nil)
+
+			Expect(features.MetricsSecure).To(BeNil())
+		})
+
+		It("should detect metrics served over plain HTTP", func() {
+			features := detect(deploymentWithManagerArgs("--metrics-secure=false"))
+
+			Expect(features.MetricsSecure).To(HaveValue(BeFalse()))
+		})
+
+		It("should detect metrics served over HTTPS", func() {
+			features := detect(deploymentWithManagerArgs("--metrics-secure=true"))
+
+			Expect(features.MetricsSecure).To(HaveValue(BeTrue()))
+		})
+
+		It("should read a bare flag as true", func() {
+			features := detect(deploymentWithManagerArgs("--metrics-secure"))
+
+			Expect(features.MetricsSecure).To(HaveValue(BeTrue()))
+		})
+
+		It("should read a separate value as true, matching boolean flag parsing", func() {
+			features := detect(deploymentWithManagerArgs("--metrics-secure", "false"))
+
+			Expect(features.MetricsSecure).To(HaveValue(BeTrue()))
+		})
+
+		It("should use the first value when the arg is duplicated", func() {
+			features := detect(deploymentWithManagerArgs(
+				"--metrics-secure=false",
+				"--metrics-secure=true",
+			))
+
+			Expect(features.MetricsSecure).To(HaveValue(BeFalse()))
+		})
+
+		It("should read the arg from the manager container, not a sidecar", func() {
+			deployment := makeDeployment(deploymentOpts{
+				containers: []map[string]any{
+					{
+						keyName:  valSidecar,
+						keyImage: valSidecarImage,
+						keyArgs:  []any{"--metrics-secure=true"},
+					},
+					{
+						keyName:  valManager,
+						keyImage: valControllerImage,
+						keyArgs:  []any{"--metrics-secure=false"},
+					},
+				},
+			})
+
+			features := detect(deployment)
+
+			Expect(features.MetricsSecure).To(HaveValue(BeFalse()))
+		})
+	})
 })

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/chart_converter_test.go
@@ -171,6 +171,7 @@ var _ = Describe("ChartConverter", func() {
 					"imagePullPolicy":  "IfNotPresent",
 					testYAMLFieldArgs: []any{
 						"--metrics-bind-address=:8443",
+						"--metrics-secure=false",
 						"--leader-elect",
 						"--custom-flag=value",
 						"--health-probe-bind-address=:8081",
@@ -218,6 +219,7 @@ var _ = Describe("ChartConverter", func() {
 			Expect(args).To(ContainElement("--leader-elect"))
 			Expect(args).To(ContainElement("--custom-flag=value"))
 			Expect(args).NotTo(ContainElement("--metrics-bind-address=:8443"))
+			Expect(args).NotTo(ContainElement("--metrics-secure=false"))
 			Expect(args).NotTo(ContainElement("--health-probe-bind-address=:8081"))
 			Expect(args).NotTo(ContainElement("--webhook-port=9443"))
 		})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -562,11 +562,15 @@ serviceAccount:
 func (f *HelmValues) addMetricsSection(buf *bytes.Buffer) {
 	port := 8443
 	enableMetrics := false
+	secure := true
 
 	if f.Extraction != nil {
 		enableMetrics = f.Extraction.Features.HasMetrics
 		if f.Extraction.Features.MetricsPort > 0 {
 			port = f.Extraction.Features.MetricsPort
+		}
+		if f.Extraction.Features.MetricsSecure != nil {
+			secure = *f.Extraction.Features.MetricsSecure
 		}
 	}
 
@@ -581,9 +585,8 @@ metrics:
 	fmt.Fprintf(buf, "  port: %d\n", port)
 	buf.WriteString(`  # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
   # Note: Metrics authn/authz needs ClusterRole access.
-  secure: true
-
 `)
+	fmt.Fprintf(buf, "  secure: %t\n\n", secure)
 }
 
 // addHealthProbeSection adds health probe configuration under the manager section

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values_test.go
@@ -98,6 +98,49 @@ var _ = Describe("HelmValues", func() {
 		})
 	})
 
+	Describe("Metrics section", func() {
+		It("should default metrics.secure to true when there is no extraction", func() {
+			values := &HelmValues{Extraction: nil}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("  secure: true"))
+		})
+
+		It("should default metrics.secure to true when the manager does not set the arg", func() {
+			values := &HelmValues{
+				Extraction: &extractor.Extraction{
+					Features: extractor.FeatureSet{
+						HasMetrics: true,
+					},
+				},
+			}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("  secure: true"))
+		})
+
+		It("should set metrics.secure to false when the manager serves plain HTTP", func() {
+			insecure := false
+			values := &HelmValues{
+				Extraction: &extractor.Extraction{
+					Features: extractor.FeatureSet{
+						HasMetrics:    true,
+						MetricsSecure: &insecure,
+					},
+				},
+			}
+			values.ProjectName = testProjectName
+
+			result := values.generateValues()
+
+			Expect(result).To(ContainSubstring("  secure: false"))
+		})
+	})
+
 	Describe("RoleNamespaces rendering", func() {
 		Context("when no roleNamespaces are detected", func() {
 			It("should not include roleNamespaces section when Extraction is nil", func() {


### PR DESCRIPTION
Fixes #5947

### The problem

A project that disables secure metrics the way the scaffolded `cmd/main.go` documents it, `--metrics-secure=false` in the manager args, got a chart whose two halves disagreed:

* `values.yaml` carried the hardcoded default `metrics.secure: true`
* the `--metrics-secure=false` arg was passed through verbatim into `manager.args`

so the rendered Deployment served plain HTTP while every template keyed off `.Values.metrics.secure` rendered for HTTPS. With `prometheus.enabled=true` the ServiceMonitor scraped `scheme: https` against an HTTP endpoint, so the scrape failed out of the box.

### The fix

The manager template already emits `--metrics-secure=false` from `.Values.metrics.secure`, and the extractor already special cases `--metrics-bind-address`, `--health-probe-bind-address`, `--webhook-port` and the cert paths. Only the extraction side was missing:

* `FeatureSet.MetricsSecure` is read from the manager container's `--metrics-secure` arg. It stays nil when the arg is absent, which leaves the chart on its secure by default value.
* `values.yaml` renders `metrics.secure` from that instead of a literal `true`.
* the arg is filtered out of the `manager.args` passthrough, so the value and the arg cannot disagree.

A bare `--metrics-secure` reads as true and a non boolean value is left alone, matching how the flag itself parses.

### Verification

Scaffolded `init --plugins go/v4`, then `edit --plugins helm/v2-alpha`, for three shapes, and rendered each with `helm template demo dist/chart --set prometheus.enabled=true`:

| manager arg | `metrics.secure` | arg in `manager.args` | manager serves | ServiceMonitor |
|---|---|---|---|---|
| none (default) | `true` | no | HTTPS | `scheme: https` |
| `--metrics-secure=false` | `false` | no | HTTP | `scheme: http` |
| `--metrics-secure=true` | `true` | no | HTTPS | `scheme: https` |

Before this change the middle row was `metrics.secure: true`, the arg present in `manager.args`, the manager on HTTP and the ServiceMonitor on `scheme: https`.

The four committed sample charts (`testdata/project-v4-with-plugins` and the three book tutorials) regenerate byte identical, since none of them set the flag.

Added unit coverage for the arg parser, for detection from the manager container (including a sidecar that sets it differently), and for the rendered `metrics.secure` default.

Reported by toddmacintyre with the root cause and the exact files, and confirmed still present on master by prash2512.
