### PR TITLE
✨(helm/v2-alpha, go/v4): add support for stop the webhook server when webhook.enabled=false

### DIFF
--- a/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/cronjob-tutorial/testdata/project/cmd/main.go
@@ -94,7 +94,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. "+
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")

--- a/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/cronjob-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -86,6 +86,9 @@ spec:
         - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- else }}
+        # Set -1 to disable the webhook server
+        - --webhook-port=-1
         {{- end }}
         {{- range .Values.manager.args }}
         - {{ tpl . $ }}
@@ -113,9 +116,11 @@ spec:
         - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
+        {{- if .Values.webhook.enabled }}
         - containerPort: {{ .Values.webhook.port }}
           name: webhook-server
           protocol: TCP
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz

--- a/docs/book/src/getting-started/testdata/project/cmd/main.go
+++ b/docs/book/src/getting-started/testdata/project/cmd/main.go
@@ -74,7 +74,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. "+
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")

--- a/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
+++ b/docs/book/src/multiversion-tutorial/testdata/project/cmd/main.go
@@ -93,7 +93,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. "+
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")

--- a/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
+++ b/docs/book/src/multiversion-tutorial/testdata/project/dist/chart/templates/manager/manager.yaml
@@ -86,6 +86,9 @@ spec:
         - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- else }}
+        # Set -1 to disable the webhook server
+        - --webhook-port=-1
         {{- end }}
         {{- range .Values.manager.args }}
         - {{ tpl . $ }}
@@ -113,9 +116,11 @@ spec:
         - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
+        {{- if .Values.webhook.enabled }}
         - containerPort: {{ .Values.webhook.port }}
           name: webhook-server
           protocol: TCP
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz

--- a/docs/book/src/plugins/available/helm-v2-alpha.md
+++ b/docs/book/src/plugins/available/helm-v2-alpha.md
@@ -205,6 +205,15 @@ For charts without conversion webhooks, install without webhooks:
 $ helm install my-release ./dist/chart --set webhook.enabled=false --set certManager.enabled=false
 ```
 
+`webhook.enabled=false` skips the webhook Service, the webhook configurations, the webhook NetworkPolicy, and the `webhook-server` container port. It also sets `--webhook-port=-1` to disable the webhook server. This works like `metrics.enabled=false`, which passes `--metrics-bind-address=0`.
+
+<aside class="note warning" role="note">
+<p class="note-title">Requires controller-runtime v0.25.0 or later</p>
+
+Older controller-runtime releases treat `--webhook-port=-1` as the default `9443`. The manager then tries to start the webhook server without a certificate and fails. See [Disabling the webhook server](../../reference/webhook-overview.md#disabling-the-webhook-server).
+
+</aside>
+
 Charts with CR version conversion reject `webhook.enabled=false`. The API server needs the webhook Service to convert custom resources.
 
 Install with NetworkPolicy resources:
@@ -266,7 +275,7 @@ For example, install the chart with the webhook server on port `9444`:
 helm install my-operator ./dist/chart --set webhook.port=9444
 ```
 
-The default is `9443`, detected from your project configuration.
+The default is `9443`, detected from your project configuration. To disable the webhook server, set `webhook.enabled=false` instead of changing the port.
 
 ### Health probe port configuration
 

--- a/docs/book/src/reference/webhook-overview.md
+++ b/docs/book/src/reference/webhook-overview.md
@@ -18,3 +18,16 @@ feature entered beta).
 Kubernetes supports the conversion webhooks as of version 1.15 (when the
 feature entered beta).
 
+## Disabling the webhook server
+
+Set `--webhook-port=-1` to disable the webhook server:
+
+```bash
+./bin/manager --webhook-port=-1
+```
+
+controller-runtime logs `Webhook server is disabled` and does not listen on any port. This needs controller-runtime `v0.25.0` or later. Older releases treat `-1` as the default `9443`.
+
+Only disable the server when no webhook configuration or CRD conversion points at the manager. Otherwise the API server cannot reach the webhooks and rejects the requests they guard.
+
+To skip webhook registration when running the manager locally with `make run`, set `ENABLE_WEBHOOKS=false` instead.

--- a/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
+++ b/pkg/plugins/golang/v4/scaffolds/internal/templates/cmd/main.go
@@ -313,7 +313,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. " +
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/manager.go
@@ -659,6 +659,12 @@ func templateControllerManagerArgs(yamlContent string) string {
 		}
 	}
 
+	// Projects scaffolded before the patch added --webhook-port still need the flag so
+	// webhook.enabled=false can turn the server off.
+	if webhookLine == "" && strings.Contains(yamlContent, "name: webhook-server") {
+		webhookLine = itemIndent + "- --webhook-port={{ .Values.webhook.port }}"
+	}
+
 	var builder strings.Builder
 	builder.WriteString(indent)
 	builder.WriteString("args:\n")
@@ -695,6 +701,12 @@ func templateControllerManagerArgs(yamlContent string) string {
 		builder.WriteString("{{- if .Values.webhook.enabled }}\n")
 		builder.WriteString(webhookLine)
 		builder.WriteString("\n")
+		builder.WriteString(itemIndent)
+		builder.WriteString("{{- else }}\n")
+		builder.WriteString(itemIndent)
+		builder.WriteString("# Set -1 to disable the webhook server\n")
+		builder.WriteString(itemIndent)
+		builder.WriteString("- --webhook-port=-1\n")
 		builder.WriteString(itemIndent)
 		builder.WriteString("{{- end }}\n")
 	}

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/appliers/ports.go
@@ -17,6 +17,7 @@ limitations under the License.
 package appliers
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -65,6 +66,7 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured, dete
 		if strings.Contains(yamlContent, "webhook-server") {
 			yamlContent = regexp.MustCompile(`(?m)(\s*- )?containerPort:\s*\d+(\s*\n\s*name:\s*webhook-server)`).
 				ReplaceAllString(yamlContent, "${1}containerPort: {{ .Values.webhook.port }}${2}")
+			yamlContent = makeWebhookContainerPortConditional(yamlContent)
 		}
 
 		// Replace targetPort with webhook.port template (matches any numeric port)
@@ -100,14 +102,28 @@ func TemplatePorts(yamlContent string, resource *unstructured.Unstructured, dete
 		yamlContent = regexp.MustCompile(`--metrics-bind-address=(\[[^\]]*\]|[^\s:]*):([0-9]+)`).
 			ReplaceAllString(yamlContent, "--metrics-bind-address=$1:{{ .Values.metrics.port }}")
 
-		// Replace --webhook-port with templated version (matches any numeric port)
-		yamlContent = regexp.MustCompile(`--webhook-port=([0-9]+)`).
+		// Replace --webhook-port with templated version. Port -1 is the disabled branch and stays as is.
+		yamlContent = regexp.MustCompile(`--webhook-port=[1-9][0-9]*`).
 			ReplaceAllString(yamlContent, "--webhook-port={{ .Values.webhook.port }}")
 
 		yamlContent = templateHealthProbePort(yamlContent)
 	}
 
 	return yamlContent
+}
+
+// makeWebhookContainerPortConditional renders the webhook-server container port only when
+// webhook.enabled is true, since the manager does not listen on it otherwise.
+func makeWebhookContainerPortConditional(yamlContent string) string {
+	if regexp.MustCompile(`\{\{- if \.Values\.webhook\.enabled \}\}\n[ \t]+- containerPort:`).MatchString(yamlContent) {
+		return yamlContent
+	}
+	portPattern := regexp.MustCompile(`(?m)^([ \t]+)- containerPort: \{\{ \.Values\.webhook\.port \}\}\n` +
+		`[ \t]+name: webhook-server(?:\n[ \t]+protocol: \w+)?$`)
+	return portPattern.ReplaceAllStringFunc(yamlContent, func(match string) string {
+		indent, _ := LeadingWhitespace(match)
+		return fmt.Sprintf("%s{{- if .Values.webhook.enabled }}\n%s\n%s{{- end }}", indent, match, indent)
+	})
 }
 
 // templateNetworkPolicyIngressPort rewrites the port only inside the NetworkPolicy's

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/internal/kustomize/templater/templater_test.go
@@ -202,6 +202,9 @@ spec:
 			Expect(result).To(ContainSubstring("- --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}"))
 			Expect(result).To(ContainSubstring(`{{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- else }}
+        # Set -1 to disable the webhook server
+        - --webhook-port=-1
         {{- end }}`))
 			Expect(result).To(ContainSubstring(
 				"{{- if and .Values.certManager.enabled .Values.webhook.enabled }}\n" +
@@ -241,6 +244,30 @@ spec:
 
 			Expect(result).NotTo(ContainSubstring("--webhook-port"))
 			Expect(result).NotTo(ContainSubstring("{{- if .Values.webhook.enabled }}"))
+		})
+
+		It("keeps a single webhook.enabled guard when a templated Deployment is templated again", func() {
+			deploymentResource := &unstructured.Unstructured{}
+			deploymentResource.SetAPIVersion("apps/v1")
+			deploymentResource.SetKind("Deployment")
+			deploymentResource.SetName("test-project-controller-manager")
+
+			content := `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP`
+
+			once := templater.ApplyHelmSubstitutions(content, deploymentResource)
+			twice := templater.ApplyHelmSubstitutions(once, deploymentResource)
+
+			Expect(strings.Count(twice, "{{- if .Values.webhook.enabled }}")).To(Equal(1))
 		})
 
 		It("should handle volume mounts with proper indentation", func() {

--- a/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
+++ b/pkg/plugins/optional/helm/v2alpha/scaffolds/test/chart_generation_integration_test.go
@@ -821,6 +821,71 @@ var _ = Describe("Chart Generation Integration Tests", func() {
 		})
 	})
 
+	Context("Webhook server toggle (rendered)", func() {
+		// managerContainerArgs returns the manager container args from the rendered Deployment.
+		managerContainerArgs := func(rendered string) []string {
+			var args []string
+			for _, line := range strings.Split(rendered, "\n") {
+				trimmed := strings.TrimSpace(line)
+				if strings.HasPrefix(trimmed, "- --") {
+					args = append(args, strings.TrimPrefix(trimmed, "- "))
+				}
+			}
+			return args
+		}
+
+		// containerPortNames returns every containerPort name declared in the rendered manifests.
+		containerPortNames := func(rendered string) []string {
+			var names []string
+			lines := strings.Split(rendered, "\n")
+			for i, line := range lines {
+				if strings.HasPrefix(strings.TrimSpace(line), "- containerPort:") && i+1 < len(lines) {
+					names = append(names, strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[i+1]), "name:")))
+				}
+			}
+			return names
+		}
+
+		render := func(kustomizeYAML string, setArgs ...string) string {
+			out, err := helmTemplate(kustomizeYAML, setArgs...)
+			Expect(err).NotTo(HaveOccurred(), "helm template failed: %s", out)
+			return out
+		}
+
+		It("turns the webhook server off and drops its container port when webhooks are disabled", func() {
+			rendered := render(createKustomizeWithWebhookServer("test-project", true),
+				"--set", "webhook.enabled=false", "--set", "certManager.enabled=false")
+
+			args := managerContainerArgs(rendered)
+			Expect(args).To(ContainElement("--webhook-port=-1"), "rendered manager args: %v", args)
+			Expect(args).NotTo(ContainElement("--webhook-port=9443"), "rendered manager args: %v", args)
+			Expect(containerPortNames(rendered)).NotTo(ContainElement("webhook-server"))
+			Expect(rendered).NotTo(ContainSubstring("-webhook-service"))
+		})
+
+		It("keeps the webhook server listening on webhook.port when webhooks are enabled", func() {
+			rendered := render(createKustomizeWithWebhookServer("test-project", true),
+				"--set", "webhook.enabled=true", "--set", "webhook.port=9444")
+
+			args := managerContainerArgs(rendered)
+			Expect(args).To(ContainElement("--webhook-port=9444"), "rendered manager args: %v", args)
+			Expect(args).NotTo(ContainElement("--webhook-port=-1"), "rendered manager args: %v", args)
+			Expect(containerPortNames(rendered)).To(ContainElement("webhook-server"))
+			Expect(rendered).To(ContainSubstring("containerPort: 9444"))
+		})
+
+		It("still toggles the webhook server when the manifests never passed the port flag", func() {
+			manifests := createKustomizeWithWebhookServer("test-project", false)
+
+			disabled := managerContainerArgs(render(manifests,
+				"--set", "webhook.enabled=false", "--set", "certManager.enabled=false"))
+			Expect(disabled).To(ContainElement("--webhook-port=-1"), "rendered manager args: %v", disabled)
+
+			enabled := managerContainerArgs(render(manifests, "--set", "webhook.enabled=true"))
+			Expect(enabled).To(ContainElement("--webhook-port=9443"), "rendered manager args: %v", enabled)
+		})
+	})
+
 	Context("NetworkPolicy conversion from kustomize (rendered)", func() {
 		networkPolicyDoc := func(rendered, suffix string) string {
 			for _, doc := range strings.Split(rendered, "\n---") {
@@ -1643,6 +1708,50 @@ spec:
   ingress:
     - ports:
         - port: 7777
+          protocol: TCP
+`
+}
+
+// createKustomizeWithWebhookServer builds a project with admission webhooks whose manager exposes the
+// webhook-server port. passesPortFlag controls whether the Deployment args carry --webhook-port, which
+// projects scaffolded before the flag was added to manager_webhook_patch.yaml do not.
+func createKustomizeWithWebhookServer(projectName string, passesPortFlag bool) string {
+	portFlag := ""
+	if passesPortFlag {
+		portFlag = "\n        - --webhook-port=9443"
+	}
+	return createKustomizeWithWebhooks(projectName) + `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ` + projectName + `
+    control-plane: controller-manager
+  name: ` + projectName + `-controller-manager
+  namespace: ` + projectName + `-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - name: manager
+        image: controller:latest
+        args:
+        - --leader-elect
+        - --health-probe-bind-address=:8081` + portFlag + `
+        ports:
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
           protocol: TCP
 `
 }

--- a/test/e2e/all/plugin_helm_test.go
+++ b/test/e2e/all/plugin_helm_test.go
@@ -236,6 +236,55 @@ var _ = Describe("kubebuilder", func() {
 			Expect(helpers.GetMetricsServicePort(namePrefix, kbc)).To(Equal(customMetricsPort))
 		})
 
+		It("should not run the webhook server when installed with webhook.enabled=false", func() {
+			By("generating a project with admission webhooks and no conversion webhook")
+			helpers.GenerateV4WithoutConversionWebhook(kbc)
+
+			By("building installer and generating helm chart")
+			Expect(kbc.Make("build-installer")).To(Succeed())
+			Expect(kbc.EditHelmPlugin()).To(Succeed())
+
+			By("disabling webhooks and cert-manager in values.yaml")
+			valuesPath := filepath.Join(kbc.Dir, "dist", "chart", "values.yaml")
+			Expect(pluginutil.ReplaceInFile(valuesPath,
+				"webhook:\n  enabled: true", "webhook:\n  enabled: false")).To(Succeed())
+			Expect(pluginutil.ReplaceInFile(valuesPath,
+				"certManager:\n  enabled: true", "certManager:\n  enabled: false")).To(Succeed())
+
+			By("deploying without webhooks and validating the manager reconciles the sample CR")
+			helpers.Run(kbc, helpers.RunOptions{
+				HasWebhook:          false,
+				HasMetrics:          true,
+				HasNetworkPolicies:  false,
+				InstallMethod:       helpers.InstallMethodHelm,
+				SkipChartGeneration: true, // Chart already generated and customized above
+			})
+
+			By("verifying the chart tells the manager to disable the webhook server")
+			controllerPodName := helpers.GetControllerPodName(kbc)
+			args, err := kbc.Kubectl.Get(true,
+				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].args}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).To(ContainSubstring("--webhook-port=-1"))
+
+			By("verifying the container does not declare the webhook-server port")
+			portNames, err := kbc.Kubectl.Get(true,
+				"pod", controllerPodName, "-o", "jsonpath={.spec.containers[0].ports[*].name}")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(portNames).NotTo(ContainSubstring("webhook-server"))
+
+			By("verifying the manager did not start the webhook server")
+			logs, err := kbc.Kubectl.Logs(controllerPodName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(logs).To(ContainSubstring("Webhook server is disabled"))
+			Expect(logs).NotTo(ContainSubstring("Starting webhook server"))
+
+			By("verifying the webhook Service was not rendered")
+			_, err = kbc.Kubectl.Get(true,
+				"service", fmt.Sprintf("e2e-%s-webhook-service", kbc.TestSuffix))
+			Expect(err).To(HaveOccurred(), "webhook Service must not exist when webhook.enabled=false")
+		})
+
 		It("should generate a namespeced runnable project using webhooks and installed with the HelmChart", func() {
 			helpers.GenerateV4Namespaced(kbc)
 

--- a/test/e2e/internal/helpers/generate_v4.go
+++ b/test/e2e/internal/helpers/generate_v4.go
@@ -206,6 +206,35 @@ func GenerateV4WithoutWebhooks(kbc *utils.TestContext) {
 		"#- ../prometheus", "#")).To(Succeed())
 }
 
+// GenerateV4WithoutConversionWebhook implements a go/v4 plugin project with admission webhooks only.
+// A Helm chart generated from it accepts webhook.enabled=false, which charts with CRD conversion reject.
+func GenerateV4WithoutConversionWebhook(kbc *utils.TestContext) {
+	initingTheProject(kbc)
+	creatingAPI(kbc)
+
+	By("scaffolding mutating and validating webhooks")
+	err := kbc.CreateWebhook(
+		"--group", kbc.Group,
+		"--version", kbc.Version,
+		"--kind", kbc.Kind,
+		"--defaulting",
+		"--programmatic-validation",
+		"--make=false",
+	)
+	Expect(err).NotTo(HaveOccurred(), "Failed to scaffold admission webhooks")
+
+	By("implementing the mutating and validating webhooks")
+	webhookFilePath := filepath.Join(
+		kbc.Dir, "internal/webhook", kbc.Version,
+		fmt.Sprintf("%s_webhook.go", strings.ToLower(kbc.Kind)))
+	err = utils.ImplementWebhooks(webhookFilePath, strings.ToLower(kbc.Kind))
+	Expect(err).NotTo(HaveOccurred(), "Failed to implement webhooks")
+
+	ExpectWithOffset(1, pluginutil.UncommentCode(
+		filepath.Join(kbc.Dir, "config", "default", "kustomization.yaml"),
+		"#- ../prometheus", "#")).To(Succeed())
+}
+
 // GenerateV4WithCustomWebhookPath tests webhooks with custom paths
 func GenerateV4WithCustomWebhookPath(kbc *utils.TestContext) {
 	initingTheProject(kbc)

--- a/testdata/project-v4-multigroup/cmd/main.go
+++ b/testdata/project-v4-multigroup/cmd/main.go
@@ -117,7 +117,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. "+
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")

--- a/testdata/project-v4-with-plugins/cmd/main.go
+++ b/testdata/project-v4-with-plugins/cmd/main.go
@@ -109,7 +109,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. "+
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")

--- a/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
+++ b/testdata/project-v4-with-plugins/dist/chart/templates/manager/manager.yaml
@@ -86,6 +86,9 @@ spec:
         - --health-probe-bind-address=:{{ .Values.manager.healthProbe.port }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}
+        {{- else }}
+        # Set -1 to disable the webhook server
+        - --webhook-port=-1
         {{- end }}
         {{- range .Values.manager.args }}
         - {{ tpl . $ }}
@@ -124,9 +127,11 @@ spec:
         - containerPort: {{ .Values.manager.healthProbe.port }}
           name: health
           protocol: TCP
+        {{- if .Values.webhook.enabled }}
         - containerPort: {{ .Values.webhook.port }}
           name: webhook-server
           protocol: TCP
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz

--- a/testdata/project-v4/cmd/main.go
+++ b/testdata/project-v4/cmd/main.go
@@ -80,7 +80,8 @@ func main() {
 	flag.StringVar(&webhookCertPath, "webhook-cert-path", "", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
-	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. Defaults to 9443.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port the webhook server listens on. "+
+		"Defaults to 9443. Set -1 to disable the webhook server.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
 		"The directory that contains the metrics server certificate.")
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")


### PR DESCRIPTION
The Helm chart now passes `--webhook-port=-1` to the manager when installed with `webhook.enabled=false`, and the scaffolded `cmd/main.go` treats `-1` as disabled. The webhook server no longer keeps listening on 9443 when webhooks are turned off. Existing projects need controller-runtime v0.25.0 or later and a small change in `cmd/main.go`; see "Disabling the webhook server" in the webhook reference. Fixes #5987.
