### PR TITLE
✨  (helm/v2-alpha): Support custom labels/annotations on the ServiceMonitor

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
+    {{- with .Values.prometheus.labels }}
+    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.prometheus.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -185,6 +185,14 @@ webhook:
 prometheus:
   enabled: true
 
+  ## Custom ServiceMonitor labels
+  ##
+  # labels: {}
+
+  ## Custom ServiceMonitor annotations
+  ##
+  # annotations: {}
+
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
+    {{- with .Values.prometheus.labels }}
+    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.prometheus.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -185,6 +185,14 @@ webhook:
 prometheus:
   enabled: false
 
+  ## Custom ServiceMonitor labels
+  ##
+  # labels: {}
+
+  ## Custom ServiceMonitor annotations
+  ##
+  # annotations: {}
+
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
+    {{- with .Values.prometheus.labels }}
+    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.prometheus.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "project.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -185,6 +185,14 @@ webhook:
 prometheus:
   enabled: true
 
+  ## Custom ServiceMonitor labels
+  ##
+  # labels: {}
+
+  ## Custom ServiceMonitor annotations
+  ##
+  # annotations: {}
+
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -324,6 +324,8 @@ The default webhook policy allows ingress from all sources to the manager pod's 
 
 Add custom labels and annotations using `manager.labels`, `manager.annotations`, `manager.pod.labels`, and `manager.pod.annotations`. Duplicate keys from kustomize are filtered automatically.
 
+The ServiceAccount and ServiceMonitor resources support the same pattern through `serviceAccount.labels`, `serviceAccount.annotations`, `prometheus.labels`, and `prometheus.annotations`.
+
 ### ServiceAccount configuration
 
 Set `serviceAccount.enabled: true` (default) to create a ServiceAccount. Set `serviceAccount.enabled: false` to use an existing one:

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/webhooks/webhook_suitetest.go
@@ -167,6 +167,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	%s
 )
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/labels.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/labels.go
@@ -30,6 +30,8 @@ import (
 const (
 	valuesServiceAccountLabels      = ".Values.serviceAccount.labels"
 	valuesServiceAccountAnnotations = ".Values.serviceAccount.annotations"
+	valuesPrometheusLabels          = ".Values.prometheus.labels"
+	valuesPrometheusAnnotations     = ".Values.prometheus.annotations"
 )
 
 // AddHelmLabelsAndAnnotations replaces kustomize managed-by labels with Helm equivalents.
@@ -178,6 +180,20 @@ func AddStandardHelmLabels(yamlContent string, _ *unstructured.Unstructured) str
 // labels and annotations blocks Kustomize already emitted, in either order, and injects the block
 // that is missing. User-supplied values therefore always render and no metadata key is duplicated.
 func AddServiceAccountLabelsAndAnnotations(yamlContent string) string {
+	return addMetadataLabelsAndAnnotations(yamlContent, valuesServiceAccountLabels, valuesServiceAccountAnnotations)
+}
+
+// AddServiceMonitorLabelsAndAnnotations makes the ServiceMonitor metadata honor
+// .Values.prometheus.labels and .Values.prometheus.annotations, using the same merge
+// semantics as AddServiceAccountLabelsAndAnnotations.
+func AddServiceMonitorLabelsAndAnnotations(yamlContent string) string {
+	return addMetadataLabelsAndAnnotations(yamlContent, valuesPrometheusLabels, valuesPrometheusAnnotations)
+}
+
+// addMetadataLabelsAndAnnotations merges into whichever labels and annotations blocks Kustomize
+// already emitted under metadata, in either order, and injects the block that is missing.
+// User-supplied values therefore always render and no metadata key is duplicated.
+func addMetadataLabelsAndAnnotations(yamlContent, labelsValuePath, annotationsValuePath string) string {
 	lines := strings.Split(yamlContent, "\n")
 	merged := make([]string, 0, len(lines))
 
@@ -194,11 +210,11 @@ func AddServiceAccountLabelsAndAnnotations(yamlContent string) string {
 			merged = append(merged, lines[lineIndex])
 		case isMetadataMapChildHeader(lines[lineIndex], common.YamlKeyLabels, metadataIndent):
 			merged, lineIndex = mergeMetadataMapBlock(
-				merged, lines, lineIndex, common.YamlKeyLabels, valuesServiceAccountLabels)
+				merged, lines, lineIndex, common.YamlKeyLabels, labelsValuePath)
 			labelsBlockEnd = len(merged)
 		case isMetadataMapChildHeader(lines[lineIndex], common.YamlKeyAnnotations, metadataIndent):
 			merged, lineIndex = mergeMetadataMapBlock(
-				merged, lines, lineIndex, common.YamlKeyAnnotations, valuesServiceAccountAnnotations)
+				merged, lines, lineIndex, common.YamlKeyAnnotations, annotationsValuePath)
 			annotationsBlockEnd = len(merged)
 		default:
 			merged = append(merged, lines[lineIndex])
@@ -210,7 +226,9 @@ func AddServiceAccountLabelsAndAnnotations(yamlContent string) string {
 		childIndent = metadataIndent + 2
 	}
 
-	merged = injectMissingMetadataBlocks(merged, childIndent, metadataLineIndex, labelsBlockEnd, annotationsBlockEnd)
+	merged = injectMissingMetadataBlocks(
+		merged, childIndent, metadataLineIndex, labelsBlockEnd, annotationsBlockEnd,
+		labelsValuePath, annotationsValuePath)
 	return strings.Join(merged, "\n")
 }
 
@@ -240,11 +258,12 @@ func isMetadataMapChildHeader(line, mapKey string, metadataIndent int) bool {
 func injectMissingMetadataBlocks(
 	merged []string,
 	childIndent, metadataLineIndex, labelsBlockEnd, annotationsBlockEnd int,
+	labelsValuePath, annotationsValuePath string,
 ) []string {
 	labelsBlock := buildGuardedMetadataMapBlock(
-		childIndent, common.YamlKeyLabels, valuesServiceAccountLabels)
+		childIndent, common.YamlKeyLabels, labelsValuePath)
 	annotationsBlock := buildGuardedMetadataMapBlock(
-		childIndent, common.YamlKeyAnnotations, valuesServiceAccountAnnotations)
+		childIndent, common.YamlKeyAnnotations, annotationsValuePath)
 
 	switch {
 	case labelsBlockEnd >= 0 && annotationsBlockEnd < 0:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/labels_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/labels_test.go
@@ -185,6 +185,52 @@ var _ = Describe("AddServiceAccountLabelsAndAnnotations", func() {
 	})
 })
 
+// A ServiceMonitor's metadata.labels always carries the standard Helm/chart labels added by
+// AddStandardHelmLabels before this applier runs.
+const smStandardLabelsOnly = `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "test-project.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "test-project.name" . }}
+      control-plane: controller-manager`
+
+var _ = Describe("AddServiceMonitorLabelsAndAnnotations", func() {
+	It("merges .Values.prometheus.labels into metadata.labels, omitting the standard keys", func() {
+		rendered := AddServiceMonitorLabelsAndAnnotations(smStandardLabelsOnly)
+
+		Expect(countMetadataHeader(rendered, "labels:")).To(Equal(1))
+		Expect(rendered).To(ContainSubstring(valuesPrometheusLabels))
+		Expect(rendered).To(ContainSubstring(`{{- with omit . "app.kubernetes.io/managed-by" ` +
+			`"app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}`))
+	})
+
+	It("injects a guarded .Values.prometheus.annotations block since none existed", func() {
+		rendered := AddServiceMonitorLabelsAndAnnotations(smStandardLabelsOnly)
+
+		Expect(countMetadataHeader(rendered, "annotations:")).To(Equal(1))
+		Expect(rendered).To(ContainSubstring(valuesPrometheusAnnotations))
+	})
+
+	It("leaves the spec.selector.matchLabels block untouched", func() {
+		rendered := AddServiceMonitorLabelsAndAnnotations(smStandardLabelsOnly)
+
+		Expect(rendered).To(ContainSubstring(
+			"  selector:\n    matchLabels:\n      app.kubernetes.io/name: " +
+				`{{ include "test-project.name" . }}` + "\n      control-plane: controller-manager"))
+		Expect(strings.Count(rendered, valuesPrometheusLabels)).To(Equal(1))
+	})
+})
+
 // The Deployment metadata reaching AddCustomLabelsAndAnnotations depends on what config/kustomize
 // produced. The scaffold ships block-style labels on both the Deployment and pod template; edits or
 // commonAnnotations can add annotations at either scope in either order. These fixtures cover the

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater.go
@@ -91,6 +91,7 @@ func (t *Templater) ApplyHelmSubstitutions(yamlContent string, resource *unstruc
 		yamlContent = appliers.TemplatePorts(yamlContent, resource, t.detectedPrefix)
 	}
 	if resource.GetKind() == common.KindServiceMonitor {
+		yamlContent = appliers.AddServiceMonitorLabelsAndAnnotations(yamlContent)
 		yamlContent = appliers.TemplateServiceMonitor(yamlContent)
 	}
 	yamlContent = appliers.CollapseBlankLineAfterIf(yamlContent)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -570,6 +570,25 @@ metadata:
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 
+		It("should honor .Values.prometheus.labels and .Values.prometheus.annotations for ServiceMonitor", func() {
+			serviceMonitorResource := &unstructured.Unstructured{}
+			serviceMonitorResource.SetAPIVersion("monitoring.coreos.com/v1")
+			serviceMonitorResource.SetKind("ServiceMonitor")
+			serviceMonitorResource.SetName("test-project-controller-manager-metrics-monitor")
+
+			content := `apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: test-project
+  name: test-project-controller-manager-metrics-monitor`
+
+			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
+
+			Expect(result).To(ContainSubstring("{{- with .Values.prometheus.labels }}"))
+			Expect(result).To(ContainSubstring("{{- with .Values.prometheus.annotations }}"))
+		})
+
 		It("should add networkPolicy conditional for NetworkPolicy resources", func() {
 			networkPolicyResource := &unstructured.Unstructured{}
 			networkPolicyResource.SetAPIVersion("networking.k8s.io/v1")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -73,6 +73,15 @@ metadata:
     helm.sh/chart: {{ "{{ .Chart.Name }}-{{ .Chart.Version | replace \"+\" \"_\" }}" }}
     app.kubernetes.io/instance: {{ "{{ .Release.Name }}" }}
     control-plane: controller-manager
+    {{ "{{- with .Values.prometheus.labels }}" }}
+` + `    {{ "{{- with omit . \"app.kubernetes.io/managed-by\" \"app.kubernetes.io/name\" \"helm.sh/chart\" \"app.kubernetes.io/instance\" \"control-plane\" }}" }}` + "\n" + //nolint:lll
+	`    {{ "{{- toYaml . | nindent 4 }}" }}
+    {{ "{{- end }}" }}
+    {{ "{{- end }}" }}
+  {{ "{{- with .Values.prometheus.annotations }}" }}
+  annotations:
+    {{ "{{- toYaml . | nindent 4 }}" }}
+  {{ "{{- end }}" }}
   name: ` +
 	`{{ "{{ include \"%s.resourceName\" " }}` +
 	`{{ "(dict \"suffix\" \"controller-manager-metrics-monitor\" \"context\" $) }}" }}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -158,6 +158,15 @@ certManager:
 prometheus:
 `)
 	fmt.Fprintf(&buf, "  enabled: %t\n\n", prometheusEnabled)
+	buf.WriteString(`  ## Custom ServiceMonitor labels
+  ##
+  # labels: {}
+
+  ## Custom ServiceMonitor annotations
+  ##
+  # annotations: {}
+
+`)
 
 	// NetworkPolicy configuration (always present, enabled when the kustomize output provides a NetworkPolicy)
 	networkPolicyEnabled := f.Extraction != nil && f.Extraction.Features.HasNetworkPolicy

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -599,6 +599,108 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		})
 	})
 
+	// serviceMonitorDoc returns the ServiceMonitor document from a multi-document render,
+	// or "" when it was not rendered.
+	serviceMonitorDoc := func(rendered string) string {
+		for _, doc := range strings.Split(rendered, "\n---") {
+			if strings.Contains(doc, "\nkind: ServiceMonitor\n") {
+				return doc
+			}
+		}
+		return ""
+	}
+
+	Context("ServiceMonitor labels and annotations (rendered, kustomize-derived)", func() {
+		renderChart := func(setArgs ...string) string {
+			out, err := helmTemplate(createKustomizeWithServiceMonitor("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("renders user-supplied labels on the kustomize-derived ServiceMonitor", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "prometheus.enabled=true",
+				"--set", "prometheus.labels.team=platform",
+			))
+
+			Expect(sm).NotTo(BeEmpty(), "expected a ServiceMonitor manifest in the render")
+			Expect(strings.Count(sm, "labels:")).To(Equal(1),
+				"ServiceMonitor must keep a single labels: block, got:\n%s", sm)
+			Expect(sm).To(ContainSubstring("team: platform"))
+		})
+
+		It("renders user-supplied annotations on the kustomize-derived ServiceMonitor", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "prometheus.enabled=true",
+				"--set", "prometheus.annotations.example\\.com/env=staging",
+			))
+
+			Expect(sm).NotTo(BeEmpty(), "expected a ServiceMonitor manifest in the render")
+			Expect(strings.Count(sm, "annotations:")).To(Equal(1),
+				"ServiceMonitor must keep a single annotations: block, got:\n%s", sm)
+			Expect(sm).To(ContainSubstring("example.com/env: staging"))
+		})
+
+		It("does not duplicate a scaffolded label a user tries to override", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "prometheus.enabled=true",
+				"--set", "prometheus.labels.control-plane=myvalue",
+			))
+
+			Expect(sm).NotTo(BeEmpty(), "expected a ServiceMonitor manifest in the render")
+			// omit strips keys already defined by the scaffolded labels block, so
+			// the user value must not appear; only the scaffolded value remains.
+			Expect(sm).NotTo(ContainSubstring("control-plane: myvalue"),
+				"the omit guard must prevent duplicating a scaffolded label, got:\n%s", sm)
+		})
+	})
+
+	Context("ServiceMonitor labels and annotations (rendered, static fallback)", func() {
+		// No ServiceMonitor in the kustomize input — the static fallback template is scaffolded.
+		renderChart := func(setArgs ...string) string {
+			out, err := helmTemplate(createBasicKustomizeOutput("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("renders user-supplied labels on the static fallback ServiceMonitor", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "prometheus.enabled=true",
+				"--set", "prometheus.labels.team=platform",
+			))
+
+			Expect(sm).NotTo(BeEmpty(), "expected a ServiceMonitor manifest in the render")
+			Expect(strings.Count(sm, "labels:")).To(Equal(1),
+				"ServiceMonitor must keep a single labels: block, got:\n%s", sm)
+			Expect(sm).To(ContainSubstring("team: platform"))
+		})
+
+		It("renders user-supplied annotations on the static fallback ServiceMonitor", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "prometheus.enabled=true",
+				"--set", "prometheus.annotations.example\\.com/env=staging",
+			))
+
+			Expect(sm).NotTo(BeEmpty(), "expected a ServiceMonitor manifest in the render")
+			Expect(strings.Count(sm, "annotations:")).To(Equal(1),
+				"ServiceMonitor must keep a single annotations: block, got:\n%s", sm)
+			Expect(sm).To(ContainSubstring("example.com/env: staging"))
+		})
+
+		It("does not duplicate a scaffolded label a user tries to override", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "prometheus.enabled=true",
+				"--set", "prometheus.labels.control-plane=myvalue",
+			))
+
+			Expect(sm).NotTo(BeEmpty(), "expected a ServiceMonitor manifest in the render")
+			// omit strips keys already defined by the scaffolded labels block, so
+			// the user value must not appear; only the scaffolded value remains.
+			Expect(sm).NotTo(ContainSubstring("control-plane: myvalue"),
+				"the omit guard must prevent duplicating a scaffolded label, got:\n%s", sm)
+		})
+	})
+
 	Context("NetworkPolicy (rendered)", func() {
 		// networkPolicyDoc returns the NetworkPolicy document whose name ends with the given
 		// suffix from a multi-document render, or "" when it was not rendered.
@@ -2073,5 +2175,30 @@ spec:
         secret:
           secretName: my-secret
       serviceAccountName: ` + projectName + `-controller-manager
+`
+}
+
+// createKustomizeWithServiceMonitor extends createBasicKustomizeOutput with a ServiceMonitor
+// resource that carries the labels kustomize typically emits, so the kustomize-derived
+// (rather than the static fallback) ServiceMonitor template is scaffolded.
+func createKustomizeWithServiceMonitor(projectName string) string {
+	return createBasicKustomizeOutput(projectName) + `---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - path: /metrics
+    port: http
+    scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ` + projectName + `
+      control-plane: controller-manager
 `
 }

--- a/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     control-plane: controller-manager
+    {{- with .Values.prometheus.labels }}
+    {{- with omit . "app.kubernetes.io/managed-by" "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "control-plane" }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- with .Values.prometheus.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "project-v4-with-plugins.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -202,6 +202,14 @@ webhook:
 prometheus:
   enabled: false
 
+  ## Custom ServiceMonitor labels
+  ##
+  # labels: {}
+
+  ## Custom ServiceMonitor annotations
+  ##
+  # annotations: {}
+
 ## Network policies for controlling traffic flow.
 ## Enable to restrict ingress to the controller manager.
 ##


### PR DESCRIPTION
## Description

Adds support for custom labels and annotations on the `ServiceMonitor` generated by the `helm/v2-alpha` plugin, using the same `.Values.<resource>.labels` / `.Values.<resource>.annotations` pattern already used for the manager `Deployment` (`manager.labels`, `manager.annotations`) and the `ServiceAccount` (`serviceAccount.labels`, `serviceAccount.annotations`).

Fixes #5993 

## Changes

- Generalized the metadata labels/annotations merge helper in `appliers/labels.go` (previously specific to `ServiceAccount`) into a shared `addMetadataLabelsAndAnnotations` function, and added `AddServiceMonitorLabelsAndAnnotations` on top of it.
- Wired the new applier into `templater.go` so kustomize-converted `ServiceMonitor` resources get `.Values.prometheus.labels` / `.Values.prometheus.annotations` merged into their `metadata`, with existing standard Helm label keys automatically omitted to avoid duplication.
- Updated the static fallback `ServiceMonitor` template (`chart-templates/servicemonitor.go`, used when kustomize doesn't already provide one) to support the same values.
- Documented `prometheus.labels` / `prometheus.annotations` in the scaffolded `values.yaml` (`templates/values.go`).
- Updated `docs/book/src/plugins/available/helm-v2-alpha.md` to describe the new options alongside the existing `manager`/`serviceAccount` custom labels documentation.
- Regenerated helm chart testdata/doc samples via `make generate-charts`.

## Testing

- Added unit tests covering the new applier (`labels_test.go`) and end-to-end templating behavior (`templater_test.go`).
- `make lint-fix`
- `make test-unit`
- `make generate-charts` (verified regenerated `values.yaml` and `controller-manager-metrics-monitor.yaml` testdata match expectations)