### PR TITLE
🐛 (CLI; alpha generate) Preserve the customised Grafana config when alpha generate runs in place

### DIFF
--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -89,6 +89,20 @@ func (opts *Generate) Generate() error {
 		slog.Info("Preserving existing license header file for regeneration")
 	}
 
+	// Save the customised Grafana config before cleanup for the same reason:
+	// in an in-place run the directory grafanaConfigMigrate reads from is
+	// cleaned first, and by migration time the file on disk is a freshly
+	// scaffolded default rather than the user's customisation.
+	var preservedGrafanaConfig []byte
+	grafanaConfigPath := filepath.Join(opts.InputDir, "grafana", "custom-metrics", "config.yaml")
+	if _, statErr := os.Stat(grafanaConfigPath); statErr == nil {
+		preservedGrafanaConfig, err = os.ReadFile(grafanaConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to read existing Grafana config file %q: %w", grafanaConfigPath, err)
+		}
+		slog.Info("Preserving existing Grafana custom metrics config for regeneration")
+	}
+
 	inPlace := opts.OutputDir == ""
 	if opts.OutputDir, err = resolveOutputDir(opts.InputDir, opts.OutputDir); err != nil {
 		return err
@@ -147,7 +161,7 @@ func (opts *Generate) Generate() error {
 		return fmt.Errorf("error creating project config: %w", err)
 	}
 
-	if err = migrateGrafanaPlugin(projectConfig, opts.InputDir, opts.OutputDir); err != nil {
+	if err = migrateGrafanaPlugin(projectConfig, opts.InputDir, opts.OutputDir, preservedGrafanaConfig); err != nil {
 		return fmt.Errorf("error migrating Grafana plugin: %w", err)
 	}
 
@@ -277,7 +291,7 @@ func kubebuilderCreate(s store.Store) error {
 }
 
 // Migrates the Grafana plugin.
-func migrateGrafanaPlugin(s store.Store, src, des string) error {
+func migrateGrafanaPlugin(s store.Store, src, des string, preservedConfig []byte) error {
 	var grafanaPlugin struct{}
 	key := plugin.GetPluginKeyForConfig(s.Config().GetPluginChain(), grafanav1alpha.Plugin{})
 	canonicalKey := plugin.KeyFor(grafanav1alpha.Plugin{})
@@ -320,7 +334,7 @@ func migrateGrafanaPlugin(s store.Store, src, des string) error {
 		return fmt.Errorf("error editing Grafana plugin: %w", err)
 	}
 
-	if err = grafanaConfigMigrate(src, des); err != nil {
+	if err = grafanaConfigMigrate(src, des, preservedConfig); err != nil {
 		return fmt.Errorf("error migrating Grafana config: %w", err)
 	}
 
@@ -751,13 +765,25 @@ func copyFile(src, des string) error {
 }
 
 // Migrates Grafana configuration files.
-func grafanaConfigMigrate(src, des string) error {
+// preservedConfig holds the content of <src>/grafana/custom-metrics/config.yaml
+// as it was before the output directory was cleaned. When src and des are the
+// same directory (an in-place regeneration), the file on disk at this point is
+// a freshly scaffolded default, so the preserved content is the one to carry
+// forward.
+func grafanaConfigMigrate(src, des string, preservedConfig []byte) error {
+	desConfig := fmt.Sprintf("%s/grafana/custom-metrics/config.yaml", des)
+	if len(preservedConfig) > 0 {
+		if err := os.WriteFile(desConfig, preservedConfig, 0o644); err != nil {
+			return fmt.Errorf("failed to write file %q: %w", desConfig, err)
+		}
+		return nil
+	}
 	grafanaConfig := fmt.Sprintf("%s/grafana/custom-metrics/config.yaml", src)
 	if _, err := os.Stat(grafanaConfig); os.IsNotExist(err) {
 		slog.Info("Grafana config file not found, skipping file migration", "path", grafanaConfig)
 		return nil // Don't fail if config files don't exist
 	}
-	return copyFile(grafanaConfig, fmt.Sprintf("%s/grafana/custom-metrics/config.yaml", des))
+	return copyFile(grafanaConfig, desConfig)
 }
 
 // Edits the project to include the Grafana plugin.

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -94,8 +94,10 @@ func (opts *Generate) Generate() error {
 	// cleaned first, and by migration time the file on disk is a freshly
 	// scaffolded default rather than the user's customisation.
 	var preservedGrafanaConfig []byte
+	var grafanaConfigExists bool
 	grafanaConfigPath := filepath.Join(opts.InputDir, "grafana", "custom-metrics", "config.yaml")
 	if _, statErr := os.Stat(grafanaConfigPath); statErr == nil {
+		grafanaConfigExists = true
 		preservedGrafanaConfig, err = os.ReadFile(grafanaConfigPath)
 		if err != nil {
 			return fmt.Errorf("failed to read existing Grafana config file %q: %w", grafanaConfigPath, err)
@@ -161,7 +163,8 @@ func (opts *Generate) Generate() error {
 		return fmt.Errorf("error creating project config: %w", err)
 	}
 
-	if err = migrateGrafanaPlugin(projectConfig, opts.InputDir, opts.OutputDir, preservedGrafanaConfig); err != nil {
+	if err = migrateGrafanaPlugin(projectConfig, opts.InputDir, opts.OutputDir,
+		preservedGrafanaConfig, grafanaConfigExists); err != nil {
 		return fmt.Errorf("error migrating Grafana plugin: %w", err)
 	}
 
@@ -291,7 +294,7 @@ func kubebuilderCreate(s store.Store) error {
 }
 
 // Migrates the Grafana plugin.
-func migrateGrafanaPlugin(s store.Store, src, des string, preservedConfig []byte) error {
+func migrateGrafanaPlugin(s store.Store, src, des string, preservedConfig []byte, preservedConfigExists bool) error {
 	var grafanaPlugin struct{}
 	key := plugin.GetPluginKeyForConfig(s.Config().GetPluginChain(), grafanav1alpha.Plugin{})
 	canonicalKey := plugin.KeyFor(grafanav1alpha.Plugin{})
@@ -334,7 +337,7 @@ func migrateGrafanaPlugin(s store.Store, src, des string, preservedConfig []byte
 		return fmt.Errorf("error editing Grafana plugin: %w", err)
 	}
 
-	if err = grafanaConfigMigrate(src, des, preservedConfig); err != nil {
+	if err = grafanaConfigMigrate(src, des, preservedConfig, preservedConfigExists); err != nil {
 		return fmt.Errorf("error migrating Grafana config: %w", err)
 	}
 
@@ -766,13 +769,15 @@ func copyFile(src, des string) error {
 
 // Migrates Grafana configuration files.
 // preservedConfig holds the content of <src>/grafana/custom-metrics/config.yaml
-// as it was before the output directory was cleaned. When src and des are the
-// same directory (an in-place regeneration), the file on disk at this point is
-// a freshly scaffolded default, so the preserved content is the one to carry
-// forward.
-func grafanaConfigMigrate(src, des string, preservedConfig []byte) error {
+// as it was before the output directory was cleaned, and preservedConfigExists
+// records whether that file was present at all: an existing empty file must be
+// restored as empty, not left as the scaffolded default. When src and des are
+// the same directory (an in-place regeneration), the file on disk at this
+// point is a freshly scaffolded default, so the preserved content is the one
+// to carry forward.
+func grafanaConfigMigrate(src, des string, preservedConfig []byte, preservedConfigExists bool) error {
 	desConfig := fmt.Sprintf("%s/grafana/custom-metrics/config.yaml", des)
-	if len(preservedConfig) > 0 {
+	if preservedConfigExists {
 		if err := os.WriteFile(desConfig, preservedConfig, 0o644); err != nil {
 			return fmt.Errorf("failed to write file %q: %w", desConfig, err)
 		}

--- a/internal/cli/alpha/internal/generate.go
+++ b/internal/cli/alpha/internal/generate.go
@@ -103,6 +103,10 @@ func (opts *Generate) Generate() error {
 			return fmt.Errorf("failed to read existing Grafana config file %q: %w", grafanaConfigPath, err)
 		}
 		slog.Info("Preserving existing Grafana custom metrics config for regeneration")
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		// Only a missing file means there is nothing to preserve. Any other
+		// error must fail the run here, before the cleanup deletes the config.
+		return fmt.Errorf("failed to check the existing Grafana config file %q: %w", grafanaConfigPath, statErr)
 	}
 
 	inPlace := opts.OutputDir == ""

--- a/internal/cli/alpha/internal/generate_integration_test.go
+++ b/internal/cli/alpha/internal/generate_integration_test.go
@@ -149,7 +149,76 @@ var _ = Describe("alpha generate", func() {
 			Expect(err).NotTo(HaveOccurred(), "missing from the regenerated project: %s", path)
 		}
 	})
+
+	// The regression these two specs guard against: the cleanup deletes the
+	// project directory before the Grafana migration copies the config, so an
+	// in-place run used to replace the user's customisation with the
+	// scaffolded default. The direct migrateGrafanaPlugin tests cannot catch
+	// that ordering, only a run through the command can.
+	It("should preserve a customised Grafana config when regenerating in place", func() {
+		configPath := scaffoldProjectWithCustomisedGrafanaConfig(kbc)
+
+		By("running alpha generate in place")
+		Expect(kbc.Regenerate()).To(Succeed())
+
+		assertGrafanaConfigPreserved(kbc, configPath)
+	})
+
+	It("should preserve a customised Grafana config with --input-dir and no --output-dir", func() {
+		configPath := scaffoldProjectWithCustomisedGrafanaConfig(kbc)
+
+		By("running alpha generate with --input-dir only")
+		Expect(kbc.Regenerate("--input-dir", kbc.Dir)).To(Succeed())
+
+		assertGrafanaConfigPreserved(kbc, configPath)
+	})
 })
+
+// grafanaSentinelConfig is a valid custom-metrics config whose metric name can
+// never appear in a freshly scaffolded default: finding it after a run proves
+// the file is the user's customisation, not a rewritten default.
+const grafanaSentinelConfig = `---
+customMetrics:
+  - metric: sentinel_survives_total
+    type: counter
+`
+
+func scaffoldProjectWithCustomisedGrafanaConfig(kbc *utils.TestContext) string {
+	GinkgoHelper()
+
+	By("scaffolding a project with the Grafana plugin")
+	err := kbc.Init(
+		"--plugins", "go/v4",
+		"--project-version", "3",
+		"--domain", kbc.Domain,
+	)
+	Expect(err).NotTo(HaveOccurred(), "Failed to initialize project")
+	Expect(kbc.Edit("--plugins", "grafana.kubebuilder.io/v1-alpha")).To(Succeed())
+
+	By("customising the Grafana custom metrics config")
+	configPath := filepath.Join(kbc.Dir, "grafana", "custom-metrics", "config.yaml")
+	Expect(os.WriteFile(configPath, []byte(grafanaSentinelConfig), 0o644)).To(Succeed())
+
+	return configPath
+}
+
+func assertGrafanaConfigPreserved(kbc *utils.TestContext, configPath string) {
+	GinkgoHelper()
+
+	By("checking the customised Grafana config survived the run")
+	preserved, err := os.ReadFile(configPath)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(preserved)).To(Equal(grafanaSentinelConfig))
+
+	// The second Grafana edit rebuilds the dashboard from the restored
+	// config, so the sentinel metric showing up there proves the preserved
+	// content actually flowed through the migration, not just back to disk.
+	By("checking the dashboard was rebuilt from the preserved config")
+	dashboard, err := os.ReadFile(
+		filepath.Join(kbc.Dir, "grafana", "custom-metrics", "custom-metrics-dashboard.json"))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(dashboard)).To(ContainSubstring("sentinel_survives_total"))
+}
 
 func loadProjectConfig(dir string) (config.Config, error) {
 	store := yaml.New(machinery.Filesystem{FS: afero.NewOsFs()})

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -991,7 +991,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("skips migration as Grafana plugin not found", func() {
 			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: grafanaPluginKey}}
 			store := &fakeStore{cfg: cfg}
-			Expect(migrateGrafanaPlugin(store, "src", "dest", nil)).To(Succeed())
+			Expect(migrateGrafanaPlugin(store, "src", "dest", nil, false)).To(Succeed())
 		})
 
 		It("returns error if decoding Grafana plugin config fails", func() {
@@ -1000,7 +1000,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 				plugins:   map[string]any{grafanaPluginKey: true},
 			}
 			store := &fakeStore{cfg: cfg}
-			Expect(migrateGrafanaPlugin(store, "src", "dest", nil)).NotTo(Succeed())
+			Expect(migrateGrafanaPlugin(store, "src", "dest", nil, false)).NotTo(Succeed())
 		})
 
 		Context("success", func() {
@@ -1022,7 +1022,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 			It("migrates Grafana plugin successfully", func() {
 				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
 				store := &fakeStore{cfg: cfg}
-				Expect(migrateGrafanaPlugin(store, src, dest, nil)).To(Succeed())
+				Expect(migrateGrafanaPlugin(store, src, dest, nil, false)).To(Succeed())
 				b, err := os.ReadFile(filepath.Join(dest, "grafana/custom-metrics/config.yaml"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(b)).To(Equal("config"))
@@ -1035,16 +1035,28 @@ var _ = Describe("generate: migrate-plugins", func() {
 				// content read before the cleanup carries the customisation.
 				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
 				store := &fakeStore{cfg: cfg}
-				Expect(migrateGrafanaPlugin(store, src, src, []byte("customised"))).To(Succeed())
+				Expect(migrateGrafanaPlugin(store, src, src, []byte("customised"), true)).To(Succeed())
 				b, err := os.ReadFile(filepath.Join(src, "grafana/custom-metrics/config.yaml"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(b)).To(Equal("customised"))
 			})
 
+			It("restores an empty config on an in-place regeneration", func() {
+				// An existing empty config.yaml is a customisation too: the
+				// user emptied it on purpose, so the restore must not leave
+				// the scaffolded default behind.
+				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
+				store := &fakeStore{cfg: cfg}
+				Expect(migrateGrafanaPlugin(store, src, src, nil, true)).To(Succeed())
+				b, err := os.ReadFile(filepath.Join(src, "grafana/custom-metrics/config.yaml"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(b).To(BeEmpty())
+			})
+
 			It("prefers the preserved config over the source file", func() {
 				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
 				store := &fakeStore{cfg: cfg}
-				Expect(migrateGrafanaPlugin(store, src, dest, []byte("customised"))).To(Succeed())
+				Expect(migrateGrafanaPlugin(store, src, dest, []byte("customised"), true)).To(Succeed())
 				b, err := os.ReadFile(filepath.Join(dest, "grafana/custom-metrics/config.yaml"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(b)).To(Equal("customised"))

--- a/internal/cli/alpha/internal/generate_test.go
+++ b/internal/cli/alpha/internal/generate_test.go
@@ -991,7 +991,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 		It("skips migration as Grafana plugin not found", func() {
 			cfg := &fakeConfig{pluginErr: &config.PluginKeyNotFoundError{Key: grafanaPluginKey}}
 			store := &fakeStore{cfg: cfg}
-			Expect(migrateGrafanaPlugin(store, "src", "dest")).To(Succeed())
+			Expect(migrateGrafanaPlugin(store, "src", "dest", nil)).To(Succeed())
 		})
 
 		It("returns error if decoding Grafana plugin config fails", func() {
@@ -1000,7 +1000,7 @@ var _ = Describe("generate: migrate-plugins", func() {
 				plugins:   map[string]any{grafanaPluginKey: true},
 			}
 			store := &fakeStore{cfg: cfg}
-			Expect(migrateGrafanaPlugin(store, "src", "dest")).NotTo(Succeed())
+			Expect(migrateGrafanaPlugin(store, "src", "dest", nil)).NotTo(Succeed())
 		})
 
 		Context("success", func() {
@@ -1022,10 +1022,32 @@ var _ = Describe("generate: migrate-plugins", func() {
 			It("migrates Grafana plugin successfully", func() {
 				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
 				store := &fakeStore{cfg: cfg}
-				Expect(migrateGrafanaPlugin(store, src, dest)).To(Succeed())
+				Expect(migrateGrafanaPlugin(store, src, dest, nil)).To(Succeed())
 				b, err := os.ReadFile(filepath.Join(dest, "grafana/custom-metrics/config.yaml"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(b)).To(Equal("config"))
+			})
+
+			It("restores the preserved config on an in-place regeneration", func() {
+				// src == dest and the file on disk holds a freshly scaffolded
+				// default: the state after cleanOutputDirPreservingGit and
+				// kubebuilderGrafanaEdit have both run. Only the preserved
+				// content read before the cleanup carries the customisation.
+				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
+				store := &fakeStore{cfg: cfg}
+				Expect(migrateGrafanaPlugin(store, src, src, []byte("customised"))).To(Succeed())
+				b, err := os.ReadFile(filepath.Join(src, "grafana/custom-metrics/config.yaml"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(b)).To(Equal("customised"))
+			})
+
+			It("prefers the preserved config over the source file", func() {
+				cfg := &fakeConfig{plugins: map[string]any{grafanaPluginKey: true}}
+				store := &fakeStore{cfg: cfg}
+				Expect(migrateGrafanaPlugin(store, src, dest, []byte("customised"))).To(Succeed())
+				b, err := os.ReadFile(filepath.Join(dest, "grafana/custom-metrics/config.yaml"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(b)).To(Equal("customised"))
 			})
 		})
 	})


### PR DESCRIPTION
Fixes #5966

**What happens today**

`alpha generate` cleans the project directory before scaffolding. In an in place run (no flags, and since #5957 also `--input-dir` without `--output-dir`) the directory that gets cleaned is the same one `grafanaConfigMigrate(src, des)` later reads from. By that time the customised `grafana/custom-metrics/config.yaml` is gone, and the first `kubebuilder edit --plugins grafana...` has already scaffolded a default at that exact path, so the migration copies the default onto itself and the run ends with the customisation silently replaced.

**The fix**

Read the config before the cleanup and write that content back during the Grafana migration, the same way `hack/boilerplate.go.txt` is already preserved across the cleanup in this function. The `config.yaml` scaffold uses `SkipFile`, so the second `kubebuilder edit` pass does not overwrite the restored file, and the dashboard JSON (scaffolded with `OverwriteFile`) is regenerated from the restored config.

When `--output-dir` points to a separate directory the behaviour is unchanged: the preserved content is identical to the source file, which is still on disk.

**Verification**

Planted a sentinel string in `grafana/custom-metrics/config.yaml` of `testdata/project-v4` (layout set to v3, grafana plugin registered in PROJECT), then ran the migration on this branch and on master (829cce5) in golang:1.26 containers, each case twice:

| case | master | this branch |
|---|---|---|
| `alpha generate` in the project dir | replaced by the default | sentinel survives |
| `alpha generate --input-dir=<proj>` (no `--output-dir`) | replaced by the default | sentinel survives |

All runs exited 0. The unrelated working directory stayed untouched in the `--input-dir` case, and `.git` survived in every run. Unit tests: two new cases cover the in place restore and the preserved content taking precedence.
