### PR TITLE
🐛 (helm/v2-alpha): Expose webhook admission settings

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -29,7 +29,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -17,6 +17,19 @@ webhooks:
       path: /mutate-batch-tutorial-kubebuilder-io-v1-cronjob
   failurePolicy: Fail
   name: mcronjob-v1.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -29,7 +29,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -17,6 +17,19 @@ webhooks:
       path: /validate-batch-tutorial-kubebuilder-io-v1-cronjob
   failurePolicy: Fail
   name: vcronjob-v1.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -178,6 +178,13 @@ webhook:
   enabled: true
   # Webhook server port
   port: 9443
+  # Optional namespace and object selectors. Empty values do not filter requests.
+  namespaceSelector: {}
+  objectSelector: {}
+  # Optional CEL admission conditions.
+  matchConditions: []
+  # Maximum time in seconds the webhook has to respond.
+  timeoutSeconds: 10
 
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -17,6 +17,19 @@ webhooks:
       path: /mutate-batch-tutorial-kubebuilder-io-v1-cronjob
   failurePolicy: Fail
   name: mcronjob-v1.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io
@@ -37,6 +50,19 @@ webhooks:
       path: /mutate-batch-tutorial-kubebuilder-io-v2-cronjob
   failurePolicy: Fail
   name: mcronjob-v2.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -29,7 +29,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io
@@ -62,7 +64,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -17,6 +17,19 @@ webhooks:
       path: /validate-batch-tutorial-kubebuilder-io-v1-cronjob
   failurePolicy: Fail
   name: vcronjob-v1.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io
@@ -37,6 +50,19 @@ webhooks:
       path: /validate-batch-tutorial-kubebuilder-io-v2-cronjob
   failurePolicy: Fail
   name: vcronjob-v2.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -29,7 +29,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io
@@ -62,7 +64,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - batch.tutorial.kubebuilder.io

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -178,6 +178,13 @@ webhook:
   enabled: true
   # Webhook server port
   port: 9443
+  # Optional namespace and object selectors. Empty values do not filter requests.
+  namespaceSelector: {}
+  objectSelector: {}
+  # Optional CEL admission conditions.
+  matchConditions: []
+  # Maximum time in seconds the webhook has to respond.
+  timeoutSeconds: 10
 
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -259,6 +259,30 @@ helm install my-operator ./dist/chart --set webhook.port=9444
 
 The default is `9443`, detected from your project configuration.
 
+### Webhook admission configuration
+
+The chart exposes admission webhook filters through `webhook` values. Empty selectors and
+conditions preserve the default Kubernetes behavior:
+
+```yaml
+webhook:
+  namespaceSelector:
+    matchLabels:
+      webhook: enabled
+  objectSelector:
+    matchLabels:
+      managed-by: my-operator
+  matchConditions:
+  - name: skip-system-users
+    expression: 'request.userInfo.username != "system:admin"'
+  timeoutSeconds: 15
+```
+
+These values are applied to the generated mutating and validating webhook configurations.
+For namespace-scoped managers, use `namespaceSelector` or `objectSelector` to keep webhook
+requests aligned with the namespaces watched by the manager. Values already supplied through
+the controller-tools webhook `patch` marker remain unchanged in the generated chart.
+
 ### Health probe port configuration
 
 Set `manager.healthProbe.port` to change the port where the manager serves its health probes. The liveness (`/healthz`) and readiness (`/readyz`) endpoints bind to this port. The chart applies the same value to the `--health-probe-bind-address` argument, the `health` container port, and the `httpGet` port of both probes.

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook.go
@@ -16,39 +16,95 @@ limitations under the License.
 
 package appliers
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // TemplateWebhookConfiguration exposes admission webhook settings through Helm values.
 // Fields already present in the Kustomize output are left untouched so that webhook patch
 // markers remain authoritative for projects that have configured them explicitly.
 func TemplateWebhookConfiguration(yamlContent string) string {
-	const webhookRule = "  rules:\n"
-	if !strings.Contains(yamlContent, "webhooks:\n") || !strings.Contains(yamlContent, webhookRule) {
+	lines := strings.Split(yamlContent, "\n")
+	webhooksIndex := slices.Index(lines, "webhooks:")
+	if webhooksIndex == -1 || webhooksIndex+1 >= len(lines) || !isWebhookItem(lines[webhooksIndex+1]) {
 		return yamlContent
 	}
 
-	var additions strings.Builder
-	if !strings.Contains(yamlContent, "  namespaceSelector:") {
-		additions.WriteString("  {{- with .Values.webhook.namespaceSelector }}\n")
-		additions.WriteString("  namespaceSelector:\n")
-		additions.WriteString("    {{- toYaml . | nindent 4 }}\n")
-		additions.WriteString("  {{- end }}\n")
-	}
-	if !strings.Contains(yamlContent, "  objectSelector:") {
-		additions.WriteString("  {{- with .Values.webhook.objectSelector }}\n")
-		additions.WriteString("  objectSelector:\n")
-		additions.WriteString("    {{- toYaml . | nindent 4 }}\n")
-		additions.WriteString("  {{- end }}\n")
-	}
-	if !strings.Contains(yamlContent, "  matchConditions:") {
-		additions.WriteString("  {{- with .Values.webhook.matchConditions }}\n")
-		additions.WriteString("  matchConditions:\n")
-		additions.WriteString("    {{- toYaml . | nindent 4 }}\n")
-		additions.WriteString("  {{- end }}\n")
-	}
-	if !strings.Contains(yamlContent, "  timeoutSeconds:") {
-		additions.WriteString("  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}\n")
+	result := append([]string{}, lines[:webhooksIndex+1]...)
+	for itemStart := webhooksIndex + 1; itemStart < len(lines) && isWebhookItem(lines[itemStart]); {
+		itemEnd := itemStart + 1
+		for itemEnd < len(lines) && (strings.HasPrefix(lines[itemEnd], " ") || lines[itemEnd] == "") {
+			itemEnd++
+		}
+
+		result = append(result, templateWebhookItem(lines[itemStart:itemEnd])...)
+		if itemEnd >= len(lines) || !isWebhookItem(lines[itemEnd]) {
+			result = append(result, lines[itemEnd:]...)
+			break
+		}
+		itemStart = itemEnd
 	}
 
-	return strings.ReplaceAll(yamlContent, webhookRule, additions.String()+webhookRule)
+	return strings.Join(result, "\n")
+}
+
+func isWebhookItem(line string) bool {
+	return strings.HasPrefix(line, "- ")
+}
+
+func templateWebhookItem(lines []string) []string {
+	rulesIndex := slices.Index(lines, "  rules:")
+	if rulesIndex == -1 {
+		return lines
+	}
+
+	var additions []string
+	if !hasWebhookField(lines, "namespaceSelector") {
+		additions = append(additions,
+			"  {{- with .Values.webhook.namespaceSelector }}",
+			"  namespaceSelector:",
+			"    {{- toYaml . | nindent 4 }}",
+			"  {{- end }}",
+		)
+	}
+	if !hasWebhookField(lines, "objectSelector") {
+		additions = append(additions,
+			"  {{- with .Values.webhook.objectSelector }}",
+			"  objectSelector:",
+			"    {{- toYaml . | nindent 4 }}",
+			"  {{- end }}",
+		)
+	}
+	if !hasWebhookField(lines, "matchConditions") {
+		additions = append(additions,
+			"  {{- with .Values.webhook.matchConditions }}",
+			"  matchConditions:",
+			"    {{- toYaml . | nindent 4 }}",
+			"  {{- end }}",
+		)
+	}
+	if !hasWebhookField(lines, "timeoutSeconds") {
+		additions = append(additions,
+			"  {{ with .Values.webhook.timeoutSeconds }}",
+			"  timeoutSeconds: {{ . }}",
+			"  {{ end }}",
+		)
+	}
+
+	result := make([]string, 0, len(lines)+len(additions))
+	result = append(result, lines[:rulesIndex]...)
+	result = append(result, additions...)
+	result = append(result, lines[rulesIndex:]...)
+	return result
+}
+
+func hasWebhookField(lines []string, field string) bool {
+	prefix := "  " + field + ":"
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appliers
+
+import "strings"
+
+// TemplateWebhookConfiguration exposes admission webhook settings through Helm values.
+// Fields already present in the Kustomize output are left untouched so that webhook patch
+// markers remain authoritative for projects that have configured them explicitly.
+func TemplateWebhookConfiguration(yamlContent string) string {
+	const webhookRule = "  rules:\n"
+	if !strings.Contains(yamlContent, "webhooks:\n") || !strings.Contains(yamlContent, webhookRule) {
+		return yamlContent
+	}
+
+	var additions strings.Builder
+	if !strings.Contains(yamlContent, "  namespaceSelector:") {
+		additions.WriteString("  {{- with .Values.webhook.namespaceSelector }}\n")
+		additions.WriteString("  namespaceSelector:\n")
+		additions.WriteString("    {{- toYaml . | nindent 4 }}\n")
+		additions.WriteString("  {{- end }}\n")
+	}
+	if !strings.Contains(yamlContent, "  objectSelector:") {
+		additions.WriteString("  {{- with .Values.webhook.objectSelector }}\n")
+		additions.WriteString("  objectSelector:\n")
+		additions.WriteString("    {{- toYaml . | nindent 4 }}\n")
+		additions.WriteString("  {{- end }}\n")
+	}
+	if !strings.Contains(yamlContent, "  matchConditions:") {
+		additions.WriteString("  {{- with .Values.webhook.matchConditions }}\n")
+		additions.WriteString("  matchConditions:\n")
+		additions.WriteString("    {{- toYaml . | nindent 4 }}\n")
+		additions.WriteString("  {{- end }}\n")
+	}
+	if !strings.Contains(yamlContent, "  timeoutSeconds:") {
+		additions.WriteString("  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}\n")
+	}
+
+	return strings.ReplaceAll(yamlContent, webhookRule, additions.String()+webhookRule)
+}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appliers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTemplateWebhookConfiguration(t *testing.T) {
+	content := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+webhooks:
+- name: validation.example.com
+  rules:
+  - apiGroups:
+    - example.com
+`
+
+	result := TemplateWebhookConfiguration(content)
+	for _, want := range []string{
+		".Values.webhook.namespaceSelector",
+		".Values.webhook.objectSelector",
+		".Values.webhook.matchConditions",
+		".Values.webhook.timeoutSeconds",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("expected generated template to contain %q", want)
+		}
+	}
+
+	configured := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+webhooks:
+- name: validation.example.com
+  namespaceSelector:
+    matchLabels:
+      webhook: enabled
+  rules:
+  - apiGroups:
+    - example.com
+`
+	configuredResult := TemplateWebhookConfiguration(configured)
+	if strings.Count(configuredResult, "  namespaceSelector:") != 1 {
+		t.Fatalf("expected an existing namespaceSelector to be preserved without duplication:\n%s", configuredResult)
+	}
+}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/webhook_test.go
@@ -18,32 +18,39 @@ package appliers
 
 import (
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestTemplateWebhookConfiguration(t *testing.T) {
-	content := `apiVersion: admissionregistration.k8s.io/v1
+var _ = Describe("TemplateWebhookConfiguration", func() {
+	It("templates settings for each webhook independently", func() {
+		content := `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
-- name: validation.example.com
+- name: configured.example.com
+  namespaceSelector:
+    matchLabels:
+      webhook: enabled
+  rules:
+  - apiGroups:
+    - example.com
+- name: unconfigured.example.com
   rules:
   - apiGroups:
     - example.com
 `
 
-	result := TemplateWebhookConfiguration(content)
-	for _, want := range []string{
-		".Values.webhook.namespaceSelector",
-		".Values.webhook.objectSelector",
-		".Values.webhook.matchConditions",
-		".Values.webhook.timeoutSeconds",
-	} {
-		if !strings.Contains(result, want) {
-			t.Errorf("expected generated template to contain %q", want)
-		}
-	}
+		result := TemplateWebhookConfiguration(content)
 
-	configured := `apiVersion: admissionregistration.k8s.io/v1
+		Expect(strings.Count(result, ".Values.webhook.objectSelector")).To(Equal(2))
+		Expect(strings.Count(result, ".Values.webhook.matchConditions")).To(Equal(2))
+		Expect(strings.Count(result, ".Values.webhook.timeoutSeconds")).To(Equal(2))
+		Expect(strings.Count(result, "  namespaceSelector:")).To(Equal(2))
+	})
+
+	It("does not duplicate fields supplied by a patch marker", func() {
+		content := `apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 webhooks:
 - name: validation.example.com
@@ -54,8 +61,26 @@ webhooks:
   - apiGroups:
     - example.com
 `
-	configuredResult := TemplateWebhookConfiguration(configured)
-	if strings.Count(configuredResult, "  namespaceSelector:") != 1 {
-		t.Fatalf("expected an existing namespaceSelector to be preserved without duplication:\n%s", configuredResult)
-	}
-}
+
+		result := TemplateWebhookConfiguration(content)
+
+		Expect(strings.Count(result, "  namespaceSelector:")).To(Equal(1))
+		Expect(result).To(ContainSubstring(".Values.webhook.objectSelector"))
+	})
+
+	It("omits the timeout when the value is unset", func() {
+		content := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+webhooks:
+- name: validation.example.com
+  rules:
+  - apiGroups:
+    - example.com
+`
+
+		result := TemplateWebhookConfiguration(content)
+
+		Expect(result).To(ContainSubstring("{{ with .Values.webhook.timeoutSeconds }}"))
+		Expect(result).To(ContainSubstring("timeoutSeconds: {{ . }}"))
+	})
+})

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
@@ -73,6 +73,9 @@ func (t *Templater) ApplyHelmSubstitutions(yamlContent string, resource *unstruc
 	yamlContent = appliers.SubstituteResourceNamesWithPrefix(t.detectedPrefix, t.chartName, yamlContent, resource)
 	yamlContent = appliers.AddHelmLabelsAndAnnotations(t.detectedPrefix, t.chartName, yamlContent, resource)
 	yamlContent = appliers.SubstituteRBACValues(t.detectedPrefix, t.chartName, yamlContent)
+	if resource.GetKind() == common.KindValidatingWebhook || resource.GetKind() == common.KindMutatingWebhook {
+		yamlContent = appliers.TemplateWebhookConfiguration(yamlContent)
+	}
 	if resource.GetKind() == common.KindServiceAccount {
 		yamlContent = appliers.TemplateServiceAccount(t.detectedPrefix, t.chartName, yamlContent)
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -987,6 +987,30 @@ metadata:
 			Expect(result).To(ContainSubstring("{{- if .Values.certManager.enabled }}"))
 		})
 
+		It("should expose webhook admission settings through values", func() {
+			resource := &unstructured.Unstructured{}
+			resource.SetAPIVersion("admissionregistration.k8s.io/v1")
+			resource.SetKind("ValidatingWebhookConfiguration")
+			resource.SetName("test-project-validating-webhook-configuration")
+
+			content := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: test-project-validating-webhook-configuration
+webhooks:
+- name: validation.example.com
+  rules:
+  - apiGroups:
+    - example.com`
+
+			result := templater.ApplyHelmSubstitutions(content, resource)
+
+			Expect(result).To(ContainSubstring(".Values.webhook.namespaceSelector"))
+			Expect(result).To(ContainSubstring(".Values.webhook.objectSelector"))
+			Expect(result).To(ContainSubstring(".Values.webhook.matchConditions"))
+			Expect(result).To(ContainSubstring(".Values.webhook.timeoutSeconds"))
+		})
+
 		It("should add crd.enabled conditional and resource-policy annotation for CRDs", func() {
 			crdResource := &unstructured.Unstructured{}
 			crdResource.SetAPIVersion("apiextensions.k8s.io/v1")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -618,7 +618,16 @@ webhook:
   enabled: true
   # Webhook server port
 `)
-	fmt.Fprintf(buf, "  port: %d\n\n", port)
+	fmt.Fprintf(buf, `  port: %d
+  # Optional namespace and object selectors. Empty values do not filter requests.
+  namespaceSelector: {}
+  objectSelector: {}
+  # Optional CEL admission conditions.
+  matchConditions: []
+  # Maximum time in seconds the webhook has to respond.
+  timeoutSeconds: 10
+
+`, port)
 }
 
 // indentYAML indents YAML content by 4 spaces

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -29,7 +29,9 @@ webhooks:
   matchConditions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+  {{ with .Values.webhook.timeoutSeconds }}
+  timeoutSeconds: {{ . }}
+  {{ end }}
   rules:
   - apiGroups:
     - example.com.testproject.org

--- a/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -17,6 +17,19 @@ webhooks:
       path: /validate-example-com-testproject-org-v1alpha1-memcached
   failurePolicy: Fail
   name: vmemcached-v1alpha1.kb.io
+  {{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.objectSelector }}
+  objectSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.matchConditions }}
+  matchConditions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
   rules:
   - apiGroups:
     - example.com.testproject.org

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -195,6 +195,13 @@ webhook:
   enabled: true
   # Webhook server port
   port: 9443
+  # Optional namespace and object selectors. Empty values do not filter requests.
+  namespaceSelector: {}
+  objectSelector: {}
+  # Optional CEL admission conditions.
+  matchConditions: []
+  # Maximum time in seconds the webhook has to respond.
+  timeoutSeconds: 10
 
 ## Prometheus ServiceMonitor for metrics scraping.
 ## Requires prometheus-operator to be installed in the cluster.


### PR DESCRIPTION
## Summary

- Expose webhook `namespaceSelector`, `objectSelector`, `matchConditions`, and `timeoutSeconds` through Helm values.
- Preserve webhook fields already supplied by controller-tools `patch` markers.
- Document the new Helm configuration and regenerate chart fixtures.

Fixes #5758

## Implementation

controller-tools v0.21.0 includes the webhook patch marker support from controller-tools#1339. This change keeps those Kustomize-generated fields authoritative while adding Helm value templates for fields that are not already present in the source webhook configuration.

## Validation

- `make install && make generate`
- `make lint-fix`
- `make lint`
- `make test-unit`
- `make verify-helm`
- `helm template` with custom selectors and timeout values