### PR TITLE
🐛 (CLI; alpha generate) Migrate go/v3-alpha layouts to go/v4 instead of a non-existent v4-alpha

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -54,6 +54,8 @@ const (
 	pluginGoKubebuilderV4           = "go.kubebuilder.io/v4"
 	pluginGoKubebuilderV3           = "go.kubebuilder.io/v3"
 	pluginGoKubebuilderV2           = "go.kubebuilder.io/v2"
+	pluginGoKubebuilderV3Alpha      = pluginGoKubebuilderV3 + "-alpha"
+	pluginGoKubebuilderV4Alpha      = pluginGoKubebuilderV4 + "-alpha"
 	generateSubcommand              = "generate"
 
 	pluginsFlagDescription = "Comma-separated list of plugin keys to use. " +
@@ -484,10 +486,15 @@ func patchProjectFileInMemoryIfNeeded(fs afero.Fs, path string) error {
 		New string
 	}
 
+	// Ordered longest key first. "go.kubebuilder.io/v3" is a prefix of
+	// "go.kubebuilder.io/v3-alpha", so replacing it first would leave a
+	// "go.kubebuilder.io/v4-alpha" that no plugin provides. That key shipped as
+	// a real plugin until go/v4 stabilized it, so it is retired here as well.
 	replacements := []pluginReplacement{
-		{pluginGoKubebuilderV2, pluginGoKubebuilderV4},
+		{pluginGoKubebuilderV3Alpha, pluginGoKubebuilderV4},
+		{pluginGoKubebuilderV4Alpha, pluginGoKubebuilderV4},
 		{pluginGoKubebuilderV3, pluginGoKubebuilderV4},
-		{pluginGoKubebuilderV3 + "-alpha", pluginGoKubebuilderV4},
+		{pluginGoKubebuilderV2, pluginGoKubebuilderV4},
 	}
 
 	content, err := afero.ReadFile(fs, path)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2112,6 +2112,26 @@ version: "3"
 			Expect(string(updated)).NotTo(ContainSubstring(pluginGoKubebuilderV3))
 		})
 
+		DescribeTable("should patch a retired Go plugin key to go/v4",
+			func(layout, expected string) {
+				fs := afero.NewMemMapFs()
+				project := func(key string) string {
+					return "domain: example.com\nlayout:\n- " + key + "\nversion: \"3\"\n"
+				}
+				content := project(layout)
+				Expect(afero.WriteFile(fs, yamlstore.DefaultPath,
+					[]byte(content), machinery.DefaultFilePermission)).To(Succeed())
+				Expect(patchProjectFileInMemoryIfNeeded(fs, yamlstore.DefaultPath)).To(Succeed())
+
+				updated, err := afero.ReadFile(fs, yamlstore.DefaultPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(updated)).To(Equal(project(expected)))
+			},
+			Entry("go/v3-alpha", pluginGoKubebuilderV3Alpha, pluginGoKubebuilderV4),
+			Entry("go/v4-alpha", pluginGoKubebuilderV4Alpha, pluginGoKubebuilderV4),
+			Entry("base go/v3 still migrates", "base.go.kubebuilder.io/v3", "base.go.kubebuilder.io/v4"),
+		)
+
 		It("should not modify files that do not need patching", func() {
 			fs := afero.NewMemMapFs()
 			content := `domain: example.com


### PR DESCRIPTION

# 🐛 (cli): Fix alpha generate rewriting a go/v3-alpha layout to a non existent v4-alpha



Fixes #6020

## Problem

`kubebuilder alpha generate` cannot read a project whose layout is `go.kubebuilder.io/v3-alpha`. A
`v2` or `v3` layout correctly becomes `go.kubebuilder.io/v4`, but `v3-alpha` becomes
`go.kubebuilder.io/v4-alpha`, which is not a registered plugin.

## Root Cause

`patchProjectFileInMemoryIfNeeded` applies plugin-key replacements
sequentially using substring matching. The replacement rules are therefore order-dependent.

`go.kubebuilder.io/v3` is a prefix of `go.kubebuilder.io/v3-alpha`. With the generic `v3 → v4`
replacement processed before the more specific `v3-alpha → v4` rule:

```text
go.kubebuilder.io/v3-alpha
        ↓  {v3 → v4}
go.kubebuilder.io/v4-alpha
```

The `v3-alpha → v4` rule can no longer match, leaving `go.kubebuilder.io/v4-alpha`, which is not a
registered plugin. The issue is therefore caused by the replacement strategy and rule ordering, rather than by plugin resolution itself.

A second problem makes the failure destructive: the patched `PROJECT` content is written to disk
before `cfg.Load()` and plugin resolution complete. Consequently, the invalid `v4-alpha` key can be
persisted even though the command ultimately fails, leaving the project in a state where subsequent
Kubebuilder commands may also fail.

## Changes

**`pkg/cli/cli.go`** — two constants named (`pluginGoKubebuilderV3Alpha`, `pluginGoKubebuilderV4Alpha`), and the table reordered longest key first:

```go
// Ordered longest key first. "go.kubebuilder.io/v3" is a prefix of
// "go.kubebuilder.io/v3-alpha", so replacing it first would leave a
// "go.kubebuilder.io/v4-alpha" that no plugin provides. That key shipped as
// a real plugin until go/v4 stabilized it, so it is retired here as well.
replacements := []pluginReplacement{
	{pluginGoKubebuilderV3Alpha, pluginGoKubebuilderV4},
	{pluginGoKubebuilderV4Alpha, pluginGoKubebuilderV4},
	{pluginGoKubebuilderV3, pluginGoKubebuilderV4},
	{pluginGoKubebuilderV2, pluginGoKubebuilderV4},
}
```

`v4-alpha`  was a real plugin until [#3237](https://github.com/kubernetes-sigs/kubebuilder/pull/3237) stabilized it into `go/v4`, so projects scaffolded before that carry it legitimately. Mapping it also repairs projects that this bug wrote a bad key into.

**`pkg/cli/cli_test.go`** — a table with three entries: `v3-alpha` → `v4` (the regression test),
`v4-alpha` → `v4`, and `base.go.kubebuilder.io/v3` still migrating to `/v4`. Each asserts the
resulting `PROJECT` in full, so an unintended edit elsewhere in the file also fails.

## Result

| Layout in `PROJECT` | Result |
| --- |--- |
| `go.kubebuilder.io/v3-alpha` | `go.kubebuilder.io/v4` |
| `go.kubebuilder.io/v4-alpha` | `go.kubebuilder.io/v4` |
| `go.kubebuilder.io/v2`, `/v3`  | unchanged |
| `base.go.kubebuilder.io/v3` | unchanged |

Every retired Go plugin key now ends on `go.kubebuilder.io/v4.

Whenever  `go.kubebuilder.io/v4` is retired: keep the longest-first rule when adding `{v4 → v5}.
