### PR TITLE
🌱 (go/v4): drop SSA plural marker workaround (follow add SSA support; prior release)

### DIFF
--- a/docs/book/src/reference/server-side-apply.md
+++ b/docs/book/src/reference/server-side-apply.md
@@ -10,7 +10,7 @@ The `--ssa` flag is an alpha feature and may change in future releases.
 </aside>
 
 This adds:
-- API markers (`+genclient`, `+kubebuilder:ac:generate=true`, `+kubebuilder:resource:path=<plural>`) for ApplyConfiguration generation
+- API markers (`+genclient`, `+kubebuilder:ac:generate=true`) for ApplyConfiguration generation
 - Makefile integration to generate type-safe ApplyConfiguration types alongside CRD and RBAC manifests
 
 ## When to use it
@@ -46,7 +46,7 @@ appsv1apply "example.com/myproject/api/v1/applyconfiguration/api/v1"
 
 ## Mixing SSA and non-SSA APIs
 
-The `+kubebuilder:ac:generate=true` marker is package-level: it enables ApplyConfiguration generation for all kinds in the same group/version. Kinds scaffolded without `--ssa` include the `+kubebuilder:ac:generate=false` marker, so ApplyConfiguration types are only generated for the kinds that opted in. When you create an API with `--ssa`, kinds previously scaffolded without this marker in that group/version receive it automatically.
+The `+kubebuilder:ac:generate=true` marker in `groupversion_info.go` is package-level: it enables ApplyConfiguration generation for the group/version. Each kind then opts in or out with its own `+kubebuilder:ac:generate` marker: kinds scaffolded with `--ssa` get `=true`, and kinds scaffolded without it get `=false`. When you create an API with `--ssa`, kinds previously scaffolded without this marker in that group/version receive it automatically.
 
 To change which kinds are generated:
 - Set `+kubebuilder:ac:generate=true` above a kind to include it

--- a/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_ssa_integration_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Server-Side Apply (--ssa) Scaffolding", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(typesContent)).To(ContainSubstring("+genclient"),
 			"the regenerated API must keep the SSA markers tracked in the PROJECT file")
-		Expect(string(typesContent)).To(ContainSubstring("+kubebuilder:resource:path=captains"))
+		Expect(string(typesContent)).To(ContainSubstring("+kubebuilder:ac:generate=true"))
 		Expect(string(typesContent)).NotTo(ContainSubstring("+kubebuilder:ac:generate=false"))
 
 		By("verifying the PROJECT file still tracks ssa")
@@ -226,7 +226,8 @@ var _ = Describe("Server-Side Apply (--ssa) Scaffolding", func() {
 			Expect(string(typesContent)).To(ContainSubstring("// +genclient\n// +genclient:nonNamespaced"),
 				"the regenerated cluster-scoped API must keep the SSA client markers")
 			Expect(string(typesContent)).To(ContainSubstring(
-				"// +kubebuilder:resource:path=admirals,scope=Cluster"))
+				"// +kubebuilder:resource:scope=Cluster"))
+			Expect(string(typesContent)).NotTo(ContainSubstring("+kubebuilder:resource:path="))
 		},
 		Entry("when --ssa is provided again", true),
 		Entry("when --ssa is omitted", false),

--- a/pkg/plugins/golang/v4/scaffolds/api_test.go
+++ b/pkg/plugins/golang/v4/scaffolds/api_test.go
@@ -159,12 +159,13 @@ var _ = Describe("API scaffolding with Server-Side Apply", func() {
 			return string(content)
 		}
 
-		It("should scaffold the genclient and resource markers when SSA is enabled", func() {
+		It("should scaffold the genclient and apply configuration markers when SSA is enabled", func() {
 			content := scaffoldTypes(ssaTestResource("Navigator", true), false)
 
 			Expect(content).To(ContainSubstring("// +genclient"))
-			Expect(content).To(ContainSubstring("// +kubebuilder:resource:path=navigators"))
+			Expect(content).To(ContainSubstring("// +kubebuilder:ac:generate=true"))
 			Expect(content).NotTo(ContainSubstring("+kubebuilder:ac:generate=false"))
+			Expect(content).NotTo(ContainSubstring("+kubebuilder:resource:path="))
 		})
 
 		It("should scaffold the nonNamespaced marker when SSA is enabled for a cluster-scoped kind", func() {
@@ -173,7 +174,8 @@ var _ = Describe("API scaffolding with Server-Side Apply", func() {
 			content := scaffoldTypes(res, false)
 
 			Expect(content).To(ContainSubstring("// +genclient\n// +genclient:nonNamespaced"))
-			Expect(content).To(ContainSubstring("// +kubebuilder:resource:path=admirals,scope=Cluster"))
+			Expect(content).To(ContainSubstring("// +kubebuilder:resource:scope=Cluster"))
+			Expect(content).NotTo(ContainSubstring("+kubebuilder:resource:path="))
 		})
 
 		It("should keep the custom plural in the resource path when SSA is enabled", func() {

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/api/types.go
@@ -119,18 +119,17 @@ type {{ .Resource.Kind }}Status struct {
 {{- if not .Resource.API.Namespaced }}
 // +genclient:nonNamespaced
 {{- end }}
+// +kubebuilder:ac:generate=true
 {{- else if .SkipApplyConfig }}
 // +kubebuilder:ac:generate=false
 {{- end }}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-{{- if and (not .Resource.API.Namespaced) (or (not .Resource.IsRegularPlural) .Resource.API.SSA) }}
+{{- if and (not .Resource.API.Namespaced) (not .Resource.IsRegularPlural) }}
 // +kubebuilder:resource:path={{ .Resource.Plural }},scope=Cluster
 {{- else if not .Resource.API.Namespaced }}
 // +kubebuilder:resource:scope=Cluster
 {{- else if not .Resource.IsRegularPlural }}
-// +kubebuilder:resource:path={{ .Resource.Plural }}
-{{- else if .Resource.API.SSA }}
 // +kubebuilder:resource:path={{ .Resource.Plural }}
 {{- end }}
 

--- a/testdata/project-v4-multigroup/api/sea-creatures/v1/prawn_types.go
+++ b/testdata/project-v4-multigroup/api/sea-creatures/v1/prawn_types.go
@@ -60,9 +60,9 @@ type PrawnStatus struct {
 }
 
 // +genclient
+// +kubebuilder:ac:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=prawns
 
 // Prawn is the Schema for the prawns API
 type Prawn struct {

--- a/testdata/project-v4/api/v1/navigator_types.go
+++ b/testdata/project-v4/api/v1/navigator_types.go
@@ -60,9 +60,9 @@ type NavigatorStatus struct {
 }
 
 // +genclient
+// +kubebuilder:ac:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=navigators
 
 // Navigator is the Schema for the navigators API
 type Navigator struct {


### PR DESCRIPTION
SSA kinds no longer scaffold a redundant +kubebuilder:resource:path= marker. controller-tools v0.22.0 makes +kubebuilder:ac:generate=true the apply-root signal, so path= is emitted only for irregular plurals, like every other kind.

Closes #5841

<!--

Hiya!  Welcome to Kubebuilder!  For a smooth PR process, please ensure
that you include the following information:

* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

Please don't @-mention people in PR or commit messages (do so in an
additional comment).

please add an icon to the title of this PR depending on the type:

- ⚠ (:warning:): breaking
- ✨ (:sparkles:): new non-breaking feature
- 🐛 (:bug:): bugfix
- 📖 (:book:): documentation
- 🌱 (:seedling:): infrastructure/other

See https://sigs.k8s.io/kubebuilder-release-tools for more information.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
