### PR TITLE
🐛 fix(cli): save PROJECT through a symbolic link and keep extra commands on the project check (Follow-up to #5845 and #5942)

### DIFF
--- a/pkg/cli/alpha.go
+++ b/pkg/cli/alpha.go
@@ -29,17 +29,14 @@ const (
 	alphaCommand = "alpha"
 )
 
-var alphaCommands = []*cobra.Command{
-	newAlphaCommand(),
-	alpha.NewScaffoldCommand(),
-	alpha.NewUpdateCommand(),
-}
-
-func newAlphaCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		// TODO: If we need to create alpha commands please add a new file for each command
+// newAlphaSubcommands returns the built-in subcommands of the alpha command. Each CLI gets its own:
+// Cobra records the parent on a command when it is added, so a command shared by several CLIs in
+// one process would run the hooks of the CLI built last.
+func newAlphaSubcommands() []*cobra.Command {
+	return []*cobra.Command{
+		alpha.NewScaffoldCommand(),
+		alpha.NewUpdateCommand(),
 	}
-	return cmd
 }
 
 func (c *CLI) newAlphaCmd() *cobra.Command {
@@ -54,17 +51,12 @@ Alpha subcommands are for unstable features.
 - No backwards compatibility is provided for any alpha subcommands.
 `),
 	}
-	// TODO: Add alpha commands here if we need to have them
-	for i := range alphaCommands {
-		cmd.AddCommand(alphaCommands[i])
-	}
+	cmd.AddCommand(newAlphaSubcommands()...)
 	return cmd
 }
 
 func (c *CLI) addAlphaCmd() {
-	if (len(alphaCommands) + len(c.extraAlphaCommands)) > 0 {
-		c.cmd.AddCommand(c.newAlphaCmd())
-	}
+	c.cmd.AddCommand(c.newAlphaCmd())
 }
 
 func (c *CLI) addExtraAlphaCommands() error {
@@ -86,6 +78,7 @@ func (c *CLI) addExtraAlphaCommands() error {
 				return fmt.Errorf("command %q already exists", fmt.Sprintf("%s %s", alphaCommand, cmd.Name()))
 			}
 		}
+		c.checkCommandLineBeforeHooks(cmd)
 		cmds.AddCommand(cmd)
 	}
 	return nil

--- a/pkg/cli/alpha_test.go
+++ b/pkg/cli/alpha_test.go
@@ -31,31 +31,13 @@ var _ = Describe("addAlphaCmd", func() {
 		}
 	})
 
-	It("should add alpha command to root when alpha commands exist", func() {
+	It("should add the alpha command with its built-in subcommands to root", func() {
 		c.addAlphaCmd()
-		Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
-	})
 
-	It("should add alpha command to root when only extra alpha commands exist", func() {
-		c.extraAlphaCommands = []*cobra.Command{
-			{Use: "custom-alpha", Short: "Custom alpha command"},
-		}
-		c.addAlphaCmd()
-		Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeTrue())
-	})
-
-	When("no alpha commands exist", func() {
-		BeforeEach(func() {
-			original := alphaCommands
-			DeferCleanup(func() { alphaCommands = original })
-			alphaCommands = []*cobra.Command{}
-			c.extraAlphaCommands = []*cobra.Command{}
-		})
-
-		It("should not add alpha command to root", func() {
-			c.addAlphaCmd()
-			Expect(hasSubCommand(c.cmd, alphaCommand)).To(BeFalse())
-		})
+		alphaCmd := findSubCommand(c.cmd, alphaCommand)
+		Expect(alphaCmd).NotTo(BeNil())
+		Expect(hasSubCommand(alphaCmd, generateSubcommand)).To(BeTrue())
+		Expect(hasSubCommand(alphaCmd, "update")).To(BeTrue())
 	})
 })
 
@@ -77,14 +59,7 @@ var _ = Describe("addExtraAlphaCommands", func() {
 		err := c.addExtraAlphaCommands()
 		Expect(err).NotTo(HaveOccurred())
 
-		alphaCmd, _ := c.cmd.Commands()[0], false
-		for _, cmd := range c.cmd.Commands() {
-			if cmd.Name() == alphaCommand {
-				alphaCmd = cmd
-				break
-			}
-		}
-		Expect(hasSubCommand(alphaCmd, "extra-alpha")).To(BeTrue())
+		Expect(hasSubCommand(findSubCommand(c.cmd, alphaCommand), "extra-alpha")).To(BeTrue())
 	})
 
 	It("should reject a duplicate alpha command", func() {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -745,7 +745,7 @@ func (c *CLI) resolvePlugins() error {
 // addSubcommands returns a root command with a subcommand tree reflecting the
 // current project's state.
 func (c *CLI) addSubcommands() {
-	// add the alpha command if it has any subcommands enabled
+	// kubebuilder alpha
 	c.addAlphaCmd()
 
 	// kubebuilder completion
@@ -784,6 +784,7 @@ func (c *CLI) addExtraCommands() error {
 				return fmt.Errorf("command %q already exists", cmd.Name())
 			}
 		}
+		c.checkCommandLineBeforeHooks(cmd)
 		c.cmd.AddCommand(cmd)
 	}
 	return nil

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -46,6 +47,9 @@ const (
 	apiSubcommand     = "api"
 	webhookSubcommand = "webhook"
 	editSubcommand    = "edit"
+	docsSubcommand    = "docs"
+	groupFlagArg      = "--group"
+	versionFlagArg    = "--version"
 	kindFlagArg       = "--kind"
 	kindValue         = "Captain"
 )
@@ -92,12 +96,17 @@ func parseFlagsFromArgs(c *CLI) error {
 }
 
 func hasSubCommand(cmd *cobra.Command, name string) bool {
+	return findSubCommand(cmd, name) != nil
+}
+
+// findSubCommand returns the direct subcommand with the given name, or nil when there is none.
+func findSubCommand(cmd *cobra.Command, name string) *cobra.Command {
 	for _, subcommand := range cmd.Commands() {
 		if subcommand.Name() == name {
-			return true
+			return subcommand
 		}
 	}
-	return false
+	return nil
 }
 
 // filesystemWithUnloadableProject returns a filesystem holding a PROJECT file that cannot be loaded
@@ -228,6 +237,86 @@ func expectNothingScaffolded(fs machinery.Filesystem) {
 	Expect(entries[0].Name()).To(Equal(yamlstore.DefaultPath))
 }
 
+// createAPIArgs returns a command line that creates an API with every required resource flag.
+func createAPIArgs() []string {
+	return []string{createSubcommand, apiSubcommand, groupFlagArg, "crew", versionFlagArg, "v1", kindFlagArg, kindValue}
+}
+
+// newExtraCommand returns a command that does nothing when run. Cobra runs no hooks for a command
+// without a run function.
+func newExtraCommand(name string) *cobra.Command {
+	return &cobra.Command{Use: name, RunE: func(*cobra.Command, []string) error { return nil }}
+}
+
+// newExtraCommandWithHook returns an extra command whose pre-run hook, set by setHook, records in
+// the returned flag that it ran.
+func newExtraCommandWithHook(name string, setHook func(*cobra.Command, *bool)) (*cobra.Command, *bool) {
+	cmd := newExtraCommand(name)
+	hookRan := false
+	setHook(cmd, &hookRan)
+
+	return cmd, &hookRan
+}
+
+// executeCLIWith builds a CLI with one more option and runs it with args, as executeCLI does.
+func executeCLIWith(filesystem machinery.Filesystem, option Option, args ...string) error {
+	GinkgoHelper()
+
+	_, err := runCLI(filesystem, args, args, option)
+
+	return err
+}
+
+// preRunHookEntries returns one entry per pre-run hook a command can set. Each hook records that
+// it ran.
+func preRunHookEntries() []TableEntry {
+	return []TableEntry{
+		Entry("for PersistentPreRunE", setPersistentPreRunE),
+		Entry("for PersistentPreRun", setPersistentPreRun),
+		Entry("for PreRunE", setPreRunE),
+		Entry("for PreRun", setPreRun),
+	}
+}
+
+func setPersistentPreRunE(cmd *cobra.Command, ran *bool) {
+	cmd.PersistentPreRunE = func(*cobra.Command, []string) error {
+		*ran = true
+		return nil
+	}
+}
+
+func setPersistentPreRun(cmd *cobra.Command, ran *bool) {
+	cmd.PersistentPreRun = func(*cobra.Command, []string) { *ran = true }
+}
+
+func setPreRunE(cmd *cobra.Command, ran *bool) {
+	cmd.PreRunE = func(*cobra.Command, []string) error {
+		*ran = true
+		return nil
+	}
+}
+
+func setPreRun(cmd *cobra.Command, ran *bool) {
+	cmd.PreRun = func(*cobra.Command, []string) { *ran = true }
+}
+
+// expectStoppedBeforeHook asserts that the command stopped on the directory at PROJECT before its
+// own hook ran.
+func expectStoppedBeforeHook(err error, hookRan *bool) {
+	GinkgoHelper()
+
+	Expect(err).To(MatchError(ContainSubstring(`"PROJECT" is a directory`)))
+	Expect(*hookRan).To(BeFalse())
+}
+
+// expectHookRan asserts that the command succeeded and its own hook ran.
+func expectHookRan(err error, hookRan *bool) {
+	GinkgoHelper()
+
+	Expect(err).NotTo(HaveOccurred())
+	Expect(*hookRan).To(BeTrue())
+}
+
 // projectReadCountingFs counts how many times the project configuration file is opened.
 type projectReadCountingFs struct {
 	afero.Fs
@@ -309,9 +398,23 @@ func runCLI(
 ) (string, error) {
 	GinkgoHelper()
 
+	return runBuiltCLI(buildCLI(filesystem, programArgs, options...), commandArgs)
+}
+
+// setProgramArgs sets the arguments of the running program until the test ends.
+func setProgramArgs(programArgs ...string) {
+	GinkgoHelper()
+
 	originalArgs := os.Args
 	DeferCleanup(func() { os.Args = originalArgs })
 	os.Args = append([]string{kubebuilderCommandName}, programArgs...)
+}
+
+// buildCLI builds a CLI over the given filesystem while the program was invoked with programArgs.
+func buildCLI(filesystem machinery.Filesystem, programArgs []string, options ...Option) *CLI {
+	GinkgoHelper()
+
+	setProgramArgs(programArgs...)
 
 	testProjectVersion := config.Version{Number: 3}
 	c, err := New(append([]Option{
@@ -324,6 +427,11 @@ func runCLI(
 	}, options...)...)
 	Expect(err).NotTo(HaveOccurred())
 
+	return c
+}
+
+// runBuiltCLI runs the CLI with commandArgs and returns what the command wrote.
+func runBuiltCLI(c *CLI, commandArgs []string) (string, error) {
 	var out bytes.Buffer
 	c.cmd.SetOut(&out)
 	// Cobra falls back to the arguments of the running program when they are set to nil.
@@ -1347,14 +1455,9 @@ version: "3"
 
 		When("the PROJECT file names a registered plugin chain that is not the default", func() {
 			var projectPlugin testCreateAPIPlugin
-			var createAPIArgs []string
 
 			BeforeEach(func() {
 				projectPlugin = newDescribedCreateAPIPlugin()
-				createAPIArgs = []string{
-					createSubcommand, apiSubcommand,
-					"--group", "crew", "--version", "v1", kindFlagArg, kindValue,
-				}
 			})
 
 			It("should build the help of a subcommand from that chain", func() {
@@ -1379,7 +1482,7 @@ version: "3"
 			})
 
 			It("should scaffold with that chain", func() {
-				_, runErr := runCLI(filesystemWithProjectChainProject(), createAPIArgs, createAPIArgs,
+				_, runErr := runCLI(filesystemWithProjectChainProject(), createAPIArgs(), createAPIArgs(),
 					WithPlugins(projectPlugin))
 				Expect(runErr).NotTo(HaveOccurred())
 				Expect(projectPlugin.subcommand.scaffolded).To(BeTrue())
@@ -1914,8 +2017,7 @@ var _ = Describe("commands driven by Command().SetArgs", func() {
 	)
 
 	It("should report the failure for a command added to the CLI", func() {
-		const docsSubcommand = "docs"
-		docs := &cobra.Command{Use: docsSubcommand, RunE: func(*cobra.Command, []string) error { return nil }}
+		docs := newExtraCommand(docsSubcommand)
 
 		err := executeEmbeddedCLI(filesystemWithInvalidProject(), programArgs, []string{docsSubcommand},
 			WithExtraCommands(docs))
@@ -1924,8 +2026,7 @@ var _ = Describe("commands driven by Command().SetArgs", func() {
 
 	DescribeTable("should report the failure for a command that consumes the configuration",
 		func(filesystem func() machinery.Filesystem, expected string) {
-			err := executeEmbeddedCLI(filesystem(), []string{kubebuilderSubcommandVersion},
-				[]string{createSubcommand, apiSubcommand, kindFlagArg, kindValue})
+			err := executeEmbeddedCLI(filesystem(), []string{kubebuilderSubcommandVersion}, programArgs)
 			Expect(err).To(MatchError(ContainSubstring(expected)))
 		},
 		Entry("when the PROJECT file is not valid YAML",
@@ -1939,15 +2040,37 @@ var _ = Describe("commands driven by Command().SetArgs", func() {
 	It("should refuse to scaffold with a plugin chain the command tree was not built for", func() {
 		// The command tree was built for the CLI defaults, so the plugins the project asks for
 		// cannot be honored anymore.
-		extraPlugin := newTestCreateAPIPlugin(projectChainPluginName, plugin.Version{Number: 1})
+		treePlugin := newTestCreateAPIPlugin("tree.example.com", plugin.Version{Number: 1})
+		projectPlugin := newTestCreateAPIPlugin(projectChainPluginName, plugin.Version{Number: 1})
 
-		err := executeEmbeddedCLI(filesystemWithResolvableProject(),
+		err := executeEmbeddedCLI(filesystemWithProjectChainProject(),
 			[]string{kubebuilderSubcommandVersion},
-			[]string{createSubcommand, apiSubcommand, kindFlagArg, kindValue},
-			WithPlugins(extraPlugin),
-			WithDefaultPlugins(config.Version{Number: 3}, extraPlugin),
+			createAPIArgs(),
+			WithPlugins(treePlugin, projectPlugin),
+			WithDefaultPlugins(config.Version{Number: 3}, treePlugin),
 		)
 		Expect(err).To(MatchError(ContainSubstring("the command tree was built for the plugin chain")))
+		Expect(treePlugin.subcommand.scaffolded).To(BeFalse())
+		Expect(projectPlugin.subcommand.scaffolded).To(BeFalse())
+	})
+
+	It("should scaffold with the plugin chain the project names when the command tree was built for it", func() {
+		projectPlugin := newTestCreateAPIPlugin(projectChainPluginName, plugin.Version{Number: 1})
+		projectVersion := config.Version{Number: 3}
+
+		setProgramArgs(kubebuilderSubcommandVersion)
+		c, err := New(
+			WithPlugins(projectPlugin),
+			WithDefaultPlugins(projectVersion, projectPlugin),
+			WithDefaultProjectVersion(projectVersion),
+			WithVersion("version string"),
+			WithFilesystem(filesystemWithProjectChainProject()),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = runBuiltCLI(c, createAPIArgs())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(projectPlugin.subcommand.scaffolded).To(BeTrue())
 	})
 
 	It("should read the skipped configuration when the command tree was built for its plugin chain", func() {
@@ -1963,12 +2086,144 @@ var _ = Describe("commands driven by Command().SetArgs", func() {
 	})
 })
 
+// A tool adds extra commands with WithExtraCommands and WithExtraAlphaCommands. The CLI cannot know
+// whether such a command reads the project, so a configuration it cannot use has to stop the
+// command before its own hooks run.
+var _ = Describe("extra commands", func() {
+	// newDocsWithGenerate returns a docs command whose generate subcommand has a persistent hook of
+	// its own.
+	newDocsWithGenerate := func() (*cobra.Command, *bool) {
+		docs := &cobra.Command{Use: docsSubcommand}
+		generate, hookRan := newExtraCommandWithHook(generateSubcommand, setPersistentPreRunE)
+		docs.AddCommand(generate)
+
+		return docs, hookRan
+	}
+
+	DescribeTable("should stop the command before its own hook when PROJECT is a directory",
+		func(setHook func(*cobra.Command, *bool)) {
+			docs, hookRan := newExtraCommandWithHook(docsSubcommand, setHook)
+
+			err := executeCLIWith(filesystemWithProjectDirectory(), WithExtraCommands(docs), docsSubcommand)
+			expectStoppedBeforeHook(err, hookRan)
+		},
+		preRunHookEntries(),
+	)
+
+	DescribeTable("should run the hook of the command when PROJECT can be used",
+		func(setHook func(*cobra.Command, *bool)) {
+			docs, hookRan := newExtraCommandWithHook(docsSubcommand, setHook)
+
+			err := executeCLIWith(filesystemWithResolvableProject(), WithExtraCommands(docs), docsSubcommand)
+			expectHookRan(err, hookRan)
+		},
+		preRunHookEntries(),
+	)
+
+	It("should stop a subcommand before its own persistent hook when PROJECT is a directory", func() {
+		docs, hookRan := newDocsWithGenerate()
+
+		err := executeCLIWith(filesystemWithProjectDirectory(), WithExtraCommands(docs),
+			docsSubcommand, generateSubcommand)
+		expectStoppedBeforeHook(err, hookRan)
+	})
+
+	It("should run the persistent hook of a subcommand when PROJECT can be used", func() {
+		docs, hookRan := newDocsWithGenerate()
+
+		err := executeCLIWith(filesystemWithResolvableProject(), WithExtraCommands(docs),
+			docsSubcommand, generateSubcommand)
+		expectHookRan(err, hookRan)
+	})
+
+	It("should stop an alpha command before its own hook when PROJECT is a directory", func() {
+		docs, hookRan := newExtraCommandWithHook(docsSubcommand, setPersistentPreRunE)
+
+		err := executeCLIWith(filesystemWithProjectDirectory(), WithExtraAlphaCommands(docs),
+			alphaCommand, docsSubcommand)
+		expectStoppedBeforeHook(err, hookRan)
+	})
+
+	It("should run the hook of an alpha command when PROJECT can be used", func() {
+		docs, hookRan := newExtraCommandWithHook(docsSubcommand, setPersistentPreRunE)
+
+		err := executeCLIWith(filesystemWithResolvableProject(), WithExtraAlphaCommands(docs),
+			alphaCommand, docsSubcommand)
+		expectHookRan(err, hookRan)
+	})
+
+	It("should report the error of the hook", func() {
+		hookErr := errors.New("hook failed")
+		docs := newExtraCommand(docsSubcommand)
+		docs.PersistentPreRunE = func(*cobra.Command, []string) error { return hookErr }
+
+		err := executeCLIWith(filesystemWithResolvableProject(), WithExtraCommands(docs), docsSubcommand)
+		Expect(err).To(MatchError(hookErr))
+	})
+
+	It("should report a plugin chain the command tree was not built for", func() {
+		docs, hookRan := newExtraCommandWithHook(docsSubcommand, setPersistentPreRunE)
+		projectPlugin := newTestCreateAPIPlugin(projectChainPluginName, plugin.Version{Number: 1})
+
+		err := executeEmbeddedCLI(filesystemWithProjectChainProject(),
+			[]string{kubebuilderSubcommandVersion}, []string{docsSubcommand},
+			WithExtraCommands(docs), WithPlugins(projectPlugin))
+		Expect(err).To(MatchError(ContainSubstring("the command tree was built for the plugin chain")))
+		Expect(*hookRan).To(BeFalse())
+	})
+})
+
+// A tool builds several CLIs in one process, as its own tests do. Each CLI has to answer for the
+// project it was built over, whatever the build order.
+var _ = Describe("several CLIs in one process", func() {
+	var generateArgs []string
+
+	BeforeEach(func() {
+		// The input directory does not exist, so a CLI that gets to the command stops at the
+		// validation of the command instead of scaffolding.
+		missingDir := filepath.Join(GinkgoT().TempDir(), "missing")
+		generateArgs = []string{alphaCommand, generateSubcommand, "--input-dir", missingDir}
+	})
+
+	// answerAlone returns what a CLI built over the filesystem answers when it is the only one.
+	answerAlone := func(filesystem func() machinery.Filesystem) error {
+		GinkgoHelper()
+
+		err := executeCLI(filesystem(), generateArgs...)
+		Expect(err).To(HaveOccurred())
+
+		return err
+	}
+
+	expectEachToAnswerForItsProject := func(unusable, usable *CLI) {
+		GinkgoHelper()
+
+		_, err := runBuiltCLI(usable, generateArgs)
+		Expect(err).To(MatchError(answerAlone(filesystemWithResolvableProject).Error()))
+
+		_, err = runBuiltCLI(unusable, generateArgs)
+		Expect(err).To(MatchError(answerAlone(filesystemWithUnresolvableProject).Error()))
+	}
+
+	It("should answer for its own project when the CLI over the unusable project is built first", func() {
+		unusable := buildCLI(filesystemWithUnresolvableProject(), generateArgs)
+		usable := buildCLI(filesystemWithResolvableProject(), generateArgs)
+
+		expectEachToAnswerForItsProject(unusable, usable)
+	})
+
+	It("should answer for its own project when the CLI over the usable project is built first", func() {
+		usable := buildCLI(filesystemWithResolvableProject(), generateArgs)
+		unusable := buildCLI(filesystemWithUnresolvableProject(), generateArgs)
+
+		expectEachToAnswerForItsProject(unusable, usable)
+	})
+})
+
 var _ = Describe("help requested through the plugins flag", func() {
 	DescribeTable("should exit successfully through the binary workflow",
 		func(args []string) {
-			originalArgs := os.Args
-			DeferCleanup(func() { os.Args = originalArgs })
-			os.Args = append([]string{kubebuilderCommandName}, args...)
+			setProgramArgs(args...)
 
 			c, err := New(
 				WithPlugins(&golangv4.Plugin{}),

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -121,44 +121,7 @@ func (c *CLI) newRootCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Check if --plugins flag contains help flags (--help, -h, help)
-			// This handles cases like: kubebuilder init --plugins --help
-			if pluginKeys, err := cmd.Flags().GetStringSlice(pluginsFlag); err == nil {
-				for _, key := range pluginKeys {
-					key = strings.TrimSpace(key)
-					if isHelpFlag(key) {
-						// Help was requested, show help and stop execution
-						cmd.SilenceUsage = true
-						cmd.SilenceErrors = true
-						_ = cmd.Help()
-						return errHelpDisplayed
-					}
-				}
-			}
-
-			if isCompletionRequest(cmd) {
-				return nil
-			}
-			// A malformed command line is reported for normal commands. Completion requests are
-			// intentionally allowed to inspect partial input.
-			if c.flagErr != nil {
-				return c.flagErr
-			}
-
-			// Cobra resolved the command, so it is now known whether it consumes the configuration.
-			if isSubcommandPathWithoutConfig(subcommandPath(cmd)) {
-				return nil
-			}
-			if c.configErr != nil {
-				return c.configErr
-			}
-			if c.configSkipped {
-				return c.resolveSkippedConfig()
-			}
-
-			return nil
-		},
+		PersistentPreRunE: c.checkCommandLine,
 	}
 
 	// Global flags for all subcommands.
@@ -172,6 +135,81 @@ func (c *CLI) newRootCmd() *cobra.Command {
 	cmd.FParseErrWhitelist = cobra.FParseErrWhitelist{UnknownFlags: true}
 
 	return cmd
+}
+
+// checkCommandLine runs before any command. It answers a help request made through the plugins
+// flag, reports a malformed command line, and reports a project configuration that the command
+// about to run cannot use.
+func (c *CLI) checkCommandLine(cmd *cobra.Command, _ []string) error {
+	// Handles command lines like: kubebuilder init --plugins --help
+	if pluginKeys, err := cmd.Flags().GetStringSlice(pluginsFlag); err == nil {
+		for _, key := range pluginKeys {
+			key = strings.TrimSpace(key)
+			if isHelpFlag(key) {
+				cmd.SilenceUsage = true
+				cmd.SilenceErrors = true
+				_ = cmd.Help()
+				return errHelpDisplayed
+			}
+		}
+	}
+
+	if isCompletionRequest(cmd) {
+		return nil
+	}
+	// A malformed command line is reported for normal commands. Completion requests are
+	// intentionally allowed to inspect partial input.
+	if c.flagErr != nil {
+		return c.flagErr
+	}
+
+	// Cobra resolved the command, so it is now known whether it consumes the configuration.
+	if isSubcommandPathWithoutConfig(subcommandPath(cmd)) {
+		return nil
+	}
+	if c.configErr != nil {
+		return c.configErr
+	}
+	if c.configSkipped {
+		return c.resolveSkippedConfig()
+	}
+
+	return nil
+}
+
+// checkCommandLineBeforeHooks makes checkCommandLine run before the persistent pre-run hook of the
+// command and of every command below it. Cobra runs only the nearest persistent pre-run hook, so an
+// extra command with a hook of its own would otherwise skip the check of the root command. That
+// hook still runs afterwards. Subcommands added after the CLI is built are not wrapped.
+func (c *CLI) checkCommandLineBeforeHooks(cmd *cobra.Command) {
+	for _, subcommand := range cmd.Commands() {
+		c.checkCommandLineBeforeHooks(subcommand)
+	}
+
+	switch {
+	case cmd.PersistentPreRunE != nil:
+		ownHook := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			if err := c.checkCommandLine(cmd, args); err != nil {
+				return err
+			}
+
+			return ownHook(cmd, args)
+		}
+	case cmd.PersistentPreRun != nil:
+		ownHook := cmd.PersistentPreRun
+		// Cobra runs PersistentPreRunE instead of PersistentPreRun when both are set, so the hook
+		// moves there to keep running.
+		cmd.PersistentPreRun = nil
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			if err := c.checkCommandLine(cmd, args); err != nil {
+				return err
+			}
+			ownHook(cmd, args)
+
+			return nil
+		}
+	}
 }
 
 // rootExamples builds the examples string for the root command before resolving plugins

--- a/pkg/config/store/yaml/store.go
+++ b/pkg/config/store/yaml/store.go
@@ -171,12 +171,19 @@ func checkReadable(fs afero.Fs, path string) error {
 }
 
 // checkSavePath verifies that the path can be used to save a configuration. It accepts a missing
-// path for a new configuration and a regular file for an update. Other path types are rejected
-// when the filesystem can identify them.
+// path for a new configuration and a regular file for an update, reached directly or through a
+// symbolic link. Other path types are rejected when the filesystem can identify them.
 func checkSavePath(fs afero.Fs, path string, mustNotExist bool) error {
 	class, err := classifyNoFollow(fs, path)
 	if err != nil {
 		return err
+	}
+
+	if class == pathSymbolicLink {
+		class, err = classifyLinkTarget(fs, path)
+		if err != nil {
+			return err
+		}
 	}
 
 	switch class {
@@ -190,6 +197,21 @@ func checkSavePath(fs afero.Fs, path string, mustNotExist bool) error {
 	default:
 		return nil
 	}
+}
+
+// classifyLinkTarget reports what the symbolic link at the path points at. A link to nothing is
+// reported as the link itself: saving through it would create a file where nobody asked for one.
+func classifyLinkTarget(fs afero.Fs, path string) (pathClass, error) {
+	target, err := classify(fs, path)
+	if err != nil {
+		return pathMissing, err
+	}
+
+	if target == pathMissing {
+		return pathSymbolicLink, nil
+	}
+
+	return target, nil
 }
 
 // LoadFrom implements store.Store interface
@@ -242,7 +264,8 @@ func (s yamlStore) SaveTo(path string) error {
 	}
 
 	// Only a missing path or a regular file can be used for saving. New configurations require
-	// the path to be missing, while existing configurations may update a regular file.
+	// the path to be missing, while existing configurations may update a regular file, even
+	// through a symbolic link.
 	if err := checkSavePath(s.fs, path, s.mustNotExist); err != nil {
 		return store.SaveError{Err: err}
 	}

--- a/pkg/config/store/yaml/store_test.go
+++ b/pkg/config/store/yaml/store_test.go
@@ -405,11 +405,46 @@ layout: ""
 			Expect(target).NotTo(BeAnExistingFile())
 		})
 
-		It("should reject a symbolic link when updating an existing configuration", func() {
+		It("should update the target when the path is a symbolic link to a regular file", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
+			Expect(os.WriteFile(target, []byte("outdated"), 0o644)).To(Succeed())
+
+			s.fs = afero.NewOsFs()
+			s.cfg = cfgv3.New()
+			s.mustNotExist = false
+
+			Expect(s.SaveTo(link)).To(Succeed())
+
+			content, err := os.ReadFile(target)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal(commentStr + v3File))
+			expectSymlink(link)
+		})
+
+		It("should report an existing configuration when initializing through a symbolic link to a file", func() {
 			skipWithoutSymlinks()
 			link, target := danglingSymlink()
 			existingContent := []byte(commentStr + v3File)
 			Expect(os.WriteFile(target, existingContent, 0o644)).To(Succeed())
+
+			s.fs = afero.NewOsFs()
+			s.cfg = cfgv3.New()
+			s.mustNotExist = true
+
+			Expect(s.SaveTo(link)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("configuration already exists in %q", link),
+			}))
+
+			content, err := os.ReadFile(target)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal(existingContent))
+			expectSymlink(link)
+		})
+
+		It("should fail without creating the target when updating through a dangling symbolic link", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
 
 			s.fs = afero.NewOsFs()
 			s.cfg = cfgv3.New()
@@ -418,14 +453,38 @@ layout: ""
 			Expect(s.SaveTo(link)).To(MatchError(store.SaveError{
 				Err: fmt.Errorf("cannot save configuration to %q: path is a symbolic link", link),
 			}))
-			Expect(target).To(BeAnExistingFile())
-			content, err := os.ReadFile(target)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(content).To(Equal(existingContent))
+			Expect(target).NotTo(BeAnExistingFile())
+			expectSymlink(link)
+		})
 
-			info, err := os.Lstat(link)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(info.Mode() & os.ModeSymlink).NotTo(BeZero())
+		It("should fail when the target of a symbolic link cannot be checked", func() {
+			skipWithoutSymlinks()
+			link, _ := danglingSymlink()
+			statErr := errors.New("permission denied")
+
+			s.fs = &unreachableLinkTargetFs{failingStatFs{Fs: afero.NewOsFs(), path: link, err: statErr}}
+			s.cfg = cfgv3.New()
+			s.mustNotExist = false
+
+			Expect(s.SaveTo(link)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("failed to check %q: %w", link, statErr),
+			}))
+		})
+
+		It("should fail if the path is a symbolic link to a directory", func() {
+			skipWithoutSymlinks()
+			link, target := danglingSymlink()
+			Expect(os.Mkdir(target, 0o755)).To(Succeed())
+
+			s.fs = afero.NewOsFs()
+			s.cfg = cfgv3.New()
+			s.mustNotExist = false
+
+			Expect(s.SaveTo(link)).To(MatchError(store.SaveError{
+				Err: fmt.Errorf("cannot save configuration to %q: path is a directory", link),
+			}))
+			Expect(target).To(BeADirectory())
+			expectSymlink(link)
 		})
 	})
 
@@ -475,6 +534,15 @@ func skipWithoutSymlinks() {
 	if runtime.GOOS == "windows" {
 		Skip("symlink creation requires elevated privileges on Windows")
 	}
+}
+
+// expectSymlink asserts that the path is still a symbolic link, so nothing replaced it.
+func expectSymlink(path string) {
+	GinkgoHelper()
+
+	info, err := os.Lstat(path)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(info.Mode() & os.ModeSymlink).NotTo(BeZero())
 }
 
 // danglingSymlink creates a symbolic link whose target does not exist, and returns both paths.
@@ -539,6 +607,21 @@ func (f *failingStatFs) Stat(name string) (os.FileInfo, error) {
 	}
 
 	return info, nil
+}
+
+// unreachableLinkTargetFs reports the symbolic link at the path but fails to follow it.
+type unreachableLinkTargetFs struct {
+	failingStatFs
+}
+
+// LstatIfPossible delegates to the wrapped filesystem, so the link itself is still reported.
+func (f *unreachableLinkTargetFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	info, lstatCalled, err := f.Fs.(afero.Lstater).LstatIfPossible(name)
+	if err != nil {
+		return nil, lstatCalled, fmt.Errorf("failed to lstat %q: %w", name, err)
+	}
+
+	return info, lstatCalled, nil
 }
 
 // Open counts reads of the configured path before delegating to the wrapped filesystem.


### PR DESCRIPTION
Follow-up to #5845 and #5942.

- Save the configuration through a symbolic link to a regular file. A link with a missing target is still refused.
- Run the root project check before the persistent pre-run hook of commands added with WithExtraCommands and WithExtraAlphaCommands.
- Build the alpha subcommands per CLI, so CLIs built in one process no longer share command state.
- Cover create api driven by Command().SetArgs on a tree built as version, which already stops on a plugin chain the tree was not built for.

Closes: https://github.com/kubernetes-sigs/kubebuilder/pull/6030