### PR TITLE
🐛 Fixed `alpha generate` deleting the current working directory when `--input-dir` was used without `--output-dir`. It now regenerates the project directory it read from.

### DIFF
--- a/.github/workflows/test-alpha-generate.yml
+++ b/.github/workflows/test-alpha-generate.yml
@@ -4,16 +4,19 @@ on:
   push:
     paths:
       - 'internal/cli/alpha/**'
+      - 'hack/test/checkprojectconfig/**'
       - '.github/workflows/test-alpha-generate.yml'
   pull_request:
     paths:
       - 'internal/cli/alpha/**'
+      - 'hack/test/checkprojectconfig/**'
       - '.github/workflows/test-alpha-generate.yml'
 
 permissions: {}
-      
+
 jobs:
-  unsupported:
+  regenerate-project:
+    name: Re-scaffold testdata/project-v4 and check its config survives
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -34,13 +37,6 @@ jobs:
       - name: Install dependencies and generate binary
         run: make install
 
-      - name: Navigate to testdata/project-v4
-        run: cd testdata/project-v4
-
-      - name: Update PROJECT file
-        run: |
-          sed -i 's#go.kubebuilder.io/v4#go.kubebuilder.io/v3#g' testdata/project-v4/PROJECT
-
       # Validate if help output is working and workaround to
       # update the PROJECT file in memory to allow upgrade
       # no longer supported layouts did not break the command options
@@ -51,9 +47,49 @@ jobs:
           else
             echo "Help output missing or invalid"
             exit 1
-          fi    
+          fi
+
+      # Keep the committed PROJECT file aside so the regenerated one can be
+      # compared against it once the command has run.
+      - name: Snapshot the original PROJECT file
+        run: |
+          mkdir -p /tmp/original
+          cp testdata/project-v4/PROJECT /tmp/original/PROJECT
+
+      # Only the layout key is rewritten. The project itself stays a v4 scaffold,
+      # which is enough to exercise reading a layout the CLI no longer supports.
+      - name: Mark the project with a layout that is no longer supported
+        run: |
+          sed -i 's#go.kubebuilder.io/v4#go.kubebuilder.io/v3#g' testdata/project-v4/PROJECT
 
       - name: Run kubebuilder alpha generate
         run: |
           cd testdata/project-v4 && kubebuilder alpha generate
 
+      # A re-scaffold must rebuild the project from the same configuration it
+      # started with. The comparison decodes both PROJECT files through the
+      # config store, so formatting and key order cannot mask a real change.
+      - name: Check the PROJECT configuration was preserved
+        run: |
+          go run ./hack/test/checkprojectconfig /tmp/original testdata/project-v4
+
+      - name: Check the layout was upgraded
+        run: |
+          if grep -q 'go.kubebuilder.io/v4' testdata/project-v4/PROJECT; then
+            echo "Layout upgraded to go.kubebuilder.io/v4"
+          else
+            echo "Layout was not upgraded"
+            cat testdata/project-v4/PROJECT
+            exit 1
+          fi
+
+      # A command that exits 0 without writing the scaffold would otherwise pass.
+      - name: Check the scaffold was written
+        run: |
+          for path in Makefile Dockerfile cmd/main.go api/v1 internal/controller config/default; do
+            if [ ! -e "testdata/project-v4/$path" ]; then
+              echo "Missing from the regenerated project: $path"
+              exit 1
+            fi
+          done
+          echo "Scaffold written"

--- a/docs/book/src/reference/commands/alpha_generate.md
+++ b/docs/book/src/reference/commands/alpha_generate.md
@@ -14,7 +14,14 @@ directory for diff-based inspection and manual integration.
 
 <aside class="warning" role="note">
     <p class="note-title">Deletes files during scaffold regeneration</p>
-When executed in-place, this command deletes all files except `.git` and `PROJECT`.
+When executed in-place, this command deletes all files except `.git`. Any file that is not part of the
+scaffold, including your own code, is removed and only comes back if you restore it yourself.
+
+Two things are carried across. Your [PROJECT][project-config] file is read before the cleanup, so the
+project configuration is preserved and the new scaffold writes it again from that configuration. Expect
+it to change when the layout changes, for example when migrating from `go.kubebuilder.io/v3` to
+`go.kubebuilder.io/v4`. The license header in `hack/boilerplate.go.txt` is preserved the same way and
+reapplied to the regenerated files.
 
 Always back up your project or use version control before running this command.
 </aside>
@@ -78,8 +85,8 @@ After running the command, you can inspect the generated scaffold in the specifi
 
 | Flag            | Description                                                                 |
 |------------------|-----------------------------------------------------------------------------|
-| `--input-dir`    | Path to the directory containing the `PROJECT` file. Defaults to CWD. Deletes all files except `.git` and `PROJECT`. |
-| `--output-dir`   | Directory where the new scaffold is written. If unset, re-scaffolds in-place. |
+| `--input-dir`    | Path to the directory containing the `PROJECT` file. Defaults to CWD.       |
+| `--output-dir`   | Directory where the new scaffold is written. If unset, re-scaffolds in-place in the input directory, which is cleaned first: all files except `.git` are deleted. |
 | `--plugins`      | Plugin keys to use for this generation.                                     |
 | `-h, --help`     | Show help for this command.                                                 |
 

--- a/hack/test/checkprojectconfig/main.go
+++ b/hack/test/checkprojectconfig/main.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// PROJECT config comparer checks that `alpha generate` rebuilt a project from the
+// same configuration it started with. It loads both PROJECT files through the
+// config store and compares the decoded values, so key order and formatting in
+// the file cannot make the check pass or fail on their own.
+//
+// Resources are compared as a set. The scaffold replays them in the order the
+// config lists them, which need not match how the original project was built.
+//
+// Run with:
+//   go run ./hack/test/checkprojectconfig <original-project-dir> <regenerated-project-dir>
+
+package main
+
+import (
+	"fmt"
+	log "log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/afero"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/config/store/yaml"
+	_ "sigs.k8s.io/kubebuilder/v4/pkg/config/v3" // registers project version 3 so the store can decode PROJECT
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/model/resource"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		log.Error("usage: checkprojectconfig <original-project-dir> <regenerated-project-dir>")
+		os.Exit(1)
+	}
+
+	original, err := loadConfig(os.Args[1])
+	if err != nil {
+		log.Error("failed to load the original PROJECT file", "error", err)
+		os.Exit(1)
+	}
+
+	regenerated, err := loadConfig(os.Args[2])
+	if err != nil {
+		log.Error("failed to load the regenerated PROJECT file", "error", err)
+		os.Exit(1)
+	}
+
+	diffs, err := compare(original, regenerated)
+	if err != nil {
+		log.Error("failed to compare the PROJECT files", "error", err)
+		os.Exit(1)
+	}
+
+	if len(diffs) > 0 {
+		log.Error("alpha generate did not preserve the project configuration")
+		for _, diff := range diffs {
+			fmt.Fprintf(os.Stderr, "  - %s\n", diff)
+		}
+		os.Exit(1)
+	}
+
+	resources, err := original.GetResources()
+	if err != nil {
+		log.Error("failed to read resources", "error", err)
+		os.Exit(1)
+	}
+
+	log.Info("PROJECT configuration preserved by alpha generate", "resources", len(resources))
+}
+
+func loadConfig(dir string) (config.Config, error) {
+	store := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})
+	if err := store.LoadFrom(filepath.Join(dir, yaml.DefaultPath)); err != nil {
+		return nil, fmt.Errorf("failed to load the PROJECT file under %q: %w", dir, err)
+	}
+
+	return store.Config(), nil
+}
+
+func compare(original, regenerated config.Config) ([]string, error) {
+	var diffs []string
+
+	scalar := func(name, want, got string) {
+		if want != got {
+			diffs = append(diffs, fmt.Sprintf("%s: expected %q, got %q", name, want, got))
+		}
+	}
+
+	scalar("domain", original.GetDomain(), regenerated.GetDomain())
+	scalar("repository", original.GetRepository(), regenerated.GetRepository())
+	scalar("projectName", original.GetProjectName(), regenerated.GetProjectName())
+	scalar("version", original.GetVersion().String(), regenerated.GetVersion().String())
+	scalar("layout", strings.Join(original.GetPluginChain(), ","),
+		strings.Join(regenerated.GetPluginChain(), ","))
+
+	if original.IsMultiGroup() != regenerated.IsMultiGroup() {
+		diffs = append(diffs, fmt.Sprintf("multigroup: expected %t, got %t",
+			original.IsMultiGroup(), regenerated.IsMultiGroup()))
+	}
+
+	originalResources, err := original.GetResources()
+	if err != nil {
+		return nil, fmt.Errorf("read resources from the original PROJECT file: %w", err)
+	}
+
+	regeneratedResources, err := regenerated.GetResources()
+	if err != nil {
+		return nil, fmt.Errorf("read resources from the regenerated PROJECT file: %w", err)
+	}
+
+	return append(diffs, compareResources(originalResources, regeneratedResources)...), nil
+}
+
+func compareResources(original, regenerated []resource.Resource) []string {
+	want := resourceKeys(original)
+	got := resourceKeys(regenerated)
+
+	var diffs []string
+	for key := range want {
+		if _, ok := got[key]; !ok {
+			diffs = append(diffs, "resource missing after regeneration: "+key)
+		}
+	}
+	for key := range got {
+		if _, ok := want[key]; !ok {
+			diffs = append(diffs, "unexpected resource after regeneration: "+key)
+		}
+	}
+	slices.Sort(diffs)
+
+	return diffs
+}
+
+// resourceKeys renders each resource as a single comparable string so resources
+// can be matched regardless of the order they appear in the config.
+func resourceKeys(resources []resource.Resource) map[string]struct{} {
+	keys := make(map[string]struct{}, len(resources))
+	for _, res := range resources {
+		key := fmt.Sprintf("%s/%s/%s controller=%t webhooks=%s",
+			res.Group, res.Version, res.Kind, res.Controller, webhooks(res))
+		keys[key] = struct{}{}
+	}
+
+	return keys
+}
+
+func webhooks(res resource.Resource) string {
+	if res.Webhooks == nil || res.Webhooks.IsEmpty() {
+		return "none"
+	}
+
+	var enabled []string
+	if res.Webhooks.Defaulting {
+		enabled = append(enabled, "defaulting")
+	}
+	if res.Webhooks.Validation {
+		enabled = append(enabled, "validation")
+	}
+	if res.Webhooks.Conversion {
+		enabled = append(enabled, "conversion")
+	}
+	if len(enabled) == 0 {
+		return "none"
+	}
+	slices.Sort(enabled)
+
+	return strings.Join(enabled, "+")
+}

--- a/internal/cli/alpha/generate.go
+++ b/internal/cli/alpha/generate.go
@@ -48,9 +48,12 @@ defined in the PROJECT file, using the latest installed Kubebuilder version and 
 
 This is useful for migrating a project to a newer Kubebuilder layout or plugin version, such as from v3 to v4.
 
-If no output directory is provided, the current working directory will be cleaned (except .git and PROJECT).`,
+If no output directory is provided, the project is re-scaffolded in place, in the input directory
+(the current working directory unless --input-dir is set). That directory is cleaned first and only
+.git is kept. The PROJECT file is read before the cleanup, and the new scaffold writes it again from
+that configuration.`,
 		Example: `
-  # **WARNING**: will delete all files except .git and PROJECT
+  # **WARNING**: will delete all files except .git
   # Re-scaffold the current project in-place
   kubebuilder alpha generate
 
@@ -70,12 +73,12 @@ If no output directory is provided, the current working directory will be cleane
 
 	scaffoldCmd.Flags().StringVar(&opts.InputDir, "input-dir", "",
 		"Path to the directory containing the PROJECT file (e.g., ./my-project). "+
-			"Defaults to the current working directory if unset. "+
-			"WARNING: deletes existing files except .git and PROJECT")
+			"Defaults to the current working directory if unset")
 
 	scaffoldCmd.Flags().StringVar(&opts.OutputDir, "output-dir", "",
 		"Directory where the new project scaffold will be written. "+
-			"If unset, re-scaffolding occurs in-place and deletes existing files except .git and PROJECT")
+			"If unset, re-scaffolding occurs in-place in the input directory, "+
+			"which is cleaned first. WARNING: deletes existing files except .git")
 
 	scaffoldCmd.Flags().BoolVar(&opts.SkipGoVersionCheck, "skip-go-version-check", true,
 		"Skip the Go version check during project generation "+

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -89,20 +89,20 @@ func (opts *Generate) Generate() error {
 		slog.Info("Preserving existing license header file for regeneration")
 	}
 
-	if opts.OutputDir == "" {
-		cwd, getWdErr := os.Getwd()
-		if getWdErr != nil {
-			return fmt.Errorf("failed to get working directory: %w", getWdErr)
-		}
-		opts.OutputDir = cwd
-		if _, err = os.Stat(opts.OutputDir); err == nil {
-			slog.Warn("Using current working directory to re-scaffold the project")
+	inPlace := opts.OutputDir == ""
+	if opts.OutputDir, err = resolveOutputDir(opts.InputDir, opts.OutputDir); err != nil {
+		return err
+	}
+
+	if inPlace {
+		if _, statErr := os.Stat(opts.OutputDir); statErr == nil {
+			slog.Warn("Re-scaffolding the project in place", "dir", opts.OutputDir)
 			slog.Warn("This directory will be cleaned up and all files removed before the re-generation")
 
 			// Ensure we clean the correct directory without shell interpolation
 			// of --output-dir (paths with metacharacters must not reach sh -c).
 			slog.Info("Cleaning directory", "dir", opts.OutputDir)
-			if err = cleanOutputDirPreservingGitAndProject(opts.OutputDir); err != nil {
+			if err = cleanOutputDirPreservingGit(opts.OutputDir); err != nil {
 				slog.Error("Cleanup failed", "error", err)
 				return fmt.Errorf("cleanup failed: %w", err)
 			}
@@ -696,16 +696,36 @@ func getWebhookResourceFlags(res resource.Resource) []string {
 	return args
 }
 
-// cleanOutputDirPreservingGitAndProject removes all top-level entries under
-// outputDir except `.git` and `PROJECT`, using Go filesystem APIs only.
-func cleanOutputDirPreservingGitAndProject(outputDir string) error {
+// resolveOutputDir returns the directory the new scaffold is written to.
+// With --output-dir unset the project is regenerated in place, which means the
+// directory it was read from. Falling back to the working directory here would
+// clean an unrelated tree whenever --input-dir points elsewhere.
+func resolveOutputDir(inputDir, outputDir string) (string, error) {
+	if outputDir != "" {
+		return outputDir, nil
+	}
+	if inputDir != "" {
+		return inputDir, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %w", err)
+	}
+	return cwd, nil
+}
+
+// cleanOutputDirPreservingGit removes all top-level entries under outputDir
+// except `.git`, using Go filesystem APIs only.
+// PROJECT must go too: `kubebuilder init` refuses to run when a config file is
+// already present, and it re-creates PROJECT from the config loaded in memory.
+func cleanOutputDirPreservingGit(outputDir string) error {
 	entries, err := os.ReadDir(outputDir)
 	if err != nil {
 		return fmt.Errorf("read output directory %q: %w", outputDir, err)
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if name == ".git" || name == "PROJECT" {
+		if name == ".git" {
 			continue
 		}
 		path := filepath.Join(outputDir, name)

--- a/internal/cli/alpha/internal/generate_cleanup_test.go
+++ b/internal/cli/alpha/internal/generate_cleanup_test.go
@@ -64,17 +64,16 @@ var _ = Describe("generate: cleanup-helpers", func() {
 			Expect(os.WriteFile(filepath.Join(tmpDir, "file;rm -rf.x"), []byte("y"), 0o644)).To(Succeed())
 		})
 
-		It("preserves .git contents and PROJECT while removing other top-level entries", func() {
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf(".git", "PROJECT"))
+		It("preserves .git contents while removing every other top-level entry", func() {
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 
 			head, err := os.ReadFile(filepath.Join(tmpDir, ".git", "HEAD"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(head)).To(Equal("ref: refs/heads/main\n"))
 
-			project, err := os.ReadFile(filepath.Join(tmpDir, "PROJECT"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(project)).To(Equal("version: 3\n"))
+			// init refuses to run when PROJECT still exists, so it must be removed.
+			Expect(filepath.Join(tmpDir, "PROJECT")).NotTo(BeAnExistingFile())
 
 			Expect(filepath.Join(tmpDir, "cmd")).NotTo(BeADirectory())
 			Expect(filepath.Join(tmpDir, "Makefile")).NotTo(BeAnExistingFile())
@@ -85,38 +84,35 @@ var _ = Describe("generate: cleanup-helpers", func() {
 		})
 	})
 
-	Context("when the output directory only has preserved entries", func() {
-		It("succeeds and leaves .git and PROJECT untouched when both exist", func() {
+	Context("when the output directory only has .git and PROJECT", func() {
+		It("leaves .git untouched and removes PROJECT", func() {
 			Expect(os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(tmpDir, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(tmpDir, "PROJECT"), []byte("version: 3\n"), 0o644)).To(Succeed())
 
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf(".git", "PROJECT"))
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 			head, err := os.ReadFile(filepath.Join(tmpDir, ".git", "HEAD"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(head)).To(Equal("ref: refs/heads/main\n"))
-			content, err := os.ReadFile(filepath.Join(tmpDir, "PROJECT"))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(string(content)).To(Equal("version: 3\n"))
 		})
 
 		It("succeeds when only PROJECT exists", func() {
 			Expect(os.WriteFile(filepath.Join(tmpDir, "PROJECT"), []byte("version: 3\n"), 0o644)).To(Succeed())
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf("PROJECT"))
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(BeEmpty())
 		})
 
 		It("succeeds when only .git exists", func() {
 			Expect(os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755)).To(Succeed())
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
 			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 		})
 	})
 
 	Context("when the output directory is empty", func() {
 		It("succeeds without error", func() {
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
 			Expect(entryNames(tmpDir)).To(BeEmpty())
 		})
 	})
@@ -126,10 +122,10 @@ var _ = Describe("generate: cleanup-helpers", func() {
 			nested := filepath.Join(tmpDir, "api", "v1", "types.go")
 			Expect(os.MkdirAll(filepath.Dir(nested), 0o755)).To(Succeed())
 			Expect(os.WriteFile(nested, []byte("package v1\n"), 0o644)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(tmpDir, "PROJECT"), []byte("version: 3\n"), 0o644)).To(Succeed())
+			Expect(os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755)).To(Succeed())
 
-			Expect(cleanOutputDirPreservingGitAndProject(tmpDir)).To(Succeed())
-			Expect(entryNames(tmpDir)).To(ConsistOf("PROJECT"))
+			Expect(cleanOutputDirPreservingGit(tmpDir)).To(Succeed())
+			Expect(entryNames(tmpDir)).To(ConsistOf(".git"))
 			Expect(filepath.Join(tmpDir, "api")).NotTo(BeADirectory())
 		})
 	})
@@ -137,10 +133,41 @@ var _ = Describe("generate: cleanup-helpers", func() {
 	Context("when the output directory cannot be read", func() {
 		It("returns an error for a non-existent path", func() {
 			missing := filepath.Join(tmpDir, "does-not-exist")
-			err := cleanOutputDirPreservingGitAndProject(missing)
+			err := cleanOutputDirPreservingGit(missing)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("read output directory"))
 			Expect(err.Error()).To(ContainSubstring(missing))
+		})
+	})
+
+	Context("when resolving the output directory", func() {
+		It("uses --output-dir when it is set", func() {
+			dir, err := resolveOutputDir("/some/input", "/some/output")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dir).To(Equal("/some/output"))
+		})
+
+		It("regenerates in the input directory when --output-dir is unset", func() {
+			dir, err := resolveOutputDir("/some/input", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dir).To(Equal("/some/input"))
+		})
+
+		It("never falls back to the working directory when --input-dir points elsewhere", func() {
+			cwd, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			dir, err := resolveOutputDir(tmpDir, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dir).To(Equal(tmpDir))
+			Expect(dir).NotTo(Equal(cwd))
+		})
+
+		It("uses the working directory when both are unset", func() {
+			cwd, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			dir, err := resolveOutputDir("", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dir).To(Equal(cwd))
 		})
 	})
 })


### PR DESCRIPTION
This PR fixes two bugs in `alpha generate` (a regression not released and within a bug )

## Fixes

### 1. Wrong directory deleted

When `--output-dir` was unset, the command cleaned the current working directory, even when `--input-dir` pointed to a different project.

The command now regenerates the project directory it read from.

### 2. `already initialized` error

The cleanup step preserved the `PROJECT` file, but `kubebuilder init` refuses to run when that file already exists.

The `PROJECT` file is now removed during cleanup, as it was before #5920, and then rewritten using the configuration loaded before cleanup.

## Impact

| Bug | Introduced by | Present in v4.15.0? |
| --- | --- | --- |
| `--input-dir` deletes the current working directory | #4500 | Yes |
| `already initialized` error | #5920 | No |

Only the first bug reached users, so only that fix is included in the release notes. The second bug is a regression fix for unreleased code.

## Documentation

The documentation and help text previously stated that both `.git` and `PROJECT` survive an in-place regeneration. In practice, only `.git` is preserved. The documentation and help text have been corrected accordingly.

## CI coverage

This PR adds a CI check to verify that the regenerated `PROJECT` file retains the same configuration.

Previously, the job checked only the command's exit code, and its path filter referenced a directory that no longer exists. As a result, the job did not catch the regression introduced by #5920 before it reached `master`.

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/5953

