### PR TITLE
🌱 (external): remove outdated TODO comment for metadata tests

### DIFF
--- a/pkg/plugins/external/external_test.go
+++ b/pkg/plugins/external/external_test.go
@@ -659,7 +659,6 @@ var _ = Describe("Run external plugin using Scaffold", func() {
 		})
 	})
 
-	// TODO(everettraven): Add tests for an external plugin setting the Metadata and Examples
 	Context("Successfully retrieving metadata and examples from external plugin", func() {
 		var (
 			pluginFileName string


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

## What this PR does

Removes an outdated TODO comment from `pkg/plugins/external/external_test.go` that was already completed.

## Why this matters

While reviewing the external plugin tests, I noticed a TODO comment at line 662 asking to "Add tests for an external plugin setting the Metadata and Examples". However, these tests were already implemented right below it (lines 663-726) covering all four subcommands:
- `init`
- `create api`
- `create webhook`
- `edit`

This is a cleanup-only change to remove the completed TODO and keep the codebase tidy.