### PR TITLE
✨ (grafana/v1-alpha): improve PromQL expressions for custom metrics

### DIFF
--- a/docs/book/src/plugins/available/grafana-v1-alpha.md
+++ b/docs/book/src/plugins/available/grafana-v1-alpha.md
@@ -75,8 +75,8 @@ See an example of how to use the plugin in your project:
   - controller_runtime_reconcile_total
   - controller_runtime_reconcile_errors_total
 - Query:
-  - sum(rate(controller_runtime_reconcile_total{job="$job"}[5m])) by (instance, pod)
-  - sum(rate(controller_runtime_reconcile_errors_total{job="$job"}[5m])) by (instance, pod)
+  - sum(rate(controller_runtime_reconcile_total{job="$job", namespace="$namespace"}[5m])) by (instance, pod)
+  - sum(rate(controller_runtime_reconcile_errors_total{job="$job", namespace="$namespace"}[5m])) by (instance, pod)
 - Description:
   - Per-second rate of total reconciliation as measured over the last 5 minutes
   - Per-second rate of reconciliation errors as measured over the last 5 minutes
@@ -165,6 +165,25 @@ See an example of how to use the plugin in your project:
   - How many seconds of work has done that is in progress and has not been observed by work_duration.
 - Sample: <img width="912" src="https://github.com/kubernetes-sigs/kubebuilder/assets/18136486/081727c0-9531-4f7a-9649-87723ebc773f">
 
+### Custom metric PromQL expressions
+
+When configuring custom metrics in `grafana/custom-metrics/config.yaml`, the plugin auto-generates PromQL expressions based on the metric type. You can also provide your own `expr` to override the default.
+
+| Type | Generated PromQL | Use case |
+|------|------------------|----------|
+| `counter` | `sum(rate(METRIC{job="$job", namespace="$namespace"}[5m])) by (instance, pod)` | Monotonically increasing values (requests, errors, reconciliations) |
+| `gauge` | `avg(METRIC{job="$job", namespace="$namespace"}) by (instance, pod)` | Current state values (memory, queue depth, active workers) |
+| `histogram` | `histogram_quantile(0.90, sum by(instance, le) (rate(METRIC{job="$job", namespace="$namespace"}[5m])))` | Distribution data (latency, duration buckets) |
+
+All auto-generated expressions include `job` and `namespace` label selectors, which map to Grafana dashboard template variables. This ensures the queries work correctly in multi-tenant or multi-namespace Prometheus setups.
+
+<aside class="note" role="note">
+<p class="note-title">Multi-pod support</p>
+
+The `gauge` expression uses `avg() by (instance, pod)` so that when your controller runs with multiple replicas, the dashboard shows an aggregated view rather than a single pod's value. Similarly, `counter` uses `sum(rate())` to combine rates across all pods.
+
+</aside>
+
 ### Visualize custom metrics
 
 The Grafana plugin supports scaffolding manifests for custom metrics.
@@ -178,14 +197,14 @@ When the plugin is triggered for the first time, `grafana/custom-metrics/config.
 customMetrics:
 #  - metric: # Raw custom metric (required)
 #    type:   # Metric type: counter/gauge/histogram (required)
-#    expr:   # Prom_ql for the metric (optional)
-#    unit:   # Unit of measurement, examples: s,none,bytes,percent,etc. (optional)
+#    expr:   # Prom_ql for the metric (optional - auto-generated if omitted)
+#    unit:   # Unit of measurement, examples: s,none,bytes,percent (optional - auto-detected if omitted)
 ```
 
 #### Add custom metrics to config
 
 You can enter multiple custom metrics in the file. For each element, you need to specify the `metric` and its `type`.
-The Grafana plugin can automatically generate `expr` for visualization.
+The Grafana plugin can automatically generate `expr` and `unit` for visualization.
 Alternatively, you can provide `expr` and the plugin uses the specified one directly.
 
 ```yaml
@@ -196,7 +215,15 @@ customMetrics:
     unit: none
   - metric: memcached_operator_reconcile_time_seconds_bucket
     type: histogram
+  - metric: memcached_operator_active_workers # Gauge example
+    type: gauge
 ```
+
+The plugin auto-generates PromQL expressions based on the metric type:
+
+- **counter** → `sum(rate(memcached_operator_reconcile_total{job="$job", namespace="$namespace"}[5m])) by (instance, pod)`
+- **histogram** → `histogram_quantile(0.90, sum by(instance, le) (rate(memcached_operator_reconcile_time_seconds_bucket{job="$job", namespace="$namespace"}[5m])))`
+- **gauge** → `avg(memcached_operator_active_workers{job="$job", namespace="$namespace"}) by (instance, pod)`
 
 #### Scaffold manifest
 

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -133,16 +133,22 @@ func hasFields(item templates.CustomMetricItem) bool {
 	return false
 }
 
-// TODO: Prom_ql exprs can improved to be more pratical and applicable
+// fillMissingExpr generates practical PromQL expressions based on metric type
 func fillMissingExpr(item templates.CustomMetricItem) templates.CustomMetricItem {
 	if item.Expr == "" {
 		switch strings.ToLower(item.Type) {
 		case "counter":
+			// Use rate() for counters to show requests/errors per second
 			item.Expr = "sum(rate(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}[5m])) by (instance, pod)`
 		case "histogram":
+			// Use histogram_quantile for p90 latency
 			//nolint:lll
 			item.Expr = "histogram_quantile(0.90, sum by(instance, le) (rate(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}[5m])))`
-		default: // gauge
+		case "gauge":
+			// Gauges show current state, use avg() to handle multiple pods
+			item.Expr = "avg(" + item.Metric + `{job=\"$job\", namespace=\"$namespace\"}) by (instance, pod)`
+		default:
+			// Fallback to raw metric
 			item.Expr = item.Metric
 		}
 	}

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit_test.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit_test.go
@@ -141,7 +141,18 @@ customMetrics:
 
 			validated := validateCustomMetricItems(items)
 			Expect(validated).To(HaveLen(1))
-			Expect(validated[0].Expr).To(Equal("foo_bar"))
+			// Gauge should use avg() for multi-pod support
+			Expect(validated[0].Expr).To(ContainSubstring("avg(foo_bar"))
+			Expect(validated[0].Expr).To(ContainSubstring(`{job=\"$job\", namespace=\"$namespace\"}`))
+			Expect(validated[0].Expr).To(ContainSubstring("by (instance, pod)"))
+		})
+
+		It("should fill missing expr for unknown type with raw metric", func() {
+			// Note: validateCustomMetricItems filters out unknown types via hasFields,
+			// so we test fillMissingExpr directly here
+			item := templates.CustomMetricItem{Metric: "foo_bar", Type: "unknown"}
+			filled := fillMissingExpr(item)
+			Expect(filled.Expr).To(Equal("foo_bar"))
 		})
 
 		It("should not override existing expr", func() {
@@ -153,6 +164,55 @@ customMetrics:
 			validated := validateCustomMetricItems(items)
 			Expect(validated).To(HaveLen(1))
 			Expect(validated[0].Expr).To(Equal(customExpr))
+		})
+	})
+
+	Describe("fillMissingExpr", func() {
+		It("should generate rate expression for counter", func() {
+			item := templates.CustomMetricItem{Metric: "http_requests_total", Type: "counter"}
+			filled := fillMissingExpr(item)
+			Expect(filled.Expr).To(ContainSubstring("sum(rate(http_requests_total"))
+			Expect(filled.Expr).To(ContainSubstring(`{job=\"$job\", namespace=\"$namespace\"}[5m])`))
+			Expect(filled.Expr).To(ContainSubstring("by (instance, pod)"))
+		})
+
+		It("should generate histogram_quantile expression for histogram", func() {
+			item := templates.CustomMetricItem{Metric: "request_duration_seconds", Type: "histogram"}
+			filled := fillMissingExpr(item)
+			Expect(filled.Expr).To(ContainSubstring("histogram_quantile(0.90"))
+			Expect(filled.Expr).To(ContainSubstring("sum by(instance, le)"))
+			Expect(filled.Expr).To(ContainSubstring("rate(request_duration_seconds"))
+		})
+
+		It("should generate avg expression for gauge", func() {
+			item := templates.CustomMetricItem{Metric: "memory_usage_bytes", Type: "gauge"}
+			filled := fillMissingExpr(item)
+			Expect(filled.Expr).To(ContainSubstring("avg(memory_usage_bytes"))
+			Expect(filled.Expr).To(ContainSubstring(`{job=\"$job\", namespace=\"$namespace\"}`))
+			Expect(filled.Expr).To(ContainSubstring("by (instance, pod)"))
+		})
+
+		It("should fallback to raw metric for unknown types", func() {
+			item := templates.CustomMetricItem{Metric: "custom_metric", Type: "summary"}
+			filled := fillMissingExpr(item)
+			Expect(filled.Expr).To(Equal("custom_metric"))
+		})
+
+		It("should not override existing expression", func() {
+			customExpr := "my_custom{label=\"value\"}"
+			item := templates.CustomMetricItem{Metric: "foo_bar", Type: "counter", Expr: customExpr}
+			filled := fillMissingExpr(item)
+			Expect(filled.Expr).To(Equal(customExpr))
+		})
+
+		It("should handle case-insensitive type matching", func() {
+			types := []string{"COUNTER", "Counter", "HISTOGRAM", "Histogram", "GAUGE", "Gauge"}
+			for _, t := range types {
+				item := templates.CustomMetricItem{Metric: "test_metric", Type: t}
+				filled := fillMissingExpr(item)
+				Expect(filled.Expr).NotTo(BeEmpty(), "Type %s should generate expression", t)
+				Expect(filled.Expr).NotTo(Equal("test_metric"), "Type %s should not use raw metric", t)
+			}
 		})
 	})
 


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->


## What this PR does

Improves the default PromQL expressions generated by the Grafana plugin for custom metrics, making them more practical and applicable for real-world monitoring scenarios.

## Why this matters

Previously, the Grafana plugin scaffolded basic PromQL expressions that weren't optimized for typical Kubernetes operator monitoring:
- **Gauges** were shown as raw metrics without aggregation
- No documentation explained why specific functions were used
- Users had to manually edit expressions for multi-pod deployments

## Changes

- **Counter metrics**: Use `sum(rate(metric[5m])) by (instance, pod)` to show requests/errors per second
- **Histogram metrics**: Use `histogram_quantile(0.90, ...)` for p90 latency visualization
- **Gauge metrics**: Use `avg(metric) by (instance, pod)` for proper multi-pod aggregation (NEW)
- Added inline comments explaining the purpose of each expression
- Removed outdated TODO comment

## Example Impact

Before (gauge):
```promql
my_custom_metric
```

After (gauge):
```promql
avg(my_custom_metric{job="$job", namespace="$namespace"}) by (instance, pod)
```

This ensures gauges are properly aggregated when multiple controller pods are running.

## Testing

```bash
make lint-fix
go test ./pkg/plugins/optional/grafana/...
```