### PR TITLE
🌱 Test mixed-case and versioned import paths

### DIFF
--- a/pkg/model/resource/resource_test.go
+++ b/pkg/model/resource/resource_test.go
@@ -110,6 +110,8 @@ var _ = Describe("Resource", func() {
 			Entry("empty path (partial resource)", ""),
 			Entry("simple relative path", "api/v1"),
 			Entry("full module import path", "github.com/org/repo/api/v1"),
+			Entry("mixed-case import path", "GitHub.com/Org/Repo/api/v1"),
+			Entry("versioned domain", "gopkg.in/yaml.v3"),
 			Entry("multi-segment path with hyphen", "github.com/my-org/my-repo/api/v1"),
 			Entry("k8s core path", "k8s.io/api/core/v1"),
 		)


### PR DESCRIPTION
## Description

Add the two requested table entries covering valid mixed-case and versioned-domain Go import paths:

- `GitHub.com/Org/Repo/api/v1`
- `gopkg.in/yaml.v3`

This is test-only and does not change validation behavior.

## Motivation

The path validation table already covers common lowercase module and Kubernetes paths. These cases explicitly preserve coverage for other import paths accepted by Go's module validation.

Fixes #5970

## Testing

- `go test ./pkg/model/resource -count=1`
- `make lint-fix`
- `make test-unit`
- `make generate`
- license, sample-permissions, testdata, docs, Helm, and kube-linter verification targets
- YAML and rendered-Helm lint with the repository configurations
