### PR TITLE
🐛 (CLI): remove PROJECT during alpha generate cleanup

### DIFF
--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -102,7 +102,7 @@ func (opts *Generate) Generate() error {
 			// Ensure we clean the correct directory without shell interpolation
 			// of --output-dir (paths with metacharacters must not reach sh -c).
 			slog.Info("Cleaning directory", "dir", opts.OutputDir)
-			if err = cleanOutputDirPreservingGitAndProject(opts.OutputDir); err != nil {
+			if err = cleanOutputDirPreservingGit(opts.OutputDir); err != nil {
 				slog.Error("Cleanup failed", "error", err)
 				return fmt.Errorf("cleanup failed: %w", err)
 			}
@@ -696,16 +696,22 @@ func getWebhookResourceFlags(res resource.Resource) []string {
 	return args
 }
 
-// cleanOutputDirPreservingGitAndProject removes all top-level entries under
-// outputDir except `.git` and `PROJECT`, using Go filesystem APIs only.
-func cleanOutputDirPreservingGitAndProject(outputDir string) error {
+// cleanOutputDirPreservingGit removes all top-level entries under outputDir
+// except `.git`, using Go filesystem APIs only (no shell).
+//
+// PROJECT must be removed: alpha generate re-runs kubebuilder init, which
+// refuses when a PROJECT file already exists ("already initialized"). The
+// historical shell cleanup (rm -rf dir/* then find) already deleted PROJECT
+// via the first glob; only .git survived. Preserving PROJECT was a regression
+// from matching the old comment instead of effective behavior (#5953).
+func cleanOutputDirPreservingGit(outputDir string) error {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
 		return fmt.Errorf("read output directory %q: %w", outputDir, err)
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if name == ".git" || name == "PROJECT" {
+		if name == ".git" {
 			continue
 		}
 		path := filepath.Join(outputDir, name)

--- a/internal/cli/alpha/internal/generate_cleanup_test.go
+++ b/internal/cli/alpha/internal/generate_cleanup_test.go
@@ -64,18 +64,17 @@ var _ = Describe("generate: cleanup-helpers", func() {
 			Expect(os.WriteFile(filepath.Join(tmpDir, "file;rm -rf.x"), []byte("y"), 0o644)).To(Succeed())
 		})
 
-		It("preserves .git contents and PROJECT while removing other top-level entries", func() {
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf(".git", "PROJECT"))
+		// Effective pre-#5920 cleanup (rm -rf dir/* then find) removed PROJECT.
+		// Only .git must survive so kubebuilder init can re-scaffold.
+		It("preserves .git contents and removes PROJECT and other top-level entries", func() {
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 
 			head, err := os.ReadFile(filepath.Join(tmpDir, ".git", "HEAD"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(head)).To(Equal("ref: refs/heads/main\n"))
 
-			project, err := os.ReadFile(filepath.Join(tmpDir, "PROJECT"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(project)).To(Equal("version: 3\n"))
-
+			Expect(filepath.Join(tmpDir, "PROJECT")).NotTo(BeAnExistingFile())
 			Expect(filepath.Join(tmpDir, "cmd")).NotTo(BeADirectory())
 			Expect(filepath.Join(tmpDir, "Makefile")).NotTo(BeAnExistingFile())
 			Expect(filepath.Join(tmpDir, ".gitignore")).NotTo(BeAnExistingFile())
@@ -86,58 +85,57 @@ var _ = Describe("generate: cleanup-helpers", func() {
 	})
 
 	Context("when the output directory only has preserved entries", func() {
-		It("succeeds and leaves .git and PROJECT untouched when both exist", func() {
+		It("succeeds and leaves .git untouched while removing PROJECT", func() {
 			Expect(os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(tmpDir, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(tmpDir, "PROJECT"), []byte("version: 3\n"), 0o644)).To(Succeed())
 
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf(".git", "PROJECT"))
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 			head, err := os.ReadFile(filepath.Join(tmpDir, ".git", "HEAD"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(head)).To(Equal("ref: refs/heads/main\n"))
-			content, err := os.ReadFile(filepath.Join(tmpDir, "PROJECT"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("version: 3\n"))
+			Expect(filepath.Join(tmpDir, "PROJECT")).NotTo(BeAnExistingFile())
 		})
 
-		It("succeeds when only PROJECT exists", func() {
+		It("removes PROJECT when it is the only top-level entry", func() {
 			Expect(os.WriteFile(filepath.Join(tmpDir, "PROJECT"), []byte("version: 3\n"), 0o644)).To(Succeed())
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf("PROJECT"))
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(BeEmpty())
 		})
 
 		It("succeeds when only .git exists", func() {
 			Expect(os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755)).To(Succeed())
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
 			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 		})
 	})
 
 	Context("when the output directory is empty", func() {
 		It("succeeds without error", func() {
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
 			Expect(entryNames(tmpDir)).To(BeEmpty())
 		})
 	})
 
 	Context("when nested content exists under a removable directory", func() {
-		It("removes the directory tree with RemoveAll", func() {
+		It("removes the directory tree with RemoveAll including PROJECT", func() {
 			nested := filepath.Join(tmpDir, "api", "v1", "types.go")
 			Expect(os.MkdirAll(filepath.Dir(nested), 0o755)).To(Succeed())
 			Expect(os.WriteFile(nested, []byte("package v1\n"), 0o644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(tmpDir, "PROJECT"), []byte("version: 3\n"), 0o644)).To(Succeed())
 
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf("PROJECT"))
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(BeEmpty())
 			Expect(filepath.Join(tmpDir, "api")).NotTo(BeADirectory())
+			Expect(filepath.Join(tmpDir, "PROJECT")).NotTo(BeAnExistingFile())
 		})
 	})
 
 	Context("when the output directory cannot be read", func() {
 		It("returns an error for a non-existent path", func() {
 			missing := filepath.Join(tmpDir, "does-not-exist")
-			err := cleanOutputDirPreservingGitAndProject(missing)
+			err := cleanOutputDirPreservingGit(missing)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("read output directory"))
 			Expect(err.Error()).To(ContainSubstring(missing))


### PR DESCRIPTION
## Summary

`kubebuilder alpha generate` has been broken on master since #5920 with:

```text
Error: failed to initialize project: already initialized
```

**Root cause:** #5920 replaced the shell cleanup with pure Go (good: no shell injection) but preserved top-level `PROJECT` to match a comment. The old sequence was effectively:

1. `rm -rf <dir>/*` — deletes `PROJECT` (not a dotfile)
2. `find … ! -name '.git' ! -name 'PROJECT'` — the PROJECT guard never protected anything

So shipped behavior was "keep only `.git`". Implementing the comment left `PROJECT` on disk; the following `kubebuilder init` refuses an existing project. After cleanup, the directory contained only `PROJECT` (see #5953).

**Fix:** Keep pure-Go `ReadDir` + `RemoveAll` cleanup and `copyFile` mode `0o644`. Stop preserving `PROJECT`. Rename helper to `cleanOutputDirPreservingGit` and document why `PROJECT` must go. Flip Ginkgo cleanup specs to match effective historical behavior.

This is fix direction (1) from #5953 (local to generate cleanup). Not a full revert of #5920 (#5955), so we keep the shell-injection fix.

Closes #5953

## Testing

```text
# Red (before production fix): cleanup-helpers specs failed — PROJECT still present
# Green:
go test ./internal/cli/alpha/internal/ -count=1 -ginkgo.focus="cleanup-helpers"
# ok

go test ./internal/cli/alpha/internal/ -count=1
# ok

make install
cp -a testdata/project-v4 /tmp/kb-alpha-repro
sed -i.bak 's#go.kubebuilder.io/v4#go.kubebuilder.io/v3#g' /tmp/kb-alpha-repro/PROJECT
(cd /tmp/kb-alpha-repro && kubebuilder alpha generate)
# exit 0; full scaffold restored (not PROJECT-only)
```

CI `Test Alpha Generate` (path filter fixed in #5954 to `internal/cli/alpha/**`) exercises the same workflow.
