### PR TITLE
🌱 fix typos in comments and one CLI error message

### DIFF
--- a/internal/cli/alpha/internal/update/update.go
+++ b/internal/cli/alpha/internal/update/update.go
@@ -414,7 +414,7 @@ func (opts *Update) prepareAncestorBranch() error {
 // cleanupBranch removes all files and folders in the current directory
 // except for the .git directory and the PROJECT file.
 // This is necessary to ensure the ancestor branch starts with a clean slate
-// TODO: Analise if this command is still needed in the future.
+// TODO: Analyse if this command is still needed in the future.
 // It is required because the alpha generate command in versions prior to v4.7.0 do not properly
 // handle the removal of files in the ancestor branch.
 func cleanupBranch() error {

--- a/internal/cli/alpha/internal/update/validate.go
+++ b/internal/cli/alpha/internal/update/validate.go
@@ -53,7 +53,7 @@ func (opts *Update) Validate() error {
 	if opts.OpenGhIssue {
 		if err := exec.Command("gh", "--version").Run(); err != nil {
 			return fmt.Errorf("`gh` CLI not found or not authenticated. "+
-				"You must have gh instaled to use the --open-gh-issue option: %s", err)
+				"You must have gh installed to use the --open-gh-issue option: %s", err)
 		}
 	}
 

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go
@@ -39,7 +39,7 @@ type Makefile struct {
 	GolangciLintVersion string
 	// ControllerRuntimeVersion version to be used to download the envtest setup script
 	ControllerRuntimeVersion string
-	// EnvtestVersion store the name of the verions to be used to install setup-envtest
+	// EnvtestVersion store the name of the version to be used to install setup-envtest
 	EnvtestVersion string
 }
 

--- a/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
+++ b/pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go
@@ -133,7 +133,7 @@ func hasFields(item templates.CustomMetricItem) bool {
 	return false
 }
 
-// TODO: Prom_ql exprs can improved to be more pratical and applicable
+// TODO: Prom_ql exprs can be improved to be more practical and applicable
 func fillMissingExpr(item templates.CustomMetricItem) templates.CustomMetricItem {
 	if item.Expr == "" {
 		switch strings.ToLower(item.Type) {


### PR DESCRIPTION
Fixes four typos found with `codespell`:

- `internal/cli/alpha/internal/update/validate.go` — user-facing error read "You must have gh instaled to use the --open-gh-issue option". Nothing asserts this string.
- `internal/cli/alpha/internal/update/update.go` — `Analise` -> `Analyse` in a TODO.
- `pkg/plugins/golang/v4/scaffolds/internal/templates/makefile.go` — `verions` -> `version` in a comment.
- `pkg/plugins/optional/grafana/v1alpha/scaffolds/edit.go` — `pratical` -> `practical`, plus the missing `be` in "can improved".

No identifiers, scaffolded output, or behaviour changed. `go build ./...` passes.