### PR TITLE
🐛 (helm/v2-alpha): keep metrics flags and metrics resources in sync.

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/values.yaml
@@ -180,7 +180,7 @@ webhook:
   port: 9443
 
 ## Prometheus ServiceMonitor for metrics scraping.
-## Requires prometheus-operator to be installed in the cluster.
+## Requires prometheus-operator to be installed in the cluster and metrics.enabled set to true.
 ##
 prometheus:
   enabled: true

--- a/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/getting-started/testdata/project/dist/chart/values.yaml
@@ -180,7 +180,7 @@ webhook:
   port: 9443
 
 ## Prometheus ServiceMonitor for metrics scraping.
-## Requires prometheus-operator to be installed in the cluster.
+## Requires prometheus-operator to be installed in the cluster and metrics.enabled set to true.
 ##
 prometheus:
   enabled: false

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/values.yaml
@@ -180,7 +180,7 @@ webhook:
   port: 9443
 
 ## Prometheus ServiceMonitor for metrics scraping.
-## Requires prometheus-operator to be installed in the cluster.
+## Requires prometheus-operator to be installed in the cluster and metrics.enabled set to true.
 ##
 prometheus:
   enabled: true

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -226,6 +226,7 @@ Webhook and metrics certificates (`webhook-certs`, `metrics-certs`) are managed 
 #### `metrics.port`
 
 Set `metrics.port` to change the port used by the metrics endpoint. The chart applies the same value to the manager `--metrics-bind-address` argument, the metrics Service port and targetPort, and the metrics NetworkPolicy.
+If the input manager does not define a metrics bind-address argument, the chart adds one so this setting still controls the endpoint.
 
 For example, install the chart with the metrics endpoint on port `8444`:
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/conditionals.go
@@ -54,8 +54,12 @@ func AddConditionalWrappers(
 	case kind == common.KindIssuer && apiVersion == common.APIVersionCertManager:
 		return fmt.Sprintf("{{- if .Values.certManager.enabled }}\n%s\n{{- end }}", yamlContent)
 	case kind == common.KindServiceMonitor && apiVersion == common.APIVersionMonitoring:
+		// The ServiceMonitor scrapes the metrics Service, so it needs metrics enabled too.
 		// CRITICAL: newline before {{- end }} prevents whitespace chomping from eating content
-		return fmt.Sprintf("{{- if .Values.prometheus.enabled }}\n%s\n{{- end }}", yamlContent)
+		return fmt.Sprintf(
+			"{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}\n%s\n{{- end }}",
+			yamlContent,
+		)
 	case kind == common.KindNetworkPolicy && apiVersion == common.APIVersionNetworking:
 		switch {
 		case IsScaffoldedPolicyName(name, detectedPrefix, "allow-webhook-traffic"):

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -111,14 +111,6 @@ func TemplateDeploymentFields(detectedPrefix, chartName, yamlContent string) str
 	return yamlContent
 }
 
-// isManagerContainerPresent reports whether yamlContent contains the manager container by literal or templated name.
-func isManagerContainerPresent(yamlContent string) bool {
-	containerName := GetDefaultContainerName(yamlContent)
-	hasLiteralName := strings.Contains(yamlContent, "name: "+containerName)
-	hasTemplatedName := strings.Contains(yamlContent, `name: {{ include "`) && strings.Contains(yamlContent, `"manager"`)
-	return hasLiteralName || hasTemplatedName
-}
-
 func templateReplicas(yamlContent string) string {
 	if strings.Contains(yamlContent, ".Values.manager.replicas") {
 		return yamlContent
@@ -180,15 +172,14 @@ func AddCustomLabelsAndAnnotations(yamlContent string) string {
 }
 
 func templateEnvironmentVariables(yamlContent string) string {
-	if !isManagerContainerPresent(yamlContent) {
+	managerStartLine, managerEndLine := FindManagerContainerRange(yamlContent)
+	if managerStartLine < 0 {
 		return yamlContent
 	}
 
-	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
-
 	lines := strings.Split(yamlContent, "\n")
 	for i := range lines {
-		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+		if i < managerStartLine || i > managerEndLine {
 			continue
 		}
 		if strings.TrimSpace(lines[i]) != "env:" {
@@ -252,15 +243,18 @@ func templateEnvironmentVariables(yamlContent string) string {
 }
 
 func templateResources(yamlContent string) string {
-	if !isManagerContainerPresent(yamlContent) || !strings.Contains(yamlContent, "resources:") {
+	if !strings.Contains(yamlContent, "resources:") {
 		return yamlContent
 	}
 
-	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
+	managerStartLine, managerEndLine := FindManagerContainerRange(yamlContent)
+	if managerStartLine < 0 {
+		return yamlContent
+	}
 
 	lines := strings.Split(yamlContent, "\n")
 	for i := range lines {
-		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+		if i < managerStartLine || i > managerEndLine {
 			continue
 		}
 		if strings.TrimSpace(lines[i]) != "resources:" {
@@ -527,15 +521,18 @@ func templatePodSecurityContext(yamlContent string) string {
 }
 
 func templateContainerSecurityContext(yamlContent string) string {
-	if !isManagerContainerPresent(yamlContent) || !strings.Contains(yamlContent, "securityContext:") {
+	if !strings.Contains(yamlContent, "securityContext:") {
 		return yamlContent
 	}
 
-	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
+	managerStartLine, managerEndLine := FindManagerContainerRange(yamlContent)
+	if managerStartLine < 0 {
+		return yamlContent
+	}
 
 	lines := strings.Split(yamlContent, "\n")
 	for i := range lines {
-		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+		if i < managerStartLine || i > managerEndLine {
 			continue
 		}
 		if strings.TrimSpace(lines[i]) != "securityContext:" {
@@ -591,141 +588,189 @@ func templateContainerSecurityContext(yamlContent string) string {
 }
 
 func templateControllerManagerArgs(yamlContent string) string {
-	if !isManagerContainerPresent(yamlContent) {
+	managerStartLine, managerEndLine := FindManagerContainerRange(yamlContent)
+	if managerStartLine < 0 || managerEndLine < managerStartLine {
 		return yamlContent
 	}
 
-	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
-
-	argsPattern := regexp.MustCompile(`(?m)([ \t]+)args:\n((?:[ \t]+-.*\n)+)`)
-	loc := argsPattern.FindStringSubmatchIndex(yamlContent)
-	if loc == nil {
+	lines := strings.Split(yamlContent, "\n")
+	managerContainerYAML := strings.Join(lines[managerStartLine:managerEndLine+1], "\n")
+	if strings.Contains(managerContainerYAML, ".Values.manager.args") {
 		return yamlContent
 	}
 
-	if rangeStart >= 0 {
-		matchLine := strings.Count(yamlContent[:loc[0]], "\n")
-		if matchLine < rangeStart || matchLine > rangeEnd {
-			return yamlContent
+	managerArguments := findManagerArguments(lines, managerStartLine, managerEndLine)
+	renderedArguments := renderManagerArguments(managerArguments)
+
+	return replaceManagerArguments(lines, managerEndLine, managerArguments, renderedArguments)
+}
+
+// managerArguments describes the existing manager args block and the controller flags
+// that must remain under Helm's control.
+type managerArguments struct {
+	startLine                int
+	endLine                  int
+	fieldIndent              string
+	itemIndent               string
+	inlineItemPrefix         string
+	metricsBindAddressLine   string
+	metricsBindAddressIndent string
+	healthProbeBindLine      string
+	webhookPortLine          string
+	certificateArgumentLines []string
+}
+
+func findManagerArguments(lines []string, managerStartLine, managerEndLine int) managerArguments {
+	arguments := managerArguments{startLine: -1, endLine: -1}
+	for lineNumber := managerStartLine; lineNumber <= managerEndLine; lineNumber++ {
+		trimmedLine := strings.TrimSpace(lines[lineNumber])
+		if trimmedLine == "args:" || strings.HasPrefix(trimmedLine, "args: ") {
+			arguments.startLine = lineNumber
+			arguments.fieldIndent, _ = LeadingWhitespace(lines[lineNumber])
+			break
 		}
-	}
-
-	match := yamlContent[loc[0]:loc[1]]
-	if strings.Contains(match, ".Values.manager.args") {
-		return yamlContent
-	}
-
-	indent := yamlContent[loc[2]:loc[3]]
-	itemsBlock := yamlContent[loc[4]:loc[5]]
-
-	itemIndent := indent + "  "
-	lines := strings.Split(itemsBlock, "\n")
-	var (
-		metricsLine    string
-		metricsIndent  string
-		healthLine     string
-		webhookLine    string
-		preservedLines []string
-	)
-
-	for _, rawLine := range lines {
-		line := strings.TrimRight(rawLine, "\r")
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
+		if !strings.HasPrefix(trimmedLine, "- args:") {
 			continue
 		}
 
-		if itemIndent == indent+"  " {
-			if idx := strings.Index(line, "-"); idx > 0 {
-				itemIndent = line[:idx]
-			}
+		arguments.startLine = lineNumber
+		dashIndex := strings.Index(lines[lineNumber], "-")
+		arguments.inlineItemPrefix = lines[lineNumber][:dashIndex] + "- "
+		arguments.itemIndent = lines[lineNumber][:dashIndex] + "  "
+		break
+	}
+
+	if arguments.startLine < 0 {
+		containerIndent, _ := LeadingWhitespace(lines[managerStartLine])
+		arguments.fieldIndent = containerIndent + "  "
+		arguments.itemIndent = arguments.fieldIndent
+		return arguments
+	}
+
+	arguments.endLine = arguments.startLine
+	for lineNumber := arguments.startLine + 1; lineNumber <= managerEndLine; lineNumber++ {
+		trimmedLine := strings.TrimSpace(lines[lineNumber])
+		if trimmedLine == "" || !strings.HasPrefix(trimmedLine, "- ") {
+			break
 		}
 
+		argumentIndent, _ := LeadingWhitespace(lines[lineNumber])
+		if arguments.itemIndent == "" {
+			arguments.itemIndent = argumentIndent
+		}
+		if len(argumentIndent) != len(arguments.itemIndent) {
+			break
+		}
+
+		argumentLine := strings.TrimRight(lines[lineNumber], "\r")
+		trimmedArgumentLine := strings.TrimSpace(argumentLine)
 		switch {
-		case strings.Contains(trimmed, "--metrics-bind-address"):
-			metricsLine = line
-			if idx := strings.Index(line, "-"); idx > 0 {
-				metricsIndent = line[:idx]
-			}
-		case strings.Contains(trimmed, "--health-probe-bind-address"):
-			healthLine = line
-		case strings.Contains(trimmed, "--webhook-port"):
-			webhookLine = line
-		case strings.Contains(trimmed, "--webhook-cert-path"),
-			strings.Contains(trimmed, "--metrics-cert-path"):
-			preservedLines = append(preservedLines, line)
-		default:
-			// Remaining args will be handled through values.yaml
+		case strings.Contains(trimmedArgumentLine, "--metrics-bind-address"):
+			arguments.metricsBindAddressLine = argumentLine
+			arguments.metricsBindAddressIndent, _ = LeadingWhitespace(argumentLine)
+		case strings.Contains(trimmedArgumentLine, "--health-probe-bind-address"):
+			arguments.healthProbeBindLine = argumentLine
+		case strings.Contains(trimmedArgumentLine, "--webhook-port"):
+			arguments.webhookPortLine = argumentLine
+		case strings.Contains(trimmedArgumentLine, "--webhook-cert-path"),
+			strings.Contains(trimmedArgumentLine, "--metrics-cert-path"):
+			arguments.certificateArgumentLines = append(
+				arguments.certificateArgumentLines,
+				argumentLine,
+			)
 		}
+		arguments.endLine = lineNumber
+	}
+	if arguments.itemIndent == "" {
+		arguments.itemIndent = arguments.fieldIndent + "  "
 	}
 
-	var builder strings.Builder
-	builder.WriteString(indent)
-	builder.WriteString("args:\n")
+	return arguments
+}
 
-	if metricsLine != "" {
-		if metricsIndent == "" {
-			metricsIndent = itemIndent
+func renderManagerArguments(arguments managerArguments) []string {
+	metricsIndent := arguments.metricsBindAddressIndent
+	if metricsIndent == "" {
+		metricsIndent = arguments.itemIndent
+	}
+	metricsBindAddressLine := arguments.metricsBindAddressLine
+	if metricsBindAddressLine == "" {
+		metricsBindAddressLine = arguments.itemIndent + "- --metrics-bind-address=:{{ .Values.metrics.port }}"
+	}
+
+	rendered := []string{
+		arguments.fieldIndent + "args:",
+		metricsIndent + "{{- if .Values.metrics.enabled }}",
+		metricsBindAddressLine,
+		metricsIndent + "{{- if not .Values.metrics.secure }}",
+		metricsIndent + "- --metrics-secure=false",
+		metricsIndent + "{{- end }}",
+		metricsIndent + "{{- else }}",
+		metricsIndent + "# Bind to :0 to disable the controller-runtime managed metrics server",
+		metricsIndent + "- --metrics-bind-address=0",
+		metricsIndent + "{{- end }}",
+	}
+
+	if arguments.healthProbeBindLine != "" {
+		rendered = append(rendered, arguments.healthProbeBindLine)
+	}
+
+	if arguments.webhookPortLine != "" {
+		rendered = append(rendered,
+			arguments.itemIndent+"{{- if .Values.webhook.enabled }}",
+			arguments.webhookPortLine,
+			arguments.itemIndent+"{{- end }}",
+		)
+	}
+
+	rendered = append(rendered,
+		arguments.itemIndent+"{{- range .Values.manager.args }}",
+		arguments.itemIndent+"- {{ tpl . $ }}",
+		arguments.itemIndent+"{{- end }}",
+	)
+
+	return append(rendered, arguments.certificateArgumentLines...)
+}
+
+func replaceManagerArguments(
+	lines []string,
+	managerEndLine int,
+	arguments managerArguments,
+	renderedArgumentLines []string,
+) string {
+	if arguments.startLine >= 0 {
+		if arguments.inlineItemPrefix != "" {
+			renderedArgumentLines[0] = arguments.inlineItemPrefix + renderedArgumentLines[0]
 		}
-		builder.WriteString(metricsIndent)
-		builder.WriteString("{{- if .Values.metrics.enabled }}\n")
-		builder.WriteString(metricsLine)
-		builder.WriteString("\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("{{- if not .Values.metrics.secure }}\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("- --metrics-secure=false\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("{{- end }}\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("{{- else }}\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("# Bind to :0 to disable the controller-runtime managed metrics server\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("- --metrics-bind-address=0\n")
-		builder.WriteString(metricsIndent)
-		builder.WriteString("{{- end }}\n")
-	}
-	if healthLine != "" {
-		builder.WriteString(healthLine)
-		builder.WriteString("\n")
-	}
-	if webhookLine != "" {
-		builder.WriteString(itemIndent)
-		builder.WriteString("{{- if .Values.webhook.enabled }}\n")
-		builder.WriteString(webhookLine)
-		builder.WriteString("\n")
-		builder.WriteString(itemIndent)
-		builder.WriteString("{{- end }}\n")
+
+		removedLineCount := arguments.endLine - arguments.startLine + 1
+		updatedLines := make([]string, 0, len(lines)+len(renderedArgumentLines)-removedLineCount)
+		updatedLines = append(updatedLines, lines[:arguments.startLine]...)
+		updatedLines = append(updatedLines, renderedArgumentLines...)
+		updatedLines = append(updatedLines, lines[arguments.endLine+1:]...)
+		return strings.Join(updatedLines, "\n")
 	}
 
-	builder.WriteString(itemIndent)
-	builder.WriteString("{{- range .Values.manager.args }}\n")
-	builder.WriteString(itemIndent)
-	builder.WriteString("- {{ tpl . $ }}\n")
-	builder.WriteString(itemIndent)
-	builder.WriteString("{{- end }}\n")
-
-	for _, line := range preservedLines {
-		builder.WriteString(line)
-		builder.WriteString("\n")
+	insertionLine := managerEndLine + 1
+	if insertionLine == len(lines) && len(lines) > 0 && lines[len(lines)-1] == "" {
+		insertionLine--
 	}
-
-	newBlock := strings.TrimRight(builder.String(), "\n") + "\n"
-
-	return yamlContent[:loc[0]] + newBlock + yamlContent[loc[1]:]
+	updatedLines := make([]string, 0, len(lines)+len(renderedArgumentLines))
+	updatedLines = append(updatedLines, lines[:insertionLine]...)
+	updatedLines = append(updatedLines, renderedArgumentLines...)
+	updatedLines = append(updatedLines, lines[insertionLine:]...)
+	return strings.Join(updatedLines, "\n")
 }
 
 func templateImageReference(yamlContent string) string {
-	if !isManagerContainerPresent(yamlContent) {
+	managerStartLine, managerEndLine := FindManagerContainerRange(yamlContent)
+	if managerStartLine < 0 {
 		return yamlContent
 	}
 
-	rangeStart, rangeEnd := FindManagerContainerRange(yamlContent)
-
 	lines := strings.Split(yamlContent, "\n")
 	for i := 0; i < len(lines); i++ {
-		if rangeStart >= 0 && (i < rangeStart || i > rangeEnd) {
+		if i < managerStartLine || i > managerEndLine {
 			continue
 		}
 		trimmed := strings.TrimSpace(lines[i])

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -565,8 +565,8 @@ metadata:
 
 			result := templater.ApplyHelmSubstitutions(content, serviceMonitorResource)
 
-			// Should be wrapped with prometheus enabled conditional
-			Expect(result).To(ContainSubstring("{{- if .Values.prometheus.enabled }}"))
+			// Should be wrapped with prometheus and metrics enabled conditional
+			Expect(result).To(ContainSubstring("{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}"))
 			Expect(result).To(ContainSubstring("{{- end }}"))
 		})
 

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/chart-templates/servicemonitor.go
@@ -63,7 +63,8 @@ func (f *ServiceMonitor) SetTemplateDefaults() error {
 	return nil
 }
 
-const serviceMonitorTemplate = `{{` + "`" + `{{- if .Values.prometheus.enabled }}` + "`" + `}}
+const serviceMonitorTemplate = `{{` + "`" +
+	`{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}` + "`" + `}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/templates/values.go
@@ -153,7 +153,7 @@ certManager:
 	prometheusEnabled := f.Extraction != nil && f.Extraction.Features.HasPrometheus
 
 	buf.WriteString(`## Prometheus ServiceMonitor for metrics scraping.
-## Requires prometheus-operator to be installed in the cluster.
+## Requires prometheus-operator to be installed in the cluster and metrics.enabled set to true.
 ##
 prometheus:
 `)

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,6 +32,8 @@ import (
 	"github.com/spf13/afero"
 	"helm.sh/helm/v3/pkg/action"
 	helmChartLoader "helm.sh/helm/v3/pkg/chart/loader"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"sigs.k8s.io/kubebuilder/v4/pkg/config"
 	cfgv3 "sigs.k8s.io/kubebuilder/v4/pkg/config/v3"
@@ -611,8 +615,10 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 	}
 
 	Context("ServiceMonitor labels and annotations (rendered, kustomize-derived)", func() {
+		// The ServiceMonitor is gated on metrics.enabled, which the fixtures leave off.
 		renderChart := func(setArgs ...string) string {
-			out, err := helmTemplate(createKustomizeWithServiceMonitor("test-project"), setArgs...)
+			args := append([]string{"--set", "metrics.enabled=true"}, setArgs...)
+			out, err := helmTemplate(createKustomizeWithServiceMonitor("test-project"), args...)
 			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
 			return out
 		}
@@ -653,12 +659,24 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			Expect(sm).NotTo(ContainSubstring("control-plane: myvalue"),
 				"the omit guard must prevent duplicating a scaffolded label, got:\n%s", sm)
 		})
+
+		It("does not render the ServiceMonitor when metrics are disabled", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "metrics.enabled=false",
+				"--set", "prometheus.enabled=true",
+			))
+
+			Expect(sm).To(BeEmpty(),
+				"the ServiceMonitor scrapes the metrics Service, so it must not render without it")
+		})
 	})
 
 	Context("ServiceMonitor labels and annotations (rendered, static fallback)", func() {
 		// No ServiceMonitor in the kustomize input — the static fallback template is scaffolded.
+		// The ServiceMonitor is gated on metrics.enabled, which the fixture leaves off.
 		renderChart := func(setArgs ...string) string {
-			out, err := helmTemplate(createBasicKustomizeOutput("test-project"), setArgs...)
+			args := append([]string{"--set", "metrics.enabled=true"}, setArgs...)
+			out, err := helmTemplate(createBasicKustomizeOutput("test-project"), args...)
 			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
 			return out
 		}
@@ -698,6 +716,16 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			// the user value must not appear; only the scaffolded value remains.
 			Expect(sm).NotTo(ContainSubstring("control-plane: myvalue"),
 				"the omit guard must prevent duplicating a scaffolded label, got:\n%s", sm)
+		})
+
+		It("does not render the ServiceMonitor when metrics are disabled", func() {
+			sm := serviceMonitorDoc(renderChart(
+				"--set", "metrics.enabled=false",
+				"--set", "prometheus.enabled=true",
+			))
+
+			Expect(sm).To(BeEmpty(),
+				"the ServiceMonitor scrapes the metrics Service, so it must not render without it")
 		})
 	})
 
@@ -1285,9 +1313,9 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 	// literal args mixed in the same list, and a templated arg that calls a Helm template
 	// function.
 	Context("Manager args templating (rendered)", func() {
-		writeValuesFile := func(content string) string {
+		writeValuesFile := func(valuesContent string) string {
 			valuesFile := filepath.Join(tmpDir, "manager-args-values.yaml")
-			Expect(os.WriteFile(valuesFile, []byte(content), 0o600)).To(Succeed())
+			Expect(os.WriteFile(valuesFile, []byte(valuesContent), 0o600)).To(Succeed())
 			return valuesFile
 		}
 
@@ -1296,7 +1324,7 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		// generated values.yaml (i.e. the default manager.args extracted from the kustomize
 		// output), exercising the same code path production users hit before ever touching
 		// manager.args themselves.
-		renderWithArgs := func(valuesContent string) string {
+		renderWithManagerArgs := func(valuesContent string) string {
 			var setArgs []string
 			if valuesContent != "" {
 				setArgs = []string{"-f", writeValuesFile(valuesContent)}
@@ -1306,48 +1334,128 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 			return out
 		}
 
-		// managerArgsLines extracts every rendered "- --flag..." list item so assertions do not
-		// depend on indentation and are not confused by other list items in the manifest.
-		managerArgsLines := func(rendered string) []string {
-			var args []string
-			for _, line := range strings.Split(rendered, "\n") {
-				trimmed := strings.TrimSpace(line)
-				if strings.HasPrefix(trimmed, "- --") {
-					args = append(args, strings.TrimPrefix(trimmed, "- "))
-				}
-			}
-			return args
+		renderedManagerArgs := func(renderedManifest string) []string {
+			managerArgs, err := renderedContainerArgs(renderedManifest, "manager")
+			Expect(err).NotTo(HaveOccurred())
+			return managerArgs
 		}
 
 		It("should render the manager Deployment successfully when manager.args uses the chart's own "+
 			"default values (no values override)", func() {
-			rendered := renderWithArgs("")
+			rendered := renderWithManagerArgs("")
 
 			By("the default extracted arg renders as a literal, unaffected by tpl")
-			Expect(managerArgsLines(rendered)).To(ContainElement("--leader-elect"))
+			Expect(renderedManagerArgs(rendered)).To(ContainElement("--leader-elect"))
+		})
+
+		It("should connect metrics values to a manager that omits the metrics bind argument", func() {
+			renderWithoutMetricsBindAddressArg := func(setArgs ...string) string {
+				out, err := helmTemplate(
+					createKustomizeWithMetricsServiceWithoutManagerArg("test-project"), setArgs...)
+				Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+				return out
+			}
+
+			By("using the metrics Service port when metrics are enabled")
+			rendered := renderWithoutMetricsBindAddressArg("--set", "metrics.enabled=true")
+			renderedArgs := renderedManagerArgs(rendered)
+			Expect(renderedArgs).To(ContainElement("--metrics-bind-address=:7443"))
+			Expect(renderedArgs).NotTo(ContainElement("--metrics-bind-address=0"))
+			Expect(renderedArgs).NotTo(ContainElement("--metrics-secure=false"))
+
+			By("using an explicitly configured metrics port")
+			rendered = renderWithoutMetricsBindAddressArg(
+				"--set", "metrics.enabled=true",
+				"--set", "metrics.port=9000",
+			)
+			renderedArgs = renderedManagerArgs(rendered)
+			Expect(renderedArgs).To(ContainElement("--metrics-bind-address=:9000"))
+			Expect(renderedArgs).NotTo(ContainElement("--metrics-bind-address=:7443"))
+
+			By("disabling the manager metrics server when metrics are disabled")
+			rendered = renderWithoutMetricsBindAddressArg("--set", "metrics.enabled=false")
+			renderedArgs = renderedManagerArgs(rendered)
+			Expect(renderedArgs).To(ContainElement("--metrics-bind-address=0"))
+			Expect(renderedArgs).NotTo(ContainElement("--metrics-bind-address=:7443"))
+
+			By("passing the secure setting to the manager")
+			rendered = renderWithoutMetricsBindAddressArg(
+				"--set", "metrics.enabled=true", "--set", "metrics.secure=false")
+			renderedArgs = renderedManagerArgs(rendered)
+			Expect(renderedArgs).To(ContainElement("--metrics-bind-address=:7443"))
+			Expect(renderedArgs).To(ContainElement("--metrics-secure=false"))
+		})
+
+		It("should add metrics arguments when the source manager has no args field", func() {
+			rendered, err := helmTemplate(
+				createKustomizeWithMetricsServiceAndNoManagerArgs("test-project"),
+				"--set", "metrics.enabled=true",
+			)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", rendered)
+
+			By("serving metrics on the Service port")
+			Expect(renderedManagerArgs(rendered)).To(ContainElement("--metrics-bind-address=:7443"))
+		})
+
+		It("should add metrics arguments when the source manager has an empty args list", func() {
+			rendered, err := helmTemplate(
+				createKustomizeWithMetricsServiceAndEmptyManagerArgs("test-project"),
+				"--set", "metrics.enabled=true",
+			)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", rendered)
+
+			By("serving metrics on the Service port")
+			Expect(renderedManagerArgs(rendered)).To(ContainElement("--metrics-bind-address=:7443"))
+		})
+
+		It("should accept manager.args overrides when the source manager has no args field", func() {
+			rendered, err := helmTemplate(
+				createKustomizeWithMetricsServiceAndNoManagerArgs("test-project"),
+				"--set", "manager.args[0]=--leader-elect",
+			)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", rendered)
+
+			By("keeping the user-provided argument alongside the generated metrics argument")
+			Expect(renderedManagerArgs(rendered)).To(ContainElements(
+				"--metrics-bind-address=:7443",
+				"--leader-elect",
+			))
+		})
+
+		It("should preserve sidecar arguments while configuring the manager container", func() {
+			rendered, err := helmTemplate(
+				createKustomizeWithSidecarBeforeManagerAndMetricsService("test-project"),
+				"--set", "metrics.enabled=true",
+			)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", rendered)
+
+			By("configuring metrics on the manager")
+			Expect(renderedManagerArgs(rendered)).To(ContainElement("--metrics-bind-address=:7443"))
+
+			By("leaving the sidecar's command-line arguments unchanged")
+			sidecarArgs, err := renderedContainerArgs(rendered, "sidecar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sidecarArgs).To(Equal([]string{"--sidecar-flag"}))
 		})
 
 		DescribeTable("should resolve manager.args entries through tpl when values are provided",
-			func(valuesContent string, wantArgs []string, unwantedSubstrings []string) {
-				rendered := renderWithArgs(valuesContent)
+			func(valuesContent string, additionalManagerArgs []string) {
+				rendered := renderWithManagerArgs(valuesContent)
 
-				args := managerArgsLines(rendered)
-				for _, want := range wantArgs {
-					Expect(args).To(ContainElement(want), "rendered manager args: %v", args)
-				}
-				for _, unwanted := range unwantedSubstrings {
-					Expect(rendered).NotTo(ContainSubstring(unwanted))
-				}
+				expectedManagerArgs := append([]string{
+					"--metrics-bind-address=0",
+					"--health-probe-bind-address=:8081",
+				}, additionalManagerArgs...)
+				renderedArgs := renderedManagerArgs(rendered)
+				Expect(renderedArgs).To(Equal(expectedManagerArgs), "rendered manager args: %v", renderedArgs)
 			},
 			Entry("should keep plain literal args unchanged when no template syntax is used (backwards compatible)",
 				"manager:\n  args:\n  - --leader-elect\n  - --zap-log-level=info\n",
 				[]string{"--leader-elect", "--zap-log-level=info"},
-				[]string(nil),
 			),
 			Entry("should resolve to the release namespace when an arg references .Release.Namespace",
 				"manager:\n  args:\n  - --leader-election-namespace={{ .Release.Namespace }}\n",
 				[]string{"--leader-election-namespace=my-namespace"},
-				[]string{"{{ .Release.Namespace }}"},
 			),
 			Entry("should resolve every arg independently and keep list order when multiple args are templated",
 				"manager:\n  args:\n"+
@@ -1359,7 +1467,6 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 					"--release-name=my-release",
 					"--chart-name=test-project",
 				},
-				[]string{"{{ .Release", "{{ .Chart"},
 			),
 			Entry("should resolve templated args and keep literal args unchanged when both appear in the same list",
 				"manager:\n  args:\n"+
@@ -1371,7 +1478,6 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 					"--leader-election-namespace=my-namespace",
 					"--zap-log-level=info",
 				},
-				[]string(nil),
 			),
 			Entry("should resolve an arg when it calls a Helm template function",
 				`manager:
@@ -1379,9 +1485,115 @@ var _ = Describe("Chart Generation Integration Tests", func() {
   - --extra-flag={{ printf "%s-%s" .Release.Name .Release.Namespace }}
 `,
 				[]string{"--extra-flag=my-release-my-namespace"},
-				[]string{"{{ printf"},
 			),
 		)
+	})
+
+	Context("Metrics feature toggles (rendered)", func() {
+		renderChart := func(setArgs ...string) string {
+			out, err := helmTemplate(createKustomizeWithMetricsResources("test-project"), setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("should enable the manager and metrics resources together", func() {
+			rendered := renderChart(
+				"--set", "metrics.enabled=true",
+				"--set", "prometheus.enabled=true",
+				"--set", "networkPolicy.enabled=true",
+			)
+
+			By("binding the manager to the metrics Service port")
+			managerArgs, err := renderedContainerArgs(rendered, "manager")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managerArgs).To(ContainElement("--metrics-bind-address=:7443"))
+
+			By("rendering the metrics Service")
+			metricsServices, err := renderedResourcesByKind(rendered, "Service")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metricsServices).To(HaveLen(1))
+
+			By("rendering the ServiceMonitor")
+			serviceMonitors, err := renderedResourcesByKind(rendered, "ServiceMonitor")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceMonitors).To(HaveLen(1))
+
+			By("rendering the metrics NetworkPolicy")
+			metricsPolicies, err := renderedResourcesByKind(rendered, "NetworkPolicy")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metricsPolicies).To(HaveLen(1))
+		})
+
+		It("should disable the manager and metrics resources together", func() {
+			rendered := renderChart(
+				"--set", "metrics.enabled=false",
+				"--set", "prometheus.enabled=true",
+				"--set", "networkPolicy.enabled=true",
+			)
+
+			By("disabling the manager metrics server")
+			managerArgs, err := renderedContainerArgs(rendered, "manager")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managerArgs).To(Equal([]string{
+				"--metrics-bind-address=0",
+				"--health-probe-bind-address=:8081",
+				"--leader-elect",
+			}))
+
+			By("removing the metrics Service")
+			metricsServices, err := renderedResourcesByKind(rendered, "Service")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metricsServices).To(BeEmpty())
+
+			By("removing the ServiceMonitor even though prometheus stays enabled")
+			serviceMonitors, err := renderedResourcesByKind(rendered, "ServiceMonitor")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceMonitors).To(BeEmpty())
+
+			By("removing the metrics NetworkPolicy")
+			metricsPolicies, err := renderedResourcesByKind(rendered, "NetworkPolicy")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metricsPolicies).To(BeEmpty())
+		})
+
+		It("should use insecure metrics settings consistently in the manager and ServiceMonitor", func() {
+			rendered := renderChart(
+				"--set", "metrics.enabled=true",
+				"--set", "metrics.secure=false",
+				"--set", "prometheus.enabled=true",
+			)
+
+			By("passing the insecure metrics flag to the manager")
+			managerArgs, err := renderedContainerArgs(rendered, "manager")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managerArgs).To(ContainElements(
+				"--metrics-bind-address=:7443",
+				"--metrics-secure=false",
+			))
+
+			By("configuring the ServiceMonitor for HTTP")
+			serviceMonitors, err := renderedResourcesByKind(rendered, "ServiceMonitor")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(serviceMonitors).To(HaveLen(1))
+			endpoints, found, err := unstructured.NestedSlice(serviceMonitors[0].Object, "spec", "endpoints")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(endpoints).To(HaveLen(1))
+			endpoint, ok := endpoints[0].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			endpointPort, _, err := unstructured.NestedString(endpoint, "port")
+			Expect(err).NotTo(HaveOccurred())
+			endpointScheme, _, err := unstructured.NestedString(endpoint, "scheme")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpointPort).To(Equal("http"))
+			Expect(endpointScheme).To(Equal("http"))
+			_, hasBearerToken, err := unstructured.NestedString(endpoint, "bearerTokenFile")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasBearerToken).To(BeFalse())
+			_, hasTLSConfig, err := unstructured.NestedMap(endpoint, "tlsConfig")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hasTLSConfig).To(BeFalse())
+		})
 	})
 })
 
@@ -1775,6 +1987,89 @@ spec:
 `
 }
 
+// createKustomizeWithMetricsServiceWithoutManagerArg represents a project whose metrics
+// Service is present but whose manager args do not include --metrics-bind-address.
+func createKustomizeWithMetricsServiceWithoutManagerArg(projectName string) string {
+	kustomizeYAML := strings.Replace(
+		createKustomizeWithFullDeploymentConfig(projectName),
+		"        - --metrics-bind-address=:8443\n",
+		"",
+		1,
+	)
+
+	return kustomizeYAML + `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ` + projectName + `-controller-manager-metrics-service
+  namespace: ` + projectName + `-system
+spec:
+  ports:
+  - name: https
+    port: 7443
+    protocol: TCP
+    targetPort: 7443
+  selector:
+    control-plane: controller-manager
+`
+}
+
+// createKustomizeWithMetricsResources represents a project with the metrics Service and the
+// scaffolded metrics NetworkPolicy. The chart adds the fallback ServiceMonitor during scaffolding.
+func createKustomizeWithMetricsResources(projectName string) string {
+	return createKustomizeWithMetricsServiceWithoutManagerArg(projectName) + `---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ` + projectName + `-allow-metrics-traffic
+  namespace: ` + projectName + `-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          metrics: enabled
+    ports:
+    - port: 7443
+      protocol: TCP
+`
+}
+
+// createKustomizeWithMetricsServiceAndNoManagerArgs represents a project whose manager has no
+// args field at all, while its metrics Service still exposes the configured endpoint.
+func createKustomizeWithMetricsServiceAndNoManagerArgs(projectName string) string {
+	kustomizeYAML := strings.Replace(
+		createKustomizeWithMetricsServiceWithoutManagerArg(projectName),
+		`        args:
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+`,
+		"",
+		1,
+	)
+	return kustomizeYAML
+}
+
+// createKustomizeWithMetricsServiceAndEmptyManagerArgs represents a project whose manager
+// explicitly declares an empty args list.
+func createKustomizeWithMetricsServiceAndEmptyManagerArgs(projectName string) string {
+	return strings.Replace(
+		createKustomizeWithMetricsServiceWithoutManagerArg(projectName),
+		`        args:
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+`,
+		`        args: []
+`,
+		1,
+	)
+}
+
 // createKustomizeForServiceAccountRender extends createBasicKustomizeOutput (Namespace +
 // ServiceAccount + Deployment) for the serviceAccountName render tests. It adds:
 //   - a pod-template annotations block, otherwise the chart nil-pointers on
@@ -1915,6 +2210,94 @@ func setupKustomizeFile(filePath, content string) error {
 		return err
 	}
 	return os.WriteFile(filePath, []byte(content), 0o644)
+}
+
+// decodeRenderedResources returns the non-empty Kubernetes objects from a Helm render.
+// Keeping render assertions at the Kubernetes object level makes tests independent of Helm
+// template layout and YAML indentation.
+func decodeRenderedResources(renderedManifest string) ([]*unstructured.Unstructured, error) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(renderedManifest), 4096)
+	var renderedResources []*unstructured.Unstructured
+
+	for {
+		resource := &unstructured.Unstructured{}
+		err := decoder.Decode(resource)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decode rendered resource: %w", err)
+		}
+		if len(resource.Object) == 0 {
+			continue
+		}
+		renderedResources = append(renderedResources, resource)
+	}
+
+	return renderedResources, nil
+}
+
+func renderedResourcesByKind(
+	renderedManifest, resourceKind string,
+) ([]*unstructured.Unstructured, error) {
+	allResources, err := decodeRenderedResources(renderedManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var matchingResources []*unstructured.Unstructured
+	for _, resource := range allResources {
+		if resource.GetKind() == resourceKind {
+			matchingResources = append(matchingResources, resource)
+		}
+	}
+	return matchingResources, nil
+}
+
+// renderedContainerArgs returns the effective args from a named container in a rendered
+// Deployment.
+func renderedContainerArgs(renderedManifest, containerName string) ([]string, error) {
+	deployments, err := renderedResourcesByKind(renderedManifest, "Deployment")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, deployment := range deployments {
+		containers, found, err := unstructured.NestedSlice(
+			deployment.Object, "spec", "template", "spec", "containers")
+		if err != nil {
+			return nil, fmt.Errorf("read deployment containers: %w", err)
+		}
+		if !found {
+			continue
+		}
+
+		for _, rawContainer := range containers {
+			container, ok := rawContainer.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			containerNameFromManifest, _, err := unstructured.NestedString(container, "name")
+			if err != nil {
+				return nil, fmt.Errorf("read container name: %w", err)
+			}
+			if containerNameFromManifest != containerName {
+				continue
+			}
+
+			containerArgs, found, err := unstructured.NestedStringSlice(container, "args")
+			if err != nil {
+				return nil, fmt.Errorf("read %s container args: %w", containerName, err)
+			}
+			if !found {
+				return nil, fmt.Errorf("%s container has no args", containerName)
+			}
+			return containerArgs, nil
+		}
+	}
+
+	return nil, fmt.Errorf("rendered Deployment container %q not found", containerName)
 }
 
 // createKustomizeWithTolerationsAndSchedulingFields simulates a manager.yaml that already
@@ -2126,6 +2509,48 @@ spec:
         configMap:
           name: my-config
       serviceAccountName: ` + projectName + `-controller-manager
+`
+}
+
+// createKustomizeWithSidecarBeforeManagerAndMetricsService represents a sidecar-first Pod whose
+// manager has no args field. The fixture verifies that manager-specific defaults do not leak into
+// the sidecar when the templater has to add the manager args block.
+func createKustomizeWithSidecarBeforeManagerAndMetricsService(projectName string) string {
+	kustomizeYAML := strings.Replace(
+		createKustomizeWithSidecarBeforeManager(projectName),
+		`        args:
+        - --leader-elect
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+`,
+		"",
+		1,
+	)
+	kustomizeYAML = strings.Replace(
+		kustomizeYAML,
+		`        image: sidecar:v1
+        env:`,
+		`        image: sidecar:v1
+        args:
+        - --sidecar-flag
+        env:`,
+		1,
+	)
+
+	return kustomizeYAML + `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ` + projectName + `-controller-manager-metrics-service
+  namespace: ` + projectName + `-system
+spec:
+  ports:
+  - name: https
+    port: 7443
+    protocol: TCP
+    targetPort: 7443
+  selector:
+    control-plane: controller-manager
 `
 }
 

--- a/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enabled }}
+{{- if and .Values.prometheus.enabled .Values.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/testdata/project-v4-with-plugins/dist/chart/values.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/values.yaml
@@ -197,7 +197,7 @@ webhook:
   port: 9443
 
 ## Prometheus ServiceMonitor for metrics scraping.
-## Requires prometheus-operator to be installed in the cluster.
+## Requires prometheus-operator to be installed in the cluster and metrics.enabled set to true.
 ##
 prometheus:
   enabled: false


### PR DESCRIPTION
The ServiceMonitor now renders only when both `prometheus.enabled` and `metrics.enabled` are true. Charts generated from a manager that has no `args` field, an empty args list, or no `--metrics-bind-address` argument now get the metrics bind address added, so `metrics.enabled`, `metrics.port`, and `metrics.secure` always control the manager. Sidecar container arguments are left untouched.


Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/6021