### PR TITLE
✨ (cli): add --domain flag to create api and webhook commands

### DIFF
--- a/pkg/cli/cmd_helpers.go
+++ b/pkg/cli/cmd_helpers.go
@@ -491,9 +491,11 @@ func (factory *executionHooksFactory) preRunEFunc(
 		// Create the resource if non-nil options provided
 		var res *resource.Resource
 		if options != nil {
-			// TODO: offer a --domain flag so a fresh resource can set it directly.
-			options.Domain = cfg.GetDomain()
-			options.Domain = options.resolveDomain(cfg)
+			// Use the --domain flag if provided, otherwise resolve from config
+			if options.Domain == "" {
+				options.Domain = cfg.GetDomain()
+				options.Domain = options.resolveDomain(cfg)
+			}
 			if err := options.validate(); err != nil {
 				return fmt.Errorf("%s: failed to create resource: %w", factory.errorMessage, err)
 			}

--- a/pkg/cli/resource.go
+++ b/pkg/cli/resource.go
@@ -43,6 +43,8 @@ func bindResourceFlags(fs *pflag.FlagSet) *resourceOptions {
 	fs.StringVar(&options.Group, "group", "", "Resource Group (e.g., batch, apps)")
 	fs.StringVar(&options.Version, "version", "", "Resource Version (e.g., v1, v1beta1)")
 	fs.StringVar(&options.Kind, "kind", "", "Resource Kind (e.g., CronJob, Deployment)")
+	fs.StringVar(&options.Domain, "domain", "",
+		"Resource Domain (e.g., example.com). Overrides the project domain for this resource")
 
 	return options
 }

--- a/pkg/cli/resource_test.go
+++ b/pkg/cli/resource_test.go
@@ -159,4 +159,73 @@ var _ = Describe("resourceOptions", func() {
 			Expect(res.QualifiedGroup()).To(Equal(group + "." + externalDomain))
 		})
 	})
+
+	Context("domain flag precedence", func() {
+		const (
+			customDomain  = "custom.example.com"
+			projectDomain = "project-default.io"
+			trackedDomain = "tracked.io"
+			otherDomain   = "other.io"
+			otherGroup    = "other-group"
+			newGroup      = "new-group"
+		)
+
+		simulateCmdHelpers := func(opts *resourceOptions, cfg *cfgv3.Cfg) {
+			if opts.Domain == "" {
+				opts.Domain = cfg.GetDomain()
+				opts.Domain = opts.resolveDomain(cfg)
+			}
+		}
+
+		It("should use the --domain flag when provided, ignoring resolveDomain", func() {
+			opts := resourceOptions{GVK: resource.GVK{
+				Group: group, Domain: customDomain, Version: version, Kind: kind,
+			}}
+			cfg := &cfgv3.Cfg{Version: cfgv3.Version, Domain: projectDomain}
+			Expect(cfg.AddResource(resource.Resource{
+				GVK: resource.GVK{Group: group, Domain: trackedDomain, Version: version, Kind: kind},
+			})).To(Succeed())
+
+			simulateCmdHelpers(&opts, cfg)
+
+			Expect(opts.Domain).To(Equal(customDomain))
+			res := opts.newResource()
+			Expect(res.Domain).To(Equal(customDomain))
+			Expect(res.QualifiedGroup()).To(Equal(group + "." + customDomain))
+		})
+
+		It("should fallback to resolveDomain when --domain flag is empty", func() {
+			opts := resourceOptions{GVK: resource.GVK{
+				Group: group, Domain: "", Version: version, Kind: kind,
+			}}
+			cfg := &cfgv3.Cfg{Version: cfgv3.Version, Domain: projectDomain}
+			Expect(cfg.AddResource(resource.Resource{
+				GVK: resource.GVK{Group: group, Domain: trackedDomain, Version: version, Kind: kind},
+			})).To(Succeed())
+
+			simulateCmdHelpers(&opts, cfg)
+
+			Expect(opts.Domain).To(Equal(trackedDomain))
+			res := opts.newResource()
+			Expect(res.Domain).To(Equal(trackedDomain))
+			Expect(res.QualifiedGroup()).To(Equal(group + "." + trackedDomain))
+		})
+
+		It("should fallback to project domain when no matching resource exists", func() {
+			opts := resourceOptions{GVK: resource.GVK{
+				Group: newGroup, Domain: "", Version: version, Kind: kind,
+			}}
+			cfg := &cfgv3.Cfg{Version: cfgv3.Version, Domain: projectDomain}
+			Expect(cfg.AddResource(resource.Resource{
+				GVK: resource.GVK{Group: otherGroup, Domain: otherDomain, Version: version, Kind: kind},
+			})).To(Succeed())
+
+			simulateCmdHelpers(&opts, cfg)
+
+			Expect(opts.Domain).To(Equal(projectDomain))
+			res := opts.newResource()
+			Expect(res.Domain).To(Equal(projectDomain))
+			Expect(res.QualifiedGroup()).To(Equal(newGroup + "." + projectDomain))
+		})
+	})
 })


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

## What this PR does

Adds a `--domain` flag to `kubebuilder create api` and `kubebuilder create webhook` commands, allowing users to override the project domain for individual resources.

## Why this matters

Currently, the domain is set once during `kubebuilder init` and applies to all resources. This is problematic when:
- Creating APIs for external CRDs (e.g., `cert-manager.io`, `prometheus.io`)
- Working with multi-domain projects
- Migrating resources from different domains

Users had no way to specify a custom domain without modifying the PROJECT file or manually editing generated code.

## Changes

- **`pkg/cli/resource.go`**: Added `--domain` flag binding with clear help text
- **`pkg/cli/cmd_helpers.go`**: Updated domain resolution logic to use the flag when provided, falling back to existing behavior otherwise

## Usage Examples

```bash
# Create API with custom domain (e.g., for cert-manager)
kubebuilder create api --group cert-manager --version v1 --kind Certificate --domain cert-manager.io

# Create API with project default domain
kubebuilder create api --group apps --version v1 --kind Deployment
# Uses domain from PROJECT file

# Create webhook with custom domain
kubebuilder create webhook --group monitoring --version v1 --kind PodMonitor --domain monitoring.coreos.com --defaulting
```

