### PR TITLE
🌱 test(pkg/cli): Add missing unit tests for api, alpha, create, edit, root

### DIFF
--- a/pkg/cli/alpha_test.go
+++ b/pkg/cli/alpha_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+)
+
+var _ = Describe("newAlphaCmd", func() {
+	var c *CLI
+
+	BeforeEach(func() {
+		c = &CLI{}
+	})
+
+	When("alpha commands exist", func() {
+		It("should create alpha command with correct properties", func() {
+			cmd := c.newAlphaCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal(alphaCommand))
+			Expect(cmd.SuggestFor).To(ContainElement("experimental"))
+			Expect(cmd.Short).To(ContainSubstring("Alpha-stage subcommands"))
+		})
+
+		It("should include built-in alpha commands", func() {
+			cmd := c.newAlphaCmd()
+			Expect(cmd.Commands()).NotTo(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("addAlphaCmd", func() {
+	var c *CLI
+
+	BeforeEach(func() {
+		c = &CLI{
+			cmd: &cobra.Command{Use: "kubebuilder"},
+		}
+	})
+
+	When("alpha commands exist", func() {
+		It("should add alpha command to root", func() {
+			c.addAlphaCmd()
+			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
+		})
+	})
+
+	When("extra alpha commands exist", func() {
+		BeforeEach(func() {
+			c.extraAlphaCommands = []*cobra.Command{
+				{Use: "custom-alpha", Short: "Custom alpha command"},
+			}
+		})
+
+		It("should add alpha command to root", func() {
+			c.addAlphaCmd()
+			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
+		})
+	})
+
+	When("no alpha commands exist", func() {
+		BeforeEach(func() {
+			// Temporarily replace alphaCommands with empty slice
+			original := alphaCommands
+			DeferCleanup(func() { alphaCommands = original })
+			alphaCommands = []*cobra.Command{}
+			c.extraAlphaCommands = []*cobra.Command{}
+		})
+
+		It("should not add alpha command to root", func() {
+			c.addAlphaCmd()
+			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("addExtraAlphaCommands", func() {
+	var c *CLI
+
+	BeforeEach(func() {
+		c = &CLI{
+			cmd: &cobra.Command{Use: "kubebuilder"},
+		}
+		c.addAlphaCmd()
+	})
+
+	When("extra alpha commands are provided", func() {
+		It("should add them to the alpha command", func() {
+			c.extraAlphaCommands = []*cobra.Command{
+				{Use: "extra-alpha", Short: "Extra alpha command"},
+			}
+
+			err := c.addExtraAlphaCommands()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
+
+			alphaCmd, _ := c.cmd.Commands()[0], false
+			for _, cmd := range c.cmd.Commands() {
+				if cmd.Name() == alphaCommand {
+					alphaCmd = cmd
+					break
+				}
+			}
+			Expect(hasSubCommand(alphaCmd, "extra-alpha")).To(BeTrue())
+		})
+	})
+
+	When("extra alpha command duplicates an existing one", func() {
+		It("should return an error", func() {
+			// generate command already exists from alpha.NewScaffoldCommand()
+			c.extraAlphaCommands = []*cobra.Command{
+				{Use: "generate", Short: "Duplicate generate command"},
+			}
+
+			err := c.addExtraAlphaCommands()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists"))
+		})
+	})
+
+	When("no alpha command exists", func() {
+		It("should return an error", func() {
+			c = &CLI{
+				cmd: &cobra.Command{Use: "kubebuilder"},
+				extraAlphaCommands: []*cobra.Command{
+					{Use: "custom-alpha", Short: "Custom alpha command"},
+				},
+			}
+
+			err := c.addExtraAlphaCommands()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no \"alpha\" command found"))
+		})
+	})
+})

--- a/pkg/cli/alpha_test.go
+++ b/pkg/cli/alpha_test.go
@@ -22,61 +22,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var _ = Describe("newAlphaCmd", func() {
-	var c *CLI
-
-	BeforeEach(func() {
-		c = &CLI{}
-	})
-
-	When("alpha commands exist", func() {
-		It("should create alpha command with correct properties", func() {
-			cmd := c.newAlphaCmd()
-			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal(alphaCommand))
-			Expect(cmd.SuggestFor).To(ContainElement("experimental"))
-			Expect(cmd.Short).To(ContainSubstring("Alpha-stage subcommands"))
-		})
-
-		It("should include built-in alpha commands", func() {
-			cmd := c.newAlphaCmd()
-			Expect(cmd.Commands()).NotTo(BeEmpty())
-		})
-	})
-})
-
 var _ = Describe("addAlphaCmd", func() {
 	var c *CLI
 
 	BeforeEach(func() {
 		c = &CLI{
-			cmd: &cobra.Command{Use: "kubebuilder"},
+			cmd: &cobra.Command{Use: kubebuilderCommandName},
 		}
 	})
 
-	When("alpha commands exist", func() {
-		It("should add alpha command to root", func() {
-			c.addAlphaCmd()
-			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
-		})
+	It("should add alpha command to root when alpha commands exist", func() {
+		c.addAlphaCmd()
+		Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
 	})
 
-	When("extra alpha commands exist", func() {
-		BeforeEach(func() {
-			c.extraAlphaCommands = []*cobra.Command{
-				{Use: "custom-alpha", Short: "Custom alpha command"},
-			}
-		})
-
-		It("should add alpha command to root", func() {
-			c.addAlphaCmd()
-			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
-		})
+	It("should add alpha command to root when only extra alpha commands exist", func() {
+		c.extraAlphaCommands = []*cobra.Command{
+			{Use: "custom-alpha", Short: "Custom alpha command"},
+		}
+		c.addAlphaCmd()
+		Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
 	})
 
 	When("no alpha commands exist", func() {
 		BeforeEach(func() {
-			// Temporarily replace alphaCommands with empty slice
 			original := alphaCommands
 			DeferCleanup(func() { alphaCommands = original })
 			alphaCommands = []*cobra.Command{}
@@ -95,57 +64,49 @@ var _ = Describe("addExtraAlphaCommands", func() {
 
 	BeforeEach(func() {
 		c = &CLI{
-			cmd: &cobra.Command{Use: "kubebuilder"},
+			cmd: &cobra.Command{Use: kubebuilderCommandName},
 		}
 		c.addAlphaCmd()
 	})
 
-	When("extra alpha commands are provided", func() {
-		It("should add them to the alpha command", func() {
-			c.extraAlphaCommands = []*cobra.Command{
-				{Use: "extra-alpha", Short: "Extra alpha command"},
-			}
+	It("should add extra alpha commands to the alpha subcommand", func() {
+		c.extraAlphaCommands = []*cobra.Command{
+			{Use: "extra-alpha", Short: "Extra alpha command"},
+		}
 
-			err := c.addExtraAlphaCommands()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
+		err := c.addExtraAlphaCommands()
+		Expect(err).NotTo(HaveOccurred())
 
-			alphaCmd, _ := c.cmd.Commands()[0], false
-			for _, cmd := range c.cmd.Commands() {
-				if cmd.Name() == alphaCommand {
-					alphaCmd = cmd
-					break
-				}
+		alphaCmd, _ := c.cmd.Commands()[0], false
+		for _, cmd := range c.cmd.Commands() {
+			if cmd.Name() == alphaCommand {
+				alphaCmd = cmd
+				break
 			}
-			Expect(hasSubCommand(alphaCmd, "extra-alpha")).To(BeTrue())
-		})
+		}
+		Expect(hasSubCommand(alphaCmd, "extra-alpha")).To(BeTrue())
 	})
 
-	When("extra alpha command duplicates an existing one", func() {
-		It("should return an error", func() {
-			// generate command already exists from alpha.NewScaffoldCommand()
-			c.extraAlphaCommands = []*cobra.Command{
-				{Use: "generate", Short: "Duplicate generate command"},
-			}
+	It("should reject a duplicate alpha command", func() {
+		c.extraAlphaCommands = []*cobra.Command{
+			{Use: "generate", Short: "Duplicate generate command"},
+		}
 
-			err := c.addExtraAlphaCommands()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("already exists"))
-		})
+		err := c.addExtraAlphaCommands()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("already exists"))
 	})
 
-	When("no alpha command exists", func() {
-		It("should return an error", func() {
-			c = &CLI{
-				cmd: &cobra.Command{Use: "kubebuilder"},
-				extraAlphaCommands: []*cobra.Command{
-					{Use: "custom-alpha", Short: "Custom alpha command"},
-				},
-			}
+	It("should return an error when no alpha command exists", func() {
+		c = &CLI{
+			cmd: &cobra.Command{Use: kubebuilderCommandName},
+			extraAlphaCommands: []*cobra.Command{
+				{Use: "custom-alpha", Short: "Custom alpha command"},
+			},
+		}
 
-			err := c.addExtraAlphaCommands()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no \"alpha\" command found"))
-		})
+		err := c.addExtraAlphaCommands()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no \"alpha\" command found"))
 	})
 })

--- a/pkg/cli/api_test.go
+++ b/pkg/cli/api_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+)
+
+var _ = Describe("newCreateAPICmd", func() {
+	var c *CLI
+	var projectVersion config.Version
+
+	BeforeEach(func() {
+		projectVersion = config.Version{Number: 3}
+		c = &CLI{}
+	})
+
+	When("no plugins are resolved", func() {
+		BeforeEach(func() {
+			c.resolvedPlugins = []plugin.Plugin{}
+		})
+
+		It("should create a command that fails with no resolved plugin error", func() {
+			cmd := c.newCreateAPICmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal("api"))
+			Expect(cmd.Short).To(ContainSubstring("Scaffold a Kubernetes API"))
+
+			err := cmd.RunE(cmd, []string{})
+			Expect(err).To(MatchError(noResolvedPluginError{}))
+		})
+	})
+
+	When("resolved plugins do not implement CreateAPI", func() {
+		BeforeEach(func() {
+			c.resolvedPlugins = []plugin.Plugin{
+				newMockPlugin("noapi.kubebuilder.io", "v1", projectVersion),
+			}
+		})
+
+		It("should create a command that fails with no available plugin error", func() {
+			cmd := c.newCreateAPICmd()
+			Expect(cmd).NotTo(BeNil())
+
+			err := cmd.RunE(cmd, []string{})
+			Expect(err).To(MatchError(noAvailablePluginError{"API creation"}))
+		})
+	})
+
+	When("resolved plugins implement CreateAPI", func() {
+		var testPlugin testCreateAPIPlugin
+
+		BeforeEach(func() {
+			testPlugin = newTestCreateAPIPlugin("test.kubebuilder.io", plugin.Version{Number: 1})
+			c.resolvedPlugins = []plugin.Plugin{testPlugin}
+		})
+
+		It("should create a command with proper metadata", func() {
+			cmd := c.newCreateAPICmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal("api"))
+			Expect(cmd.Short).To(ContainSubstring("Scaffold a Kubernetes API"))
+		})
+
+		It("should have valid args function that suggests flags", func() {
+			cmd := c.newCreateAPICmd()
+			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
+
+			completions, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
+			Expect(completions).To(HaveLen(1))
+			Expect(completions[0]).To(ContainSubstring("'--'"))
+			Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+		})
+
+		It("should not show flag hint when args are provided", func() {
+			cmd := c.newCreateAPICmd()
+			completions, _ := cmd.ValidArgsFunction(cmd, []string{"--group"}, "")
+			Expect(completions).To(BeEmpty())
+		})
+
+		It("should not show flag hint when already typing a flag", func() {
+			cmd := c.newCreateAPICmd()
+			completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "--")
+			Expect(completions).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/cli/api_test.go
+++ b/pkg/cli/api_test.go
@@ -39,12 +39,8 @@ var _ = Describe("newCreateAPICmd", func() {
 			c.resolvedPlugins = []plugin.Plugin{}
 		})
 
-		It("should create a command that fails with no resolved plugin error", func() {
+		It("should fail with no resolved plugin error", func() {
 			cmd := c.newCreateAPICmd()
-			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal("api"))
-			Expect(cmd.Short).To(ContainSubstring("Scaffold a Kubernetes API"))
-
 			err := cmd.RunE(cmd, []string{})
 			Expect(err).To(MatchError(noResolvedPluginError{}))
 		})
@@ -57,10 +53,8 @@ var _ = Describe("newCreateAPICmd", func() {
 			}
 		})
 
-		It("should create a command that fails with no available plugin error", func() {
+		It("should fail with no available plugin error", func() {
 			cmd := c.newCreateAPICmd()
-			Expect(cmd).NotTo(BeNil())
-
 			err := cmd.RunE(cmd, []string{})
 			Expect(err).To(MatchError(noAvailablePluginError{"API creation"}))
 		})
@@ -74,14 +68,7 @@ var _ = Describe("newCreateAPICmd", func() {
 			c.resolvedPlugins = []plugin.Plugin{testPlugin}
 		})
 
-		It("should create a command with proper metadata", func() {
-			cmd := c.newCreateAPICmd()
-			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal("api"))
-			Expect(cmd.Short).To(ContainSubstring("Scaffold a Kubernetes API"))
-		})
-
-		It("should have valid args function that suggests flags", func() {
+		It("should provide shell completion hints for flags", func() {
 			cmd := c.newCreateAPICmd()
 			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
 
@@ -91,13 +78,13 @@ var _ = Describe("newCreateAPICmd", func() {
 			Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
 		})
 
-		It("should not show flag hint when args are provided", func() {
+		It("should suppress completion hints when args are already provided", func() {
 			cmd := c.newCreateAPICmd()
-			completions, _ := cmd.ValidArgsFunction(cmd, []string{"--group"}, "")
+			completions, _ := cmd.ValidArgsFunction(cmd, []string{"some-arg"}, "")
 			Expect(completions).To(BeEmpty())
 		})
 
-		It("should not show flag hint when already typing a flag", func() {
+		It("should suppress completion hints when user is already typing a flag", func() {
 			cmd := c.newCreateAPICmd()
 			completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "--")
 			Expect(completions).To(BeEmpty())

--- a/pkg/cli/create_test.go
+++ b/pkg/cli/create_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
+)
+
+var _ = Describe("newCreateCmd", func() {
+	var c *CLI
+	var projectVersion config.Version
+
+	BeforeEach(func() {
+		projectVersion = config.Version{Number: 3}
+	})
+
+	When("CLI is configured with plugins", func() {
+		BeforeEach(func() {
+			var err error
+			c, err = New(
+				WithPlugins(&golangv4.Plugin{}),
+				WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+				WithDefaultProjectVersion(projectVersion),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create command with correct use", func() {
+			cmd := c.newCreateCmd()
+			Expect(cmd.Use).To(Equal("create"))
+		})
+
+		It("should suggest 'new' as alternative", func() {
+			cmd := c.newCreateCmd()
+			Expect(cmd.SuggestFor).To(ContainElement("new"))
+		})
+
+		It("should have short description", func() {
+			cmd := c.newCreateCmd()
+			Expect(cmd.Short).To(ContainSubstring("Scaffold a Kubernetes API or webhook"))
+		})
+
+		It("should have long description with plugin table", func() {
+			cmd := c.newCreateCmd()
+			Expect(cmd.Long).To(ContainSubstring("create api"))
+			Expect(cmd.Long).To(ContainSubstring("create webhook"))
+			Expect(cmd.Long).To(ContainSubstring("Available plugins"))
+		})
+
+		It("should exclude default scaffold plugins from plugin table", func() {
+			cmd := c.newCreateCmd()
+			// The plugin table in create command should not show go/v4 or kustomize
+			// since they are the default scaffold bundle
+			Expect(cmd.Long).NotTo(ContainSubstring("go/v4"))
+			Expect(cmd.Long).NotTo(ContainSubstring("kustomize"))
+		})
+	})
+
+	When("CLI has no plugins", func() {
+		BeforeEach(func() {
+			c = &CLI{}
+		})
+
+		It("should still create the command", func() {
+			cmd := c.newCreateCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal("create"))
+		})
+
+		It("should show no plugins message", func() {
+			cmd := c.newCreateCmd()
+			Expect(cmd.Long).To(ContainSubstring("No plugins available"))
+		})
+	})
+})

--- a/pkg/cli/create_test.go
+++ b/pkg/cli/create_test.go
@@ -43,34 +43,9 @@ var _ = Describe("newCreateCmd", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should create command with correct use", func() {
+		It("should build the command without error", func() {
 			cmd := c.newCreateCmd()
-			Expect(cmd.Use).To(Equal("create"))
-		})
-
-		It("should suggest 'new' as alternative", func() {
-			cmd := c.newCreateCmd()
-			Expect(cmd.SuggestFor).To(ContainElement("new"))
-		})
-
-		It("should have short description", func() {
-			cmd := c.newCreateCmd()
-			Expect(cmd.Short).To(ContainSubstring("Scaffold a Kubernetes API or webhook"))
-		})
-
-		It("should have long description with plugin table", func() {
-			cmd := c.newCreateCmd()
-			Expect(cmd.Long).To(ContainSubstring("create api"))
-			Expect(cmd.Long).To(ContainSubstring("create webhook"))
-			Expect(cmd.Long).To(ContainSubstring("Available plugins"))
-		})
-
-		It("should exclude default scaffold plugins from plugin table", func() {
-			cmd := c.newCreateCmd()
-			// The plugin table in create command should not show go/v4 or kustomize
-			// since they are the default scaffold bundle
-			Expect(cmd.Long).NotTo(ContainSubstring("go/v4"))
-			Expect(cmd.Long).NotTo(ContainSubstring("kustomize"))
+			Expect(cmd).NotTo(BeNil())
 		})
 	})
 
@@ -79,15 +54,9 @@ var _ = Describe("newCreateCmd", func() {
 			c = &CLI{}
 		})
 
-		It("should still create the command", func() {
+		It("should still build the command", func() {
 			cmd := c.newCreateCmd()
 			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal("create"))
-		})
-
-		It("should show no plugins message", func() {
-			cmd := c.newCreateCmd()
-			Expect(cmd.Long).To(ContainSubstring("No plugins available"))
 		})
 	})
 })

--- a/pkg/cli/edit_test.go
+++ b/pkg/cli/edit_test.go
@@ -39,12 +39,8 @@ var _ = Describe("newEditCmd", func() {
 			c.resolvedPlugins = []plugin.Plugin{}
 		})
 
-		It("should create a command that fails with no resolved plugin error", func() {
+		It("should fail with no resolved plugin error", func() {
 			cmd := c.newEditCmd()
-			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal("edit"))
-			Expect(cmd.Short).To(ContainSubstring("Update the project configuration"))
-
 			err := cmd.RunE(cmd, []string{})
 			Expect(err).To(MatchError(noResolvedPluginError{}))
 		})
@@ -57,10 +53,8 @@ var _ = Describe("newEditCmd", func() {
 			}
 		})
 
-		It("should create a command that fails with no available plugin error", func() {
+		It("should fail with no available plugin error", func() {
 			cmd := c.newEditCmd()
-			Expect(cmd).NotTo(BeNil())
-
 			err := cmd.RunE(cmd, []string{})
 			Expect(err).To(MatchError(noAvailablePluginError{"edit project"}))
 		})
@@ -78,11 +72,9 @@ var _ = Describe("newEditCmd", func() {
 			c.resolvedPlugins = []plugin.Plugin{testPlugin}
 		})
 
-		It("should create a command with proper metadata", func() {
+		It("should build the command without error", func() {
 			cmd := c.newEditCmd()
-			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal("edit"))
-			Expect(cmd.Short).To(ContainSubstring("Update the project configuration"))
+			Expect(cmd.RunE).NotTo(BeNil())
 		})
 	})
 })

--- a/pkg/cli/edit_test.go
+++ b/pkg/cli/edit_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/machinery"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+)
+
+var _ = Describe("newEditCmd", func() {
+	var c *CLI
+	var projectVersion config.Version
+
+	BeforeEach(func() {
+		projectVersion = config.Version{Number: 3}
+		c = &CLI{}
+	})
+
+	When("no plugins are resolved", func() {
+		BeforeEach(func() {
+			c.resolvedPlugins = []plugin.Plugin{}
+		})
+
+		It("should create a command that fails with no resolved plugin error", func() {
+			cmd := c.newEditCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal("edit"))
+			Expect(cmd.Short).To(ContainSubstring("Update the project configuration"))
+
+			err := cmd.RunE(cmd, []string{})
+			Expect(err).To(MatchError(noResolvedPluginError{}))
+		})
+	})
+
+	When("resolved plugins do not implement Edit", func() {
+		BeforeEach(func() {
+			c.resolvedPlugins = []plugin.Plugin{
+				newMockPlugin("noedit.kubebuilder.io", "v1", projectVersion),
+			}
+		})
+
+		It("should create a command that fails with no available plugin error", func() {
+			cmd := c.newEditCmd()
+			Expect(cmd).NotTo(BeNil())
+
+			err := cmd.RunE(cmd, []string{})
+			Expect(err).To(MatchError(noAvailablePluginError{"edit project"}))
+		})
+	})
+
+	When("resolved plugins implement Edit", func() {
+		var testPlugin testEditPlugin
+
+		BeforeEach(func() {
+			testPlugin = testEditPlugin{
+				name:        "test.kubebuilder.io",
+				version:     plugin.Version{Number: 1},
+				projectVers: []config.Version{projectVersion},
+			}
+			c.resolvedPlugins = []plugin.Plugin{testPlugin}
+		})
+
+		It("should create a command with proper metadata", func() {
+			cmd := c.newEditCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal("edit"))
+			Expect(cmd.Short).To(ContainSubstring("Update the project configuration"))
+		})
+	})
+})
+
+type testEditPlugin struct {
+	name        string
+	version     plugin.Version
+	projectVers []config.Version
+}
+
+func (p testEditPlugin) Name() string                               { return p.name }
+func (p testEditPlugin) Version() plugin.Version                    { return p.version }
+func (p testEditPlugin) SupportedProjectVersions() []config.Version { return p.projectVers }
+func (p testEditPlugin) GetEditSubcommand() plugin.EditSubcommand {
+	return &testEditSubcommand{}
+}
+
+type testEditSubcommand struct{}
+
+func (s *testEditSubcommand) Scaffold(_ machinery.Filesystem) error { return nil }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/kubebuilder/v4/pkg/config"
+	"sigs.k8s.io/kubebuilder/v4/pkg/plugin"
+	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
+)
+
+var _ = Describe("Root command utilities", func() {
+	Describe("isHelpFlagArg", func() {
+		DescribeTable("should return true for help flags",
+			func(arg string) {
+				Expect(isHelpFlagArg(arg)).To(BeTrue())
+			},
+			Entry("--help", "--help"),
+			Entry("-h", "-h"),
+			Entry("--help=true", "--help=true"),
+			Entry("--help=1", "--help=1"),
+			Entry("-h=true", "-h=true"),
+			Entry("-h=1", "-h=1"),
+		)
+
+		DescribeTable("should return false for non-help flags",
+			func(arg string) {
+				Expect(isHelpFlagArg(arg)).To(BeFalse())
+			},
+			Entry("--help=false", "--help=false"),
+			Entry("--help=0", "--help=0"),
+			Entry("-h=false", "-h=false"),
+			Entry("-h=0", "-h=0"),
+			Entry("--help=invalid", "--help=invalid"),
+			Entry("--domain", "--domain"),
+			Entry("example.com", "example.com"),
+			Entry("", ""),
+		)
+	})
+
+	Describe("isHelpFlag", func() {
+		DescribeTable("should return true for help indicators",
+			func(s string) {
+				Expect(isHelpFlag(s)).To(BeTrue())
+			},
+			Entry("--help", "--help"),
+			Entry("-h", "-h"),
+			Entry("help", kubebuilderSubcommandHelp),
+		)
+
+		It("should return false for non-help strings", func() {
+			Expect(isHelpFlag("init")).To(BeFalse())
+			Expect(isHelpFlag("create")).To(BeFalse())
+			Expect(isHelpFlag("foo")).To(BeFalse())
+		})
+	})
+
+	Describe("isCompletionRequest", func() {
+		It("should return true for shell completion commands", func() {
+			root := &cobra.Command{Use: "root"}
+			cmd1 := &cobra.Command{Use: cobra.ShellCompRequestCmd}
+			root.AddCommand(cmd1)
+			Expect(isCompletionRequest(cmd1)).To(BeTrue())
+
+			cmd2 := &cobra.Command{Use: cobra.ShellCompNoDescRequestCmd}
+			root.AddCommand(cmd2)
+			Expect(isCompletionRequest(cmd2)).To(BeTrue())
+		})
+
+		It("should return false for regular commands", func() {
+			root := &cobra.Command{Use: "root"}
+			cmd := &cobra.Command{Use: "init"}
+			root.AddCommand(cmd)
+			Expect(isCompletionRequest(cmd)).To(BeFalse())
+		})
+	})
+
+	Describe("subcommandPath", func() {
+		It("should return the path from root to the command", func() {
+			root := &cobra.Command{Use: kubebuilderCommandName}
+			create := &cobra.Command{Use: createSubcommand}
+			api := &cobra.Command{Use: apiSubcommand}
+
+			root.AddCommand(create)
+			create.AddCommand(api)
+
+			path := subcommandPath(api)
+			Expect(path).To(Equal([]string{createSubcommand, apiSubcommand}))
+		})
+
+		It("should return empty slice for root command", func() {
+			root := &cobra.Command{Use: kubebuilderCommandName}
+			path := subcommandPath(root)
+			Expect(path).To(BeEmpty())
+		})
+
+		It("should return single element for direct child", func() {
+			root := &cobra.Command{Use: kubebuilderCommandName}
+			init := &cobra.Command{Use: kubebuilderSubcommandInit}
+			root.AddCommand(init)
+
+			path := subcommandPath(init)
+			Expect(path).To(Equal([]string{kubebuilderSubcommandInit}))
+		})
+	})
+
+	Describe("getShortKey", func() {
+		DescribeTable("should shorten plugin keys",
+			func(fullKey, expected string) {
+				Expect(getShortKey(fullKey)).To(Equal(expected))
+			},
+			Entry("standard kubebuilder plugin", "go.kubebuilder.io/v4", "go/v4"),
+			Entry("kustomize plugin", "kustomize.common.kubebuilder.io/v2", "kustomize/v2"),
+			Entry("deploy-image plugin", "deploy-image.go.kubebuilder.io/v1-alpha", "deploy-image/v1-alpha"),
+			Entry("external plugin with domain", "foo.example.com/v1", "foo.example/v1"),
+			Entry("plugin without version", "go.kubebuilder.io", "go"),
+			Entry("simple external plugin", "example.com/v1", "example.com/v1"),
+		)
+	})
+
+	Describe("getPluginDescription", func() {
+		It("should return fallback description", func() {
+			Expect(getPluginDescription("foo.example.com/v1")).To(Equal("External or custom plugin"))
+		})
+	})
+})
+
+var _ = Describe("getPluginTableFilteredWithOptions", func() {
+	var c *CLI
+	var projectVersion config.Version
+
+	BeforeEach(func() {
+		projectVersion = config.Version{Number: 3}
+		c = &CLI{
+			plugins: make(map[string]plugin.Plugin),
+		}
+	})
+
+	When("no plugins are registered", func() {
+		It("should return no plugins message", func() {
+			Expect(c.getPluginTableFiltered(nil)).To(Equal("No plugins available for this subcommand"))
+		})
+	})
+
+	When("plugins are registered", func() {
+		BeforeEach(func() {
+			c.plugins = makeMapFor(
+				newMockPlugin("go.kubebuilder.io", "v4", projectVersion),
+				newMockPlugin("kustomize.common.kubebuilder.io", "v2", projectVersion),
+			)
+		})
+
+		It("should return formatted plugin table", func() {
+			table := c.getPluginTableFiltered(nil)
+			Expect(table).To(ContainSubstring("KEY"))
+			Expect(table).To(ContainSubstring("DESCRIPTION"))
+			Expect(table).To(ContainSubstring("go/v4"))
+			Expect(table).To(ContainSubstring("kustomize/v2"))
+		})
+
+		It("should exclude deprecated plugins", func() {
+			c.plugins = makeMapFor(
+				newMockPlugin("go.kubebuilder.io", "v4", projectVersion),
+				newMockDeprecatedPlugin("old.kubebuilder.io", "v3", "use go/v4 instead", projectVersion),
+			)
+
+			table := c.getPluginTableFiltered(nil)
+			Expect(table).To(ContainSubstring("go/v4"))
+			Expect(table).NotTo(ContainSubstring("old/v3"))
+		})
+
+		It("should exclude base.go plugin to avoid duplication", func() {
+			c.plugins = makeMapFor(
+				newMockPlugin("go.kubebuilder.io", "v4", projectVersion),
+				newMockPlugin("base.go.kubebuilder.io", "v4", projectVersion),
+			)
+
+			table := c.getPluginTableFiltered(nil)
+			Expect(table).To(ContainSubstring("go/v4"))
+			Expect(table).NotTo(ContainSubstring("base.go"))
+		})
+
+		It("should filter by predicate", func() {
+			c.plugins = makeMapFor(
+				newMockPlugin("go.kubebuilder.io", "v4", projectVersion),
+				newMockPlugin("kustomize.common.kubebuilder.io", "v2", projectVersion),
+			)
+
+			table := c.getPluginTableFiltered(func(p plugin.Plugin) bool {
+				return p.Name() == "go.kubebuilder.io"
+			})
+			Expect(table).To(ContainSubstring("go/v4"))
+			Expect(table).NotTo(ContainSubstring("kustomize"))
+		})
+
+		It("should exclude default scaffold plugins for subcommands", func() {
+			table := c.getPluginTableFilteredForSubcommand(func(_ plugin.Plugin) bool {
+				return true
+			})
+			Expect(table).NotTo(ContainSubstring("go/v4"))
+			Expect(table).NotTo(ContainSubstring("kustomize"))
+		})
+	})
+
+	When("plugins implement Describable", func() {
+		It("should use plugin description", func() {
+			describablePlugin := &mockDescribablePlugin{
+				name:     "custom.kubebuilder.io",
+				version:  plugin.Version{Number: 1},
+				desc:     "Custom plugin for testing",
+				projVers: []config.Version{projectVersion},
+			}
+			c.plugins = makeMapFor(describablePlugin)
+
+			table := c.getPluginTableFiltered(nil)
+			Expect(table).To(ContainSubstring("Custom plugin for testing"))
+		})
+	})
+})
+
+var _ = Describe("newRootCmd", func() {
+	var c *CLI
+	var projectVersion config.Version
+
+	BeforeEach(func() {
+		projectVersion = config.Version{Number: 3}
+	})
+
+	When("CLI is properly configured", func() {
+		BeforeEach(func() {
+			var err error
+			c, err = New(
+				WithPlugins(&golangv4.Plugin{}),
+				WithDefaultPlugins(projectVersion, &golangv4.Plugin{}),
+				WithDefaultProjectVersion(projectVersion),
+				WithVersion("test-version"),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create root command with correct use", func() {
+			cmd := c.newRootCmd()
+			Expect(cmd.Use).To(Equal(c.commandName))
+		})
+
+		It("should have plugins flag", func() {
+			cmd := c.newRootCmd()
+			flag := cmd.PersistentFlags().Lookup(pluginsFlag)
+			Expect(flag).NotTo(BeNil())
+		})
+
+		It("should have project-version flag", func() {
+			cmd := c.newRootCmd()
+			flag := cmd.Flags().Lookup(projectVersionFlag)
+			Expect(flag).NotTo(BeNil())
+		})
+
+		It("should allow unknown flags", func() {
+			cmd := c.newRootCmd()
+			Expect(cmd.FParseErrWhitelist.UnknownFlags).To(BeTrue())
+		})
+
+		It("should include plugin table in examples", func() {
+			cmd := c.newRootCmd()
+			Expect(cmd.Example).To(ContainSubstring("Available plugins"))
+		})
+
+		It("should show default plugin in examples", func() {
+			cmd := c.newRootCmd()
+			Expect(cmd.Example).To(ContainSubstring("Default plugin"))
+			Expect(cmd.Example).To(ContainSubstring(pluginGoKubebuilderV4))
+		})
+	})
+})
+
+type mockDescribablePlugin struct {
+	name     string
+	version  plugin.Version
+	desc     string
+	projVers []config.Version
+}
+
+func (p *mockDescribablePlugin) Name() string                               { return p.name }
+func (p *mockDescribablePlugin) Version() plugin.Version                    { return p.version }
+func (p *mockDescribablePlugin) SupportedProjectVersions() []config.Version { return p.projVers }
+func (p *mockDescribablePlugin) Description() string                        { return p.desc }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -26,119 +26,117 @@ import (
 	golangv4 "sigs.k8s.io/kubebuilder/v4/pkg/plugins/golang/v4"
 )
 
-var _ = Describe("Root command utilities", func() {
-	Describe("isHelpFlagArg", func() {
-		DescribeTable("should return true for help flags",
-			func(arg string) {
-				Expect(isHelpFlagArg(arg)).To(BeTrue())
-			},
-			Entry("--help", "--help"),
-			Entry("-h", "-h"),
-			Entry("--help=true", "--help=true"),
-			Entry("--help=1", "--help=1"),
-			Entry("-h=true", "-h=true"),
-			Entry("-h=1", "-h=1"),
-		)
+var _ = Describe("isHelpFlagArg", func() {
+	DescribeTable("should return true for help flags",
+		func(arg string) {
+			Expect(isHelpFlagArg(arg)).To(BeTrue())
+		},
+		Entry("--help", "--help"),
+		Entry("-h", "-h"),
+		Entry("--help=true", "--help=true"),
+		Entry("--help=1", "--help=1"),
+		Entry("-h=true", "-h=true"),
+		Entry("-h=1", "-h=1"),
+	)
 
-		DescribeTable("should return false for non-help flags",
-			func(arg string) {
-				Expect(isHelpFlagArg(arg)).To(BeFalse())
-			},
-			Entry("--help=false", "--help=false"),
-			Entry("--help=0", "--help=0"),
-			Entry("-h=false", "-h=false"),
-			Entry("-h=0", "-h=0"),
-			Entry("--help=invalid", "--help=invalid"),
-			Entry("--domain", "--domain"),
-			Entry("example.com", "example.com"),
-			Entry("", ""),
-		)
+	DescribeTable("should return false for non-help flags",
+		func(arg string) {
+			Expect(isHelpFlagArg(arg)).To(BeFalse())
+		},
+		Entry("--help=false", "--help=false"),
+		Entry("--help=0", "--help=0"),
+		Entry("-h=false", "-h=false"),
+		Entry("-h=0", "-h=0"),
+		Entry("--help=invalid", "--help=invalid"),
+		Entry("--domain", "--domain"),
+		Entry("example.com", "example.com"),
+		Entry("", ""),
+	)
+})
+
+var _ = Describe("isHelpFlag", func() {
+	DescribeTable("should return true for help indicators",
+		func(s string) {
+			Expect(isHelpFlag(s)).To(BeTrue())
+		},
+		Entry("--help", "--help"),
+		Entry("-h", "-h"),
+		Entry("help", kubebuilderSubcommandHelp),
+	)
+
+	It("should return false for non-help strings", func() {
+		Expect(isHelpFlag("init")).To(BeFalse())
+		Expect(isHelpFlag("create")).To(BeFalse())
+		Expect(isHelpFlag("foo")).To(BeFalse())
+	})
+})
+
+var _ = Describe("isCompletionRequest", func() {
+	It("should return true for shell completion commands", func() {
+		root := &cobra.Command{Use: "root"}
+		cmd1 := &cobra.Command{Use: cobra.ShellCompRequestCmd}
+		root.AddCommand(cmd1)
+		Expect(isCompletionRequest(cmd1)).To(BeTrue())
+
+		cmd2 := &cobra.Command{Use: cobra.ShellCompNoDescRequestCmd}
+		root.AddCommand(cmd2)
+		Expect(isCompletionRequest(cmd2)).To(BeTrue())
 	})
 
-	Describe("isHelpFlag", func() {
-		DescribeTable("should return true for help indicators",
-			func(s string) {
-				Expect(isHelpFlag(s)).To(BeTrue())
-			},
-			Entry("--help", "--help"),
-			Entry("-h", "-h"),
-			Entry("help", kubebuilderSubcommandHelp),
-		)
+	It("should return false for regular commands", func() {
+		root := &cobra.Command{Use: "root"}
+		cmd := &cobra.Command{Use: "init"}
+		root.AddCommand(cmd)
+		Expect(isCompletionRequest(cmd)).To(BeFalse())
+	})
+})
 
-		It("should return false for non-help strings", func() {
-			Expect(isHelpFlag("init")).To(BeFalse())
-			Expect(isHelpFlag("create")).To(BeFalse())
-			Expect(isHelpFlag("foo")).To(BeFalse())
-		})
+var _ = Describe("subcommandPath", func() {
+	It("should return the path from root to the command", func() {
+		root := &cobra.Command{Use: kubebuilderCommandName}
+		create := &cobra.Command{Use: createSubcommand}
+		api := &cobra.Command{Use: apiSubcommand}
+
+		root.AddCommand(create)
+		create.AddCommand(api)
+
+		path := subcommandPath(api)
+		Expect(path).To(Equal([]string{createSubcommand, apiSubcommand}))
 	})
 
-	Describe("isCompletionRequest", func() {
-		It("should return true for shell completion commands", func() {
-			root := &cobra.Command{Use: "root"}
-			cmd1 := &cobra.Command{Use: cobra.ShellCompRequestCmd}
-			root.AddCommand(cmd1)
-			Expect(isCompletionRequest(cmd1)).To(BeTrue())
-
-			cmd2 := &cobra.Command{Use: cobra.ShellCompNoDescRequestCmd}
-			root.AddCommand(cmd2)
-			Expect(isCompletionRequest(cmd2)).To(BeTrue())
-		})
-
-		It("should return false for regular commands", func() {
-			root := &cobra.Command{Use: "root"}
-			cmd := &cobra.Command{Use: "init"}
-			root.AddCommand(cmd)
-			Expect(isCompletionRequest(cmd)).To(BeFalse())
-		})
+	It("should return empty slice for root command", func() {
+		root := &cobra.Command{Use: kubebuilderCommandName}
+		path := subcommandPath(root)
+		Expect(path).To(BeEmpty())
 	})
 
-	Describe("subcommandPath", func() {
-		It("should return the path from root to the command", func() {
-			root := &cobra.Command{Use: kubebuilderCommandName}
-			create := &cobra.Command{Use: createSubcommand}
-			api := &cobra.Command{Use: apiSubcommand}
+	It("should return single element for direct child", func() {
+		root := &cobra.Command{Use: kubebuilderCommandName}
+		init := &cobra.Command{Use: kubebuilderSubcommandInit}
+		root.AddCommand(init)
 
-			root.AddCommand(create)
-			create.AddCommand(api)
-
-			path := subcommandPath(api)
-			Expect(path).To(Equal([]string{createSubcommand, apiSubcommand}))
-		})
-
-		It("should return empty slice for root command", func() {
-			root := &cobra.Command{Use: kubebuilderCommandName}
-			path := subcommandPath(root)
-			Expect(path).To(BeEmpty())
-		})
-
-		It("should return single element for direct child", func() {
-			root := &cobra.Command{Use: kubebuilderCommandName}
-			init := &cobra.Command{Use: kubebuilderSubcommandInit}
-			root.AddCommand(init)
-
-			path := subcommandPath(init)
-			Expect(path).To(Equal([]string{kubebuilderSubcommandInit}))
-		})
+		path := subcommandPath(init)
+		Expect(path).To(Equal([]string{kubebuilderSubcommandInit}))
 	})
+})
 
-	Describe("getShortKey", func() {
-		DescribeTable("should shorten plugin keys",
-			func(fullKey, expected string) {
-				Expect(getShortKey(fullKey)).To(Equal(expected))
-			},
-			Entry("standard kubebuilder plugin", "go.kubebuilder.io/v4", "go/v4"),
-			Entry("kustomize plugin", "kustomize.common.kubebuilder.io/v2", "kustomize/v2"),
-			Entry("deploy-image plugin", "deploy-image.go.kubebuilder.io/v1-alpha", "deploy-image/v1-alpha"),
-			Entry("external plugin with domain", "foo.example.com/v1", "foo.example/v1"),
-			Entry("plugin without version", "go.kubebuilder.io", "go"),
-			Entry("simple external plugin", "example.com/v1", "example.com/v1"),
-		)
-	})
+var _ = Describe("getShortKey", func() {
+	DescribeTable("should shorten plugin keys",
+		func(fullKey, expected string) {
+			Expect(getShortKey(fullKey)).To(Equal(expected))
+		},
+		Entry("standard kubebuilder plugin", "go.kubebuilder.io/v4", "go/v4"),
+		Entry("kustomize plugin", "kustomize.common.kubebuilder.io/v2", "kustomize/v2"),
+		Entry("deploy-image plugin", "deploy-image.go.kubebuilder.io/v1-alpha", "deploy-image/v1-alpha"),
+		Entry("external plugin with domain", "foo.example.com/v1", "foo.example/v1"),
+		Entry("plugin without version", "go.kubebuilder.io", "go"),
+		Entry("simple external plugin", "example.com/v1", "example.com/v1"),
+	)
+})
 
-	Describe("getPluginDescription", func() {
-		It("should return fallback description", func() {
-			Expect(getPluginDescription("foo.example.com/v1")).To(Equal("External or custom plugin"))
-		})
+var _ = Describe("getPluginDescription", func() {
+	It("should return fallback description", func() {
+		Expect(getPluginDescription("foo.example.com/v1")).To(Equal("External or custom plugin"))
 	})
 })
 
@@ -165,14 +163,6 @@ var _ = Describe("getPluginTableFilteredWithOptions", func() {
 				newMockPlugin("go.kubebuilder.io", "v4", projectVersion),
 				newMockPlugin("kustomize.common.kubebuilder.io", "v2", projectVersion),
 			)
-		})
-
-		It("should return formatted plugin table", func() {
-			table := c.getPluginTableFiltered(nil)
-			Expect(table).To(ContainSubstring("KEY"))
-			Expect(table).To(ContainSubstring("DESCRIPTION"))
-			Expect(table).To(ContainSubstring("go/v4"))
-			Expect(table).To(ContainSubstring("kustomize/v2"))
 		})
 
 		It("should exclude deprecated plugins", func() {
@@ -255,37 +245,21 @@ var _ = Describe("newRootCmd", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should create root command with correct use", func() {
-			cmd := c.newRootCmd()
-			Expect(cmd.Use).To(Equal(c.commandName))
-		})
-
-		It("should have plugins flag", func() {
+		It("should register the plugins flag", func() {
 			cmd := c.newRootCmd()
 			flag := cmd.PersistentFlags().Lookup(pluginsFlag)
 			Expect(flag).NotTo(BeNil())
 		})
 
-		It("should have project-version flag", func() {
+		It("should register the project-version flag", func() {
 			cmd := c.newRootCmd()
 			flag := cmd.Flags().Lookup(projectVersionFlag)
 			Expect(flag).NotTo(BeNil())
 		})
 
-		It("should allow unknown flags", func() {
+		It("should allow unknown flags to prevent parsing errors during help display", func() {
 			cmd := c.newRootCmd()
 			Expect(cmd.FParseErrWhitelist.UnknownFlags).To(BeTrue())
-		})
-
-		It("should include plugin table in examples", func() {
-			cmd := c.newRootCmd()
-			Expect(cmd.Example).To(ContainSubstring("Available plugins"))
-		})
-
-		It("should show default plugin in examples", func() {
-			cmd := c.newRootCmd()
-			Expect(cmd.Example).To(ContainSubstring("Default plugin"))
-			Expect(cmd.Example).To(ContainSubstring(pluginGoKubebuilderV4))
 		})
 	})
 })


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

Fix #6012 

## What this PR does / why we need it

Adds 5 new test files to `pkg/cli/` covering previously untested command files:
- `api_test.go` - Tests `newCreateAPICmd` behavior with no plugins, no CreateAPI plugins, and valid plugins
- `alpha_test.go` - Tests alpha command creation, registration, and duplicate detection
- `create_test.go` - Tests `newCreateCmd` metadata and plugin table filtering
- `edit_test.go` - Tests `newEditCmd` behavior with no plugins, no Edit plugins, and valid plugins
- `root_test.go` - Tests utility functions (`isHelpFlagArg`, `getShortKey`, `subcommandPath`, etc.) and plugin table formatting

## Test Coverage Added
- **64 new test cases** across 5 new test files
- Tests pass: `go test ./pkg/cli/... -count=1` (802 total, up from 738)

## Special Notes for Reviewers
- The remaining lint warnings (goconst) are in existing files (`cli_test.go`, `resource_test.go`), not in the new test files
- All new tests follow the existing Ginkgo/Gomega patterns used in `cli_test.go`