### PR TITLE
🌱 (ci): point the alpha generate workflow at internal/cli/alpha

### DIFF
--- a/.github/workflows/test-alpha-generate.yml
+++ b/.github/workflows/test-alpha-generate.yml
@@ -3,11 +3,11 @@ name: Test Alpha Generate
 on:
   push:
     paths:
-      - 'pkg/cli/alpha/**'
+      - 'internal/cli/alpha/**'
       - '.github/workflows/test-alpha-generate.yml'
   pull_request:
     paths:
-      - 'pkg/cli/alpha/**'
+      - 'internal/cli/alpha/**'
       - '.github/workflows/test-alpha-generate.yml'
 
 permissions: {}


### PR DESCRIPTION
`.github/workflows/test-alpha-generate.yml` filters on `pkg/cli/alpha/**`. That directory does not exist. The alpha code lives in `internal/cli/alpha/`, so the filter matches nothing and the job cannot run on a code change.

Its last run was 2026-07-21, triggered by a dependabot bump of the workflow file itself, which is also the last commit at which it passed.

Ref: #5953

### About the red check on this PR

This PR edits the workflow file, so the job runs here, and it fails. That failure is #5953, a regression that reached master while this job was unable to run. The red check is the change doing its job rather than a problem with the change.

That does mean this cannot go green until #5953 is fixed. I am happy to send that fix separately, or to fold it into this PR if you would rather have the job green in a single change. Whichever order suits the release.
