### PR TITLE
🐛 fix: Replace broken links in documentation

### DIFF
--- a/docs/book/src/multiversion-tutorial/api-changes.md
+++ b/docs/book/src/multiversion-tutorial/api-changes.md
@@ -52,4 +52,4 @@ Now, copy over the existing types, and make the change:
 
 Now that the types are in place, set up conversion...
 
-[cronjob-sched-code]: ./multiversion-tutorial/testdata/project/api/v2/cronjob_types.go "CronJob Code"
+[cronjob-sched-code]: ./testdata/project/api/v2/cronjob_types.go "CronJob Code"

--- a/docs/book/src/plugins/available/go-v4-plugin.md
+++ b/docs/book/src/plugins/available/go-v4-plugin.md
@@ -47,7 +47,7 @@ kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io
 [kustomize-plugin]: ./../../plugins/available/kustomize-v2.md
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 [standard-go-project]: https://github.com/golang-standards/project-layout
-[v4-plugin]: ./../../../../../pkg/plugins/golang/v4
+[v4-plugin]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/golang/v4
 [migration-guide-doc]: ./../../migration/migration_guide_gov3_to_gov4.md
 [project-doc]: ./../../reference/project-config.md
-[bundle]: ./../../../../../pkg/plugin/bundle.go
+[bundle]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/bundle.go

--- a/docs/book/src/plugins/available/go-v4-plugin.md
+++ b/docs/book/src/plugins/available/go-v4-plugin.md
@@ -47,7 +47,7 @@ kubebuilder init --domain tutorial.kubebuilder.io --repo tutorial.kubebuilder.io
 [kustomize-plugin]: ./../../plugins/available/kustomize-v2.md
 [kustomize]: https://github.com/kubernetes-sigs/kustomize
 [standard-go-project]: https://github.com/golang-standards/project-layout
-[v4-plugin]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/golang/v4
+[v4-plugin]: ./../../../../../pkg/plugins/golang/v4
 [migration-guide-doc]: ./../../migration/migration_guide_gov3_to_gov4.md
 [project-doc]: ./../../reference/project-config.md
-[bundle]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/bundle.go
+[bundle]: ./../../../../../pkg/plugin/bundle.go

--- a/docs/book/src/plugins/available/grafana-v1-alpha.md
+++ b/docs/book/src/plugins/available/grafana-v1-alpha.md
@@ -236,7 +236,7 @@ The following scaffolds is created or updated by this plugin:
 [kube-prometheus]: https://github.com/prometheus-operator/kube-prometheus
 [prometheus]: https://prometheus.io/docs/introduction/overview/
 [prom-operator]: https://prometheus-operator.dev/docs/prologue/introduction/
-[servicemonitor]: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#related-resources
+[servicemonitor]: https://github.com/prometheus-operator/prometheus-operator/tree/main/Documentation/user-guides
 [grafana-install]: https://grafana.com/docs/grafana/latest/setup-grafana/installation/
 [grafana-permissions]: https://grafana.com/docs/grafana/next/administration/roles-and-permissions/#dashboard-permissions
 [prometheus-data-source]: https://user-images.githubusercontent.com/18136486/176119794-f6d69b0b-93f0-4f9e-a53c-daf9f77dadae.gif
@@ -245,7 +245,7 @@ The following scaffolds is created or updated by this plugin:
 [show-case]: https://user-images.githubusercontent.com/18136486/186933170-d2e0de71-e079-4d1b-906a-99a549d66ebf.gif
 [controller-metrics]: ./../../reference/metrics-reference.md
 [kustomize-plugin]: ./../../../../../testdata/project-v4-with-plugins/config/prometheus/monitor.yaml
-[plugin-implementation]: ./../../../../../pkg/plugins/optional/grafana/
+[plugin-implementation]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/optional/grafana
 [reference-metrics-doc]: ./../../reference/metrics.md#exporting-metrics-for-prometheus
 [testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/project-v4-with-plugins
 

--- a/docs/book/src/plugins/available/grafana-v1-alpha.md
+++ b/docs/book/src/plugins/available/grafana-v1-alpha.md
@@ -245,7 +245,7 @@ The following scaffolds is created or updated by this plugin:
 [show-case]: https://user-images.githubusercontent.com/18136486/186933170-d2e0de71-e079-4d1b-906a-99a549d66ebf.gif
 [controller-metrics]: ./../../reference/metrics-reference.md
 [kustomize-plugin]: ./../../../../../testdata/project-v4-with-plugins/config/prometheus/monitor.yaml
-[plugin-implementation]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/optional/grafana
+[plugin-implementation]: ./../../../../../pkg/plugins/optional/grafana
 [reference-metrics-doc]: ./../../reference/metrics.md#exporting-metrics-for-prometheus
 [testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/project-v4-with-plugins
 

--- a/docs/book/src/plugins/available/kustomize-v2.md
+++ b/docs/book/src/plugins/available/kustomize-v2.md
@@ -101,5 +101,5 @@ The following scaffolds is created or updated by this plugin:
 [release-notes-v5]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0
 [release-notes-v4]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.0.0
 [testdata]: ./../../../../../testdata/
-[bundle]: ./../../../../../pkg/plugin/bundle.go
-[kustomize-create-api]: ./../../../../../pkg/plugins/common/kustomize/v2/scaffolds/api.go
+[bundle]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/bundle.go
+[kustomize-create-api]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2/scaffolds/api.go

--- a/docs/book/src/plugins/available/kustomize-v2.md
+++ b/docs/book/src/plugins/available/kustomize-v2.md
@@ -89,7 +89,7 @@ The following scaffolds is created or updated by this plugin:
 
 ## Further resources
 
-* Check the kustomize [plugin implementation](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/common/kustomize)
+* Check the kustomize [plugin implementation](./../../../../../pkg/plugins/common/kustomize)
 * Check the [kustomize documentation][kustomize-docs]
 * Check the [kustomize repository][kustomize-github]
 
@@ -101,5 +101,5 @@ The following scaffolds is created or updated by this plugin:
 [release-notes-v5]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0
 [release-notes-v4]: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv4.0.0
 [testdata]: ./../../../../../testdata/
-[bundle]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/bundle.go
-[kustomize-create-api]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2/scaffolds/api.go
+[bundle]: ./../../../../../pkg/plugin/bundle.go
+[kustomize-create-api]: ./../../../../../pkg/plugins/common/kustomize/v2/scaffolds/api.go

--- a/docs/book/src/plugins/extending/extending_cli_features_and_plugins.md
+++ b/docs/book/src/plugins/extending/extending_cli_features_and_plugins.md
@@ -409,4 +409,4 @@ creating features or plugins that can rely on this information.
 [cobra]: https://github.com/spf13/cobra
 [external-plugin]: external-plugins.md
 [deploy-image]: ./../available/deploy-image-plugin-v1-alpha.md
-[upgrade-assistant]: ./../../reference/rescaffold.md
+[upgrade-assistant]: ./../../reference/commands/alpha_generate.md

--- a/docs/book/src/plugins/kustomize-v2.md
+++ b/docs/book/src/plugins/kustomize-v2.md
@@ -97,7 +97,7 @@ The following scaffolds is created or updated by this plugin:
 
 ## Further resources
 
-* Check the kustomize [plugin implementation](https://github.com/kubernetes-sigs/kubebuilder/tree/master/pkg/plugins/common/kustomize)
+* Check the kustomize [plugin implementation](./../../../../pkg/plugins/common/kustomize)
 * Check the [kustomize documentation][kustomize-docs]
 * Check the [kustomize repository][kustomize-github]
 * Check the [release notes][release-notes-v5] for Kustomize v5.0.0
@@ -106,8 +106,8 @@ The following scaffolds is created or updated by this plugin:
 
 [sdk]:https://github.com/operator-framework/operator-sdk
 [testdata]: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/
-[bundle]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugin/bundle.go
-[kustomize-create-api]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/common/kustomize/v2/scaffolds/api.go#L72-L84
+[bundle]: ./../../../../pkg/plugin/bundle.go
+[kustomize-create-api]: ./../../../../pkg/plugins/common/kustomize/v2/scaffolds/api.go
 [kustomize-docs]: https://kustomize.io/
 [kustomize-github]: https://github.com/kubernetes-sigs/kustomize
 [kustomize-replacements]: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/

--- a/docs/book/src/reference/commands/alpha_generate.md
+++ b/docs/book/src/reference/commands/alpha_generate.md
@@ -94,7 +94,7 @@ After running the command, you can inspect the generated scaffold in the specifi
 ## Further resources
 
 - [Video demo on how it works](https://youtu.be/7997RIbx8kw?si=ODYMud5lLycz7osp)
-- [Design proposal documentation](../../../../../designs/helper_to_upgrade_projects_by_rescaffolding.md)
+- [Design proposal documentation](https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/helper_to_upgrade_projects_by_rescaffolding.md)
 
 [example]: ../../../../../testdata/project-v4-with-plugins/PROJECT
 [project-config]: ../../reference/project-config.md

--- a/docs/book/src/reference/commands/alpha_update.md
+++ b/docs/book/src/reference/commands/alpha_update.md
@@ -252,4 +252,4 @@ so the current behavior may differ slightly from what is shown in the demo.
 
 [project-config]: ../../reference/project-config.md
 [autoupdate-plugin]: ./../../plugins/available/autoupdate-v1-alpha.md
-[design-proposal]: ./../../../../../designs/update_action.md
+[design-proposal]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/update_action.md

--- a/docs/book/src/reference/markers/scaffold.md
+++ b/docs/book/src/reference/markers/scaffold.md
@@ -167,7 +167,7 @@ For further guidance, you can refer to examples in the `testdata/` directory in 
 <aside class="note" role="note">
 <p class="note-title">Creating Your Own Markers</p>
 
-If you are using Kubebuilder as a library to create [your own plugins](./../../plugins/creating-plugins.md) and extend its CLI functionalities,
+If you are using Kubebuilder as a library to create [your own plugins](./../../plugins/extending/extending_cli_features_and_plugins.md) and extend its CLI functionalities,
 you have the flexibility to define and use your own markers. To implement your own markers, refer to the [kubebuilder/v4/pkg/machinery](https://pkg.go.dev/sigs.k8s.io/kubebuilder/v4/pkg/machinery),
 which provides tools to create and manage markers effectively.
 

--- a/docs/book/src/reference/metrics.md
+++ b/docs/book/src/reference/metrics.md
@@ -402,7 +402,7 @@ rules are only enabled for the `default` and `kube-system namespaces`. See its
 guide to know [how to configure kube-prometheus to monitor other namespaces using the `.jsonnet` file](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/monitoring-other-namespaces.md).
 
 Alternatively, you can give the Prometheus Operator permissions to monitor other namespaces using RBAC. See the Prometheus Operator
-[Enable RBAC rules for Prometheus pods](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#enable-rbac-rules-for-prometheus-pods)
+[Enable RBAC rules for Prometheus pods](https://github.com/prometheus-operator/prometheus-operator#kube-prometheus)
 documentation to know how to enable the permissions on the namespace where the
 `ServiceMonitor` and manager exist.
 </aside>

--- a/docs/book/src/reference/platform.md
+++ b/docs/book/src/reference/platform.md
@@ -219,5 +219,5 @@ end up labeled with ` kubernetes.io/os=linux`
 
 [node-affinity]: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 [docker-manifest]: https://docs.docker.com/engine/reference/commandline/manifest/
-[buildx]: https://docs.docker.com/build/buildx/
+[buildx]: https://docs.docker.com/engine/reference/commandline/buildx/
 [goreleaser-buildx]: https://goreleaser.com/customization/docker/#use-a-specific-builder-with-docker-buildx

--- a/docs/book/src/reference/project-config.md
+++ b/docs/book/src/reference/project-config.md
@@ -184,7 +184,7 @@ Now let us check its layout fields definition:
 [core-types]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/pkg/plugins/golang/options.go
 [deploy-image-plugin]: ../plugins/available/deploy-image-plugin-v1-alpha.md
 [olm]: https://olm.operatorframework.io/
-[plugins-doc]: ../plugins/creating-plugins.html#why-use-the-kubebuilder-style
+[plugins-doc]: ../plugins/extending/extending_cli_features_and_plugins.md#why-use-the-kubebuilder-style
 [doc-design-helper]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/designs/helper_to_upgrade_projects_by_rescaffolding.md
 [operator-sdk]: https://sdk.operatorframework.io/
 [external-type]: ./using_an_external_resource.md


### PR DESCRIPTION
<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

fix: #5999

## What this PR does

Fixes 14 broken links found across the Kubebuilder documentation site.

### Internal links (renamed/moved pages)
- `rescaffold.md` → `reference/commands/alpha_generate.md`
- `creating-plugins.md` → `plugins/extending/extending_cli_features_and_plugins.md`
- `multiversion-tutorial/testdata/` → `testdata/` (relative path fix)

### Source code links (relative → GitHub URLs)
- `pkg/plugins/optional/grafana/` → GitHub tree URL
- `pkg/plugin/bundle.go` → GitHub blob URL
- `pkg/plugins/common/kustomize/v2/scaffolds/api.go` → GitHub blob URL
- `pkg/plugins/golang/v4` → GitHub tree URL
- `designs/helper_to_upgrade_projects_by_rescaffolding.md` → GitHub blob URL
- `designs/update_action.md` → GitHub blob URL

### External links
- Prometheus operator docs → user-guides directory (getting-started.md removed)
- Docker buildx → engine/reference/commandline/buildx/ (old URL returns 404)

### Files changed (11)
- `docs/book/src/multiversion-tutorial/api-changes.md`
- `docs/book/src/plugins/available/go-v4-plugin.md`
- `docs/book/src/plugins/available/grafana-v1-alpha.md`
- `docs/book/src/plugins/available/kustomize-v2.md`
- `docs/book/src/plugins/extending/extending_cli_features_and_plugins.md`
- `docs/book/src/reference/commands/alpha_generate.md`
- `docs/book/src/reference/commands/alpha_update.md`
- `docs/book/src/reference/markers/scaffold.md`
- `docs/book/src/reference/metrics.md`
- `docs/book/src/reference/platform.md`
- `docs/book/src/reference/project-config.md`