### PR TITLE
📖 fix grammatical errors and typos in documentation

### DIFF
--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -372,7 +372,7 @@ For more information, see the Kubernetes documentation on [Owners and Dependents
 
 ### Granting permissions
 
-It's important to ensure that the Controller has the necessary permissions(i.e. to create, get, update, and list)
+It's important to ensure that the Controller has the necessary permissions (i.e., to create, get, update, and list)
 the resources it manages.
 
 You configure the [RBAC permissions][k8s-rbac] via [RBAC markers][rbac-markers], which [controller-gen][controller-gen] uses to generate and update the

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -2,7 +2,7 @@
 >Impatient readers may head straight to [Quick Start](quick-start.md).
 
 >[!Important]
->Using previous version of Kubebuilder? Check the legacy documentation for [v1](https://book-v1.book.kubebuilder.io), [v2](https://book-v2.book.kubebuilder.io) or [v3](https://book-v3.book.kubebuilder.io).
+>Using a previous version of Kubebuilder? Check the legacy documentation for [v1](https://book-v1.book.kubebuilder.io), [v2](https://book-v2.book.kubebuilder.io) or [v3](https://book-v3.book.kubebuilder.io).
 
 ## Who is this for
 
@@ -41,7 +41,7 @@ Including:
 
 ## Why Kubernetes APIs
 
-Kubernetes APIs provide consistent and well defined endpoints for
+Kubernetes APIs provide consistent and well-defined endpoints for
 objects adhering to a consistent and rich structure.
 
 This approach has fostered a rich ecosystem of tools and libraries for working
@@ -65,7 +65,7 @@ running Kubernetes clusters.
 
 ## Contribution
 
-If you like to contribute to either this book or the code, please be so kind
+If you like to contribute to either this book or the code, please be kind enough
 to read our [Contribution](https://github.com/kubernetes-sigs/kubebuilder/blob/master/CONTRIBUTING.md) guidelines first.
 
 ## Resources

--- a/docs/book/src/plugins/extending.md
+++ b/docs/book/src/plugins/extending.md
@@ -22,7 +22,7 @@ Kubebuilder and SDK are both broadly adopted projects which leverage the [contro
 
 Adopting these standards can bring significant benefits, such as joining forces on maintaining the common standards as the features provided by Kubebuilder and take advantage of the contributions made by the community. This allows you to focus on the specific needs and requirements for your plugin and use-case.
 
-And then, you will also be able to use custom plugins and options currently or in the future which might to be provided by these projects as any other which decides to persuade the same standards.
+And then, you will also be able to use custom plugins and options currently or in the future which might be provided by these projects, as well as any other that decides to pursue the same standards.
 
 </aside>
 
@@ -35,8 +35,8 @@ Extending Kubebuilder can be achieved in two main ways:
    its features and plugins][extending-cli]. This is useful when you need to add specific
    features to a tool that already benefits from Kubebuilder's scaffolding system.
    For example, [Operator SDK][sdk] leverages the [kustomize plugin][kustomize-plugin]
-   to provide language support for tools like Ansible or Helm. So that the project
-   can be focused to keep maintained only what is specific language based.
+   to provide language support for tools like Ansible or Helm. This allows the project
+   to focus strictly on maintaining what is language-specific.
 
 2. **Creating External Plugins**:
    You can build standalone, independent plugins as binaries. These plugins can be written in any

--- a/docs/book/src/plugins/extending/testing-plugins.md
+++ b/docs/book/src/plugins/extending/testing-plugins.md
@@ -83,7 +83,7 @@ Here’s a general workflow to create a sample project using the `go/v4` plugin 
   	"--defaulting",
   	"--programmatic-validation",
   )
-  Expect(err).NotTo(HaveOccurred(), "Failed to create an webhook")
+  Expect(err).NotTo(HaveOccurred(), "Failed to create a webhook")
   ```
 
 [cert-manager-install]: https://pkg.go.dev/sigs.k8s.io/kubebuilder/v4/test/e2e/utils#TestContext.InstallCertManager

--- a/docs/book/src/quick-start.md
+++ b/docs/book/src/quick-start.md
@@ -17,7 +17,7 @@ This Quick Start guide will cover:
 <aside class="note" role="note">
 <p class="note-title">Versions Compatibility and Supportability</p>
 
-Please, ensure that you see the [guidance](./versions_compatibility_supportability.md).
+Please ensure that you see the [guidance](./versions_compatibility_supportability.md).
 
 </aside>
 
@@ -48,7 +48,7 @@ Kubebuilder provides autocompletion support via the command `kubebuilder complet
 
 ## Create a project
 
-Create a directory, and then run the init command inside of it to initialize a new project. Follows an example.
+Create a directory, and then run the init command inside of it to initialize a new project. Below is an example:
 
 ```bash
 mkdir -p ~/projects/guestbook

--- a/docs/book/src/reference/project-config.md
+++ b/docs/book/src/reference/project-config.md
@@ -73,8 +73,8 @@ version: "3"
 
 Following some examples of motivations to track the input used:
 - check if a plugin can or cannot be scaffolded on top of an existing plugin (i.e.) plugin compatibility while chaining multiple of them together.
-- what operations can or cannot be done such as verify if the layout allow API(s) for different groups to be scaffolded for the current configuration or not.
-- verify what data can or not be used in the CLI operations such as to ensure that WebHooks can only be created for pre-existent API(s)
+- what operations can or cannot be done such as verify if the layout allows API(s) for different groups to be scaffolded for the current configuration or not.
+- verify what data can or cannot be used in the CLI operations such as to ensure that WebHooks can only be created for pre-existent API(s)
 
 Note that KubeBuilder is not only a CLI tool but can also be used as a library to allow users to create their plugins/tools, provide helpers and customizations on top of their existing projects - an example of which is [Operator-SDK][operator-sdk]. SDK leverages KubeBuilder to create plugins to allow users to work with other languages and provide helpers for their users to integrate their projects with, for example, the [Operator Framework solutions/OLM][olm]. You can check the [plugin's documentation][plugins-doc] to know more about creating custom plugins.
 

--- a/docs/book/src/reference/webhook-overview.md
+++ b/docs/book/src/reference/webhook-overview.md
@@ -1,7 +1,7 @@
 # Webhook
 
 Webhooks are requests for information sent in a blocking fashion. A web
-application implementing webhooks sends a HTTP request to other applications
+application implementing webhooks sends an HTTP request to other applications
 when a certain event happens.
 
 In the Kubernetes world, there are 3 kinds of webhooks:

--- a/docs/book/src/versions_compatibility_supportability.md
+++ b/docs/book/src/versions_compatibility_supportability.md
@@ -13,7 +13,7 @@ Therefore, the versions defined in the `Makefile` and `go.mod` files are the one
 
 Each minor version of Kubebuilder is tested with a specific minor version of client-go.
 While a Kubebuilder minor version *may* be compatible with other client-go minor versions,
-or other tools this compatibility is not guaranteed, supported, or tested.
+or other tools, this compatibility is not guaranteed, supported, or tested.
 
 The minimum Go version required by Kubebuilder is determined by the highest minimum
 Go version required by its dependencies. This is usually aligned with the minimum
@@ -36,12 +36,12 @@ Contributions towards supporting Windows are not planned.
 <aside class="warning" role="note">
     <p class="note-title">Project customizations</p>
 
-After using the CLI to create your project, you are free to customize how
+After using the CLI to create your project, you are free to customize it as
 you see fit. Bear in mind, that it is not recommended to deviate from
 the proposed layout unless you know what you are doing.
 
-For example, you should refrain from moving the scaffolded files,
-doing so makes it difficult in upgrading your project in the future.
+For example, you should refrain from moving the scaffolded files;
+doing so makes it difficult to upgrade your project in the future.
 You may also lose the ability to use some of the CLI features and helpers.
 For further information on the project layout, see the doc [What's in a basic project?][basic-project-doc]
 

--- a/docs/testing/integration.md
+++ b/docs/testing/integration.md
@@ -4,7 +4,7 @@
 
 This article explores steps to write and run integration tests for controllers created using Kubebuilder. Kubebuilder provides a template for writing integration tests. You can simply run all integration (and unit) tests within the project by running: `make test`
 
-For example, there is a controller watching *Parent* objects. The *Parent* objects create *Child* objects. Note that the *Child* objects must have their `.ownerReferences` field setting to the `Parent` objects. You can find the template under `pkg/controllers/parent/parent_controller_test.go`:
+For example, there is a controller watching *Parent* objects. The *Parent* objects create *Child* objects. Note that the *Child* objects must have their `.ownerReferences` field set to the `Parent` objects. You can find the template under `pkg/controllers/parent/parent_controller_test.go`:
 ```
 package parent
 


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->



## Description

This PR fixes grammatical errors, article mismatches, subject-verb agreement, and phrasing issues across the Kubebuilder documentation.

fix: #6002 

## Changes Made

* Fixed grammar and phrasing in plugins/extending.md.
* Corrected article usage (a/an) in webhook documentation.
* Fixed subject-verb agreement and auxiliary verb usage in project-config.md.
* Corrected spacing and punctuation around i.e..
* Improved phrasing and hyphenation in introduction.md and quick-start.md.
* Fixed punctuation and prepositional phrasing in versions_compatibility_supportability.md.
* Corrected verb form in docs/testing/integration.md.

## Checklist

* Ran make remove-spaces.
* Followed PR title guidelines (:book: emoji).